### PR TITLE
Add Apple Speech live transcription

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ARCH ?= $(shell uname -m)
 ICON_SOURCE = Resources/AppIcon-Source.png
 ICON_ICNS = Resources/AppIcon.icns
 
-.PHONY: all clean run icon dmg codesign-dmg notarize install
+.PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run
 
 all: $(APP_EXECUTABLE_TARGET)
 
@@ -111,9 +111,19 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 install: all
-	@rm -rf "/Applications/$(APP_NAME).app"
-	@cp -R "$(APP_BUNDLE)" /Applications/
+	@mkdir -p "/Applications/$(APP_NAME).app"
+	@ditto "$(APP_BUNDLE)" "/Applications/$(APP_NAME).app"
 	@echo "Installed $(APP_NAME).app to /Applications"
+
+reset-permissions:
+	tccutil reset All "$(BUNDLE_ID)"
+
+install-and-run: install
+	@if pgrep -fl "/Applications/$(APP_NAME).app|$(APP_NAME)" >/dev/null; then \
+		pkill -f "/Applications/$(APP_NAME).app|$(APP_NAME)"; \
+		sleep 1; \
+	fi
+	@open "/Applications/$(APP_NAME).app"
 
 run: all
 	open "$(APP_BUNDLE)"

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -258,7 +258,9 @@ private func showNoteBrowserWindow() {
         }
 
         if !AXIsProcessTrusted() {
-            appState.showAccessibilityAlert()
+            Task { @MainActor in
+                appState.showAccessibilityAlert()
+            }
         }
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1967,7 +1967,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     }
 
                     transcriber.onAudioLevel = { [weak self] level in
-                        self?.overlayManager.updateAudioLevel(level)
+                        Task { @MainActor [weak self] in
+                            self?.overlayManager.updateAudioLevel(level)
+                        }
                     }
 
                     // 녹음 시작 전 예비 노트를 생성해 Note Browser에 즉시 표시

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -470,6 +470,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var transcriptionTask: Task<Void, Never>?
     private var liveTranscriber: (any LiveTranscriber)?
     private var liveNoteID: UUID?
+    private var isCancelConfirmationShowing = false
     private var transcribingAudioFileName: String?
     private var overlayTranscriptionID: UUID = UUID()
     private var contextService: AppContextService

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -468,6 +468,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var recordingInitializationTimer: DispatchSourceTimer?
     private var transcribingIndicatorTask: Task<Void, Never>?
     private var transcriptionTask: Task<Void, Never>?
+    private var liveTranscriber: (any LiveTranscriber)?
+    private var liveNoteID: UUID?
     private var transcribingAudioFileName: String?
     private var overlayTranscriptionID: UUID = UUID()
     private var contextService: AppContextService
@@ -1541,6 +1543,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
         activeRecordingTriggerMode = nil
         audioRecorder.onRecordingReady = nil
         audioRecorder.onRecordingFailure = nil
+        audioRecorder.onAudioBuffer = nil
+        liveTranscriber?.cancel()
+        liveTranscriber = nil
+        if let id = liveNoteID {
+            liveNoteID = nil
+            pipelineHistory.removeAll { $0.id == id }
+            try? pipelineHistoryStore.delete(id: id)
+        }
         audioLevelCancellable?.cancel()
         audioLevelCancellable = nil
         cancelRecordingInitializationTimer()
