### PR TITLE
Merge upstream + MCP list/get transcript tools

### DIFF
--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -66,7 +66,7 @@ Return only two sentences, no labels, no markdown, no extra commentary.
             appName: frontmostApp.localizedName,
             bundleIdentifier: frontmostApp.bundleIdentifier,
             windowTitle: focusedWindowTitle(from: appElement) ?? frontmostApp.localizedName,
-            selectedText: selectedText(from: appElement)
+            selectedText: rawSelectedText(from: appElement)
         )
     }
 
@@ -309,6 +309,19 @@ Selected text: \(selectedText ?? "None")
         return nil
     }
 
+    private func rawSelectedText(from appElement: AXUIElement) -> String? {
+        if let focusedElement = accessibilityElement(from: appElement, attribute: kAXFocusedUIElementAttribute as CFString),
+           let selectedText = accessibilityRawString(from: focusedElement, attribute: kAXSelectedTextAttribute as CFString) {
+            return selectedText
+        }
+
+        if let selectedText = accessibilityRawString(from: appElement, attribute: kAXSelectedTextAttribute as CFString) {
+            return selectedText
+        }
+
+        return nil
+    }
+
     private func accessibilityElement(from element: AXUIElement, attribute: CFString) -> AXUIElement? {
         var value: CFTypeRef?
         let result = AXUIElementCopyAttributeValue(element, attribute, &value)
@@ -325,6 +338,13 @@ Selected text: \(selectedText ?? "None")
         let result = AXUIElementCopyAttributeValue(element, attribute, &value)
         guard result == .success, let stringValue = value as? String else { return nil }
         return trimmedText(stringValue)
+    }
+
+    private func accessibilityRawString(from element: AXUIElement, attribute: CFString) -> String? {
+        var value: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(element, attribute, &value)
+        guard result == .success, let stringValue = value as? String else { return nil }
+        return stringValue.isEmpty ? nil : stringValue
     }
 
     private func accessibilityPoint(from element: AXUIElement, attribute: CFString) -> CGPoint? {

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -2,6 +2,13 @@ import Foundation
 import ApplicationServices
 import AppKit
 
+struct AppSelectionSnapshot {
+    let appName: String?
+    let bundleIdentifier: String?
+    let windowTitle: String?
+    let selectedText: String?
+}
+
 struct AppContext {
     let appName: String?
     let bundleIdentifier: String?
@@ -42,6 +49,25 @@ Return only two sentences, no labels, no markdown, no extra commentary.
         self.apiKey = apiKey
         self.baseURL = baseURL
         self.customContextPrompt = customContextPrompt
+    }
+
+    func collectSelectionSnapshot() -> AppSelectionSnapshot {
+        guard let frontmostApp = NSWorkspace.shared.frontmostApplication else {
+            return AppSelectionSnapshot(
+                appName: nil,
+                bundleIdentifier: nil,
+                windowTitle: nil,
+                selectedText: nil
+            )
+        }
+
+        let appElement = AXUIElementCreateApplication(frontmostApp.processIdentifier)
+        return AppSelectionSnapshot(
+            appName: frontmostApp.localizedName,
+            bundleIdentifier: frontmostApp.bundleIdentifier,
+            windowTitle: focusedWindowTitle(from: appElement) ?? frontmostApp.localizedName,
+            selectedText: selectedText(from: appElement)
+        )
     }
 
     func collectContext() async -> AppContext {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -371,6 +371,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var pendingManualCommandInvocation = false
     private var pendingShortcutStartTask: Task<Void, Never>?
     private var pendingShortcutStartMode: RecordingTriggerMode?
+    private var pendingOverlayDismissToken: UUID?
     private var shouldMonitorHotkeys = false
     private var isCapturingShortcut = false
 
@@ -1248,6 +1249,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let t0 = CFAbsoluteTimeGetCurrent()
         os_log(.info, log: recordingLog, "startRecording() entered")
         guard !isRecording && !isTranscribing else { return }
+        clearPendingOverlayDismissToken()
         let scheduledSelectionSnapshot = pendingSelectionSnapshot
         let scheduledManualCommandInvocation = pendingManualCommandInvocation
         cancelPendingShortcutStart()
@@ -1330,6 +1332,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             guard let self, !overlayShown else { return }
             overlayShown = true
             os_log(.info, log: recordingLog, "engine slow — showing initializing overlay")
+            self.clearPendingOverlayDismissToken()
             self.overlayManager.showInitializing(
                 mode: self.activeRecordingTriggerMode ?? triggerMode,
                 isCommandMode: self.currentSessionIntent.isCommandMode
@@ -1345,6 +1348,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 self.cancelRecordingInitializationTimer()
                 os_log(.info, log: recordingLog, "first real audio — transitioning to waveform")
                 self.statusText = "Recording..."
+                self.clearPendingOverlayDismissToken()
                 if overlayShown {
                     self.overlayManager.transitionToRecording(
                         mode: self.activeRecordingTriggerMode ?? triggerMode,
@@ -1717,15 +1721,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
                         if trimmedFinalTranscript.isEmpty {
                             self.statusText = "Nothing to transcribe"
+                            self.clearPendingOverlayDismissToken()
                             self.overlayManager.dismiss()
                         } else {
                             self.statusText = completionStatusText
                             if shouldPersistRawDictationFallback {
-                                self.overlayManager.showFailureIndicator()
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
-                                    self.overlayManager.dismiss()
-                                }
+                                self.scheduleOverlayDismissAfterFailureIndicator(after: 2.5)
                             } else {
+                                self.clearPendingOverlayDismissToken()
                                 self.overlayManager.dismiss()
                             }
 
@@ -1978,6 +1981,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func startDebugOverlay() {
         isDebugOverlayActive = true
+        clearPendingOverlayDismissToken()
         overlayManager.showRecording()
 
         // Simulate audio levels with a timer
@@ -1997,7 +2001,23 @@ final class AppState: ObservableObject, @unchecked Sendable {
         debugOverlayTimer?.invalidate()
         debugOverlayTimer = nil
         isDebugOverlayActive = false
+        clearPendingOverlayDismissToken()
         overlayManager.dismiss()
+    }
+
+    private func clearPendingOverlayDismissToken() {
+        pendingOverlayDismissToken = nil
+    }
+
+    private func scheduleOverlayDismissAfterFailureIndicator(after delay: TimeInterval) {
+        let dismissToken = UUID()
+        pendingOverlayDismissToken = dismissToken
+        overlayManager.showFailureIndicator()
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self, self.pendingOverlayDismissToken == dismissToken else { return }
+            self.pendingOverlayDismissToken = nil
+            self.overlayManager.dismiss()
+        }
     }
 
     func toggleDebugPanel() {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1206,6 +1206,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let t0 = CFAbsoluteTimeGetCurrent()
         os_log(.info, log: recordingLog, "startRecording() entered")
         guard !isRecording && !isTranscribing else { return }
+        let scheduledSelectionSnapshot = pendingSelectionSnapshot
+        let scheduledManualCommandInvocation = pendingManualCommandInvocation
         cancelPendingShortcutStart()
         activeRecordingTriggerMode = triggerMode
         guard hasAccessibility else {
@@ -1218,17 +1220,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return
         }
         os_log(.info, log: recordingLog, "accessibility check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-        let selectionSnapshot = pendingSelectionSnapshot ?? contextService.collectSelectionSnapshot()
-        let manualCommandRequested = pendingSelectionSnapshot == nil
+        let selectionSnapshot = scheduledSelectionSnapshot ?? contextService.collectSelectionSnapshot()
+        let manualCommandRequested = scheduledSelectionSnapshot == nil
             ? hotkeyManager.currentPressedModifiers.contains(commandModeManualModifier.shortcutModifier)
-            : pendingManualCommandInvocation
+            : scheduledManualCommandInvocation
         guard let resolvedIntent = resolveSessionIntent(
             triggerMode: triggerMode,
             selectionSnapshot: selectionSnapshot,
             manualCommandRequested: manualCommandRequested
         ) else { return }
-        pendingSelectionSnapshot = nil
-        pendingManualCommandInvocation = false
         currentSessionIntent = resolvedIntent
         overlayManager.setRecordingTriggerMode(triggerMode, animated: false)
         guard ensureMicrophoneAccess() else { return }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1707,13 +1707,25 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.debugStatusMessage = "Done"
                         let completionStatusText = self.preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
 
+                        let shouldPersistRawDictationFallback: Bool
+                        switch result.outcome {
+                        case .postProcessingFailedFallback:
+                            shouldPersistRawDictationFallback = !trimmedFinalTranscript.isEmpty
+                        default:
+                            shouldPersistRawDictationFallback = false
+                        }
+
                         if trimmedFinalTranscript.isEmpty {
                             self.statusText = "Nothing to transcribe"
                             self.overlayManager.dismiss()
                         } else {
                             self.statusText = completionStatusText
-                            self.overlayManager.showDone()
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                            if shouldPersistRawDictationFallback {
+                                self.overlayManager.showFallbackMessage("Used raw dictation")
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
+                                    self.overlayManager.dismiss()
+                                }
+                            } else {
                                 self.overlayManager.dismiss()
                             }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -127,6 +127,34 @@ private enum SessionIntent {
             return true
         }
     }
+
+    var persistedIntent: String {
+        switch self {
+        case .dictation:
+            return "dictation"
+        case .command(let invocation, _):
+            return "command:\(invocation.rawValue)"
+        }
+    }
+
+    var persistedSelectedText: String? {
+        switch self {
+        case .dictation:
+            return nil
+        case .command(_, let selectedText):
+            return selectedText
+        }
+    }
+
+    static func fromPersisted(intent: String, selectedText: String?) -> SessionIntent {
+        if intent == "command:automatic", let selectedText {
+            return .command(invocation: .automatic, selectedText: selectedText)
+        }
+        if intent == "command:manual", let selectedText {
+            return .command(invocation: .manual, selectedText: selectedText)
+        }
+        return .dictation
+    }
 }
 
 final class AppState: ObservableObject, @unchecked Sendable {
@@ -627,9 +655,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 let finalTranscript: String
                 let processingStatus: String
                 let postProcessingPrompt: String
+                let restoredIntent = SessionIntent.fromPersisted(
+                    intent: item.intent,
+                    selectedText: item.selectedText
+                )
                 let result = await self.processTranscript(
                     rawTranscript,
-                    intent: .dictation,
+                    intent: restoredIntent,
                     context: restoredContext,
                     postProcessingService: postProcessingService,
                     customVocabulary: capturedCustomVocabulary,
@@ -641,6 +673,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
                 await MainActor.run {
                     let updatedItem = PipelineHistoryItem(
+                        intent: item.intent,
+                        selectedText: item.selectedText,
                         id: item.id,
                         timestamp: item.timestamp,
                         rawTranscript: rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -666,6 +700,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             } catch {
                 await MainActor.run {
                     let updatedItem = PipelineHistoryItem(
+                        intent: item.intent,
+                        selectedText: item.selectedText,
                         id: item.id,
                         timestamp: item.timestamp,
                         rawTranscript: item.rawTranscript,
@@ -1146,12 +1182,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return .dictation
         }
 
-        let trimmedSelectedText = selectionSnapshot.selectedText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let rawSelectedText = selectionSnapshot.selectedText ?? ""
+        let trimmedSelectedText = rawSelectedText.trimmingCharacters(in: .whitespacesAndNewlines)
 
         switch commandModeStyle {
         case .automatic:
             if !trimmedSelectedText.isEmpty {
-                return .command(invocation: .automatic, selectedText: trimmedSelectedText)
+                return .command(invocation: .automatic, selectedText: rawSelectedText)
             }
             return .dictation
         case .manual:
@@ -1166,7 +1203,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 rejectCommandModeSelectionRequirement(triggerMode: triggerMode)
                 return nil
             }
-            return .command(invocation: .manual, selectedText: trimmedSelectedText)
+            return .command(invocation: .manual, selectedText: rawSelectedText)
         }
     }
 
@@ -1510,7 +1547,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             do {
                 let result = try await postProcessingService.commandTransform(
                     selectedText: selectedText,
-                    voiceCommand: trimmedRawTranscript,
+                    voiceCommand: rawTranscript,
                     context: context,
                     customVocabulary: customVocabulary
                 )
@@ -1653,6 +1690,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             postProcessingPrompt: result.prompt,
                             context: appContext,
                             processingStatus: processingStatus,
+                            intent: sessionIntent,
                             audioFileName: savedAudioFile?.fileName
                         )
                         self.transcriptionTask = nil
@@ -1722,6 +1760,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             postProcessingPrompt: "",
                             context: resolvedContext,
                             processingStatus: "Error: \(error.localizedDescription)",
+                            intent: sessionIntent,
                             audioFileName: savedAudioFile?.fileName
                         )
                         self.audioRecorder.cleanup()
@@ -1738,9 +1777,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         postProcessingPrompt: String,
         context: AppContext,
         processingStatus: String,
+        intent: SessionIntent,
         audioFileName: String? = nil
     ) {
         let newEntry = PipelineHistoryItem(
+            intent: intent.persistedIntent,
+            selectedText: intent.persistedSelectedText,
             timestamp: Date(),
             rawTranscript: rawTranscript,
             postProcessedTranscript: postProcessedTranscript,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1721,7 +1721,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         } else {
                             self.statusText = completionStatusText
                             if shouldPersistRawDictationFallback {
-                                self.overlayManager.showFallbackMessage("Used raw dictation")
+                                self.overlayManager.showFailureIndicator()
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
                                     self.overlayManager.dismiss()
                                 }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1249,7 +1249,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let t0 = CFAbsoluteTimeGetCurrent()
         os_log(.info, log: recordingLog, "startRecording() entered")
         guard !isRecording && !isTranscribing else { return }
-        clearPendingOverlayDismissToken()
         let scheduledSelectionSnapshot = pendingSelectionSnapshot
         let scheduledManualCommandInvocation = pendingManualCommandInvocation
         cancelPendingShortcutStart()
@@ -1316,6 +1315,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func beginRecording(triggerMode: RecordingTriggerMode) {
         os_log(.info, log: recordingLog, "beginRecording() entered")
+        clearPendingOverlayDismissToken()
         errorMessage = nil
 
         isRecording = true

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -972,12 +972,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         let derivedHold = holdBinding.withAddedModifiers(manualModifier)
-        if !holdBinding.isDisabled && (derivedHold == holdBinding || derivedHold == toggleBinding) {
+        if !holdBinding.isDisabled && derivedHold == toggleBinding {
             return "That modifier would make the command hold shortcut overlap an existing dictation shortcut."
         }
 
         let derivedToggle = toggleBinding.withAddedModifiers(manualModifier)
-        if !toggleBinding.isDisabled && (derivedToggle == holdBinding || derivedToggle == toggleBinding) {
+        if !toggleBinding.isDisabled && derivedToggle == holdBinding {
             return "That modifier would make the command tap shortcut overlap an existing dictation shortcut."
         }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -110,6 +110,25 @@ private struct PendingClipboardRestore {
     let expectedChangeCount: Int
 }
 
+private enum CommandInvocation: String {
+    case automatic
+    case manual
+}
+
+private enum SessionIntent {
+    case dictation
+    case command(invocation: CommandInvocation, selectedText: String)
+
+    var isCommandMode: Bool {
+        switch self {
+        case .dictation:
+            return false
+        case .command:
+            return true
+        }
+    }
+}
+
 final class AppState: ObservableObject, @unchecked Sendable {
     private let apiKeyStorageKey = "groq_api_key"
     private let apiBaseURLStorageKey = "api_base_url"
@@ -128,6 +147,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let alertSoundsEnabledStorageKey = "alert_sounds_enabled"
     private let soundVolumeStorageKey = "sound_volume"
     private let voiceMacrosStorageKey = "voice_macros"
+    private let commandModeEnabledStorageKey = "command_mode_enabled"
+    private let commandModeStyleStorageKey = "command_mode_style"
+    private let commandModeManualModifierStorageKey = "command_mode_manual_modifier"
     private let transcribingIndicatorDelay: TimeInterval = 0.25
     private let clipboardRestoreDelay: TimeInterval = 0.15
     let maxPipelineHistoryCount = 20
@@ -175,6 +197,24 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published private(set) var savedToggleCustomShortcut: ShortcutBinding? {
         didSet {
             persistOptionalShortcut(savedToggleCustomShortcut, key: savedToggleCustomShortcutStorageKey)
+        }
+    }
+
+    @Published var isCommandModeEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(isCommandModeEnabled, forKey: commandModeEnabledStorageKey)
+        }
+    }
+
+    @Published var commandModeStyle: CommandModeStyle {
+        didSet {
+            UserDefaults.standard.set(commandModeStyle.rawValue, forKey: commandModeStyleStorageKey)
+        }
+    }
+
+    @Published private(set) var commandModeManualModifier: CommandModeManualModifier {
+        didSet {
+            UserDefaults.standard.set(commandModeManualModifier.rawValue, forKey: commandModeManualModifierStorageKey)
         }
     }
 
@@ -293,6 +333,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let pipelineHistoryStore = PipelineHistoryStore()
     private let shortcutSessionController = DictationShortcutSessionController()
     private var activeRecordingTriggerMode: RecordingTriggerMode?
+    private var currentSessionIntent: SessionIntent = .dictation
+    private var pendingSelectionSnapshot: AppSelectionSnapshot?
+    private var pendingManualCommandInvocation = false
     private var pendingShortcutStartTask: Task<Void, Never>?
     private var pendingShortcutStartMode: RecordingTriggerMode?
     private var shouldMonitorHotkeys = false
@@ -317,6 +360,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let customSystemPromptLastModified = UserDefaults.standard.string(forKey: customSystemPromptLastModifiedStorageKey) ?? ""
         let customContextPromptLastModified = UserDefaults.standard.string(forKey: customContextPromptLastModifiedStorageKey) ?? ""
         let shortcutStartDelay = max(0, UserDefaults.standard.double(forKey: shortcutStartDelayStorageKey))
+        let isCommandModeEnabled = UserDefaults.standard.object(forKey: commandModeEnabledStorageKey) == nil
+            ? false
+            : UserDefaults.standard.bool(forKey: commandModeEnabledStorageKey)
+        let commandModeStyle = CommandModeStyle(
+            rawValue: UserDefaults.standard.string(forKey: commandModeStyleStorageKey) ?? ""
+        ) ?? .automatic
+        let commandModeManualModifier = CommandModeManualModifier(
+            rawValue: UserDefaults.standard.string(forKey: commandModeManualModifierStorageKey) ?? ""
+        ) ?? .option
         let preserveClipboard = UserDefaults.standard.object(forKey: preserveClipboardStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: preserveClipboardStorageKey)
@@ -357,6 +409,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.toggleShortcut = shortcuts.toggle
         self.savedHoldCustomShortcut = savedHoldCustomShortcut
         self.savedToggleCustomShortcut = savedToggleCustomShortcut
+        self.isCommandModeEnabled = isCommandModeEnabled
+        self.commandModeStyle = commandModeStyle
+        self.commandModeManualModifier = commandModeManualModifier
         self.customVocabulary = customVocabulary
         self.customSystemPrompt = customSystemPrompt
         self.customContextPrompt = customContextPrompt
@@ -574,6 +629,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 let postProcessingPrompt: String
                 let result = await self.processTranscript(
                     rawTranscript,
+                    intent: .dictation,
                     context: restoredContext,
                     postProcessingService: postProcessingService,
                     customVocabulary: capturedCustomVocabulary,
@@ -786,14 +842,60 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    var commandModeManualModifierValidationMessage: String? {
+        guard isCommandModeEnabled, commandModeStyle == .manual else { return nil }
+        return commandModeManualModifierCollisionMessage(for: commandModeManualModifier)
+    }
+
+    @discardableResult
+    func setCommandModeEnabled(_ enabled: Bool) -> String? {
+        isCommandModeEnabled = enabled
+        if enabled, commandModeStyle == .manual {
+            return commandModeManualModifierCollisionMessage(for: commandModeManualModifier)
+        }
+        return nil
+    }
+
+    @discardableResult
+    func setCommandModeStyle(_ style: CommandModeStyle) -> String? {
+        commandModeStyle = style
+        if isCommandModeEnabled, style == .manual {
+            return commandModeManualModifierCollisionMessage(for: commandModeManualModifier)
+        }
+        return nil
+    }
+
+    @discardableResult
+    func setCommandModeManualModifier(_ modifier: CommandModeManualModifier) -> String? {
+        if isCommandModeEnabled,
+           commandModeStyle == .manual,
+           let message = commandModeManualModifierCollisionMessage(for: modifier) {
+            return message
+        }
+
+        commandModeManualModifier = modifier
+        return nil
+    }
+
     @discardableResult
     func setShortcut(_ binding: ShortcutBinding, for role: ShortcutRole) -> String? {
+        let nextHoldShortcut = role == .hold ? binding : holdShortcut
+        let nextToggleShortcut = role == .toggle ? binding : toggleShortcut
         let otherBinding = role == .hold ? toggleShortcut : holdShortcut
         if binding.isDisabled && otherBinding.isDisabled {
             return "At least one shortcut must remain enabled."
         }
         guard binding != otherBinding else {
             return "Hold and tap shortcuts must be different."
+        }
+        if isCommandModeEnabled,
+           commandModeStyle == .manual,
+           let message = commandModeManualModifierCollisionMessage(
+            for: commandModeManualModifier,
+            holdBinding: nextHoldShortcut,
+            toggleBinding: nextToggleShortcut
+           ) {
+            return message
         }
 
         switch role {
@@ -807,6 +909,35 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 savedToggleCustomShortcut = binding
             }
             toggleShortcut = binding
+        }
+
+        return nil
+    }
+
+    private func commandModeManualModifierCollisionMessage(
+        for modifier: CommandModeManualModifier,
+        holdBinding: ShortcutBinding? = nil,
+        toggleBinding: ShortcutBinding? = nil
+    ) -> String? {
+        let holdBinding = holdBinding ?? holdShortcut
+        let toggleBinding = toggleBinding ?? toggleShortcut
+        let manualModifier = modifier.shortcutModifier
+
+        if !holdBinding.isDisabled && holdBinding.modifiers.contains(manualModifier) {
+            return "That modifier is already part of the hold shortcut."
+        }
+        if !toggleBinding.isDisabled && toggleBinding.modifiers.contains(manualModifier) {
+            return "That modifier is already part of the tap shortcut."
+        }
+
+        let derivedHold = holdBinding.withAddedModifiers(manualModifier)
+        if !holdBinding.isDisabled && (derivedHold == holdBinding || derivedHold == toggleBinding) {
+            return "That modifier would make the command hold shortcut overlap an existing dictation shortcut."
+        }
+
+        let derivedToggle = toggleBinding.withAddedModifiers(manualModifier)
+        if !toggleBinding.isDisabled && (derivedToggle == holdBinding || derivedToggle == toggleBinding) {
+            return "That modifier would make the command tap shortcut overlap an existing dictation shortcut."
         }
 
         return nil
@@ -922,6 +1053,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         contextCaptureTask?.cancel()
         contextCaptureTask = nil
         capturedContext = nil
+        currentSessionIntent = .dictation
         isRecording = false
         errorMessage = nil
         debugStatusMessage = "Cancelled"
@@ -946,6 +1078,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         capturedContext = nil
         shortcutSessionController.reset()
         activeRecordingTriggerMode = nil
+        currentSessionIntent = .dictation
         isRecording = false
         isTranscribing = false
         errorMessage = nil
@@ -965,6 +1098,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func scheduleShortcutStart(mode: RecordingTriggerMode) {
         cancelPendingShortcutStart(resetMode: false)
+        pendingSelectionSnapshot = contextService.collectSelectionSnapshot()
+        pendingManualCommandInvocation = hotkeyManager.currentPressedModifiers.contains(
+            commandModeManualModifier.shortcutModifier
+        )
         pendingShortcutStartMode = mode
         let delay = shortcutStartDelay
 
@@ -993,9 +1130,76 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func cancelPendingShortcutStart(resetMode: Bool = true) {
         pendingShortcutStartTask?.cancel()
         pendingShortcutStartTask = nil
+        pendingSelectionSnapshot = nil
+        pendingManualCommandInvocation = false
         if resetMode {
             pendingShortcutStartMode = nil
         }
+    }
+
+    private func resolveSessionIntent(
+        triggerMode: RecordingTriggerMode,
+        selectionSnapshot: AppSelectionSnapshot,
+        manualCommandRequested: Bool
+    ) -> SessionIntent? {
+        guard isCommandModeEnabled else {
+            return .dictation
+        }
+
+        let trimmedSelectedText = selectionSnapshot.selectedText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        switch commandModeStyle {
+        case .automatic:
+            if !trimmedSelectedText.isEmpty {
+                return .command(invocation: .automatic, selectedText: trimmedSelectedText)
+            }
+            return .dictation
+        case .manual:
+            if let message = commandModeManualModifierCollisionMessage(for: commandModeManualModifier) {
+                rejectInvalidCommandModeModifier(triggerMode: triggerMode, message: message)
+                return nil
+            }
+            guard manualCommandRequested else {
+                return .dictation
+            }
+            guard !trimmedSelectedText.isEmpty else {
+                rejectCommandModeSelectionRequirement(triggerMode: triggerMode)
+                return nil
+            }
+            return .command(invocation: .manual, selectedText: trimmedSelectedText)
+        }
+    }
+
+    private func rejectCommandModeSelectionRequirement(triggerMode: RecordingTriggerMode) {
+        currentSessionIntent = .dictation
+        activeRecordingTriggerMode = nil
+        pendingSelectionSnapshot = nil
+        pendingManualCommandInvocation = false
+        errorMessage = "Select text to transform first."
+        statusText = "Select text to transform first"
+        debugStatusMessage = "Command mode requires selected text"
+        shortcutSessionController.reset()
+        if triggerMode == .toggle {
+            cancelPendingShortcutStart()
+        }
+        playAlertSound(named: "Basso")
+        scheduleReadyStatusReset(after: 2, matching: ["Select text to transform first"])
+    }
+
+    private func rejectInvalidCommandModeModifier(triggerMode: RecordingTriggerMode, message: String) {
+        currentSessionIntent = .dictation
+        activeRecordingTriggerMode = nil
+        pendingSelectionSnapshot = nil
+        pendingManualCommandInvocation = false
+        errorMessage = message
+        statusText = "Fix Command Mode modifier"
+        debugStatusMessage = "Command mode modifier conflicts with dictation shortcuts"
+        shortcutSessionController.reset()
+        if triggerMode == .toggle {
+            cancelPendingShortcutStart()
+        }
+        playAlertSound(named: "Basso")
+        scheduleReadyStatusReset(after: 2, matching: ["Fix Command Mode modifier"])
     }
 
     private func startRecording(triggerMode: RecordingTriggerMode) {
@@ -1004,16 +1208,29 @@ final class AppState: ObservableObject, @unchecked Sendable {
         guard !isRecording && !isTranscribing else { return }
         cancelPendingShortcutStart()
         activeRecordingTriggerMode = triggerMode
-        overlayManager.setRecordingTriggerMode(triggerMode, animated: false)
         guard hasAccessibility else {
             errorMessage = "Accessibility permission required. Grant access in System Settings > Privacy & Security > Accessibility."
             statusText = "No Accessibility"
             activeRecordingTriggerMode = nil
+            currentSessionIntent = .dictation
             shortcutSessionController.reset()
             showAccessibilityAlert()
             return
         }
         os_log(.info, log: recordingLog, "accessibility check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
+        let selectionSnapshot = pendingSelectionSnapshot ?? contextService.collectSelectionSnapshot()
+        let manualCommandRequested = pendingSelectionSnapshot == nil
+            ? hotkeyManager.currentPressedModifiers.contains(commandModeManualModifier.shortcutModifier)
+            : pendingManualCommandInvocation
+        guard let resolvedIntent = resolveSessionIntent(
+            triggerMode: triggerMode,
+            selectionSnapshot: selectionSnapshot,
+            manualCommandRequested: manualCommandRequested
+        ) else { return }
+        pendingSelectionSnapshot = nil
+        pendingManualCommandInvocation = false
+        currentSessionIntent = resolvedIntent
+        overlayManager.setRecordingTriggerMode(triggerMode, animated: false)
         guard ensureMicrophoneAccess() else { return }
         os_log(.info, log: recordingLog, "mic access check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
         beginRecording(triggerMode: triggerMode)
@@ -1035,6 +1252,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self?.errorMessage = "Microphone permission denied. Grant access in System Settings > Privacy & Security > Microphone."
                         self?.statusText = "No Microphone"
                         self?.activeRecordingTriggerMode = nil
+                        self?.currentSessionIntent = .dictation
                         self?.shortcutSessionController.reset()
                         self?.showMicrophonePermissionAlert()
                     }
@@ -1045,6 +1263,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             errorMessage = "Microphone permission denied. Grant access in System Settings > Privacy & Security > Microphone."
             statusText = "No Microphone"
             activeRecordingTriggerMode = nil
+            currentSessionIntent = .dictation
             shortcutSessionController.reset()
             showMicrophonePermissionAlert()
             return false
@@ -1069,7 +1288,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
             guard let self, !overlayShown else { return }
             overlayShown = true
             os_log(.info, log: recordingLog, "engine slow — showing initializing overlay")
-            self.overlayManager.showInitializing(mode: self.activeRecordingTriggerMode ?? triggerMode)
+            self.overlayManager.showInitializing(
+                mode: self.activeRecordingTriggerMode ?? triggerMode,
+                isCommandMode: self.currentSessionIntent.isCommandMode
+            )
         }
         initTimer.resume()
 
@@ -1082,9 +1304,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 os_log(.info, log: recordingLog, "first real audio — transitioning to waveform")
                 self.statusText = "Recording..."
                 if overlayShown {
-                    self.overlayManager.transitionToRecording(mode: self.activeRecordingTriggerMode ?? triggerMode)
+                    self.overlayManager.transitionToRecording(
+                        mode: self.activeRecordingTriggerMode ?? triggerMode,
+                        isCommandMode: self.currentSessionIntent.isCommandMode
+                    )
                 } else {
-                    self.overlayManager.showRecording(mode: self.activeRecordingTriggerMode ?? triggerMode)
+                    self.overlayManager.showRecording(
+                        mode: self.activeRecordingTriggerMode ?? triggerMode,
+                        isCommandMode: self.currentSessionIntent.isCommandMode
+                    )
                 }
                 overlayShown = true
                 self.playAlertSound(named: "Tink")
@@ -1145,6 +1373,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             self.transcribingAudioFileName = nil
         }
         activeRecordingTriggerMode = nil
+        currentSessionIntent = .dictation
         shortcutSessionController.reset()
         errorMessage = formattedRecordingStartError(error)
         statusText = "Error"
@@ -1240,6 +1469,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         case voiceMacro(command: String)
         case postProcessingSucceeded
         case postProcessingFailedFallback
+        case commandModeSucceeded(invocation: CommandInvocation)
+        case commandModeFailedFallback(invocation: CommandInvocation)
 
         func statusMessage(isRetry: Bool = false) -> String {
             switch self {
@@ -1253,12 +1484,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 return isRetry
                     ? "Post-processing failed on retry, using raw transcript"
                     : "Post-processing failed, using raw transcript"
+            case .commandModeSucceeded(let invocation):
+                return "Command mode succeeded (\(invocation.rawValue))"
+            case .commandModeFailedFallback(let invocation):
+                return "Command mode failed, using selected text (\(invocation.rawValue))"
             }
         }
     }
 
     private func processTranscript(
         _ rawTranscript: String,
+        intent: SessionIntent,
         context: AppContext,
         postProcessingService: PostProcessingService,
         customVocabulary: String,
@@ -1268,6 +1504,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         guard !trimmedRawTranscript.isEmpty else {
             return ("", .skippedEmptyRawTranscript, "")
+        }
+
+        if case .command(let invocation, let selectedText) = intent {
+            do {
+                let result = try await postProcessingService.commandTransform(
+                    selectedText: selectedText,
+                    voiceCommand: trimmedRawTranscript,
+                    context: context,
+                    customVocabulary: customVocabulary
+                )
+                return (result.transcript, .commandModeSucceeded(invocation: invocation), result.prompt)
+            } catch {
+                os_log(.error, log: recordingLog, "Command mode failed: %{public}@", error.localizedDescription)
+                return (selectedText, .commandModeFailedFallback(invocation: invocation), "")
+            }
         }
 
         if let macro = findMatchingMacro(for: trimmedRawTranscript) {
@@ -1294,6 +1545,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         cancelRecordingInitializationTimer()
         shortcutSessionController.reset()
         activeRecordingTriggerMode = nil
+        let sessionIntent = currentSessionIntent
+        currentSessionIntent = .dictation
         audioRecorder.onRecordingReady = nil
         audioRecorder.onRecordingFailure = nil
         audioLevelCancellable?.cancel()
@@ -1373,6 +1626,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     }
                     let result = await self.processTranscript(
                         rawTranscript,
+                        intent: sessionIntent,
                         context: appContext,
                         postProcessingService: postProcessingService,
                         customVocabulary: self.customVocabulary,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1930,6 +1930,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             postProcessingPrompt: "",
                             context: resolvedContext,
                             processingStatus: "Error: \(error.localizedDescription)",
+                            intent: self.currentSessionIntent,
                             audioFileName: savedAudioFile?.fileName
                         )
                         self.audioRecorder.cleanup()
@@ -1954,17 +1955,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.lastContextScreenshotDataURL = resolvedContext.screenshotDataURL
                         self.lastContextScreenshotStatus = resolvedContext.screenshotError
                             ?? "available (\(resolvedContext.screenshotMimeType ?? "image"))"
-                        self.recordPipelineHistoryEntry(
-                            rawTranscript: "",
-                            postProcessedTranscript: "",
-                            postProcessingPrompt: "",
-                            context: resolvedContext,
-                            processingStatus: "Error: \(error.localizedDescription)",
-                            intent: sessionIntent,
-                            audioFileName: savedAudioFile?.fileName
-                        )
-                        self.audioRecorder.cleanup()
-                        self.refreshAvailableMicrophonesIfNeeded()
                     }
                 }
             }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -128,12 +128,17 @@ private enum SessionIntent {
         }
     }
 
-    var persistedIntent: String {
+    var persistedIntent: PipelineHistoryItemIntent {
         switch self {
         case .dictation:
-            return "dictation"
+            return .dictation
         case .command(let invocation, _):
-            return "command:\(invocation.rawValue)"
+            switch invocation {
+            case .automatic:
+                return .commandAutomatic
+            case .manual:
+                return .commandManual
+            }
         }
     }
 
@@ -146,11 +151,11 @@ private enum SessionIntent {
         }
     }
 
-    static func fromPersisted(intent: String, selectedText: String?) -> SessionIntent {
-        if intent == "command:automatic", let selectedText {
+    static func fromPersisted(intent: PipelineHistoryItemIntent, selectedText: String?) -> SessionIntent {
+        if intent == .commandAutomatic, let selectedText {
             return .command(invocation: .automatic, selectedText: selectedText)
         }
-        if intent == "command:manual", let selectedText {
+        if intent == .commandManual, let selectedText {
             return .command(invocation: .manual, selectedText: selectedText)
         }
         return .dictation
@@ -1214,7 +1219,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         pendingManualCommandInvocation = false
         errorMessage = "Select text to transform first."
         statusText = "Select text to transform first"
-        debugStatusMessage = "Command mode requires selected text"
+        debugStatusMessage = "Edit mode requires selected text"
         shortcutSessionController.reset()
         if triggerMode == .toggle {
             cancelPendingShortcutStart()
@@ -1229,14 +1234,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
         pendingSelectionSnapshot = nil
         pendingManualCommandInvocation = false
         errorMessage = message
-        statusText = "Fix Command Mode modifier"
-        debugStatusMessage = "Command mode modifier conflicts with dictation shortcuts"
+        statusText = "Fix Edit Mode modifier"
+        debugStatusMessage = "Edit mode modifier conflicts with dictation shortcuts"
         shortcutSessionController.reset()
         if triggerMode == .toggle {
             cancelPendingShortcutStart()
         }
         playAlertSound(named: "Basso")
-        scheduleReadyStatusReset(after: 2, matching: ["Fix Command Mode modifier"])
+        scheduleReadyStatusReset(after: 2, matching: ["Fix Edit Mode modifier"])
     }
 
     private func startRecording(triggerMode: RecordingTriggerMode) {
@@ -1522,9 +1527,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     ? "Post-processing failed on retry, using raw transcript"
                     : "Post-processing failed, using raw transcript"
             case .commandModeSucceeded(let invocation):
-                return "Command mode succeeded (\(invocation.rawValue))"
+                return "Edit mode succeeded (\(invocation.rawValue))"
             case .commandModeFailedFallback(let invocation):
-                return "Command mode failed, using selected text (\(invocation.rawValue))"
+                return "Edit mode failed, using selected text (\(invocation.rawValue))"
             }
         }
     }
@@ -1553,7 +1558,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 )
                 return (result.transcript, .commandModeSucceeded(invocation: invocation), result.prompt)
             } catch {
-                os_log(.error, log: recordingLog, "Command mode failed: %{public}@", error.localizedDescription)
+                os_log(.error, log: recordingLog, "Edit mode failed: %{public}@", error.localizedDescription)
                 return (selectedText, .commandModeFailedFallback(invocation: invocation), "")
             }
         }

--- a/Sources/HotkeyManager.swift
+++ b/Sources/HotkeyManager.swift
@@ -19,6 +19,10 @@ final class HotkeyManager {
     var onShortcutEvent: ((ShortcutEvent) -> Void)?
     var onEscapeKeyPressed: (() -> Bool)?
 
+    var currentPressedModifiers: ShortcutModifiers {
+        currentModifiers
+    }
+
     func start(configuration: ShortcutConfiguration) {
         stop()
         self.configuration = configuration

--- a/Sources/MCPServer.swift
+++ b/Sources/MCPServer.swift
@@ -211,6 +211,33 @@ final class MCPServer {
                     "type": "object",
                     "properties": [:]
                 ]
+            ],
+            [
+                "name": "list_transcripts",
+                "description": "List recent transcription history entries with id, timestamp, and a short preview.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "limit": [
+                            "type": "integer",
+                            "description": "Maximum number of entries to return (default: 10, max: 50)"
+                        ]
+                    ]
+                ]
+            ],
+            [
+                "name": "get_transcript",
+                "description": "Get the full content of a specific transcription entry by id.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "id": [
+                            "type": "string",
+                            "description": "UUID of the transcript entry from list_transcripts"
+                        ]
+                    ],
+                    "required": ["id"]
+                ]
             ]
         ]
     }
@@ -262,14 +289,49 @@ final class MCPServer {
                 status = "idle"
             }
             let ctx = appState.mcpAdditionalContext
-            let last = appState.lastTranscript
             let failed = appState.mcpLastRecordingFailed
-            let transcriptValue = failed ? "(transcription failed)" : last.isEmpty ? "(none)" : last
+            let lastEntry = appState.pipelineHistory.first
+            let lastTranscript = lastEntry?.postProcessedTranscript ?? lastEntry?.rawTranscript ?? ""
+            let transcriptValue = failed ? "(transcription failed)" : lastTranscript.isEmpty ? "(none)" : lastTranscript
             return textContent("""
                 status: \(status)
                 context: \(ctx.isEmpty ? "(none)" : ctx)
                 last_transcript: \(transcriptValue)
                 """)
+
+        case "list_transcripts":
+            let limit = min(args["limit"] as? Int ?? 10, 50)
+            let entries = Array(appState.pipelineHistory.prefix(limit))
+            if entries.isEmpty {
+                return textContent("No transcripts found.")
+            }
+            let formatter = ISO8601DateFormatter()
+            let lines = entries.map { item -> String in
+                let preview = item.postProcessedTranscript.isEmpty ? item.rawTranscript : item.postProcessedTranscript
+                let truncated = preview.count > 80 ? String(preview.prefix(80)) + "…" : preview
+                return "[\(formatter.string(from: item.timestamp))] \(item.id.uuidString)\n  \(truncated)"
+            }
+            return textContent(lines.joined(separator: "\n\n"))
+
+        case "get_transcript":
+            guard let idString = args["id"] as? String, let uuid = UUID(uuidString: idString) else {
+                return textContent("Error: valid 'id' is required.", isError: true)
+            }
+            guard let item = appState.pipelineHistory.first(where: { $0.id == uuid }) else {
+                return textContent("Error: transcript not found.", isError: true)
+            }
+            let formatter = ISO8601DateFormatter()
+            var lines = ["id: \(item.id.uuidString)", "timestamp: \(formatter.string(from: item.timestamp))"]
+            if !item.postProcessedTranscript.isEmpty {
+                lines.append("transcript: \(item.postProcessedTranscript)")
+            }
+            if !item.rawTranscript.isEmpty {
+                lines.append("raw_transcript: \(item.rawTranscript)")
+            }
+            if !item.contextSummary.isEmpty {
+                lines.append("context: \(item.contextSummary)")
+            }
+            return textContent(lines.joined(separator: "\n"))
 
         default:
             return textContent("Unknown tool: \(name)", isError: true)

--- a/Sources/MCPServer.swift
+++ b/Sources/MCPServer.swift
@@ -300,7 +300,7 @@ final class MCPServer {
                 """)
 
         case "list_transcripts":
-            let limit = min(args["limit"] as? Int ?? 10, 50)
+            let limit = max(0, min(args["limit"] as? Int ?? 10, 50))
             let entries = Array(appState.pipelineHistory.prefix(limit))
             if entries.isEmpty {
                 return textContent("No transcripts found.")

--- a/Sources/PipelineHistoryItem.swift
+++ b/Sources/PipelineHistoryItem.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 struct PipelineHistoryItem: Identifiable, Codable {
+    let intent: String
+    let selectedText: String?
     let id: UUID
     let timestamp: Date
     let rawTranscript: String
@@ -16,6 +18,8 @@ struct PipelineHistoryItem: Identifiable, Codable {
     let audioFileName: String?
 
     init(
+        intent: String = "dictation",
+        selectedText: String? = nil,
         id: UUID = UUID(),
         timestamp: Date,
         rawTranscript: String,
@@ -30,6 +34,8 @@ struct PipelineHistoryItem: Identifiable, Codable {
         customVocabulary: String,
         audioFileName: String? = nil
     ) {
+        self.intent = intent
+        self.selectedText = selectedText
         self.id = id
         self.timestamp = timestamp
         self.rawTranscript = rawTranscript

--- a/Sources/PipelineHistoryItem.swift
+++ b/Sources/PipelineHistoryItem.swift
@@ -1,7 +1,13 @@
 import Foundation
 
+enum PipelineHistoryItemIntent: String, Codable {
+    case dictation
+    case commandAutomatic = "command:automatic"
+    case commandManual = "command:manual"
+}
+
 struct PipelineHistoryItem: Identifiable, Codable {
-    let intent: String
+    let intent: PipelineHistoryItemIntent
     let selectedText: String?
     let id: UUID
     let timestamp: Date
@@ -18,7 +24,7 @@ struct PipelineHistoryItem: Identifiable, Codable {
     let audioFileName: String?
 
     init(
-        intent: String = "dictation",
+        intent: PipelineHistoryItemIntent = .dictation,
         selectedText: String? = nil,
         id: UUID = UUID(),
         timestamp: Date,

--- a/Sources/PipelineHistoryStore.swift
+++ b/Sources/PipelineHistoryStore.swift
@@ -88,6 +88,8 @@ final class PipelineHistoryStore {
                 let request = pipelineHistoryRequest()
                 request.predicate = NSPredicate(format: "id == %@", item.id as CVarArg)
                 guard let entity = try container.viewContext.fetch(request).first else { return }
+                entity.intent = item.intent
+                entity.selectedText = item.selectedText
                 entity.rawTranscript = item.rawTranscript
                 entity.postProcessedTranscript = item.postProcessedTranscript
                 entity.postProcessingPrompt = item.postProcessingPrompt
@@ -182,6 +184,8 @@ final class PipelineHistoryStore {
                 let context = container.viewContext
                 let entity = PipelineHistoryEntry(context: context)
                 entity.id = item.id
+                entity.intent = item.intent
+                entity.selectedText = item.selectedText
                 entity.timestamp = item.timestamp
                 entity.rawTranscript = item.rawTranscript
                 entity.postProcessedTranscript = item.postProcessedTranscript
@@ -251,6 +255,8 @@ final class PipelineHistoryStore {
 
     private static func makeHistoryItem(from entity: PipelineHistoryEntry) -> PipelineHistoryItem {
         PipelineHistoryItem(
+            intent: entity.intent ?? "dictation",
+            selectedText: entity.selectedText,
             id: entity.id,
             timestamp: entity.timestamp ?? Date(),
             rawTranscript: entity.rawTranscript ?? "",
@@ -275,6 +281,8 @@ final class PipelineHistoryStore {
         entity.managedObjectClassName = NSStringFromClass(PipelineHistoryEntry.self)
 
         entity.properties = [
+            makeAttribute(name: "intent", type: .stringAttributeType, isOptional: false),
+            makeAttribute(name: "selectedText", type: .stringAttributeType, isOptional: true),
             makeAttribute(name: "id", type: .UUIDAttributeType, isOptional: false),
             makeAttribute(name: "timestamp", type: .dateAttributeType, isOptional: false),
             makeAttribute(name: "rawTranscript", type: .stringAttributeType, isOptional: false),
@@ -306,6 +314,8 @@ final class PipelineHistoryStore {
 @objc(PipelineHistoryEntry)
 final class PipelineHistoryEntry: NSManagedObject {
     @NSManaged var id: UUID
+    @NSManaged var intent: String?
+    @NSManaged var selectedText: String?
     @NSManaged var timestamp: Date?
     @NSManaged var rawTranscript: String?
     @NSManaged var postProcessedTranscript: String?

--- a/Sources/PipelineHistoryStore.swift
+++ b/Sources/PipelineHistoryStore.swift
@@ -88,7 +88,7 @@ final class PipelineHistoryStore {
                 let request = pipelineHistoryRequest()
                 request.predicate = NSPredicate(format: "id == %@", item.id as CVarArg)
                 guard let entity = try container.viewContext.fetch(request).first else { return }
-                entity.intent = item.intent
+                entity.intent = item.intent.rawValue
                 entity.selectedText = item.selectedText
                 entity.rawTranscript = item.rawTranscript
                 entity.postProcessedTranscript = item.postProcessedTranscript
@@ -184,7 +184,7 @@ final class PipelineHistoryStore {
                 let context = container.viewContext
                 let entity = PipelineHistoryEntry(context: context)
                 entity.id = item.id
-                entity.intent = item.intent
+                entity.intent = item.intent.rawValue
                 entity.selectedText = item.selectedText
                 entity.timestamp = item.timestamp
                 entity.rawTranscript = item.rawTranscript
@@ -255,7 +255,7 @@ final class PipelineHistoryStore {
 
     private static func makeHistoryItem(from entity: PipelineHistoryEntry) -> PipelineHistoryItem {
         PipelineHistoryItem(
-            intent: entity.intent ?? "dictation",
+            intent: PipelineHistoryItemIntent(rawValue: entity.intent ?? "") ?? .dictation,
             selectedText: entity.selectedText,
             id: entity.id,
             timestamp: entity.timestamp ?? Date(),
@@ -281,7 +281,7 @@ final class PipelineHistoryStore {
         entity.managedObjectClassName = NSStringFromClass(PipelineHistoryEntry.self)
 
         entity.properties = [
-            makeAttribute(name: "intent", type: .stringAttributeType, isOptional: false),
+            makeAttribute(name: "intent", type: .stringAttributeType, isOptional: true, defaultValue: "dictation"),
             makeAttribute(name: "selectedText", type: .stringAttributeType, isOptional: true),
             makeAttribute(name: "id", type: .UUIDAttributeType, isOptional: false),
             makeAttribute(name: "timestamp", type: .dateAttributeType, isOptional: false),
@@ -302,11 +302,17 @@ final class PipelineHistoryStore {
         return model
     }
 
-    private static func makeAttribute(name: String, type: NSAttributeType, isOptional: Bool) -> NSAttributeDescription {
+    private static func makeAttribute(
+        name: String,
+        type: NSAttributeType,
+        isOptional: Bool,
+        defaultValue: Any? = nil
+    ) -> NSAttributeDescription {
         let attribute = NSAttributeDescription()
         attribute.name = name
         attribute.attributeType = type
         attribute.isOptional = isOptional
+        attribute.defaultValue = defaultValue
         return attribute
     }
 }

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -380,7 +380,7 @@ Model: \(model)
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
         }
 
-        let sanitizedTranscript = sanitizeCommandModeTranscript(content)
+        let sanitizedTranscript = sanitizePostProcessedTranscript(content)
         guard !sanitizedTranscript.isEmpty else {
             throw PostProcessingError.emptyOutput
         }
@@ -480,7 +480,7 @@ Model: \(model)
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
         }
 
-        let sanitizedTranscript = sanitizePostProcessedTranscript(content)
+        let sanitizedTranscript = sanitizeCommandModeTranscript(content)
         guard !sanitizedTranscript.isEmpty else {
             throw PostProcessingError.emptyOutput
         }

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -116,6 +116,7 @@ Behavior:
     private let baseURL: String
     private let defaultModel = "openai/gpt-oss-20b"
     private let fallbackModel = "meta-llama/llama-4-scout-17b-16e-instruct"
+    private let defaultModelReasoningEffort = "low"
     private let postProcessingMaxCompletionTokens = 4096
     private let postProcessingTimeoutSeconds: TimeInterval = 20
 
@@ -355,6 +356,8 @@ Model: \(model)
         ]
         if model == defaultModel {
             payload["max_completion_tokens"] = postProcessingMaxCompletionTokens
+            payload["reasoning_effort"] = defaultModelReasoningEffort
+            payload["include_reasoning"] = false
         }
 
         request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
@@ -453,6 +456,8 @@ Model: \(model)
         ]
         if model == defaultModel {
             payload["max_completion_tokens"] = postProcessingMaxCompletionTokens
+            payload["reasoning_effort"] = defaultModelReasoningEffort
+            payload["include_reasoning"] = false
         }
 
         request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -3,6 +3,7 @@ import Foundation
 enum PostProcessingError: LocalizedError {
     case requestFailed(Int, String)
     case invalidResponse(String)
+    case invalidInput(String)
     case emptyOutput
     case requestTimedOut(TimeInterval)
 
@@ -12,6 +13,8 @@ enum PostProcessingError: LocalizedError {
             "Post-processing failed with status \(statusCode): \(details)"
         case .invalidResponse(let details):
             "Invalid post-processing response: \(details)"
+        case .invalidInput(let details):
+            "Invalid post-processing input: \(details)"
         case .emptyOutput:
             "Post-processing returned empty output"
         case .requestTimedOut(let seconds):
@@ -170,6 +173,12 @@ Behavior:
         let vocabularyTerms = mergedVocabularyTerms(rawVocabulary: customVocabulary)
         let trimmedSelectedText = selectedText.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedVoiceCommand = voiceCommand.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedSelectedText.isEmpty else {
+            throw PostProcessingError.invalidInput("Selected text must not be empty")
+        }
+        guard !trimmedVoiceCommand.isEmpty else {
+            throw PostProcessingError.invalidInput("Voice command must not be empty")
+        }
 
         let timeoutSeconds = postProcessingTimeoutSeconds
         return try await withThrowingTaskGroup(of: PostProcessingResult.self) { group in

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -187,8 +187,8 @@ Behavior:
                     throw PostProcessingError.invalidResponse("Post-processing service deallocated")
                 }
                 return try await self.processCommandTransformWithFallback(
-                    selectedText: trimmedSelectedText,
-                    voiceCommand: trimmedVoiceCommand,
+                    selectedText: selectedText,
+                    voiceCommand: voiceCommand,
                     contextSummary: context.contextSummary,
                     customVocabulary: vocabularyTerms
                 )
@@ -377,7 +377,7 @@ Model: \(model)
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
         }
 
-        let sanitizedTranscript = sanitizePostProcessedTranscript(content)
+        let sanitizedTranscript = sanitizeCommandModeTranscript(content)
         guard !sanitizedTranscript.isEmpty else {
             throw PostProcessingError.emptyOutput
         }
@@ -503,6 +503,10 @@ Model: \(model)
         }
 
         return result
+    }
+
+    private func sanitizeCommandModeTranscript(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func mergedVocabularyTerms(rawVocabulary: String) -> [String] {

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -380,11 +380,11 @@ Model: \(model)
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
         }
 
-        let sanitizedTranscript = sanitizePostProcessedTranscript(content)
-        guard !sanitizedTranscript.isEmpty else {
+        guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw PostProcessingError.emptyOutput
         }
 
+        let sanitizedTranscript = sanitizePostProcessedTranscript(content)
         return PostProcessingResult(
             transcript: sanitizedTranscript,
             prompt: promptForDisplay
@@ -480,11 +480,11 @@ Model: \(model)
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
         }
 
-        let sanitizedTranscript = sanitizeCommandModeTranscript(content)
-        guard !sanitizedTranscript.isEmpty else {
+        guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw PostProcessingError.emptyOutput
         }
 
+        let sanitizedTranscript = sanitizeCommandModeTranscript(content)
         return PostProcessingResult(
             transcript: sanitizedTranscript,
             prompt: promptForDisplay

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -88,6 +88,26 @@ Output hygiene:
 - If the transcript is empty or only filler, return exactly: EMPTY
 """
     static let defaultSystemPromptDate = "2026-04-08"
+    static let commandModeSystemPrompt = """
+You transform highlighted text according to a spoken editing command.
+
+Hard contract:
+- Treat SELECTED_TEXT as the only source material to transform.
+- Treat VOICE_COMMAND as the user's instruction for how to transform SELECTED_TEXT.
+- Return only the replacement text.
+- No explanations.
+- No markdown.
+- No surrounding quotes.
+- Do not answer questions outside the scope of rewriting SELECTED_TEXT.
+- If the requested change would produce effectively the same text, return the original selected text.
+
+Behavior:
+- Preserve the original language unless VOICE_COMMAND explicitly requests translation.
+- Use CONTEXT only as a supporting hint for tone, spelling, or intent.
+- Use custom vocabulary only as a spelling reference when relevant.
+- Never invent unrelated content that is not a transformation of SELECTED_TEXT.
+- Do not treat VOICE_COMMAND as dictation to clean up and paste directly.
+"""
 
     private let apiKey: String
     private let baseURL: String
@@ -120,6 +140,48 @@ Output hygiene:
                     contextSummary: context.contextSummary,
                     customVocabulary: vocabularyTerms,
                     customSystemPrompt: customSystemPrompt
+                )
+            }
+
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+                throw PostProcessingError.requestTimedOut(timeoutSeconds)
+            }
+
+            do {
+                guard let result = try await group.next() else {
+                    throw PostProcessingError.invalidResponse("No post-processing result")
+                }
+                group.cancelAll()
+                return result
+            } catch {
+                group.cancelAll()
+                throw error
+            }
+        }
+    }
+
+    func commandTransform(
+        selectedText: String,
+        voiceCommand: String,
+        context: AppContext,
+        customVocabulary: String
+    ) async throws -> PostProcessingResult {
+        let vocabularyTerms = mergedVocabularyTerms(rawVocabulary: customVocabulary)
+        let trimmedSelectedText = selectedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedVoiceCommand = voiceCommand.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let timeoutSeconds = postProcessingTimeoutSeconds
+        return try await withThrowingTaskGroup(of: PostProcessingResult.self) { group in
+            group.addTask { [weak self] in
+                guard let self else {
+                    throw PostProcessingError.invalidResponse("Post-processing service deallocated")
+                }
+                return try await self.processCommandTransformWithFallback(
+                    selectedText: trimmedSelectedText,
+                    voiceCommand: trimmedVoiceCommand,
+                    contextSummary: context.contextSummary,
+                    customVocabulary: vocabularyTerms
                 )
             }
 
@@ -180,6 +242,45 @@ Output hygiene:
         )
     }
 
