### PR TITLE
Document Quill MCP setup for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,29 @@ Some day!
 
 **Update:** You can now use a custom model with FreeFlow by configuring the LLM API URL in the FreeFlow settings to use Ollama. Thank you @taciturnaxolotl!
 
+## Claude Code MCP Setup
+
+Quill exposes a local MCP server at `http://localhost:3457` while the app is running.
+
+To connect Quill to Claude Code, run:
+
+```bash
+claude mcp add -s user -t http quill http://localhost:3457
+```
+
+Then:
+
+1. Install and launch Quill
+2. Complete the app setup if prompted
+3. Keep Quill running
+4. Ask Claude to use the `quill` MCP server
+
+### Notes
+
+- Quill MCP does not require a separate MCP API key.
+- This is a user-scoped local connection.
+- Each person should run Quill on their own machine and register their own local `quill` MCP server.
+
 ## License
 
 Licensed under the MIT license.

--- a/Sources/MCPServer.swift
+++ b/Sources/MCPServer.swift
@@ -4,7 +4,7 @@ import Combine
 
 // MCP server over HTTP (localhost:3457)
 // Claude Code MCP config:
-//   { "mcpServers": { "freeflow": { "url": "http://localhost:3457" } } }
+//   { "mcpServers": { "quill": { "url": "http://localhost:3457" } } }
 
 final class MCPServer {
     static let port: UInt16 = 3457


### PR DESCRIPTION
## Summary
- add README instructions for connecting Quill to Claude Code over MCP
- document the user-scoped `claude mcp add` command using the `quill` server name
- update the MCPServer config comment to match the documented server name

## Test plan
- [ ] Run `claude mcp add -s user -t http quill http://localhost:3457`
- [ ] Launch Quill and verify the `quill` MCP server connects successfully in Claude Code
- [ ] Ask Claude to use the `quill` MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)