@@ -1941,26 +1951,71 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         // Start engine on background thread so UI isn't blocked
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            guard let self else { return }
-            let t0 = CFAbsoluteTimeGetCurrent()
-            do {
-                try self.audioRecorder.startRecording(deviceUID: deviceUID)
-                os_log(.info, log: recordingLog, "audioRecorder.startRecording() done: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-                DispatchQueue.main.async {
-                    guard self.isRecording, self.activeRecordingTriggerMode != nil else { return }
-                    self.startContextCapture()
-                    self.audioLevelCancellable = self.audioRecorder.$audioLevel
-                        .receive(on: DispatchQueue.main)
-                        .sink { [weak self] level in
-                            self?.overlayManager.updateAudioLevel(level)
+        if useLocalTranscription, let transcriber = localTranscriptionModel.makeLiveTranscriber() {
+            // Live transcription: initialize before recording starts so the request is ready
+            // to receive buffers from the very first sample
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    try await transcriber.start(locale: transcriptionLanguage.sfSpeechLocale)
+                    self.liveTranscriber = transcriber
+                    self.audioRecorder.onAudioBuffer = { [weak transcriber] buffer in
+                        transcriber?.append(buffer)
+                    }
+
+                    // 녹음 시작 전 예비 노트를 생성해 Note Browser에 즉시 표시
+                    let liveID = UUID()
+                    transcriber.onPartialResult = { [weak self] text in
+                        Task { @MainActor [weak self] in
+                            self?.updateLiveNoteTranscript(text)
                         }
+                    }
+                    await MainActor.run {
+                        self.createLiveNote(id: liveID)
+                    }
+
+                    let t0 = CFAbsoluteTimeGetCurrent()
+                    try self.audioRecorder.startRecording(deviceUID: deviceUID)
+                    os_log(.info, log: recordingLog, "audioRecorder.startRecording() done: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
+                    await MainActor.run {
+                        guard self.isRecording, self.activeRecordingTriggerMode != nil else { return }
+                        self.startContextCapture()
+                        self.audioLevelCancellable = self.audioRecorder.$audioLevel
+                            .receive(on: DispatchQueue.main)
+                            .sink { [weak self] level in
+                                self?.overlayManager.updateAudioLevel(level)
+                            }
+                    }
+                } catch {
+                    await MainActor.run {
+                        self.cancelRecordingInitializationTimer()
+                        guard self.isRecording || self.activeRecordingTriggerMode != nil else { return }
+                        self.handleRecordingFailure(error)
+                    }
                 }
-            } catch {
-                DispatchQueue.main.async {
-                    self.cancelRecordingInitializationTimer()
-                    guard self.isRecording || self.activeRecordingTriggerMode != nil else { return }
-                    self.handleRecordingFailure(error)
+            }
+        } else {
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                guard let self else { return }
+                let t0 = CFAbsoluteTimeGetCurrent()
+                do {
+                    try self.audioRecorder.startRecording(deviceUID: deviceUID)
+                    os_log(.info, log: recordingLog, "audioRecorder.startRecording() done: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
+                    DispatchQueue.main.async {
+                        guard self.isRecording, self.activeRecordingTriggerMode != nil else { return }
+                        self.startContextCapture()
+                        self.audioLevelCancellable = self.audioRecorder.$audioLevel
+                            .receive(on: DispatchQueue.main)
+                            .sink { [weak self] level in
+                                self?.overlayManager.updateAudioLevel(level)
+                            }
+                    }
+                } catch {
+                    DispatchQueue.main.async {
+                        self.cancelRecordingInitializationTimer()
+                        guard self.isRecording || self.activeRecordingTriggerMode != nil else { return }
+                        self.handleRecordingFailure(error)
+                    }
                 }
             }
         }
@@ -2245,20 +2300,28 @@ final class AppState: ObservableObject, @unchecked Sendable {
             let capturedTranscriptionModel = self.transcriptionModel
             let capturedCustomVocabulary = self.customVocabulary
             let capturedCustomSystemPrompt = self.customSystemPrompt
+            let capturedLiveTranscriber = self.liveTranscriber
+            self.liveTranscriber = nil
+            self.audioRecorder.onAudioBuffer = nil
             self.transcriptionTask = Task { [weak self] in
                 guard let self else { return }
                 do {
-                    let transcriptionService = try TranscriptionService(
-                        apiKey: capturedApiKey,
-                        baseURL: capturedApiBaseURL,
-                        useLocalTranscription: capturedUseLocalTranscription,
-                        localWhisperPath: capturedLocalWhisperPath.isEmpty ? nil : capturedLocalWhisperPath,
-                        transcriptionLanguage: capturedTranscriptionLanguage,
-                        localTranscriptionModel: capturedLocalTranscriptionModel,
-                        transcriptionModel: capturedTranscriptionModel
-                    )
-                    async let transcript = transcriptionService.transcribe(fileURL: transcriptionFileURL)
-                    let rawTranscript = try await transcript
+                    let rawTranscript: String
+                    let liveResult = try await capturedLiveTranscriber?.finalize()
+                    if let text = liveResult, !text.isEmpty {
+                        rawTranscript = text
+                    } else {
+                        let transcriptionService = try TranscriptionService(
+                            apiKey: capturedApiKey,
+                            baseURL: capturedApiBaseURL,
+                            useLocalTranscription: capturedUseLocalTranscription,
+                            localWhisperPath: capturedLocalWhisperPath.isEmpty ? nil : capturedLocalWhisperPath,
+                            transcriptionLanguage: capturedTranscriptionLanguage,
+                            localTranscriptionModel: capturedLocalTranscriptionModel,
+                            transcriptionModel: capturedTranscriptionModel
+                        )
+                        rawTranscript = try await transcriptionService.transcribe(fileURL: transcriptionFileURL)
+                    }
                     try Task.checkCancellation()
                     let appContext: AppContext
                     if let sessionContext {
@@ -2403,6 +2466,68 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    // 라이브 전사 시작 시 Note Browser에 즉시 표시될 예비 노트 생성
+    private func createLiveNote(id: UUID) {
+        liveNoteID = id
+        let entry = PipelineHistoryItem(
+            id: id,
+            timestamp: Date(),
+            rawTranscript: "",
+            postProcessedTranscript: "",
+            postProcessingPrompt: nil,
+            contextSummary: "",
+            contextPrompt: nil,
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "",
+            postProcessingStatus: "live-recording",
+            debugStatus: "",
+            customVocabulary: "",
+            usedLocalTranscription: true,
+            usedContextCapture: false,
+            usedPostProcessing: false,
+            transcriptionLanguageCode: transcriptionLanguage.code
+        )
+        do {
+            let removed = try pipelineHistoryStore.append(entry, maxCount: maxPipelineHistoryCount)
+            for f in removed { Self.deleteAudioFile(f) }
+            pipelineHistory = pipelineHistoryStore.loadAllHistory()
+        } catch {
+            liveNoteID = nil
+        }
+    }
+
+    // 라이브 전사 partial 결과로 노트 텍스트 업데이트
+    @MainActor
+    private func updateLiveNoteTranscript(_ text: String) {
+        guard let id = liveNoteID,
+              let index = pipelineHistory.firstIndex(where: { $0.id == id }) else { return }
+        let existing = pipelineHistory[index]
+        let updated = PipelineHistoryItem(
+            intent: existing.intent,
+            selectedText: existing.selectedText,
+            id: existing.id,
+            timestamp: existing.timestamp,
+            rawTranscript: existing.rawTranscript,
+            postProcessedTranscript: text,
+            postProcessingPrompt: existing.postProcessingPrompt,
+            contextSummary: existing.contextSummary,
+            contextPrompt: existing.contextPrompt,
+            contextScreenshotDataURL: existing.contextScreenshotDataURL,
+            contextScreenshotStatus: existing.contextScreenshotStatus,
+            postProcessingStatus: "live-recording",
+            debugStatus: existing.debugStatus,
+            customVocabulary: existing.customVocabulary,
+            audioFileName: existing.audioFileName,
+            usedLocalTranscription: existing.usedLocalTranscription,
+            usedContextCapture: existing.usedContextCapture,
+            usedPostProcessing: existing.usedPostProcessing,
+            transcriptionLanguageCode: existing.transcriptionLanguageCode,
+            transcriptFileName: existing.transcriptFileName
+        )
+        // DB write 없이 메모리만 업데이트 — partial 결과는 최종 저장 시 반영됨
+        pipelineHistory[index] = updated
+    }
+
     private func recordPipelineHistoryEntry(
         rawTranscript: String,
         postProcessedTranscript: String,
@@ -2416,10 +2541,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
             rawTranscript: rawTranscript,
             postProcessedTranscript: postProcessedTranscript
         )
-        let newEntry = PipelineHistoryItem(
+        let existingID = liveNoteID
+        liveNoteID = nil
+        let entry = PipelineHistoryItem(
             intent: intent.persistedIntent,
             selectedText: intent.persistedSelectedText,
-            timestamp: Date(),
+            id: existingID ?? UUID(),
+            timestamp: existingID != nil
+                ? (pipelineHistory.first(where: { $0.id == existingID })?.timestamp ?? Date())
+                : Date(),
             rawTranscript: "",
             postProcessedTranscript: postProcessedTranscript,
             postProcessingPrompt: postProcessingPrompt,
@@ -2441,9 +2571,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
             transcriptFileName: transcriptFileName
         )
         do {
-            let removedAudioFileNames = try pipelineHistoryStore.append(newEntry, maxCount: maxPipelineHistoryCount)
-            for audioFileName in removedAudioFileNames {
-                Self.deleteAudioFile(audioFileName)
+            if existingID != nil {
+                try pipelineHistoryStore.update(entry)
+            } else {
+                let removedAudioFileNames = try pipelineHistoryStore.append(entry, maxCount: maxPipelineHistoryCount)
+                for audioFileName in removedAudioFileNames {
+                    Self.deleteAudioFile(audioFileName)
+                }
             }
             pipelineHistory = pipelineHistoryStore.loadAllHistory()
         } catch {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1960,8 +1960,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 do {
                     try await transcriber.start(locale: transcriptionLanguage.sfSpeechLocale)
                     self.liveTranscriber = transcriber
-                    self.audioRecorder.onAudioBuffer = { [weak transcriber] buffer in
-                        transcriber?.append(buffer)
+                    if !transcriber.handlesRecording {
+                        self.audioRecorder.onAudioBuffer = { [weak transcriber] buffer in
+                            transcriber?.append(buffer)
+                        }
                     }
 
                     // 녹음 시작 전 예비 노트를 생성해 Note Browser에 즉시 표시
@@ -1976,16 +1978,23 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     }
 
                     let t0 = CFAbsoluteTimeGetCurrent()
-                    try self.audioRecorder.startRecording(deviceUID: deviceUID)
-                    os_log(.info, log: recordingLog, "audioRecorder.startRecording() done: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
+                    if transcriber.handlesRecording {
+                        // AVAudioEngine이 transcriber.start()에서 이미 시작됨 — 녹음 UI만 트리거
+                        self.audioRecorder.onRecordingReady?()
+                    } else {
+                        try self.audioRecorder.startRecording(deviceUID: deviceUID)
+                        os_log(.info, log: recordingLog, "audioRecorder.startRecording() done: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
+                    }
                     await MainActor.run {
                         guard self.isRecording, self.activeRecordingTriggerMode != nil else { return }
                         self.startContextCapture()
-                        self.audioLevelCancellable = self.audioRecorder.$audioLevel
-                            .receive(on: DispatchQueue.main)
-                            .sink { [weak self] level in
-                                self?.overlayManager.updateAudioLevel(level)
-                            }
+                        if !transcriber.handlesRecording {
+                            self.audioLevelCancellable = self.audioRecorder.$audioLevel
+                                .receive(on: DispatchQueue.main)
+                                .sink { [weak self] level in
+                                    self?.overlayManager.updateAudioLevel(level)
+                                }
+                        }
                     }
                 } catch {
                     await MainActor.run {
@@ -2245,6 +2254,184 @@ final class AppState: ObservableObject, @unchecked Sendable {
         errorMessage = nil
         playAlertSound(named: "Pop")
         overlayManager.prepareForTranscribing()
+        let postProcessingService = PostProcessingService(
+            apiKey: apiKey,
+            baseURL: apiBaseURL,
+            preferredModel: postProcessingModel,
+            preferredFallbackModel: postProcessingFallbackModel
+        )
+        let capturedApiKey = apiKey
+        let capturedApiBaseURL = apiBaseURL
+        let capturedUseLocalTranscription = useLocalTranscription
+        let capturedLocalWhisperPath = localWhisperPath
+        let capturedTranscriptionLanguage = transcriptionLanguage
+        let capturedLocalTranscriptionModel = localTranscriptionModel
+        let capturedTranscriptionModel = transcriptionModel
+        let capturedCustomVocabulary = customVocabulary
+        let capturedCustomSystemPrompt = customSystemPrompt
+        let capturedLiveTranscriber = liveTranscriber
+        liveTranscriber = nil
+        audioRecorder.onAudioBuffer = nil
+
+        if let transcriber = capturedLiveTranscriber, transcriber.handlesRecording {
+            // AVAudioEngine 기반: AudioRecorder 없이 직접 전사 + 파일 저장
+            if overlayTranscriptionID == myOverlayID {
+                transcribingAudioFileName = nil
+                statusText = "Transcribing..."
+                debugStatusMessage = "Transcribing audio"
+                transcribingIndicatorTask?.cancel()
+                let indicatorDelay = transcribingIndicatorDelay
+                transcribingIndicatorTask = Task { [weak self] in
+                    do {
+                        try await Task.sleep(nanoseconds: UInt64(indicatorDelay * 1_000_000_000))
+                        guard self?.overlayTranscriptionID == myOverlayID else { return }
+                        await MainActor.run { [weak self] in
+                            guard self?.overlayTranscriptionID == myOverlayID else { return }
+                            self?.overlayManager.showTranscribing()
+                        }
+                    } catch {}
+                }
+            }
+            transcriptionTask = Task { [weak self] in
+                guard let self else { return }
+                do {
+                    let rawTranscript = try await transcriber.finalize()
+                    let savedAudioFile = transcriber.recordedAudioURL.flatMap { url -> SavedAudioFile? in
+                        let saved = Self.saveAudioFile(from: url)
+                        try? FileManager.default.removeItem(at: url)
+                        return saved
+                    }
+                    try Task.checkCancellation()
+                    let appContext: AppContext
+                    if let sessionContext {
+                        appContext = sessionContext
+                    } else if let inFlightContext = await inFlightContextTask?.value {
+                        appContext = inFlightContext
+                    } else {
+                        appContext = self.fallbackContextAtStop()
+                    }
+                    try Task.checkCancellation()
+                    await MainActor.run { [weak self] in
+                        self?.debugStatusMessage = "Running post-processing"
+                    }
+                    let result = await self.processTranscript(
+                        rawTranscript,
+                        intent: sessionIntent,
+                        context: appContext,
+                        postProcessingService: postProcessingService,
+                        customVocabulary: capturedCustomVocabulary,
+                        customSystemPrompt: capturedCustomSystemPrompt
+                    )
+                    try Task.checkCancellation()
+                    await MainActor.run {
+                        let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+                        let trimmedFinalTranscript = result.finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+                        let processingStatus = result.outcome.statusMessage()
+                        self.recordPipelineHistoryEntry(
+                            rawTranscript: trimmedRawTranscript,
+                            postProcessedTranscript: trimmedFinalTranscript,
+                            postProcessingPrompt: result.prompt,
+                            context: appContext,
+                            processingStatus: processingStatus,
+                            intent: sessionIntent,
+                            audioFileName: savedAudioFile?.fileName
+                        )
+                        self.audioRecorder.cleanup()
+                        self.refreshAvailableMicrophonesIfNeeded()
+                        guard self.overlayTranscriptionID == myOverlayID else { return }
+                        self.lastContextSummary = appContext.contextSummary
+                        self.lastContextScreenshotDataURL = appContext.screenshotDataURL
+                        self.lastContextScreenshotStatus = appContext.screenshotError
+                            ?? "available (\(appContext.screenshotMimeType ?? "image"))"
+                        self.lastPostProcessingPrompt = result.prompt
+                        self.lastRawTranscript = trimmedRawTranscript
+                        self.lastPostProcessedTranscript = trimmedFinalTranscript
+                        self.lastPostProcessingStatus = processingStatus
+                        self.transcriptionTask = nil
+                        self.transcribingIndicatorTask?.cancel()
+                        self.transcribingIndicatorTask = nil
+                        self.transcribingAudioFileName = nil
+                        self.lastTranscript = trimmedFinalTranscript
+                        self.isTranscribing = false
+                        self.debugStatusMessage = "Done"
+                        let completionStatusText = self.preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
+                        let shouldPersistRawDictationFallback: Bool
+                        switch result.outcome {
+                        case .postProcessingFailedFallback:
+                            shouldPersistRawDictationFallback = !trimmedFinalTranscript.isEmpty
+                        default:
+                            shouldPersistRawDictationFallback = false
+                        }
+                        if trimmedFinalTranscript.isEmpty {
+                            self.mcpLastRecordingFailed = true
+                            self.statusText = "Nothing to transcribe"
+                            self.clearPendingOverlayDismissToken()
+                            self.overlayManager.dismiss()
+                        } else {
+                            self.statusText = completionStatusText
+                            if shouldPersistRawDictationFallback {
+                                self.scheduleOverlayDismissAfterFailureIndicator(after: 2.5)
+                            } else {
+                                self.clearPendingOverlayDismissToken()
+                                self.overlayManager.dismiss()
+                            }
+                            if !self.disableAutoPaste {
+                                let pendingClipboardRestore = self.writeTranscriptToPasteboard(trimmedFinalTranscript)
+                                self.pasteAtCursorWhenShortcutReleased {
+                                    self.restoreClipboardIfNeeded(pendingClipboardRestore)
+                                }
+                            }
+                        }
+                        self.scheduleReadyStatusReset(after: 3, matching: [completionStatusText, "Nothing to transcribe"])
+                    }
+                } catch is CancellationError {
+                    await MainActor.run {
+                        self.transcriptionTask = nil
+                    }
+                } catch {
+                    let resolvedContext: AppContext
+                    if let sessionContext {
+                        resolvedContext = sessionContext
+                    } else if let inFlightContext = await inFlightContextTask?.value {
+                        resolvedContext = inFlightContext
+                    } else {
+                        resolvedContext = self.fallbackContextAtStop()
+                    }
+                    await MainActor.run {
+                        self.recordPipelineHistoryEntry(
+                            rawTranscript: "",
+                            postProcessedTranscript: "",
+                            postProcessingPrompt: "",
+                            context: resolvedContext,
+                            processingStatus: "Error: \(error.localizedDescription)",
+                            intent: self.currentSessionIntent,
+                            audioFileName: nil
+                        )
+                        self.audioRecorder.cleanup()
+                        self.refreshAvailableMicrophonesIfNeeded()
+                        guard self.overlayTranscriptionID == myOverlayID else { return }
+                        self.transcriptionTask = nil
+                        self.transcribingIndicatorTask?.cancel()
+                        self.transcribingIndicatorTask = nil
+                        self.transcribingAudioFileName = nil
+                        self.errorMessage = error.localizedDescription
+                        self.isTranscribing = false
+                        self.statusText = "Error"
+                        self.overlayManager.dismiss()
+                        self.lastPostProcessedTranscript = ""
+                        self.lastRawTranscript = ""
+                        self.lastContextSummary = ""
+                        self.lastPostProcessingStatus = "Error: \(error.localizedDescription)"
+                        self.lastPostProcessingPrompt = ""
+                        self.lastContextScreenshotDataURL = resolvedContext.screenshotDataURL
+                        self.lastContextScreenshotStatus = resolvedContext.screenshotError
+                            ?? "available (\(resolvedContext.screenshotMimeType ?? "image"))"
+                    }
+                }
+            }
+            return
+        }
+
         audioRecorder.stopRecording { [weak self] fileURL in
             guard let self else { return }
             guard let fileURL else {
@@ -2284,26 +2471,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 }
             }
 
-        let postProcessingService = PostProcessingService(
-            apiKey: apiKey,
-            baseURL: apiBaseURL,
-            preferredModel: postProcessingModel,
-            preferredFallbackModel: postProcessingFallbackModel
-        )
-
-            // 이전 전사 태스크는 취소하지 않고 백그라운드에서 계속 실행
-            let capturedApiKey = self.apiKey
-            let capturedApiBaseURL = self.apiBaseURL
-            let capturedUseLocalTranscription = self.useLocalTranscription
-            let capturedLocalWhisperPath = self.localWhisperPath
-            let capturedTranscriptionLanguage = self.transcriptionLanguage
-            let capturedLocalTranscriptionModel = self.localTranscriptionModel
-            let capturedTranscriptionModel = self.transcriptionModel
-            let capturedCustomVocabulary = self.customVocabulary
-            let capturedCustomSystemPrompt = self.customSystemPrompt
-            let capturedLiveTranscriber = self.liveTranscriber
-            self.liveTranscriber = nil
-            self.audioRecorder.onAudioBuffer = nil
             self.transcriptionTask = Task { [weak self] in
                 guard let self else { return }
                 do {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2397,6 +2397,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     } else {
                         resolvedContext = self.fallbackContextAtStop()
                     }
+                    let errorAudioFile = transcriber.recordedAudioURL.flatMap { url -> SavedAudioFile? in
+                        let saved = Self.saveAudioFile(from: url)
+                        try? FileManager.default.removeItem(at: url)
+                        return saved
+                    }
                     await MainActor.run {
                         self.recordPipelineHistoryEntry(
                             rawTranscript: "",
@@ -2405,7 +2410,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             context: resolvedContext,
                             processingStatus: "Error: \(error.localizedDescription)",
                             intent: self.currentSessionIntent,
-                            audioFileName: nil
+                            audioFileName: errorAudioFile?.fileName
                         )
                         self.audioRecorder.cleanup()
                         self.refreshAvailableMicrophonesIfNeeded()

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2079,6 +2079,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     func showMicrophonePermissionAlert() {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.showMicrophonePermissionAlert()
+            }
+            return
+        }
+
         let alert = NSAlert()
         alert.messageText = "Microphone Permission Required"
         alert.informativeText = "Quill cannot record audio without Microphone access.\n\nGo to System Settings > Privacy & Security > Microphone and enable Quill."
@@ -2094,6 +2101,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     func showAccessibilityAlert() {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.showAccessibilityAlert()
+            }
+            return
+        }
+
         let alert = NSAlert()
         alert.messageText = "Accessibility Permission Required"
         alert.informativeText = "Quill cannot type transcriptions without Accessibility access.\n\nGo to System Settings > Privacy & Security > Accessibility and enable Quill."
@@ -2896,6 +2910,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private func showScreenshotPermissionAlert(message: String) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.showScreenshotPermissionAlert(message: message)
+            }
+            return
+        }
+
         let alert = NSAlert()
         alert.messageText = "Screen Recording Permission Required"
         alert.informativeText = "\(message)\n\nQuill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill."

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1966,6 +1966,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         }
                     }
 
+                    transcriber.onAudioLevel = { [weak self] level in
+                        self?.overlayManager.updateAudioLevel(level)
+                    }
+
                     // 녹음 시작 전 예비 노트를 생성해 Note Browser에 즉시 표시
                     let liveID = UUID()
                     transcriber.onPartialResult = { [weak self] text in

--- a/Sources/AppleSpeechLiveTranscriber.swift
+++ b/Sources/AppleSpeechLiveTranscriber.swift
@@ -64,9 +64,6 @@ final class AppleSpeechLiveTranscriber: LiveTranscriber {
         self.recognizer = recognizer
 
         let request = SFSpeechAudioBufferRecognitionRequest()
-        if recognizer.supportsOnDeviceRecognition {
-            request.requiresOnDeviceRecognition = true
-        }
         request.addsPunctuation = true
         request.shouldReportPartialResults = true
         self.recognitionRequest = request

--- a/Sources/AppleSpeechLiveTranscriber.swift
+++ b/Sources/AppleSpeechLiveTranscriber.swift
@@ -1,0 +1,234 @@
+import AVFoundation
+import CoreMedia
+import os.log
+import Speech
+
+private let speechLog = OSLog(subsystem: "com.woosublee.quill", category: "AppleSpeech")
+
+// 실시간 전사를 지원하는 모든 백엔드가 따르는 프로토콜
+protocol LiveTranscriber: AnyObject {
+    var onPartialResult: ((String) -> Void)? { get set }
+    func start(locale: Locale) async throws
+    func append(_ sampleBuffer: CMSampleBuffer)
+    func finalize() async throws -> String
+    func cancel()
+}
+
+// LiveTranscriber를 지원하는 모델인지 확인하고 인스턴스를 반환하는 팩토리
+extension TranscriptionModel {
+    func makeLiveTranscriber() -> (any LiveTranscriber)? {
+        if isAppleSpeech { return AppleSpeechLiveTranscriber() }
+        return nil
+    }
+}
+
+// MARK: - Apple Speech
+
+final class AppleSpeechLiveTranscriber: LiveTranscriber {
+    var onPartialResult: ((String) -> Void)?
+
+    private var recognizer: SFSpeechRecognizer?
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+
+    private let lock = OSAllocatedUnfairLock(initialState: ())
+    private var finalizeContinuation: CheckedContinuation<String, Error>?
+    private var finalResult: Result<String, Error>?
+    private var latestTranscript: String = ""
+    private var cachedConverter: AVAudioConverter?
+    private var appendCount = 0
+
+    // endAudio() 후 결과가 돌아오지 않을 때 대기하는 최대 시간
+    private static let finalizeTimeoutSeconds: TimeInterval = 10
+
+    func start(locale: Locale) async throws {
+        let authStatus = await withCheckedContinuation { (cont: CheckedContinuation<SFSpeechRecognizerAuthorizationStatus, Never>) in
+            SFSpeechRecognizer.requestAuthorization { cont.resume(returning: $0) }
+        }
+        os_log(.default, log: speechLog, "authStatus=%ld", authStatus.rawValue)
+        guard authStatus == .authorized else {
+            throw AppleSpeechError.notAuthorized
+        }
+
+        guard let recognizer = SFSpeechRecognizer(locale: locale), recognizer.isAvailable else {
+            os_log(.default, log: speechLog, "recognizer not available locale=%{public}@", locale.identifier)
+            throw AppleSpeechError.notAvailable(locale.identifier)
+        }
+        self.recognizer = recognizer
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.requiresOnDeviceRecognition = true
+        request.addsPunctuation = true
+        request.shouldReportPartialResults = true
+        self.recognitionRequest = request
+
+        os_log(.default, log: speechLog,
+               "recognition task starting locale=%{public}@ supportsOnDevice=%d",
+               locale.identifier, recognizer.supportsOnDeviceRecognition)
+        recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            self?.handleTaskResult(result, error: error)
+        }
+        os_log(.default, log: speechLog, "recognition task created state=%ld",
+               recognitionTask?.state.rawValue ?? -1)
+    }
+
+    // Called from AudioRecorder's sampleBufferQueue
+    func append(_ sampleBuffer: CMSampleBuffer) {
+        guard let request = recognitionRequest else { return }
+        guard let pcmBuffer = convertToSpeechBuffer(sampleBuffer) else { return }
+        request.append(pcmBuffer)
+        appendCount += 1
+        if appendCount == 1 || appendCount % 100 == 0 {
+            os_log(.default, log: speechLog, "appended buffer #%d frameLength=%d",
+                   appendCount, pcmBuffer.frameLength)
+        }
+    }
+
+    // CMSampleBuffer(Float32 interleaved) → AVAudioPCMBuffer(Float32 non-interleaved mono)
+    // SFSpeechRecognizer는 non-interleaved native-rate 버퍼에서 안정적으로 동작함
+    private func convertToSpeechBuffer(_ sampleBuffer: CMSampleBuffer) -> AVAudioPCMBuffer? {
+        guard let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer) else { return nil }
+        let srcFormat = AVAudioFormat(cmAudioFormatDescription: formatDescription)
+        let frameCount = AVAudioFrameCount(CMSampleBufferGetNumSamples(sampleBuffer))
+        guard frameCount > 0 else { return nil }
+
+        // 소스 버퍼 생성 (AudioRecorder의 interleaved Float32 포맷)
+        guard let srcBuffer = AVAudioPCMBuffer(pcmFormat: srcFormat, frameCapacity: frameCount) else { return nil }
+        srcBuffer.frameLength = frameCount
+        let copyStatus = CMSampleBufferCopyPCMDataIntoAudioBufferList(
+            sampleBuffer, at: 0, frameCount: Int32(frameCount), into: srcBuffer.mutableAudioBufferList
+        )
+        guard copyStatus == noErr else { return nil }
+
+        // 이미 non-interleaved mono면 그대로 반환
+        if !srcFormat.isInterleaved && srcFormat.channelCount == 1 {
+            return srcBuffer
+        }
+
+        // non-interleaved mono Float32로 변환 (변환기 캐싱으로 매 버퍼마다 재생성 방지)
+        if cachedConverter == nil {
+            let dstFormat = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: srcFormat.sampleRate,
+                channels: 1,
+                interleaved: false
+            )
+            guard let dstFormat else { return nil }
+            cachedConverter = AVAudioConverter(from: srcFormat, to: dstFormat)
+            os_log(.default, log: speechLog, "converter created sampleRate=%.0f", srcFormat.sampleRate)
+        }
+        guard let converter = cachedConverter,
+              let dstBuffer = AVAudioPCMBuffer(pcmFormat: converter.outputFormat, frameCapacity: frameCount) else { return nil }
+
+        var error: NSError?
+        let inputBlock: AVAudioConverterInputBlock = { _, outStatus in
+            outStatus.pointee = .haveData
+            return srcBuffer
+        }
+        let status = converter.convert(to: dstBuffer, error: &error, withInputFrom: inputBlock)
+        if let error {
+            os_log(.error, log: speechLog, "audio conversion failed: %{public}@", error.localizedDescription)
+            return nil
+        }
+        if appendCount <= 1 {
+            os_log(.default, log: speechLog,
+                   "convert status=%ld srcFrames=%d dstFrames=%d",
+                   status.rawValue, frameCount, dstBuffer.frameLength)
+        }
+        guard dstBuffer.frameLength > 0 else { return nil }
+        return dstBuffer
+    }
+
+    func finalize() async throws -> String {
+        os_log(.default, log: speechLog, "finalize() called endAudio()")
+        recognitionRequest?.endAudio()
+
+        if let existing = lock.withLock({ finalResult }) {
+            return try existing.get()
+        }
+
+        // endAudio() 후 결과가 돌아오지 않으면 타임아웃 후 현재까지 누적된 텍스트 반환
+        return try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask {
+                try await withCheckedThrowingContinuation { continuation in
+                    self.lock.withLock {
+                        if let result = self.finalResult {
+                            continuation.resume(with: result)
+                        } else {
+                            self.finalizeContinuation = continuation
+                        }
+                    }
+                }
+            }
+            group.addTask { [weak self] in
+                try await Task.sleep(nanoseconds: UInt64(Self.finalizeTimeoutSeconds * 1_000_000_000))
+                let latest = self?.lock.withLock { self?.latestTranscript ?? "" } ?? ""
+                os_log(.default, log: speechLog, "finalize timeout — returning latestTranscript=%{public}@", latest)
+                self?.resumeAll(with: .success(latest))
+                return latest
+            }
+            guard let result = try await group.next() else {
+                return lock.withLock { latestTranscript }
+            }
+            group.cancelAll()
+            return result
+        }
+    }
+
+    func cancel() {
+        recognitionTask?.cancel()
+        cachedConverter = nil
+        let latest = lock.withLock { latestTranscript }
+        resumeAll(with: .success(latest))
+    }
+
+    private func handleTaskResult(_ result: SFSpeechRecognitionResult?, error: Error?) {
+        if let result {
+            let text = result.bestTranscription.formattedString
+            lock.withLock { latestTranscript = text }
+            os_log(.default, log: speechLog, "result isFinal=%d text=%{public}@", result.isFinal, text)
+            // partial이든 final이든 UI 업데이트 — macOS는 partial 결과를 잘 안 보내므로 final도 반영
+            onPartialResult?(text)
+            if result.isFinal {
+                resumeAll(with: .success(text))
+            }
+        } else if let error {
+            let nsError = error as NSError
+            os_log(.error, log: speechLog, "recognition error domain=%{public}@ code=%ld msg=%{public}@",
+                   nsError.domain, nsError.code, nsError.localizedDescription)
+            if nsError.code == 1110 || nsError.code == 203 {
+                os_log(.default, log: speechLog, "handled silent error code=%ld", nsError.code)
+                resumeAll(with: .success(""))
+            } else {
+                resumeAll(with: .failure(error))
+            }
+        } else {
+            os_log(.default, log: speechLog, "task completed with no result/error")
+            resumeAll(with: .success(lock.withLock { latestTranscript }))
+        }
+    }
+
+    private func resumeAll(with result: Result<String, Error>) {
+        let continuation = lock.withLock { () -> CheckedContinuation<String, Error>? in
+            guard finalResult == nil else { return nil }
+            finalResult = result
+            defer { finalizeContinuation = nil }
+            return finalizeContinuation
+        }
+        continuation?.resume(with: result)
+    }
+}
+
+enum AppleSpeechError: LocalizedError {
+    case notAuthorized
+    case notAvailable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notAuthorized:
+            return "Speech recognition permission denied. Enable it in System Settings > Privacy & Security > Speech Recognition."
+        case .notAvailable(let locale):
+            return "Apple Speech Recognizer not available for '\(locale)'."
+        }
+    }
+}

--- a/Sources/AppleSpeechLiveTranscriber.swift
+++ b/Sources/AppleSpeechLiveTranscriber.swift
@@ -8,6 +8,7 @@ private let speechLog = OSLog(subsystem: "com.woosublee.quill", category: "Apple
 // 실시간 전사를 지원하는 모든 백엔드가 따르는 프로토콜
 protocol LiveTranscriber: AnyObject {
     var onPartialResult: ((String) -> Void)? { get set }
+    var onAudioLevel: ((Float) -> Void)? { get set }
     /// true이면 이 트랜스크라이버가 마이크 캡처와 파일 저장을 직접 처리 (AudioRecorder 불필요)
     var handlesRecording: Bool { get }
     /// finalize() 후 저장된 오디오 파일 URL (handlesRecording == true일 때만 유효)
@@ -30,6 +31,7 @@ extension TranscriptionModel {
 
 final class AppleSpeechLiveTranscriber: LiveTranscriber {
     var onPartialResult: ((String) -> Void)?
+    var onAudioLevel: ((Float) -> Void)?
     let handlesRecording = true
     private(set) var recordedAudioURL: URL?
 
@@ -41,6 +43,7 @@ final class AppleSpeechLiveTranscriber: LiveTranscriber {
     private var tempFileURL: URL?
 
     private let lock = OSAllocatedUnfairLock(initialState: ())
+    private let levelNormalizerLock = OSAllocatedUnfairLock(initialState: LiveAudioLevelNormalizer())
     private var finalizeContinuation: CheckedContinuation<String, Error>?
     private var finalResult: Result<String, Error>?
     private var latestTranscript: String = ""
@@ -88,9 +91,10 @@ final class AppleSpeechLiveTranscriber: LiveTranscriber {
         self.tempFileURL = tempURL
         self.audioFile = audioFile
 
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { [weak request] buffer, _ in
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { [weak self, weak request] buffer, _ in
             request?.append(buffer)
             try? audioFile.write(from: buffer)
+            self?.onAudioLevel?(self?.normalizedLevel(from: buffer) ?? 0)
         }
 
         engine.prepare()
@@ -141,6 +145,7 @@ final class AppleSpeechLiveTranscriber: LiveTranscriber {
     }
 
     func cancel() {
+        onAudioLevel?(0)
         stopEngine()
         recognitionTask?.cancel()
         if let url = tempFileURL {
@@ -159,6 +164,28 @@ final class AppleSpeechLiveTranscriber: LiveTranscriber {
         audioFile = nil
         audioEngine = nil
         os_log(.default, log: speechLog, "AVAudioEngine stopped")
+    }
+
+    private func normalizedLevel(from buffer: AVAudioPCMBuffer) -> Float {
+        guard let channelData = buffer.floatChannelData else { return 0 }
+        let channelCount = Int(buffer.format.channelCount)
+        let frameLength = Int(buffer.frameLength)
+        guard channelCount > 0, frameLength > 0 else { return 0 }
+
+        var sumOfSquares: Float = 0
+        for channel in 0..<channelCount {
+            let samples = channelData[channel]
+            for index in 0..<frameLength {
+                let sample = samples[index]
+                sumOfSquares += sample * sample
+            }
+        }
+
+        let sampleCount = Float(channelCount * frameLength)
+        let rms = sqrtf(sumOfSquares / max(sampleCount, 1))
+        return levelNormalizerLock.withLock {
+            $0.normalizedLevel(forRMS: rms)
+        }
     }
 
     private func handleTaskResult(_ result: SFSpeechRecognitionResult?, error: Error?) {

--- a/Sources/AppleSpeechLiveTranscriber.swift
+++ b/Sources/AppleSpeechLiveTranscriber.swift
@@ -3,7 +3,7 @@ import CoreMedia
 import os.log
 import Speech
 
-private let speechLog = OSLog(subsystem: "com.woosublee.quill", category: "AppleSpeech")
+private let speechLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "AppleSpeech")
 
 // 실시간 전사를 지원하는 모든 백엔드가 따르는 프로토콜
 protocol LiveTranscriber: AnyObject {
@@ -201,8 +201,10 @@ final class AppleSpeechLiveTranscriber: LiveTranscriber {
             let nsError = error as NSError
             os_log(.error, log: speechLog, "recognition error domain=%{public}@ code=%ld msg=%{public}@",
                    nsError.domain, nsError.code, nsError.localizedDescription)
-            if nsError.code == 1110 || nsError.code == 203 {
-                os_log(.default, log: speechLog, "handled silent error code=%ld", nsError.code)
+            let assistantNoSpeechErrorCode = 1110
+            let assistantRetryStoppedErrorCode = 203
+            if nsError.code == assistantNoSpeechErrorCode || nsError.code == assistantRetryStoppedErrorCode {
+                os_log(.default, log: speechLog, "handled Apple Speech non-fatal error code=%ld", nsError.code)
                 resumeAll(with: .success(lock.withLock { latestTranscript }))
             } else {
                 resumeAll(with: .failure(error))

--- a/Sources/AppleSpeechLiveTranscriber.swift
+++ b/Sources/AppleSpeechLiveTranscriber.swift
@@ -8,6 +8,10 @@ private let speechLog = OSLog(subsystem: "com.woosublee.quill", category: "Apple
 // 실시간 전사를 지원하는 모든 백엔드가 따르는 프로토콜
 protocol LiveTranscriber: AnyObject {
     var onPartialResult: ((String) -> Void)? { get set }
+    /// true이면 이 트랜스크라이버가 마이크 캡처와 파일 저장을 직접 처리 (AudioRecorder 불필요)
+    var handlesRecording: Bool { get }
+    /// finalize() 후 저장된 오디오 파일 URL (handlesRecording == true일 때만 유효)
+    var recordedAudioURL: URL? { get }
     func start(locale: Locale) async throws
     func append(_ sampleBuffer: CMSampleBuffer)
     func finalize() async throws -> String
@@ -26,17 +30,20 @@ extension TranscriptionModel {
 
 final class AppleSpeechLiveTranscriber: LiveTranscriber {
     var onPartialResult: ((String) -> Void)?
+    let handlesRecording = true
+    private(set) var recordedAudioURL: URL?
 
     private var recognizer: SFSpeechRecognizer?
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?
+    private var audioEngine: AVAudioEngine?
+    private var audioFile: AVAudioFile?
+    private var tempFileURL: URL?
 
     private let lock = OSAllocatedUnfairLock(initialState: ())
     private var finalizeContinuation: CheckedContinuation<String, Error>?
     private var finalResult: Result<String, Error>?
     private var latestTranscript: String = ""
-    private var cachedConverter: AVAudioConverter?
-    private var appendCount = 0
 
     // endAudio() 후 결과가 돌아오지 않을 때 대기하는 최대 시간
     private static let finalizeTimeoutSeconds: TimeInterval = 10
@@ -57,7 +64,9 @@ final class AppleSpeechLiveTranscriber: LiveTranscriber {
         self.recognizer = recognizer
 
         let request = SFSpeechAudioBufferRecognitionRequest()
-        request.requiresOnDeviceRecognition = true
+        if recognizer.supportsOnDeviceRecognition {
+            request.requiresOnDeviceRecognition = true
+        }
         request.addsPunctuation = true
         request.shouldReportPartialResults = true
         self.recognitionRequest = request
@@ -68,79 +77,38 @@ final class AppleSpeechLiveTranscriber: LiveTranscriber {
         recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
             self?.handleTaskResult(result, error: error)
         }
-        os_log(.default, log: speechLog, "recognition task created state=%ld",
-               recognitionTask?.state.rawValue ?? -1)
+
+        // AVAudioEngine으로 마이크를 직접 탭 — SFSpeechRecognizer 공급 + 파일 저장을 하나의 세션으로 처리
+        let engine = AVAudioEngine()
+        let inputNode = engine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+        os_log(.default, log: speechLog, "engine input format sampleRate=%.0f channels=%d",
+               format.sampleRate, format.channelCount)
+
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".wav")
+        let audioFile = try AVAudioFile(forWriting: tempURL, settings: format.settings)
+        self.tempFileURL = tempURL
+        self.audioFile = audioFile
+
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { [weak request] buffer, _ in
+            request?.append(buffer)
+            try? audioFile.write(from: buffer)
+        }
+
+        engine.prepare()
+        try engine.start()
+        self.audioEngine = engine
+        os_log(.default, log: speechLog, "AVAudioEngine started")
     }
 
-    // Called from AudioRecorder's sampleBufferQueue
-    func append(_ sampleBuffer: CMSampleBuffer) {
-        guard let request = recognitionRequest else { return }
-        guard let pcmBuffer = convertToSpeechBuffer(sampleBuffer) else { return }
-        request.append(pcmBuffer)
-        appendCount += 1
-        if appendCount == 1 || appendCount % 100 == 0 {
-            os_log(.default, log: speechLog, "appended buffer #%d frameLength=%d",
-                   appendCount, pcmBuffer.frameLength)
-        }
-    }
-
-    // CMSampleBuffer(Float32 interleaved) → AVAudioPCMBuffer(Float32 non-interleaved mono)
-    // SFSpeechRecognizer는 non-interleaved native-rate 버퍼에서 안정적으로 동작함
-    private func convertToSpeechBuffer(_ sampleBuffer: CMSampleBuffer) -> AVAudioPCMBuffer? {
-        guard let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer) else { return nil }
-        let srcFormat = AVAudioFormat(cmAudioFormatDescription: formatDescription)
-        let frameCount = AVAudioFrameCount(CMSampleBufferGetNumSamples(sampleBuffer))
-        guard frameCount > 0 else { return nil }
-
-        // 소스 버퍼 생성 (AudioRecorder의 interleaved Float32 포맷)
-        guard let srcBuffer = AVAudioPCMBuffer(pcmFormat: srcFormat, frameCapacity: frameCount) else { return nil }
-        srcBuffer.frameLength = frameCount
-        let copyStatus = CMSampleBufferCopyPCMDataIntoAudioBufferList(
-            sampleBuffer, at: 0, frameCount: Int32(frameCount), into: srcBuffer.mutableAudioBufferList
-        )
-        guard copyStatus == noErr else { return nil }
-
-        // 이미 non-interleaved mono면 그대로 반환
-        if !srcFormat.isInterleaved && srcFormat.channelCount == 1 {
-            return srcBuffer
-        }
-
-        // non-interleaved mono Float32로 변환 (변환기 캐싱으로 매 버퍼마다 재생성 방지)
-        if cachedConverter == nil {
-            let dstFormat = AVAudioFormat(
-                commonFormat: .pcmFormatFloat32,
-                sampleRate: srcFormat.sampleRate,
-                channels: 1,
-                interleaved: false
-            )
-            guard let dstFormat else { return nil }
-            cachedConverter = AVAudioConverter(from: srcFormat, to: dstFormat)
-            os_log(.default, log: speechLog, "converter created sampleRate=%.0f", srcFormat.sampleRate)
-        }
-        guard let converter = cachedConverter,
-              let dstBuffer = AVAudioPCMBuffer(pcmFormat: converter.outputFormat, frameCapacity: frameCount) else { return nil }
-
-        var error: NSError?
-        let inputBlock: AVAudioConverterInputBlock = { _, outStatus in
-            outStatus.pointee = .haveData
-            return srcBuffer
-        }
-        let status = converter.convert(to: dstBuffer, error: &error, withInputFrom: inputBlock)
-        if let error {
-            os_log(.error, log: speechLog, "audio conversion failed: %{public}@", error.localizedDescription)
-            return nil
-        }
-        if appendCount <= 1 {
-            os_log(.default, log: speechLog,
-                   "convert status=%ld srcFrames=%d dstFrames=%d",
-                   status.rawValue, frameCount, dstBuffer.frameLength)
-        }
-        guard dstBuffer.frameLength > 0 else { return nil }
-        return dstBuffer
-    }
+    // AVAudioEngine이 마이크를 직접 탭하므로 AudioRecorder 버퍼는 사용하지 않음
+    func append(_ sampleBuffer: CMSampleBuffer) {}
 
     func finalize() async throws -> String {
-        os_log(.default, log: speechLog, "finalize() called endAudio()")
+        os_log(.default, log: speechLog, "finalize() called")
+        stopEngine()
+        recordedAudioURL = tempFileURL
         recognitionRequest?.endAudio()
 
         if let existing = lock.withLock({ finalResult }) {
@@ -176,10 +144,24 @@ final class AppleSpeechLiveTranscriber: LiveTranscriber {
     }
 
     func cancel() {
+        stopEngine()
         recognitionTask?.cancel()
-        cachedConverter = nil
+        if let url = tempFileURL {
+            try? FileManager.default.removeItem(at: url)
+            tempFileURL = nil
+        }
+        recordedAudioURL = nil
         let latest = lock.withLock { latestTranscript }
         resumeAll(with: .success(latest))
+    }
+
+    private func stopEngine() {
+        guard let engine = audioEngine else { return }
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        audioFile = nil
+        audioEngine = nil
+        os_log(.default, log: speechLog, "AVAudioEngine stopped")
     }
 
     private func handleTaskResult(_ result: SFSpeechRecognitionResult?, error: Error?) {
@@ -187,7 +169,6 @@ final class AppleSpeechLiveTranscriber: LiveTranscriber {
             let text = result.bestTranscription.formattedString
             lock.withLock { latestTranscript = text }
             os_log(.default, log: speechLog, "result isFinal=%d text=%{public}@", result.isFinal, text)
-            // partial이든 final이든 UI 업데이트 — macOS는 partial 결과를 잘 안 보내므로 final도 반영
             onPartialResult?(text)
             if result.isFinal {
                 resumeAll(with: .success(text))
@@ -198,7 +179,7 @@ final class AppleSpeechLiveTranscriber: LiveTranscriber {
                    nsError.domain, nsError.code, nsError.localizedDescription)
             if nsError.code == 1110 || nsError.code == 203 {
                 os_log(.default, log: speechLog, "handled silent error code=%ld", nsError.code)
-                resumeAll(with: .success(""))
+                resumeAll(with: .success(lock.withLock { latestTranscript }))
             } else {
                 resumeAll(with: .failure(error))
             }

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -94,6 +94,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
 
     var onRecordingReady: (() -> Void)?
     var onRecordingFailure: ((Error) -> Void)?
+    var onAudioBuffer: ((CMSampleBuffer) -> Void)?
     private var readyFired = false
     private var failureReported = false
     private static let watchdogTimeout: TimeInterval = 2.0
@@ -566,6 +567,8 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         from connection: AVCaptureConnection
     ) {
         guard _recording.withLock({ $0 }) else { return }
+
+        onAudioBuffer?(sampleBuffer)
 
         do {
             try appendSampleBufferToFile(sampleBuffer)

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -590,7 +590,7 @@ private struct NoteListRow: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 9)
-        .frame(maxWidth: .infinity, minHeight: 64, alignment: .topLeading)
+        .frame(maxWidth: .infinity, minHeight: 80, maxHeight: 80, alignment: .topLeading)
         .background {
             RoundedRectangle(cornerRadius: 8)
                 .fill(

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -96,6 +96,7 @@ private enum TranscriptStatus {
 
 private func transcriptStatus(for item: PipelineHistoryItem, retrying: Set<UUID>) -> TranscriptStatus {
     if retrying.contains(item.id) { return .progress }
+    if item.postProcessingStatus == "live-recording" { return .progress }
     if item.postProcessingStatus.hasPrefix("Error:") { return .fail }
     return .done
 }
@@ -578,13 +579,12 @@ private struct NoteListRow: View {
                     .foregroundStyle(isSelected ? .white : .primary)
                     .lineLimit(1)
 
-                if !notePreview.isEmpty {
-                    Text(notePreview)
-                        .font(.system(size: 11.5))
-                        .foregroundStyle(isSelected ? Color.white.opacity(0.72) : .secondary)
-                        .lineLimit(2)
-                        .multilineTextAlignment(.leading)
-                }
+                Text(notePreview.isEmpty ? " " : notePreview)
+                    .font(.system(size: 11.5))
+                    .foregroundStyle(isSelected ? Color.white.opacity(0.72) : .secondary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+                    .opacity(notePreview.isEmpty ? 0 : 1)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
@@ -611,10 +611,7 @@ private struct NoteListRow: View {
                 .fill(isSelected ? Color.white.opacity(0.5) : Color.green)
                 .frame(width: 6, height: 6)
         case .progress:
-            ProgressView()
-                .controlSize(.mini)
-                .scaleEffect(0.7)
-                .tint(isSelected ? .white : .orange)
+            YellowSpinner(color: isSelected ? .white : .yellow)
         case .fail:
             Circle()
                 .fill(isSelected ? Color.white.opacity(0.5) : Color.red)
@@ -635,7 +632,11 @@ private struct NoteListRow: View {
 
     private var autoTitle: String {
         let content = item.postProcessedTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-        if content.isEmpty { return status == .fail ? "전사 실패" : "(내용 없음)" }
+        if content.isEmpty {
+            if status == .fail { return "전사 실패" }
+            if status == .progress { return "녹음 중..." }
+            return "(내용 없음)"
+        }
         let firstLine = content.components(separatedBy: .newlines)
             .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? content
         let trimmed = firstLine.trimmingCharacters(in: .whitespaces)
@@ -672,6 +673,7 @@ private struct NoteDetailView: View {
     @State private var showDeleteConfirmation = false
 
     private var isError: Bool { item.postProcessingStatus.hasPrefix("Error:") }
+    private var isLiveRecording: Bool { item.postProcessingStatus == "live-recording" }
     private var canRetry: Bool { item.audioFileName != nil }
     private var displayContent: String { loadedContent ?? item.postProcessedTranscript }
 
@@ -722,7 +724,9 @@ private struct NoteDetailView: View {
                     .textCase(.uppercase)
                     .kerning(0.5)
                 statusBadges
-                if isError {
+                if isLiveRecording {
+                    LiveRecordingBadge()
+                } else if isError {
                     Image(systemName: "exclamationmark.triangle")
                         .font(.system(size: 10, weight: .light))
                         .foregroundStyle(.red.opacity(0.6))
@@ -1493,5 +1497,46 @@ private struct NoteTextView: NSViewRepresentable {
             RunLoop.current.add(timer, forMode: .common)
             debounceTimer = timer
         }
+    }
+}
+
+// MARK: - Shared Indicators
+
+private struct YellowSpinner: View {
+    var color: Color = .yellow
+    @State private var rotation: Double = 0
+
+    var body: some View {
+        Circle()
+            .trim(from: 0, to: 0.65)
+            .stroke(color, style: StrokeStyle(lineWidth: 1.5, lineCap: .round))
+            .frame(width: 8, height: 8)
+            .rotationEffect(.degrees(rotation))
+            .onAppear {
+                withAnimation(.linear(duration: 0.75).repeatForever(autoreverses: false)) {
+                    rotation = 360
+                }
+            }
+    }
+}
+
+// MARK: - Live Recording Badge
+
+private struct LiveRecordingBadge: View {
+    @State private var pulsing = false
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(Color.red)
+                .frame(width: 5, height: 5)
+                .opacity(pulsing ? 0.3 : 1.0)
+                .animation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true), value: pulsing)
+                .onAppear { pulsing = true }
+            Text("REC")
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .foregroundStyle(.red.opacity(0.7))
+        }
+        .help("실시간 전사 중")
     }
 }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -2411,7 +2411,11 @@ struct ModelRowView: View {
             .disabled(!isInstalled)
 
             // 상태 / 다운로드 버튼
-            if isDownloading {
+            if model.isAppleSpeech {
+                Label("Built-in", systemImage: "apple.logo")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            } else if isDownloading {
                 HStack(spacing: 4) {
                     ProgressView()
                         .controlSize(.mini)

--- a/Sources/TranscriptionLanguage.swift
+++ b/Sources/TranscriptionLanguage.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Speech
 
 struct TranscriptionLanguage: Identifiable, Hashable, Codable {
     let code: String      // mlx-whisper에 넘기는 언어 코드 (e.g. "ko")
@@ -28,5 +29,18 @@ struct TranscriptionLanguage: Identifiable, Hashable, Codable {
     // mlx-whisper에 넘길 인자값 (auto이면 language 옵션 생략)
     var whisperArgument: String? {
         code == "auto" ? nil : code
+    }
+
+    // SFSpeechRecognizer에 넘길 Locale (auto이면 시스템 언어 사용)
+    // 언어 코드만 있는 경우 SFSpeechRecognizer가 지원하는 전체 로케일 중 가장 근접한 것을 선택
+    var sfSpeechLocale: Locale {
+        if code == "auto" { return .current }
+        let requested = Locale(identifier: code)
+        let supported = SFSpeechRecognizer.supportedLocales()
+        // 정확히 일치하는 로케일이 있으면 그대로 사용
+        if supported.contains(requested) { return requested }
+        // 언어 코드가 같은 로케일 중 첫 번째 선택 (예: "ko" → "ko-KR")
+        let lang = requested.language.languageCode?.identifier ?? code
+        return supported.first { $0.language.languageCode?.identifier == lang } ?? requested
     }
 }

--- a/Sources/TranscriptionModel.swift
+++ b/Sources/TranscriptionModel.swift
@@ -1,11 +1,16 @@
 import Foundation
 
 struct TranscriptionModel: Identifiable, Hashable, Codable {
-    let id: String           // mlx-whisper에 넘기는 모델 ID
+    let id: String           // mlx-whisper에 넘기는 모델 ID (또는 "apple-speech" 센티넬)
     let displayName: String  // UI에 표시되는 이름
     let description: String  // 설명
 
     static let all: [TranscriptionModel] = [
+        TranscriptionModel(
+            id: "apple-speech",
+            displayName: "Apple Speech",
+            description: "시스템 내장 · 온디바이스 · 빠름"
+        ),
         TranscriptionModel(
             id: "mlx-community/whisper-large-v3-turbo",
             displayName: "Whisper Large v3 Turbo",
@@ -28,6 +33,8 @@ struct TranscriptionModel: Identifiable, Hashable, Codable {
         ),
     ]
 
+    var isAppleSpeech: Bool { id == "apple-speech" }
+
     static let `default` = all[0]
 
     static func find(id: String) -> TranscriptionModel {
@@ -42,6 +49,8 @@ struct TranscriptionModel: Identifiable, Hashable, Codable {
 
     // 모델 가중치 파일이 존재하는지 확인 (snapshots 또는 blobs)
     var isInstalled: Bool {
+        if isAppleSpeech { return true }
+
         let cacheDir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".cache/huggingface/hub")
             .appendingPathComponent(cacheDirectoryName)

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Foundation
+import Speech
 import os.log
 
 private let transcriptionLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "Transcription")
@@ -91,8 +92,53 @@ class TranscriptionService {
         }
     }
 
-    // Run mlx_whisper locally and return transcript text
+    // Run local transcription: Apple Speech or mlx_whisper
     private func transcribeAudioLocally(fileURL: URL) async throws -> String {
+        if localTranscriptionModel.isAppleSpeech {
+            return try await transcribeWithAppleSpeech(fileURL: fileURL)
+        }
+        return try await transcribeWithMlxWhisper(fileURL: fileURL)
+    }
+
+    private func transcribeWithAppleSpeech(fileURL: URL) async throws -> String {
+        let authStatus = await withCheckedContinuation { (continuation: CheckedContinuation<SFSpeechRecognizerAuthorizationStatus, Never>) in
+            SFSpeechRecognizer.requestAuthorization { continuation.resume(returning: $0) }
+        }
+        guard authStatus == .authorized else {
+            throw TranscriptionError.submissionFailed("Speech recognition permission denied. Enable it in System Settings > Privacy & Security > Speech Recognition.")
+        }
+
+        let locale = transcriptionLanguage.sfSpeechLocale
+        guard let recognizer = SFSpeechRecognizer(locale: locale), recognizer.isAvailable else {
+            throw TranscriptionError.submissionFailed("Apple Speech Recognizer not available for locale '\(locale.identifier)'")
+        }
+
+        let request = SFSpeechURLRecognitionRequest(url: fileURL)
+        request.requiresOnDeviceRecognition = true
+        request.addsPunctuation = true
+        request.shouldReportPartialResults = false
+
+        return try await withCheckedThrowingContinuation { continuation in
+            var resumed = false
+            recognizer.recognitionTask(with: request) { result, error in
+                guard !resumed else { return }
+                if let error = error {
+                    resumed = true
+                    continuation.resume(throwing: TranscriptionError.transcriptionFailed(error.localizedDescription))
+                    return
+                }
+                if let result = result, result.isFinal {
+                    resumed = true
+                    let text = result.bestTranscription.formattedString
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    continuation.resume(returning: text)
+                }
+            }
+        }
+    }
+
+    // Run mlx_whisper locally and return transcript text
+    private func transcribeWithMlxWhisper(fileURL: URL) async throws -> String {
         try await Task.detached(priority: .userInitiated) { [localWhisperPath, transcriptionLanguage, localTranscriptionModel] in
             let home = FileManager.default.homeDirectoryForCurrentUser.path
             let whisperBin = (localWhisperPath?.isEmpty == false)


### PR DESCRIPTION
## Summary
- add an Apple Speech live transcription path on top of the rebased shortcut refactor branch
- keep note browser row height fixed and improve the local dev install/relaunch workflow
- wire Apple Speech live audio levels into the overlay while preserving partial transcript updates

## Test plan
- [x] build Quill from the Apple Speech worktree with the Apple Development signing identity
- [x] install the build to /Applications/Quill.app and relaunch it locally
- [ ] verify Apple Speech live transcription returns partial/final transcript text in the app
- [ ] verify the recording overlay waveform responds to Apple Speech microphone input
- [ ] verify denied microphone permission shows an alert without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)