+    private func processCommandTransformWithFallback(
+        selectedText: String,
+        voiceCommand: String,
+        contextSummary: String,
+        customVocabulary: [String]
+    ) async throws -> PostProcessingResult {
+        do {
+            return try await processCommandTransform(
+                selectedText: selectedText,
+                voiceCommand: voiceCommand,
+                contextSummary: contextSummary,
+                model: defaultModel,
+                customVocabulary: customVocabulary
+            )
+        } catch let error as PostProcessingError {
+            let shouldFallback: Bool
+            switch error {
+            case .requestFailed(let statusCode, _):
+                shouldFallback = statusCode == 429
+            case .emptyOutput:
+                shouldFallback = true
+            default:
+                shouldFallback = false
+            }
+
+            guard shouldFallback else {
+                throw error
+            }
+        }
+
+        return try await processCommandTransform(
+            selectedText: selectedText,
+            voiceCommand: voiceCommand,
+            contextSummary: contextSummary,
+            model: fallbackModel,
+            customVocabulary: customVocabulary
+        )
+    }
+
     private func process(
         transcript: String,
         contextSummary: String,
@@ -217,6 +318,104 @@ Instructions: Clean up RAW_TRANSCRIPTION and return only the cleaned transcript 
 CONTEXT: "\(contextSummary)"
 
 RAW_TRANSCRIPTION: "\(transcript)"
+"""
+
+        let promptForDisplay = """
+Model: \(model)
+
+[System]
+\(systemPrompt)
+
+[User]
+\(userMessage)
+"""
+
+        var payload: [String: Any] = [
+            "model": model,
+            "temperature": 0.0,
+            "messages": [
+                [
+                    "role": "system",
+                    "content": systemPrompt
+                ],
+                [
+                    "role": "user",
+                    "content": userMessage
+                ]
+            ]
+        ]
+        if model == defaultModel {
+            payload["max_completion_tokens"] = postProcessingMaxCompletionTokens
+        }
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+        let (data, response) = try await LLMAPITransport.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PostProcessingError.invalidResponse("No HTTP response")
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let message = String(data: data, encoding: .utf8) ?? ""
+            throw PostProcessingError.requestFailed(httpResponse.statusCode, message)
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = json["choices"] as? [[String: Any]],
+              let firstChoice = choices.first,
+              let message = firstChoice["message"] as? [String: Any],
+              let content = message["content"] as? String else {
+            throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
+        }
+
+        let sanitizedTranscript = sanitizePostProcessedTranscript(content)
+        guard !sanitizedTranscript.isEmpty else {
+            throw PostProcessingError.emptyOutput
+        }
+
+        return PostProcessingResult(
+            transcript: sanitizedTranscript,
+            prompt: promptForDisplay
+        )
+    }
+
+    private func processCommandTransform(
+        selectedText: String,
+        voiceCommand: String,
+        contextSummary: String,
+        model: String,
+        customVocabulary: [String]
+    ) async throws -> PostProcessingResult {
+        var request = URLRequest(url: URL(string: "\(baseURL)/chat/completions")!)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = postProcessingTimeoutSeconds
+
+        let normalizedVocabulary = normalizedVocabularyText(customVocabulary)
+        let vocabularyPrompt = if !normalizedVocabulary.isEmpty {
+            """
+The following vocabulary must be treated as high-priority terms while rewriting.
+Use these spellings exactly in the output when relevant:
+\(normalizedVocabulary)
+"""
+        } else {
+            ""
+        }
+
+        var systemPrompt = Self.commandModeSystemPrompt
+        if !vocabularyPrompt.isEmpty {
+            systemPrompt += "\n\n" + vocabularyPrompt
+        }
+
+        let userMessage = """
+Transform SELECTED_TEXT according to VOICE_COMMAND and return only the replacement text.
+
+CONTEXT: "\(contextSummary)"
+
+VOICE_COMMAND: "\(voiceCommand)"
+
+SELECTED_TEXT: "\(selectedText)"
 """
 
         let promptForDisplay = """

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -298,7 +298,10 @@ Behavior:
         customVocabulary: [String],
         customSystemPrompt: String = ""
     ) async throws -> PostProcessingResult {
-        var request = URLRequest(url: URL(string: "\(baseURL)/chat/completions")!)
+        guard let url = URL(string: "\(baseURL)/chat/completions") else {
+            throw PostProcessingError.invalidInput("Invalid base URL: \(baseURL)")
+        }
+        var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -398,7 +401,10 @@ Model: \(model)
         model: String,
         customVocabulary: [String]
     ) async throws -> PostProcessingResult {
-        var request = URLRequest(url: URL(string: "\(baseURL)/chat/completions")!)
+        guard let url = URL(string: "\(baseURL)/chat/completions") else {
+            throw PostProcessingError.invalidInput("Invalid base URL: \(baseURL)")
+        }
+        var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -9,13 +9,14 @@ final class RecordingOverlayState: ObservableObject {
     @Published var recordingTriggerMode: RecordingTriggerMode = .hold
     @Published var isCommandMode = false
     @Published var showsTranscribingSpinner = false
+    @Published var feedbackMessage: String?
 }
 
 enum OverlayPhase {
     case initializing
     case recording
     case transcribing
-    case done
+    case feedback
 }
 
 // MARK: - Panel Helpers
@@ -92,6 +93,7 @@ final class RecordingOverlayManager {
             self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .initializing
             self.overlayState.showsTranscribingSpinner = false
+            self.overlayState.feedbackMessage = nil
             self.overlayState.audioLevel = 0
             self.showOverlayPanel(animatedResize: false)
         }
@@ -104,6 +106,7 @@ final class RecordingOverlayManager {
             self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .recording
             self.overlayState.showsTranscribingSpinner = false
+            self.overlayState.feedbackMessage = nil
             self.overlayState.audioLevel = 0
             self.showOverlayPanel(animatedResize: true)
         }
@@ -116,6 +119,7 @@ final class RecordingOverlayManager {
             self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .recording
             self.overlayState.showsTranscribingSpinner = false
+            self.overlayState.feedbackMessage = nil
             self.updateOverlayLayout(animated: true)
         }
     }
