### PR TITLE
Fix retry isolation and note browser layout

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -869,6 +869,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         Task { [weak self] in
             guard let self else { return }
+
+            let updatedItem: PipelineHistoryItem
             do {
                 let transcriptionService = try TranscriptionService(
                     apiKey: apiKey,
@@ -880,79 +882,38 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     transcriptionModel: transcriptionModel
                 )
                 let rawTranscript = try await transcriptionService.transcribe(fileURL: snapshot.audioURL)
-
                 let result = await self.processTranscriptForRetry(
                     rawTranscript,
                     snapshot: snapshot,
                     postProcessingService: postProcessingService
                 )
-                let updatedItem = PipelineHistoryItem(
-                    intent: snapshot.item.intent,
-                    selectedText: snapshot.item.selectedText,
-                    id: snapshot.item.id,
-                    timestamp: snapshot.item.timestamp,
+                updatedItem = self.makeRetryHistoryItem(
+                    from: snapshot,
                     rawTranscript: rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
                     postProcessedTranscript: result.finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
                     postProcessingPrompt: result.prompt,
-                    contextSummary: snapshot.item.contextSummary,
-                    contextPrompt: snapshot.item.contextPrompt,
-                    contextScreenshotDataURL: snapshot.item.contextScreenshotDataURL,
-                    contextScreenshotStatus: snapshot.item.contextScreenshotStatus,
                     postProcessingStatus: result.outcome.statusMessage(isRetry: true),
-                    debugStatus: "Retried",
-                    customVocabulary: snapshot.customVocabulary,
-                    customSystemPrompt: snapshot.customSystemPrompt,
-                    audioFileName: snapshot.item.audioFileName,
-                    usedLocalTranscription: snapshot.useLocalTranscription,
-                    usedContextCapture: snapshot.item.usedContextCapture,
-                    usedPostProcessing: snapshot.postProcessingEnabled,
-                    transcriptionLanguageCode: snapshot.transcriptionLanguage.code,
-                    localTranscriptionModelID: snapshot.localTranscriptionModel.id,
-                    transcriptFileName: snapshot.item.transcriptFileName
+                    debugStatus: "Retried"
                 )
-
-                await MainActor.run {
-                    do {
-                        try pipelineHistoryStore.update(updatedItem)
-                        pipelineHistory = pipelineHistoryStore.loadAllHistory()
-                    } catch {
-                        errorMessage = "Failed to save retry result: \(error.localizedDescription)"
-                    }
-                    retryingItemIDs.remove(snapshot.item.id)
-                }
             } catch {
-                let updatedItem = PipelineHistoryItem(
-                    intent: snapshot.item.intent,
-                    selectedText: snapshot.item.selectedText,
-                    id: snapshot.item.id,
-                    timestamp: snapshot.item.timestamp,
+                updatedItem = self.makeRetryHistoryItem(
+                    from: snapshot,
                     rawTranscript: snapshot.item.rawTranscript,
                     postProcessedTranscript: snapshot.item.postProcessedTranscript,
                     postProcessingPrompt: snapshot.item.postProcessingPrompt,
-                    contextSummary: snapshot.item.contextSummary,
-                    contextPrompt: snapshot.item.contextPrompt,
-                    contextScreenshotDataURL: snapshot.item.contextScreenshotDataURL,
-                    contextScreenshotStatus: snapshot.item.contextScreenshotStatus,
                     postProcessingStatus: "Error: \(error.localizedDescription)",
-                    debugStatus: "Retry failed",
-                    customVocabulary: snapshot.customVocabulary,
-                    customSystemPrompt: snapshot.customSystemPrompt,
-                    audioFileName: snapshot.item.audioFileName,
-                    usedLocalTranscription: snapshot.useLocalTranscription,
-                    usedContextCapture: snapshot.item.usedContextCapture,
-                    usedPostProcessing: snapshot.postProcessingEnabled,
-                    transcriptionLanguageCode: snapshot.transcriptionLanguage.code,
-                    localTranscriptionModelID: snapshot.localTranscriptionModel.id,
-                    transcriptFileName: snapshot.item.transcriptFileName
+                    debugStatus: "Retry failed"
                 )
+            }
 
-                await MainActor.run {
-                    do {
-                        try pipelineHistoryStore.update(updatedItem)
-                        pipelineHistory = pipelineHistoryStore.loadAllHistory()
-                    } catch {}
-                    retryingItemIDs.remove(snapshot.item.id)
+            await MainActor.run {
+                do {
+                    try self.pipelineHistoryStore.update(updatedItem)
+                    self.pipelineHistory = self.pipelineHistoryStore.loadAllHistory()
+                } catch {
+                    self.errorMessage = "Failed to save retry result: \(error.localizedDescription)"
                 }
+                self.retryingItemIDs.remove(snapshot.item.id)
             }
         }
     }
@@ -989,6 +950,40 @@ final class AppState: ObservableObject, @unchecked Sendable {
             customSystemPrompt: item.customSystemPrompt,
             postProcessingEnabled: item.usedPostProcessing,
             localWhisperPath: localWhisperPath.isEmpty ? nil : localWhisperPath
+        )
+    }
+
+    private func makeRetryHistoryItem(
+        from snapshot: RetrySnapshot,
+        rawTranscript: String,
+        postProcessedTranscript: String,
+        postProcessingPrompt: String?,
+        postProcessingStatus: String,
+        debugStatus: String
+    ) -> PipelineHistoryItem {
+        PipelineHistoryItem(
+            intent: snapshot.item.intent,
+            selectedText: snapshot.item.selectedText,
+            id: snapshot.item.id,
+            timestamp: snapshot.item.timestamp,
+            rawTranscript: rawTranscript,
+            postProcessedTranscript: postProcessedTranscript,
+            postProcessingPrompt: postProcessingPrompt,
+            contextSummary: snapshot.item.contextSummary,
+            contextPrompt: snapshot.item.contextPrompt,
+            contextScreenshotDataURL: snapshot.item.contextScreenshotDataURL,
+            contextScreenshotStatus: snapshot.item.contextScreenshotStatus,
+            postProcessingStatus: postProcessingStatus,
+            debugStatus: debugStatus,
+            customVocabulary: snapshot.customVocabulary,
+            customSystemPrompt: snapshot.customSystemPrompt,
+            audioFileName: snapshot.item.audioFileName,
+            usedLocalTranscription: snapshot.useLocalTranscription,
+            usedContextCapture: snapshot.item.usedContextCapture,
+            usedPostProcessing: snapshot.postProcessingEnabled,
+            transcriptionLanguageCode: snapshot.transcriptionLanguage.code,
+            localTranscriptionModelID: snapshot.localTranscriptionModel.id,
+            transcriptFileName: snapshot.item.transcriptFileName
         )
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -110,6 +110,20 @@ private struct PendingClipboardRestore {
     let expectedChangeCount: Int
 }
 
+private struct RetrySnapshot {
+    let item: PipelineHistoryItem
+    let audioURL: URL
+    let restoredContext: AppContext
+    let restoredIntent: SessionIntent
+    let transcriptionLanguage: TranscriptionLanguage
+    let localTranscriptionModel: TranscriptionModel
+    let useLocalTranscription: Bool
+    let customVocabulary: String
+    let customSystemPrompt: String
+    let postProcessingEnabled: Bool
+    let localWhisperPath: String?
+}
+
 private enum CommandInvocation: String {
     case automatic
     case manual
@@ -456,6 +470,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var contextCaptureTask: Task<AppContext?, Never>?
     private var capturedContext: AppContext?
     private var hasShownScreenshotPermissionAlert = false
+    private var isEscapeCancelAlertPresented = false
     private var audioDeviceObservers: [NSObjectProtocol] = []
     private var needsMicrophoneRefreshAfterRecording = false
     private let pipelineHistoryStore = PipelineHistoryStore()
@@ -813,11 +828,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
             postProcessingStatus: item.postProcessingStatus,
             debugStatus: item.debugStatus,
             customVocabulary: item.customVocabulary,
+            customSystemPrompt: item.customSystemPrompt,
             audioFileName: item.audioFileName,
             usedLocalTranscription: item.usedLocalTranscription,
             usedContextCapture: item.usedContextCapture,
             usedPostProcessing: item.usedPostProcessing,
             transcriptionLanguageCode: item.transcriptionLanguageCode,
+            localTranscriptionModelID: item.localTranscriptionModelID,
             transcriptFileName: item.transcriptFileName
         )
         do {
@@ -831,29 +848,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     func retryTranscription(item: PipelineHistoryItem) {
-        guard let audioFileName = item.audioFileName else { return }
         guard !retryingItemIDs.contains(item.id) else { return }
 
-        retryingItemIDs.insert(item.id)
-
-        let audioURL = Self.audioStorageDirectory().appendingPathComponent(audioFileName)
-        guard FileManager.default.fileExists(atPath: audioURL.path) else {
-            retryingItemIDs.remove(item.id)
-            errorMessage = "Audio file not found for retry."
+        let snapshot: RetrySnapshot
+        do {
+            snapshot = try makeRetrySnapshot(for: item)
+        } catch {
+            errorMessage = error.localizedDescription
             return
         }
 
-        let restoredContext = AppContext(
-            appName: nil,
-            bundleIdentifier: nil,
-            windowTitle: nil,
-            selectedText: nil,
-            currentActivity: item.contextSummary,
-            contextPrompt: item.contextPrompt,
-            screenshotDataURL: item.contextScreenshotDataURL,
-            screenshotMimeType: item.contextScreenshotDataURL != nil ? "image/jpeg" : nil,
-            screenshotError: nil
-        )
+        retryingItemIDs.insert(item.id)
 
         let postProcessingService = PostProcessingService(
             apiKey: apiKey,
@@ -861,8 +866,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
             preferredModel: postProcessingModel,
             preferredFallbackModel: postProcessingFallbackModel
         )
-        let capturedCustomVocabulary = customVocabulary
-        let capturedCustomSystemPrompt = customSystemPrompt
 
         Task { [weak self] in
             guard let self else { return }
@@ -870,85 +873,171 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 let transcriptionService = try TranscriptionService(
                     apiKey: apiKey,
                     baseURL: apiBaseURL,
-                    useLocalTranscription: useLocalTranscription,
-                    localWhisperPath: localWhisperPath.isEmpty ? nil : localWhisperPath,
-                    transcriptionLanguage: transcriptionLanguage,
-                    localTranscriptionModel: localTranscriptionModel,
+                    useLocalTranscription: snapshot.useLocalTranscription,
+                    localWhisperPath: snapshot.localWhisperPath,
+                    transcriptionLanguage: snapshot.transcriptionLanguage,
+                    localTranscriptionModel: snapshot.localTranscriptionModel,
                     transcriptionModel: transcriptionModel
                 )
-                let rawTranscript = try await transcriptionService.transcribe(fileURL: audioURL)
+                let rawTranscript = try await transcriptionService.transcribe(fileURL: snapshot.audioURL)
 
-                let finalTranscript: String
-                let processingStatus: String
-                let postProcessingPrompt: String
-                let restoredIntent = SessionIntent.fromPersisted(
-                    intent: item.intent,
-                    selectedText: item.selectedText
-                )
-                let result = await self.processTranscript(
+                let result = await self.processTranscriptForRetry(
                     rawTranscript,
-                    intent: restoredIntent,
-                    context: restoredContext,
-                    postProcessingService: postProcessingService,
-                    customVocabulary: capturedCustomVocabulary,
-                    customSystemPrompt: capturedCustomSystemPrompt
+                    snapshot: snapshot,
+                    postProcessingService: postProcessingService
                 )
-                finalTranscript = result.finalTranscript
-                processingStatus = result.outcome.statusMessage(isRetry: true)
-                postProcessingPrompt = result.prompt
+                let updatedItem = PipelineHistoryItem(
+                    intent: snapshot.item.intent,
+                    selectedText: snapshot.item.selectedText,
+                    id: snapshot.item.id,
+                    timestamp: snapshot.item.timestamp,
+                    rawTranscript: rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
+                    postProcessedTranscript: result.finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
+                    postProcessingPrompt: result.prompt,
+                    contextSummary: snapshot.item.contextSummary,
+                    contextPrompt: snapshot.item.contextPrompt,
+                    contextScreenshotDataURL: snapshot.item.contextScreenshotDataURL,
+                    contextScreenshotStatus: snapshot.item.contextScreenshotStatus,
+                    postProcessingStatus: result.outcome.statusMessage(isRetry: true),
+                    debugStatus: "Retried",
+                    customVocabulary: snapshot.customVocabulary,
+                    customSystemPrompt: snapshot.customSystemPrompt,
+                    audioFileName: snapshot.item.audioFileName,
+                    usedLocalTranscription: snapshot.useLocalTranscription,
+                    usedContextCapture: snapshot.item.usedContextCapture,
+                    usedPostProcessing: snapshot.postProcessingEnabled,
+                    transcriptionLanguageCode: snapshot.transcriptionLanguage.code,
+                    localTranscriptionModelID: snapshot.localTranscriptionModel.id,
+                    transcriptFileName: snapshot.item.transcriptFileName
+                )
 
                 await MainActor.run {
-                    let updatedItem = PipelineHistoryItem(
-                        intent: item.intent,
-                        selectedText: item.selectedText,
-                        id: item.id,
-                        timestamp: item.timestamp,
-                        rawTranscript: rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
-                        postProcessedTranscript: finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
-                        postProcessingPrompt: postProcessingPrompt,
-                        contextSummary: item.contextSummary,
-                        contextPrompt: item.contextPrompt,
-                        contextScreenshotDataURL: item.contextScreenshotDataURL,
-                        contextScreenshotStatus: item.contextScreenshotStatus,
-                        postProcessingStatus: processingStatus,
-                        debugStatus: "Retried",
-                        customVocabulary: item.customVocabulary,
-                        audioFileName: item.audioFileName
-                    )
                     do {
                         try pipelineHistoryStore.update(updatedItem)
                         pipelineHistory = pipelineHistoryStore.loadAllHistory()
                     } catch {
                         errorMessage = "Failed to save retry result: \(error.localizedDescription)"
                     }
-                    retryingItemIDs.remove(item.id)
+                    retryingItemIDs.remove(snapshot.item.id)
                 }
             } catch {
+                let updatedItem = PipelineHistoryItem(
+                    intent: snapshot.item.intent,
+                    selectedText: snapshot.item.selectedText,
+                    id: snapshot.item.id,
+                    timestamp: snapshot.item.timestamp,
+                    rawTranscript: snapshot.item.rawTranscript,
+                    postProcessedTranscript: snapshot.item.postProcessedTranscript,
+                    postProcessingPrompt: snapshot.item.postProcessingPrompt,
+                    contextSummary: snapshot.item.contextSummary,
+                    contextPrompt: snapshot.item.contextPrompt,
+                    contextScreenshotDataURL: snapshot.item.contextScreenshotDataURL,
+                    contextScreenshotStatus: snapshot.item.contextScreenshotStatus,
+                    postProcessingStatus: "Error: \(error.localizedDescription)",
+                    debugStatus: "Retry failed",
+                    customVocabulary: snapshot.customVocabulary,
+                    customSystemPrompt: snapshot.customSystemPrompt,
+                    audioFileName: snapshot.item.audioFileName,
+                    usedLocalTranscription: snapshot.useLocalTranscription,
+                    usedContextCapture: snapshot.item.usedContextCapture,
+                    usedPostProcessing: snapshot.postProcessingEnabled,
+                    transcriptionLanguageCode: snapshot.transcriptionLanguage.code,
+                    localTranscriptionModelID: snapshot.localTranscriptionModel.id,
+                    transcriptFileName: snapshot.item.transcriptFileName
+                )
+
                 await MainActor.run {
-                    let updatedItem = PipelineHistoryItem(
-                        intent: item.intent,
-                        selectedText: item.selectedText,
-                        id: item.id,
-                        timestamp: item.timestamp,
-                        rawTranscript: item.rawTranscript,
-                        postProcessedTranscript: item.postProcessedTranscript,
-                        postProcessingPrompt: item.postProcessingPrompt,
-                        contextSummary: item.contextSummary,
-                        contextPrompt: item.contextPrompt,
-                        contextScreenshotDataURL: item.contextScreenshotDataURL,
-                        contextScreenshotStatus: item.contextScreenshotStatus,
-                        postProcessingStatus: "Error: \(error.localizedDescription)",
-                        debugStatus: "Retry failed",
-                        customVocabulary: item.customVocabulary,
-                        audioFileName: item.audioFileName
-                    )
                     do {
                         try pipelineHistoryStore.update(updatedItem)
                         pipelineHistory = pipelineHistoryStore.loadAllHistory()
                     } catch {}
-                    retryingItemIDs.remove(item.id)
+                    retryingItemIDs.remove(snapshot.item.id)
                 }
             }
+        }
+    }
+
+    private func makeRetrySnapshot(for item: PipelineHistoryItem) throws -> RetrySnapshot {
+        guard let audioFileName = item.audioFileName else {
+            throw TranscriptionError.submissionFailed("Audio file not found for retry.")
+        }
+
+        let audioURL = Self.audioStorageDirectory().appendingPathComponent(audioFileName)
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            throw TranscriptionError.submissionFailed("Audio file not found for retry.")
+        }
+
+        return RetrySnapshot(
+            item: item,
+            audioURL: audioURL,
+            restoredContext: AppContext(
+                appName: nil,
+                bundleIdentifier: nil,
+                windowTitle: nil,
+                selectedText: nil,
+                currentActivity: item.contextSummary,
+                contextPrompt: item.contextPrompt,
+                screenshotDataURL: item.contextScreenshotDataURL,
+                screenshotMimeType: item.contextScreenshotDataURL != nil ? "image/jpeg" : nil,
+                screenshotError: nil
+            ),
+            restoredIntent: SessionIntent.fromPersisted(intent: item.intent, selectedText: item.selectedText),
+            transcriptionLanguage: TranscriptionLanguage.find(code: item.transcriptionLanguageCode),
+            localTranscriptionModel: TranscriptionModel.find(id: item.localTranscriptionModelID),
+            useLocalTranscription: item.usedLocalTranscription,
+            customVocabulary: item.customVocabulary,
+            customSystemPrompt: item.customSystemPrompt,
+            postProcessingEnabled: item.usedPostProcessing,
+            localWhisperPath: localWhisperPath.isEmpty ? nil : localWhisperPath
+        )
+    }
+
+    private func processTranscriptForRetry(
+        _ rawTranscript: String,
+        snapshot: RetrySnapshot,
+        postProcessingService: PostProcessingService
+    ) async -> (finalTranscript: String, outcome: TranscriptProcessingOutcome, prompt: String) {
+        let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedRawTranscript.isEmpty else {
+            return ("", .skippedEmptyRawTranscript, "")
+        }
+
+        if case .command(let invocation, let selectedText) = snapshot.restoredIntent {
+            do {
+                let result = try await postProcessingService.commandTransform(
+                    selectedText: selectedText,
+                    voiceCommand: rawTranscript,
+                    context: snapshot.restoredContext,
+                    customVocabulary: snapshot.customVocabulary
+                )
+                return (result.transcript, .commandModeSucceeded(invocation: invocation), result.prompt)
+            } catch {
+                os_log(.error, log: recordingLog, "Edit mode failed: %{public}@", error.localizedDescription)
+                return (selectedText, .commandModeFailedFallback(invocation: invocation), "")
+            }
+        }
+
+        if let macro = findMatchingMacro(for: trimmedRawTranscript) {
+            os_log(.info, log: recordingLog, "Voice macro triggered: %{public}@", macro.command)
+            return (macro.payload, .voiceMacro(command: macro.command), "")
+        }
+
+        if !snapshot.postProcessingEnabled {
+            return (rawTranscript, .postProcessingDisabled, "")
+        }
+
+        do {
+            let result = try await postProcessingService.postProcess(
+                transcript: trimmedRawTranscript,
+                context: snapshot.restoredContext,
+                customVocabulary: snapshot.customVocabulary,
+                customSystemPrompt: snapshot.customSystemPrompt
+            )
+            return (result.transcript, .postProcessingSucceeded, result.prompt)
+        } catch {
+            os_log(.error, log: recordingLog, "Post-processing failed: %{public}@", error.localizedDescription)
+            return (trimmedRawTranscript, .postProcessingFailedFallback, "")
         }
     }
 
@@ -1272,17 +1361,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private func handleEscapeKeyPress() -> Bool {
-        if isTranscribing {
-            cancelTranscription()
-            return true
-        }
-
-        if pendingShortcutStartMode == .toggle || activeRecordingTriggerMode == .toggle {
-            cancelToggleShortcutSession()
-            return true
-        }
-
-        return false
+        guard shouldConfirmEscapeCancellation else { return false }
+        presentEscapeCancellationAlert()
+        return true
     }
 
     func toggleRecording() {
@@ -1312,6 +1393,41 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func handleOverlayStopButtonPressed() {
         guard isRecording, activeRecordingTriggerMode == .toggle else { return }
         stopAndTranscribe()
+    }
+
+    private var shouldConfirmEscapeCancellation: Bool {
+        guard !isEscapeCancelAlertPresented else { return false }
+        if isRecording || isTranscribing {
+            return true
+        }
+        return pendingShortcutStartMode == .toggle || activeRecordingTriggerMode == .toggle
+    }
+
+    private func presentEscapeCancellationAlert() {
+        guard !isEscapeCancelAlertPresented else { return }
+        isEscapeCancelAlertPresented = true
+
+        let alert = NSAlert()
+        alert.messageText = "Cancel current recording?"
+        alert.informativeText = "Press Cancel to keep recording, or Stop Recording to discard the current recording session."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Stop Recording")
+        alert.addButton(withTitle: "Cancel")
+        alert.icon = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: nil)
+
+        let response = alert.runModal()
+        isEscapeCancelAlertPresented = false
+
+        guard response == .alertFirstButtonReturn else { return }
+
+        if isTranscribing {
+            cancelTranscription()
+            return
+        }
+
+        if isRecording || pendingShortcutStartMode == .toggle || activeRecordingTriggerMode == .toggle {
+            cancelToggleShortcutSession()
+        }
     }
 
     private func cancelToggleShortcutSession() {
@@ -2047,7 +2163,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             postProcessingPrompt: "",
                             context: resolvedContext,
                             processingStatus: "Error: \(error.localizedDescription)",
-                            intent: self.currentSessionIntent,
+                            intent: sessionIntent,
                             audioFileName: savedAudioFile?.fileName
                         )
                         self.audioRecorder.cleanup()
@@ -2106,11 +2222,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
             postProcessingStatus: processingStatus,
             debugStatus: debugStatusMessage,
             customVocabulary: customVocabulary,
+            customSystemPrompt: customSystemPrompt,
             audioFileName: audioFileName,
             usedLocalTranscription: useLocalTranscription,
             usedContextCapture: !disableContextCapture,
             usedPostProcessing: !disablePostProcessing,
             transcriptionLanguageCode: transcriptionLanguage.code,
+            localTranscriptionModelID: localTranscriptionModel.id,
             transcriptFileName: transcriptFileName
         )
         do {

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -586,10 +586,11 @@ private struct NoteListRow: View {
                         .multilineTextAlignment(.leading)
                 }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 9)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, minHeight: 64, alignment: .topLeading)
         .background {
             RoundedRectangle(cornerRadius: 8)
                 .fill(
@@ -697,6 +698,9 @@ private struct NoteDetailView: View {
                 customTitle: titleStore.title(for: item.id),
                 onDismiss: { showExportSheet = false }
             )
+        }
+        .onReceive(appState.$retryingItemIDs) { ids in
+            isRetrying = ids.contains(item.id)
         }
         .confirmationDialog("노트를 삭제할까요?", isPresented: $showDeleteConfirmation, titleVisibility: .visible) {
             Button("삭제", role: .destructive) { onDelete() }
@@ -1004,14 +1008,7 @@ private struct NoteDetailView: View {
     }
 
     private func retryTranscription() {
-        isRetrying = true
         appState.retryTranscription(item: item)
-        Task {
-            while appState.retryingItemIDs.contains(item.id) {
-                try? await Task.sleep(nanoseconds: 300_000_000)
-            }
-            await MainActor.run { isRetrying = false }
-        }
     }
 
     private func copyContent() {

--- a/Sources/PipelineHistoryItem.swift
+++ b/Sources/PipelineHistoryItem.swift
@@ -51,7 +51,7 @@ struct PipelineHistoryItem: Identifiable, Codable {
         usedContextCapture: Bool = true,
         usedPostProcessing: Bool = true,
         transcriptionLanguageCode: String = "auto",
-        localTranscriptionModelID: String = "mlx-community/whisper-large-v3-turbo",
+        localTranscriptionModelID: String? = nil,
         transcriptFileName: String? = nil
     ) {
         self.intent = intent
@@ -74,7 +74,7 @@ struct PipelineHistoryItem: Identifiable, Codable {
         self.usedContextCapture = usedContextCapture
         self.usedPostProcessing = usedPostProcessing
         self.transcriptionLanguageCode = transcriptionLanguageCode
-        self.localTranscriptionModelID = localTranscriptionModelID
+        self.localTranscriptionModelID = localTranscriptionModelID ?? "mlx-community/whisper-large-v3-turbo"
         self.transcriptFileName = transcriptFileName
     }
 }

--- a/Sources/PipelineHistoryItem.swift
+++ b/Sources/PipelineHistoryItem.swift
@@ -21,11 +21,13 @@ struct PipelineHistoryItem: Identifiable, Codable {
     let postProcessingStatus: String
     let debugStatus: String
     let customVocabulary: String
+    let customSystemPrompt: String
     let audioFileName: String?
     let usedLocalTranscription: Bool
     let usedContextCapture: Bool
     let usedPostProcessing: Bool
     let transcriptionLanguageCode: String
+    let localTranscriptionModelID: String
     let transcriptFileName: String?
 
     init(
@@ -43,11 +45,13 @@ struct PipelineHistoryItem: Identifiable, Codable {
         postProcessingStatus: String,
         debugStatus: String,
         customVocabulary: String,
+        customSystemPrompt: String = "",
         audioFileName: String? = nil,
         usedLocalTranscription: Bool = false,
         usedContextCapture: Bool = true,
         usedPostProcessing: Bool = true,
         transcriptionLanguageCode: String = "auto",
+        localTranscriptionModelID: String = "mlx-community/whisper-large-v3-turbo",
         transcriptFileName: String? = nil
     ) {
         self.intent = intent
@@ -64,11 +68,13 @@ struct PipelineHistoryItem: Identifiable, Codable {
         self.postProcessingStatus = postProcessingStatus
         self.debugStatus = debugStatus
         self.customVocabulary = customVocabulary
+        self.customSystemPrompt = customSystemPrompt
         self.audioFileName = audioFileName
         self.usedLocalTranscription = usedLocalTranscription
         self.usedContextCapture = usedContextCapture
         self.usedPostProcessing = usedPostProcessing
         self.transcriptionLanguageCode = transcriptionLanguageCode
+        self.localTranscriptionModelID = localTranscriptionModelID
         self.transcriptFileName = transcriptFileName
     }
 }

--- a/Sources/PipelineHistoryStore.swift
+++ b/Sources/PipelineHistoryStore.swift
@@ -93,8 +93,21 @@ final class PipelineHistoryStore {
                 entity.rawTranscript = item.rawTranscript
                 entity.postProcessedTranscript = item.postProcessedTranscript
                 entity.postProcessingPrompt = item.postProcessingPrompt
+                entity.contextSummary = item.contextSummary
+                entity.contextPrompt = item.contextPrompt
+                entity.contextScreenshotDataURL = item.contextScreenshotDataURL
+                entity.contextScreenshotStatus = item.contextScreenshotStatus
                 entity.postProcessingStatus = item.postProcessingStatus
                 entity.debugStatus = item.debugStatus
+                entity.customVocabulary = item.customVocabulary
+                entity.customSystemPrompt = item.customSystemPrompt
+                entity.audioFileName = item.audioFileName
+                entity.usedLocalTranscription = item.usedLocalTranscription
+                entity.usedContextCapture = item.usedContextCapture
+                entity.usedPostProcessing = item.usedPostProcessing
+                entity.transcriptionLanguageCode = item.transcriptionLanguageCode
+                entity.localTranscriptionModelID = item.localTranscriptionModelID
+                entity.transcriptFileName = item.transcriptFileName
                 try saveContext()
             } catch {
                 thrownError = error
@@ -197,11 +210,13 @@ final class PipelineHistoryStore {
                 entity.postProcessingStatus = item.postProcessingStatus
                 entity.debugStatus = item.debugStatus
                 entity.customVocabulary = item.customVocabulary
+                entity.customSystemPrompt = item.customSystemPrompt
                 entity.audioFileName = item.audioFileName
                 entity.usedLocalTranscription = item.usedLocalTranscription
                 entity.usedContextCapture = item.usedContextCapture
                 entity.usedPostProcessing = item.usedPostProcessing
                 entity.transcriptionLanguageCode = item.transcriptionLanguageCode
+                entity.localTranscriptionModelID = item.localTranscriptionModelID
                 entity.transcriptFileName = item.transcriptFileName
                 try saveContext()
             } catch {
@@ -274,11 +289,13 @@ final class PipelineHistoryStore {
             postProcessingStatus: entity.postProcessingStatus ?? "",
             debugStatus: entity.debugStatus ?? "",
             customVocabulary: entity.customVocabulary ?? "",
+            customSystemPrompt: entity.customSystemPrompt ?? "",
             audioFileName: entity.audioFileName,
             usedLocalTranscription: entity.usedLocalTranscription,
             usedContextCapture: entity.usedContextCapture,
             usedPostProcessing: entity.usedPostProcessing,
             transcriptionLanguageCode: entity.transcriptionLanguageCode ?? "auto",
+            localTranscriptionModelID: entity.localTranscriptionModelID ?? TranscriptionModel.default.id,
             transcriptFileName: entity.transcriptFileName
         )
     }
@@ -305,11 +322,13 @@ final class PipelineHistoryStore {
             makeAttribute(name: "postProcessingStatus", type: .stringAttributeType, isOptional: false),
             makeAttribute(name: "debugStatus", type: .stringAttributeType, isOptional: false),
             makeAttribute(name: "customVocabulary", type: .stringAttributeType, isOptional: false),
+            makeAttribute(name: "customSystemPrompt", type: .stringAttributeType, isOptional: false, defaultValue: ""),
             makeAttribute(name: "audioFileName", type: .stringAttributeType, isOptional: true),
             makeAttribute(name: "usedLocalTranscription", type: .booleanAttributeType, isOptional: false),
             makeAttribute(name: "usedContextCapture", type: .booleanAttributeType, isOptional: false),
             makeAttribute(name: "usedPostProcessing", type: .booleanAttributeType, isOptional: false),
             makeAttribute(name: "transcriptionLanguageCode", type: .stringAttributeType, isOptional: true),
+            makeAttribute(name: "localTranscriptionModelID", type: .stringAttributeType, isOptional: false, defaultValue: "mlx-community/whisper-large-v3-turbo"),
             makeAttribute(name: "transcriptFileName", type: .stringAttributeType, isOptional: true),
         ]
 
@@ -348,10 +367,12 @@ final class PipelineHistoryEntry: NSManagedObject {
     @NSManaged var postProcessingStatus: String?
     @NSManaged var debugStatus: String?
     @NSManaged var customVocabulary: String?
+    @NSManaged var customSystemPrompt: String?
     @NSManaged var audioFileName: String?
     @NSManaged var usedLocalTranscription: Bool
     @NSManaged var usedContextCapture: Bool
     @NSManaged var usedPostProcessing: Bool
     @NSManaged var transcriptionLanguageCode: String?
+    @NSManaged var localTranscriptionModelID: String?
     @NSManaged var transcriptFileName: String?
 }

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -116,7 +116,8 @@ class TranscriptionService {
                 "--model", localTranscriptionModel.id,
                 "--output-format", "json",
                 "--output-dir", outputDir.path,
-                "--condition-on-previous-text", "False"
+                "--condition-on-previous-text", "False",
+                "--verbose", "False"
             ]
             if let langCode = transcriptionLanguage.whisperArgument {
                 arguments += ["--language", langCode]
@@ -135,20 +136,55 @@ class TranscriptionService {
             }
 
             process.waitUntilExit()
+            try Task.checkCancellation()
+
+            let stdoutText = String(
+                data: stdout.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let stderrText = String(
+                data: stderr.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if stderrText.contains("No such file or directory: 'ffmpeg'") {
+                throw TranscriptionError.submissionFailed("ffmpeg not found. Install ffmpeg and try local transcription again.")
+            }
 
             guard process.terminationStatus == 0 else {
-                let errorData = stderr.fileHandleForReading.readDataToEndOfFile()
-                let errorText = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                let errorText = stderrText.isEmpty ? stdoutText : stderrText
                 throw TranscriptionError.submissionFailed("mlx_whisper failed (exit \(process.terminationStatus)): \(errorText)")
             }
 
             let inputName = fileURL.deletingPathExtension().lastPathComponent
-            let outputFile = outputDir.appendingPathComponent(inputName).appendingPathExtension("json")
+            let expectedOutputFile = outputDir.appendingPathComponent(inputName).appendingPathExtension("json")
+            let outputFile: URL?
+            if FileManager.default.fileExists(atPath: expectedOutputFile.path) {
+                outputFile = expectedOutputFile
+            } else {
+                let jsonFiles = (try? FileManager.default.contentsOfDirectory(at: outputDir, includingPropertiesForKeys: nil))?
+                    .filter { $0.pathExtension.lowercased() == "json" } ?? []
+                if jsonFiles.count == 1 {
+                    outputFile = jsonFiles[0]
+                } else {
+                    outputFile = nil
+                }
+            }
 
-            guard let jsonData = try? Data(contentsOf: outputFile),
+            guard let outputFile,
+                  let jsonData = try? Data(contentsOf: outputFile),
                   let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
                   let text = json["text"] as? String else {
-                throw TranscriptionError.pollFailed("mlx_whisper produced no output")
+                if !stderrText.isEmpty {
+                    throw TranscriptionError.submissionFailed(stderrText)
+                }
+                if stdoutText.contains("Skipping ") {
+                    throw TranscriptionError.submissionFailed(stdoutText)
+                }
+                let jsonCount = ((try? FileManager.default.contentsOfDirectory(at: outputDir, includingPropertiesForKeys: nil)) ?? [])
+                    .filter { $0.pathExtension.lowercased() == "json" }
+                    .count
+                throw TranscriptionError.pollFailed("mlx_whisper produced no usable output (json files: \(jsonCount))")
             }
 
             if self.isHallucination(text: text, json: json) {

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -135,17 +135,24 @@ class TranscriptionService {
                 throw TranscriptionError.submissionFailed("mlx_whisper not found at \(whisperBin). Install with: pipx install mlx-whisper")
             }
 
+            let stdoutReader = Task.detached(priority: .userInitiated) {
+                String(
+                    data: stdout.fileHandleForReading.readDataToEndOfFile(),
+                    encoding: .utf8
+                )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            }
+            let stderrReader = Task.detached(priority: .userInitiated) {
+                String(
+                    data: stderr.fileHandleForReading.readDataToEndOfFile(),
+                    encoding: .utf8
+                )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            }
+
             process.waitUntilExit()
             try Task.checkCancellation()
 
-            let stdoutText = String(
-                data: stdout.fileHandleForReading.readDataToEndOfFile(),
-                encoding: .utf8
-            )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            let stderrText = String(
-                data: stderr.fileHandleForReading.readDataToEndOfFile(),
-                encoding: .utf8
-            )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let stdoutText = await stdoutReader.value
+            let stderrText = await stderrReader.value
 
             if stderrText.contains("No such file or directory: 'ffmpeg'") {
                 throw TranscriptionError.submissionFailed("ffmpeg not found. Install ffmpeg and try local transcription again.")


### PR DESCRIPTION
## Summary
- isolate per-note retry execution so concurrent retries do not mix note state or current global settings
- persist retry-relevant history fields and improve local `mlx_whisper` output/error handling
- keep note browser rows at a consistent height and top-align row content

## Test plan
- [x] Build and install Quill with Apple Development signing
- [x] Verify `mlx-whisper` and `ffmpeg` are installed locally
- [ ] Retry two different failed notes concurrently and confirm their states/results stay isolated
- [ ] Retry a failed note after changing global transcription settings and confirm the note reuses persisted retry settings
- [ ] Confirm note list rows keep a consistent height and top-aligned text for empty/error/non-empty items

🤖 Generated with [Claude Code](https://claude.com/claude-code)