@@ -145,9 +149,9 @@ final class RecordingOverlayManager {
         }
     }
 
-    func showDone() {
+    func showFallbackMessage(_ message: String) {
         DispatchQueue.main.async {
-            self.showDonePanel()
+            self.showFeedbackPanel(message: message)
         }
     }
 
@@ -202,6 +206,7 @@ final class RecordingOverlayManager {
         lockedOverlayWidth = overlayWindow?.frame.width ?? overlayWidth
         overlayState.phase = .transcribing
         overlayState.showsTranscribingSpinner = showsTranscribingSpinner
+        overlayState.feedbackMessage = nil
         showOverlayPanel(animatedResize: true)
     }
 
@@ -244,8 +249,15 @@ final class RecordingOverlayManager {
     }
 
     private var overlayWidth: CGFloat {
-        if let lockedOverlayWidth, (overlayState.phase == .transcribing || overlayState.phase == .done) {
+        if let lockedOverlayWidth, overlayState.phase == .transcribing {
             return lockedOverlayWidth
+        }
+
+        if overlayState.phase == .feedback {
+            let approximateTextWidth = CGFloat((overlayState.feedbackMessage?.count ?? 0) * 7)
+            let feedbackWidth = max(168, min(260, 48 + approximateTextWidth))
+            guard screenHasNotch else { return feedbackWidth }
+            return max(notchWidth, feedbackWidth)
         }
 
         let commandModeWidth: CGFloat = 180
@@ -265,22 +277,18 @@ final class RecordingOverlayManager {
         return max(notchWidth, baseWidth)
     }
 
-    private func showDonePanel() {
-        overlayState.phase = .done
-
-        guard let panel = overlayWindow else { return }
-        panel.contentView = makeOverlayContent(frame: panel.frame)
-
-        NSAnimationContext.runAnimationGroup { context in
-            context.duration = 0.2
-            panel.animator().alphaValue = 0
-        }
+    private func showFeedbackPanel(message: String) {
+        lockedOverlayWidth = nil
+        overlayState.phase = .feedback
+        overlayState.feedbackMessage = message
+        showOverlayPanel(animatedResize: true)
     }
 
     private func dismissAll() {
         lockedOverlayWidth = nil
         overlayState.isCommandMode = false
         overlayState.showsTranscribingSpinner = false
+        overlayState.feedbackMessage = nil
         if let panel = overlayWindow {
             panel.orderOut(nil)
             overlayWindow = nil
@@ -344,6 +352,33 @@ struct WaveformView: View {
     }
 }
 
+struct ProcessingWaveformView: View {
+    private static let barCount = 9
+    private static let multipliers: [CGFloat] = [0.42, 0.58, 0.76, 0.9, 1.0, 0.9, 0.76, 0.58, 0.42]
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: false)) { context in
+            let time = context.date.timeIntervalSinceReferenceDate
+
+            HStack(spacing: 2.5) {
+                ForEach(0..<Self.barCount, id: \.self) { index in
+                    let wave = 0.5 + 0.5 * sin((time * 5.6) - Double(index) * 0.5)
+                    let shimmer = 0.5 + 0.5 * sin((time * 2.8) + Double(index) * 0.75)
+                    let amplitude = min(
+                        0.16 + CGFloat(wave) * Self.multipliers[index] * 0.52 + CGFloat(shimmer) * 0.08,
+                        1.0
+                    )
+
+                    WaveformBar(amplitude: amplitude)
+                        .opacity(0.45 + CGFloat(wave) * 0.5)
+                }
+            }
+            .frame(height: 20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
 struct InitializingDotsView: View {
     @State private var activeDot = 0
     @State private var timer: Timer?
@@ -393,14 +428,14 @@ struct RecordingOverlayView: View {
                 if state.phase == .initializing {
                     InitializingDotsView()
                         .transition(.opacity)
-                } else if state.phase == .done {
-                    DoneView()
+                } else if state.phase == .feedback, let feedbackMessage = state.feedbackMessage {
+                    FeedbackMessageView(message: feedbackMessage)
                         .transition(.opacity.combined(with: .scale(scale: 0.96)))
                 } else if showsLiveRecordingContent {
                     WaveformView(audioLevel: state.audioLevel)
                         .transition(.opacity)
                 } else {
-                    TranscribingSpinnerView()
+                    ProcessingWaveformView()
                         .transition(.opacity.combined(with: .scale(scale: 0.96)))
                 }
             }
@@ -443,15 +478,6 @@ struct RecordingOverlayView: View {
 
 // MARK: - Transcribing Indicator
 
-struct DoneView: View {
-    var body: some View {
-        Image(systemName: "checkmark")
-            .font(.system(size: 12, weight: .bold))
-            .foregroundStyle(.white)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-}
-
 struct CommandModeIndicator: View {
     var body: some View {
         Image(systemName: "pencil")
@@ -461,24 +487,19 @@ struct CommandModeIndicator: View {
     }
 }
 
-struct TranscribingSpinnerView: View {
-    @State private var isAnimating = false
+struct FeedbackMessageView: View {
+    let message: String
 
     var body: some View {
-        Circle()
-            .trim(from: 0.14, to: 0.82)
-            .stroke(
-                Color.white,
-                style: StrokeStyle(lineWidth: 2.2, lineCap: .round)
-            )
-            .frame(width: 14, height: 14)
-            .rotationEffect(.degrees(isAnimating ? 360 : 0))
-            .animation(
-                .linear(duration: 0.75).repeatForever(autoreverses: false),
-                value: isAnimating
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .onAppear { isAnimating = true }
-            .onDisappear { isAnimating = false }
+        HStack(spacing: 8) {
+            WaveformView(audioLevel: 0.42)
+                .frame(width: 26)
+
+            Text(message)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(.white.opacity(0.92))
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -7,6 +7,7 @@ final class RecordingOverlayState: ObservableObject {
     @Published var phase: OverlayPhase = .recording
     @Published var audioLevel: Float = 0.0
     @Published var recordingTriggerMode: RecordingTriggerMode = .hold
+    @Published var isCommandMode = false
     @Published var showsTranscribingSpinner = false
 }
 
@@ -84,10 +85,11 @@ final class RecordingOverlayManager {
         overlayState.phase == .recording && overlayState.recordingTriggerMode == .toggle
     }
 
-    func showInitializing(mode: RecordingTriggerMode = .hold) {
+    func showInitializing(mode: RecordingTriggerMode = .hold, isCommandMode: Bool = false) {
         DispatchQueue.main.async {
             self.lockedOverlayWidth = nil
             self.overlayState.recordingTriggerMode = mode
+            self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .initializing
             self.overlayState.showsTranscribingSpinner = false
             self.overlayState.audioLevel = 0
@@ -95,10 +97,11 @@ final class RecordingOverlayManager {
         }
     }
 
-    func showRecording(mode: RecordingTriggerMode = .hold) {
+    func showRecording(mode: RecordingTriggerMode = .hold, isCommandMode: Bool = false) {
         DispatchQueue.main.async {
             self.lockedOverlayWidth = nil
             self.overlayState.recordingTriggerMode = mode
+            self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .recording
             self.overlayState.showsTranscribingSpinner = false
             self.overlayState.audioLevel = 0
@@ -106,10 +109,11 @@ final class RecordingOverlayManager {
         }
     }
 
-    func transitionToRecording(mode: RecordingTriggerMode = .hold) {
+    func transitionToRecording(mode: RecordingTriggerMode = .hold, isCommandMode: Bool = false) {
         DispatchQueue.main.async {
             self.lockedOverlayWidth = nil
             self.overlayState.recordingTriggerMode = mode
+            self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .recording
             self.overlayState.showsTranscribingSpinner = false
             self.updateOverlayLayout(animated: true)
@@ -244,7 +248,11 @@ final class RecordingOverlayManager {
             return lockedOverlayWidth
         }
 
-        let baseWidth: CGFloat = overlayState.phase == .recording && overlayState.recordingTriggerMode == .toggle ? 150 : 92
+        let toggleWidth: CGFloat = overlayState.isCommandMode ? 180 : 150
+        let defaultWidth: CGFloat = overlayState.isCommandMode ? 124 : 92
+        let baseWidth: CGFloat = overlayState.phase == .recording && overlayState.recordingTriggerMode == .toggle
+            ? toggleWidth
+            : defaultWidth
         guard screenHasNotch else { return baseWidth }
         return max(notchWidth, baseWidth)
     }
@@ -263,6 +271,7 @@ final class RecordingOverlayManager {
 
     private func dismissAll() {
         lockedOverlayWidth = nil
+        overlayState.isCommandMode = false
         overlayState.showsTranscribingSpinner = false
         if let panel = overlayWindow {
             panel.orderOut(nil)
@@ -359,6 +368,9 @@ struct RecordingOverlayView: View {
     @ObservedObject var state: RecordingOverlayState
     let onStopButtonPressed: () -> Void
 
+    private let leadingAccessoryWidth: CGFloat = 20
+    private let trailingAccessoryWidth: CGFloat = 32
+
     private var showsLiveRecordingContent: Bool {
         state.phase == .recording || (state.phase == .transcribing && !state.showsTranscribingSpinner)
     }
@@ -368,7 +380,7 @@ struct RecordingOverlayView: View {
     }
 
     var body: some View {
-        HStack(spacing: 10) {
+        ZStack {
             Group {
                 if state.phase == .initializing {
                     InitializingDotsView()
@@ -385,27 +397,38 @@ struct RecordingOverlayView: View {
                 }
             }
 
-            if showsStopButton {
-                Button(action: onStopButtonPressed) {
-                    HStack(spacing: 5) {
-                        Image(systemName: "stop.fill")
-                            .font(.system(size: 9, weight: .bold))
-                        Text("Stop")
-                            .font(.system(size: 11, weight: .semibold, design: .rounded))
+            HStack {
+                Group {
+                    if state.isCommandMode {
+                        CommandModeIndicator()
+                            .transition(.opacity.combined(with: .scale(scale: 0.96)))
                     }
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
-                    .background(Capsule().fill(Color.red.opacity(0.92)))
                 }
-                .buttonStyle(.plain)
-                .transition(.move(edge: .trailing).combined(with: .opacity))
+                .frame(width: leadingAccessoryWidth, alignment: .leading)
+
+                Spacer(minLength: 0)
+
+                Group {
+                    if showsStopButton {
+                        Button(action: onStopButtonPressed) {
+                            Image(systemName: "stop.fill")
+                                .font(.system(size: 9, weight: .bold))
+                            .foregroundStyle(.white)
+                            .frame(width: 20, height: 20)
+                            .background(Circle().fill(Color.red.opacity(0.92)))
+                        }
+                        .buttonStyle(.plain)
+                        .transition(.move(edge: .trailing).combined(with: .opacity))
+                    }
+                }
+                .frame(width: trailingAccessoryWidth, alignment: .trailing)
             }
         }
         .padding(.horizontal, 12)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.phase)
         .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.recordingTriggerMode)
+        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.isCommandMode)
     }
 }
 
@@ -417,6 +440,14 @@ struct DoneView: View {
             .font(.system(size: 12, weight: .bold))
             .foregroundStyle(.white)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+struct CommandModeIndicator: View {
+    var body: some View {
+        Image(systemName: "square.and.pencil")
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(.white.opacity(0.92))
     }
 }
 

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -9,7 +9,6 @@ final class RecordingOverlayState: ObservableObject {
     @Published var recordingTriggerMode: RecordingTriggerMode = .hold
     @Published var isCommandMode = false
     @Published var showsTranscribingSpinner = false
-    @Published var feedbackMessage: String?
 }
 
 enum OverlayPhase {
@@ -93,7 +92,6 @@ final class RecordingOverlayManager {
             self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .initializing
             self.overlayState.showsTranscribingSpinner = false
-            self.overlayState.feedbackMessage = nil
             self.overlayState.audioLevel = 0
             self.showOverlayPanel(animatedResize: false)
         }
@@ -106,7 +104,6 @@ final class RecordingOverlayManager {
             self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .recording
             self.overlayState.showsTranscribingSpinner = false
-            self.overlayState.feedbackMessage = nil
             self.overlayState.audioLevel = 0
             self.showOverlayPanel(animatedResize: true)
         }
@@ -119,7 +116,6 @@ final class RecordingOverlayManager {
             self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .recording
             self.overlayState.showsTranscribingSpinner = false
-            self.overlayState.feedbackMessage = nil
             self.updateOverlayLayout(animated: true)
         }
     }
@@ -149,9 +145,9 @@ final class RecordingOverlayManager {
         }
     }
 
-    func showFallbackMessage(_ message: String) {
+    func showFailureIndicator() {
         DispatchQueue.main.async {
-            self.showFeedbackPanel(message: message)
+            self.showFeedbackPanel()
         }
     }
 
@@ -206,7 +202,6 @@ final class RecordingOverlayManager {
         lockedOverlayWidth = overlayWindow?.frame.width ?? overlayWidth
         overlayState.phase = .transcribing
         overlayState.showsTranscribingSpinner = showsTranscribingSpinner
-        overlayState.feedbackMessage = nil
         showOverlayPanel(animatedResize: true)
     }
 
@@ -254,8 +249,7 @@ final class RecordingOverlayManager {
         }
 
         if overlayState.phase == .feedback {
-            let approximateTextWidth = CGFloat((overlayState.feedbackMessage?.count ?? 0) * 7)
-            let feedbackWidth = max(168, min(260, 48 + approximateTextWidth))
+            let feedbackWidth: CGFloat = 92
             guard screenHasNotch else { return feedbackWidth }
             return max(notchWidth, feedbackWidth)
         }
@@ -277,10 +271,9 @@ final class RecordingOverlayManager {
         return max(notchWidth, baseWidth)
     }
 
-    private func showFeedbackPanel(message: String) {
+    private func showFeedbackPanel() {
         lockedOverlayWidth = nil
         overlayState.phase = .feedback
-        overlayState.feedbackMessage = message
         showOverlayPanel(animatedResize: true)
     }
 
@@ -288,7 +281,6 @@ final class RecordingOverlayManager {
         lockedOverlayWidth = nil
         overlayState.isCommandMode = false
         overlayState.showsTranscribingSpinner = false
-        overlayState.feedbackMessage = nil
         if let panel = overlayWindow {
             panel.orderOut(nil)
             overlayWindow = nil
@@ -423,49 +415,52 @@ struct RecordingOverlayView: View {
     }
 
     var body: some View {
-        ZStack {
-            Group {
-                if state.phase == .initializing {
-                    InitializingDotsView()
-                        .transition(.opacity)
-                } else if state.phase == .feedback, let feedbackMessage = state.feedbackMessage {
-                    FeedbackMessageView(message: feedbackMessage)
-                        .transition(.opacity.combined(with: .scale(scale: 0.96)))
-                } else if showsLiveRecordingContent {
-                    WaveformView(audioLevel: state.audioLevel)
-                        .transition(.opacity)
-                } else {
-                    ProcessingWaveformView()
-                        .transition(.opacity.combined(with: .scale(scale: 0.96)))
-                }
-            }
-
-            HStack {
-                Group {
-                    if state.isCommandMode {
-                        CommandModeIndicator()
-                            .transition(.opacity.combined(with: .scale(scale: 0.96)))
-                    }
-                }
-                .frame(width: leadingAccessoryWidth, alignment: .center)
-                .frame(maxHeight: .infinity, alignment: .center)
-
-                Spacer(minLength: 0)
-
-                Group {
-                    if showsStopButton {
-                        Button(action: onStopButtonPressed) {
-                            Image(systemName: "stop.fill")
-                                .font(.system(size: 9, weight: .bold))
-                            .foregroundStyle(.white)
-                            .frame(width: 20, height: 20)
-                            .background(Circle().fill(Color.red.opacity(0.92)))
+        Group {
+            if state.phase == .feedback {
+                FailureIndicatorView()
+            } else {
+                ZStack {
+                    Group {
+                        if state.phase == .initializing {
+                            InitializingDotsView()
+                                .transition(.opacity)
+                        } else if showsLiveRecordingContent {
+                            WaveformView(audioLevel: state.audioLevel)
+                                .transition(.opacity)
+                        } else {
+                            ProcessingWaveformView()
+                                .transition(.opacity.combined(with: .scale(scale: 0.96)))
                         }
-                        .buttonStyle(.plain)
-                        .transition(.move(edge: .trailing).combined(with: .opacity))
+                    }
+
+                    HStack {
+                        Group {
+                            if state.isCommandMode {
+                                CommandModeIndicator()
+                                    .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                            }
+                        }
+                        .frame(width: leadingAccessoryWidth, alignment: .center)
+                        .frame(maxHeight: .infinity, alignment: .center)
+
+                        Spacer(minLength: 0)
+
+                        Group {
+                            if showsStopButton {
+                                Button(action: onStopButtonPressed) {
+                                    Image(systemName: "stop.fill")
+                                        .font(.system(size: 9, weight: .bold))
+                                        .foregroundStyle(.white)
+                                        .frame(width: 20, height: 20)
+                                        .background(Circle().fill(Color.red.opacity(0.92)))
+                                }
+                                .buttonStyle(.plain)
+                                .transition(.move(edge: .trailing).combined(with: .opacity))
+                            }
+                        }
+                        .frame(width: trailingAccessoryWidth, alignment: .trailing)
                     }
                 }
-                .frame(width: trailingAccessoryWidth, alignment: .trailing)
             }
         }
         .padding(.horizontal, 12)
@@ -487,19 +482,13 @@ struct CommandModeIndicator: View {
     }
 }
 
-struct FeedbackMessageView: View {
-    let message: String
-
+struct FailureIndicatorView: View {
     var body: some View {
-        HStack(spacing: 8) {
-            WaveformView(audioLevel: 0.42)
-                .frame(width: 26)
-
-            Text(message)
-                .font(.system(size: 11.5, weight: .medium))
-                .foregroundStyle(.white.opacity(0.92))
-                .lineLimit(1)
-        }
+        Image(systemName: "xmark")
+            .font(.system(size: 12, weight: .bold))
+            .foregroundStyle(.white)
+            .frame(width: 20, height: 20)
+            .background(Circle().fill(Color.red.opacity(0.92)))
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -248,11 +248,19 @@ final class RecordingOverlayManager {
             return lockedOverlayWidth
         }
 
-        let toggleWidth: CGFloat = overlayState.isCommandMode ? 180 : 150
-        let defaultWidth: CGFloat = overlayState.isCommandMode ? 124 : 92
-        let baseWidth: CGFloat = overlayState.phase == .recording && overlayState.recordingTriggerMode == .toggle
-            ? toggleWidth
-            : defaultWidth
+        let commandModeWidth: CGFloat = 180
+        let toggleWidth: CGFloat = 150
+        let defaultWidth: CGFloat = 92
+        let baseWidth: CGFloat
+
+        if overlayState.isCommandMode {
+            baseWidth = commandModeWidth
+        } else if overlayState.phase == .recording && overlayState.recordingTriggerMode == .toggle {
+            baseWidth = toggleWidth
+        } else {
+            baseWidth = defaultWidth
+        }
+
         guard screenHasNotch else { return baseWidth }
         return max(notchWidth, baseWidth)
     }
@@ -368,7 +376,7 @@ struct RecordingOverlayView: View {
     @ObservedObject var state: RecordingOverlayState
     let onStopButtonPressed: () -> Void
 
-    private let leadingAccessoryWidth: CGFloat = 20
+    private let leadingAccessoryWidth: CGFloat = 24
     private let trailingAccessoryWidth: CGFloat = 32
 
     private var showsLiveRecordingContent: Bool {
@@ -404,7 +412,8 @@ struct RecordingOverlayView: View {
                             .transition(.opacity.combined(with: .scale(scale: 0.96)))
                     }
                 }
-                .frame(width: leadingAccessoryWidth, alignment: .leading)
+                .frame(width: leadingAccessoryWidth, alignment: .center)
+                .frame(maxHeight: .infinity, alignment: .center)
 
                 Spacer(minLength: 0)
 
@@ -445,9 +454,10 @@ struct DoneView: View {
 
 struct CommandModeIndicator: View {
     var body: some View {
-        Image(systemName: "square.and.pencil")
+        Image(systemName: "pencil")
             .font(.system(size: 12, weight: .semibold))
             .foregroundStyle(.white.opacity(0.92))
+            .frame(width: 16, height: 16, alignment: .center)
     }
 }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -564,7 +564,7 @@ struct GeneralSettingsView: View {
             .pickerStyle(.segmented)
             .disabled(!appState.isCommandModeEnabled)
 
-            if appState.isCommandModeEnabled {
+            Group {
                 switch appState.commandModeStyle {
                 case .automatic:
                     Text("If text is selected, your normal dictation shortcut transforms the selection instead of dictating over it.")
@@ -590,9 +590,11 @@ struct GeneralSettingsView: View {
                                 Text(modifier.title).tag(modifier)
                             }
                         }
+                        .disabled(!appState.isCommandModeEnabled || appState.commandModeStyle != .manual)
                     }
                 }
             }
+            .opacity(appState.isCommandModeEnabled ? 1 : 0.5)
 
             if let validationMessage = commandModeValidationMessage ?? appState.commandModeManualModifierValidationMessage {
                 Label(validationMessage, systemImage: "xmark.circle.fill")

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -100,7 +100,6 @@ struct GeneralSettingsView: View {
     @State private var keyValidationError: String?
     @State private var keyValidationSuccess = false
     @State private var customVocabularyInput: String = ""
-    @State private var commandModeValidationMessage: String?
     @State private var micPermissionGranted = false
     @StateObject private var githubCache = GitHubMetadataCache.shared
     @ObservedObject private var updateManager = UpdateManager.shared
@@ -263,7 +262,6 @@ struct GeneralSettingsView: View {
             apiKeyInput = appState.apiKey
             apiBaseURLInput = appState.apiBaseURL
             customVocabularyInput = appState.customVocabulary
-            commandModeValidationMessage = appState.commandModeManualModifierValidationMessage
             checkMicPermission()
             appState.refreshLaunchAtLoginStatus()
             Task { await githubCache.fetchIfNeeded() }
@@ -535,11 +533,7 @@ struct GeneralSettingsView: View {
             Toggle("Enable Command Mode", isOn: Binding(
                 get: { appState.isCommandModeEnabled },
                 set: { newValue in
-                    if let message = appState.setCommandModeEnabled(newValue) {
-                        commandModeValidationMessage = message
-                    } else {
-                        commandModeValidationMessage = nil
-                    }
+                    _ = appState.setCommandModeEnabled(newValue)
                 }
             ))
 
@@ -550,11 +544,7 @@ struct GeneralSettingsView: View {
             Picker("Invocation Style", selection: Binding(
                 get: { appState.commandModeStyle },
                 set: { newValue in
-                    if let message = appState.setCommandModeStyle(newValue) {
-                        commandModeValidationMessage = message
-                    } else {
-                        commandModeValidationMessage = nil
-                    }
+                    _ = appState.setCommandModeStyle(newValue)
                 }
             )) {
                 ForEach(CommandModeStyle.allCases) { style in
@@ -579,11 +569,7 @@ struct GeneralSettingsView: View {
                         Picker("Extra Modifier", selection: Binding(
                             get: { appState.commandModeManualModifier },
                             set: { newValue in
-                                if let message = appState.setCommandModeManualModifier(newValue) {
-                                    commandModeValidationMessage = message
-                                } else {
-                                    commandModeValidationMessage = nil
-                                }
+                                _ = appState.setCommandModeManualModifier(newValue)
                             }
                         )) {
                             ForEach(CommandModeManualModifier.allCases) { modifier in
@@ -596,7 +582,7 @@ struct GeneralSettingsView: View {
             }
             .opacity(appState.isCommandModeEnabled ? 1 : 0.5)
 
-            if let validationMessage = commandModeValidationMessage ?? appState.commandModeManualModifierValidationMessage {
+            if let validationMessage = appState.commandModeManualModifierValidationMessage {
                 Label(validationMessage, systemImage: "xmark.circle.fill")
                     .font(.caption)
                     .foregroundStyle(.red)

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -100,6 +100,7 @@ struct GeneralSettingsView: View {
     @State private var keyValidationError: String?
     @State private var keyValidationSuccess = false
     @State private var customVocabularyInput: String = ""
+    @State private var commandModeValidationMessage: String?
     @State private var micPermissionGranted = false
     @StateObject private var githubCache = GitHubMetadataCache.shared
     @ObservedObject private var updateManager = UpdateManager.shared
@@ -237,6 +238,9 @@ struct GeneralSettingsView: View {
                 SettingsCard("Dictation Shortcuts", icon: "keyboard.fill") {
                     hotkeySection
                 }
+                SettingsCard("Command Mode", icon: "wand.and.stars") {
+                    commandModeSection
+                }
                 SettingsCard("Clipboard", icon: "doc.on.clipboard") {
                     clipboardSection
                 }
@@ -259,6 +263,7 @@ struct GeneralSettingsView: View {
             apiKeyInput = appState.apiKey
             apiBaseURLInput = appState.apiBaseURL
             customVocabularyInput = appState.customVocabulary
+            commandModeValidationMessage = appState.commandModeManualModifierValidationMessage
             checkMicPermission()
             appState.refreshLaunchAtLoginStatus()
             Task { await githubCache.fetchIfNeeded() }
@@ -521,6 +526,78 @@ struct GeneralSettingsView: View {
                 Text("Applies before recording starts for both hold and tap shortcuts. Stopping still happens immediately.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var commandModeSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Toggle("Enable Command Mode", isOn: Binding(
+                get: { appState.isCommandModeEnabled },
+                set: { newValue in
+                    if let message = appState.setCommandModeEnabled(newValue) {
+                        commandModeValidationMessage = message
+                    } else {
+                        commandModeValidationMessage = nil
+                    }
+                }
+            ))
+
+            Text("Transform highlighted text with a spoken instruction instead of dictating over it.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Picker("Invocation Style", selection: Binding(
+                get: { appState.commandModeStyle },
+                set: { newValue in
+                    if let message = appState.setCommandModeStyle(newValue) {
+                        commandModeValidationMessage = message
+                    } else {
+                        commandModeValidationMessage = nil
+                    }
+                }
+            )) {
+                ForEach(CommandModeStyle.allCases) { style in
+                    Text(style.title).tag(style)
+                }
+            }
+            .pickerStyle(.segmented)
+            .disabled(!appState.isCommandModeEnabled)
+
+            if appState.isCommandModeEnabled {
+                switch appState.commandModeStyle {
+                case .automatic:
+                    Text("If text is selected, your normal dictation shortcut transforms the selection instead of dictating over it.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                case .manual:
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Hold the extra modifier together with your normal dictation shortcut to transform selected text.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        Picker("Extra Modifier", selection: Binding(
+                            get: { appState.commandModeManualModifier },
+                            set: { newValue in
+                                if let message = appState.setCommandModeManualModifier(newValue) {
+                                    commandModeValidationMessage = message
+                                } else {
+                                    commandModeValidationMessage = nil
+                                }
+                            }
+                        )) {
+                            ForEach(CommandModeManualModifier.allCases) { modifier in
+                                Text(modifier.title).tag(modifier)
+                            }
+                        }
+                    }
+                }
+            }
+
+            if let validationMessage = commandModeValidationMessage ?? appState.commandModeManualModifierValidationMessage {
+                Label(validationMessage, systemImage: "xmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
             }
         }
     }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -237,7 +237,7 @@ struct GeneralSettingsView: View {
                 SettingsCard("Dictation Shortcuts", icon: "keyboard.fill") {
                     hotkeySection
                 }
-                SettingsCard("Command Mode", icon: "wand.and.stars") {
+                SettingsCard("Edit Mode", icon: "pencil") {
                     commandModeSection
                 }
                 SettingsCard("Clipboard", icon: "doc.on.clipboard") {
@@ -530,7 +530,7 @@ struct GeneralSettingsView: View {
 
     private var commandModeSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Toggle("Enable Command Mode", isOn: Binding(
+            Toggle("Enable Edit Mode", isOn: Binding(
                 get: { appState.isCommandModeEnabled },
                 set: { newValue in
                     _ = appState.setCommandModeEnabled(newValue)

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -17,6 +17,7 @@ struct SetupView: View {
         case screenRecording
         case holdShortcut
         case toggleShortcut
+        case commandMode
         case vocabulary
         case launchAtLogin
         case testTranscription
@@ -47,6 +48,7 @@ struct SetupView: View {
     @State private var testMicPulsing = false
     @State private var holdShortcutValidationMessage: String?
     @State private var toggleShortcutValidationMessage: String?
+    @State private var commandModeValidationMessage: String?
     @State private var isCapturingHoldShortcut = false
     @State private var isCapturingToggleShortcut = false
     @StateObject private var testHotkeyHarness = SetupTestHotkeyHarness()
@@ -143,6 +145,7 @@ struct SetupView: View {
             customVocabularyInput = appState.customVocabulary
             checkMicPermission()
             checkAccessibility()
+            commandModeValidationMessage = appState.commandModeManualModifierValidationMessage
             Task {
                 await githubCache.fetchIfNeeded()
             }
@@ -178,6 +181,8 @@ struct SetupView: View {
             holdShortcutStep
         case .toggleShortcut:
             toggleShortcutStep
+        case .commandMode:
+            commandModeStep
         case .vocabulary:
             vocabularyStep
         case .launchAtLogin:
@@ -612,6 +617,85 @@ struct SetupView: View {
         }
     }
 
+    var commandModeStep: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "wand.and.stars")
+                .font(.system(size: 60))
+                .foregroundStyle(.blue)
+
+            Text("Command Mode")
+                .font(.title)
+                .fontWeight(.bold)
+
+            Text("Transform selected text with a spoken instruction instead of dictating over it.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 14) {
+                Toggle("Enable Command Mode", isOn: Binding(
+                    get: { appState.isCommandModeEnabled },
+                    set: { newValue in
+                        commandModeValidationMessage = appState.setCommandModeEnabled(newValue)
+                    }
+                ))
+
+                Picker("Invocation Style", selection: Binding(
+                    get: { appState.commandModeStyle },
+                    set: { newValue in
+                        commandModeValidationMessage = appState.setCommandModeStyle(newValue)
+                    }
+                )) {
+                    ForEach(CommandModeStyle.allCases) { style in
+                        Text(style.title).tag(style)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .disabled(!appState.isCommandModeEnabled)
+
+                Group {
+                    switch appState.commandModeStyle {
+                    case .automatic:
+                        Text("Automatic mode uses your normal dictation shortcut. If text is selected, FreeFlow transforms that selection instead of dictating new text.")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    case .manual:
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Manual mode only triggers when you hold an extra modifier together with your normal dictation shortcut.")
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+
+                            Picker("Extra Modifier", selection: Binding(
+                                get: { appState.commandModeManualModifier },
+                                set: { newValue in
+                                    commandModeValidationMessage = appState.setCommandModeManualModifier(newValue)
+                                }
+                            )) {
+                                ForEach(CommandModeManualModifier.allCases) { modifier in
+                                    Text(modifier.title).tag(modifier)
+                                }
+                            }
+                            .disabled(!appState.isCommandModeEnabled || appState.commandModeStyle != .manual)
+                        }
+                    }
+                }
+                .opacity(appState.isCommandModeEnabled ? 1 : 0.5)
+
+                if let validationMessage = commandModeValidationMessage ?? appState.commandModeManualModifierValidationMessage {
+                    Label(validationMessage, systemImage: "xmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .cornerRadius(10)
+        }
+    }
+
     var launchAtLoginStep: some View {
         VStack(spacing: 20) {
             Image(systemName: "sunrise.fill")
@@ -802,6 +886,17 @@ struct SetupView: View {
                 }
                 if appState.hasEnabledHoldShortcut && appState.hasEnabledToggleShortcut {
                     HowToRow(icon: "arrow.triangle.branch", text: "While holding, press the toggle shortcut to latch on")
+                }
+                if appState.isCommandModeEnabled {
+                    switch appState.commandModeStyle {
+                    case .automatic:
+                        HowToRow(icon: "wand.and.stars", text: "With text selected, your normal shortcut transforms the selection")
+                    case .manual:
+                        HowToRow(
+                            icon: "wand.and.stars",
+                            text: "Hold \(appState.commandModeManualModifier.title) with your normal shortcut to transform selected text"
+                        )
+                    }
                 }
                 HowToRow(icon: "doc.on.clipboard", text: "Text is typed at your cursor & copied")
             }

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -48,7 +48,6 @@ struct SetupView: View {
     @State private var testMicPulsing = false
     @State private var holdShortcutValidationMessage: String?
     @State private var toggleShortcutValidationMessage: String?
-    @State private var commandModeValidationMessage: String?
     @State private var isCapturingHoldShortcut = false
     @State private var isCapturingToggleShortcut = false
     @StateObject private var testHotkeyHarness = SetupTestHotkeyHarness()
@@ -145,7 +144,6 @@ struct SetupView: View {
             customVocabularyInput = appState.customVocabulary
             checkMicPermission()
             checkAccessibility()
-            commandModeValidationMessage = appState.commandModeManualModifierValidationMessage
             Task {
                 await githubCache.fetchIfNeeded()
             }
@@ -636,14 +634,14 @@ struct SetupView: View {
                 Toggle("Enable Command Mode", isOn: Binding(
                     get: { appState.isCommandModeEnabled },
                     set: { newValue in
-                        commandModeValidationMessage = appState.setCommandModeEnabled(newValue)
+                        _ = appState.setCommandModeEnabled(newValue)
                     }
                 ))
 
                 Picker("Invocation Style", selection: Binding(
                     get: { appState.commandModeStyle },
                     set: { newValue in
-                        commandModeValidationMessage = appState.setCommandModeStyle(newValue)
+                        _ = appState.setCommandModeStyle(newValue)
                     }
                 )) {
                     ForEach(CommandModeStyle.allCases) { style in
@@ -670,7 +668,7 @@ struct SetupView: View {
                             Picker("Extra Modifier", selection: Binding(
                                 get: { appState.commandModeManualModifier },
                                 set: { newValue in
-                                    commandModeValidationMessage = appState.setCommandModeManualModifier(newValue)
+                                    _ = appState.setCommandModeManualModifier(newValue)
                                 }
                             )) {
                                 ForEach(CommandModeManualModifier.allCases) { modifier in
@@ -683,7 +681,7 @@ struct SetupView: View {
                 }
                 .opacity(appState.isCommandModeEnabled ? 1 : 0.5)
 
-                if let validationMessage = commandModeValidationMessage ?? appState.commandModeManualModifierValidationMessage {
+                if let validationMessage = appState.commandModeManualModifierValidationMessage {
                     Label(validationMessage, systemImage: "xmark.circle.fill")
                         .font(.caption)
                         .foregroundStyle(.red)

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -617,11 +617,11 @@ struct SetupView: View {
 
     var commandModeStep: some View {
         VStack(spacing: 20) {
-            Image(systemName: "wand.and.stars")
+            Image(systemName: "pencil")
                 .font(.system(size: 60))
                 .foregroundStyle(.blue)
 
-            Text("Command Mode")
+            Text("Edit Mode")
                 .font(.title)
                 .fontWeight(.bold)
 
@@ -631,7 +631,7 @@ struct SetupView: View {
                 .fixedSize(horizontal: false, vertical: true)
 
             VStack(alignment: .leading, spacing: 14) {
-                Toggle("Enable Command Mode", isOn: Binding(
+                Toggle("Enable Edit Mode", isOn: Binding(
                     get: { appState.isCommandModeEnabled },
                     set: { newValue in
                         _ = appState.setCommandModeEnabled(newValue)

--- a/Sources/ShortcutBinding.swift
+++ b/Sources/ShortcutBinding.swift
@@ -62,6 +62,47 @@ enum RecordingTriggerMode: String, Codable {
     }
 }
 
+enum CommandModeStyle: String, CaseIterable, Codable, Identifiable {
+    case automatic
+    case manual
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .automatic: return "Automatic"
+        case .manual: return "Manual"
+        }
+    }
+}
+
+enum CommandModeManualModifier: String, CaseIterable, Codable, Identifiable {
+    case command
+    case control
+    case option
+    case shift
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .command: return "Command"
+        case .control: return "Control"
+        case .option: return "Option"
+        case .shift: return "Shift"
+        }
+    }
+
+    var shortcutModifier: ShortcutModifiers {
+        switch self {
+        case .command: return .command
+        case .control: return .control
+        case .option: return .option
+        case .shift: return .shift
+        }
+    }
+}
+
 enum ShortcutRole {
     case hold
     case toggle


### PR DESCRIPTION
## Summary

- Upstream sync (Edit Mode, better overlay, low reasoning, empty result fix)
- `list_transcripts` / `get_transcript` MCP 툴 추가
- `get_status`의 `last_transcript`를 `pipelineHistory` 기반으로 변경 (삭제된 항목 반영)

## Upstream 변경사항 (zachlatta/freeflow)

- **Edit Mode**: 선택 텍스트를 음성 명령으로 변환 (자동/수동 모드)
- **Better overlay**: 실패 표시, ProcessingWaveform 애니메이션, dismiss 토큰 race condition 수정
- **Low reasoning**: 후처리 모델에 `reasoning_effort=low` 적용
- **Fix empty result**: 공백만 있는 후처리 출력 거부

## 우리 기능 유지 확인

- MCP Server, Note Browser, 로컬 Whisper 전사
- `disableAutoPaste` / `disablePostProcessing` / `disableContextCapture` 토글
- `TranscriptionLanguage` / `TranscriptionModel` 설정
- Concurrent recording 동작

## MCP 변경사항

- `list_transcripts(limit?)`: 최근 전사 목록 (시간, 80자 미리보기)
- `get_transcript(id)`: UUID로 특정 항목 전체 조회
- `get_status`: `lastTranscript` 캐시 → `pipelineHistory.first` 기반으로 변경

## Test plan

- [ ] 앱 정상 실행 확인
- [ ] Edit Mode 동작 확인 (Settings > Edit Mode 활성화 후 텍스트 선택 + 단축키)
- [ ] MCP `list_transcripts` / `get_transcript` 호출 확인
- [ ] Note Browser 정상 동작 확인
- [ ] 로컬 Whisper 전사 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)