### PR TITLE
Fix note file cleanup consistency

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1563,7 +1563,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         if let id = liveNoteID {
             liveNoteID = nil
             pipelineHistory.removeAll { $0.id == id }
-            _ = try? pipelineHistoryStore.delete(id: id)
+            if let deletedAssets = try? pipelineHistoryStore.delete(id: id) {
+                Self.deleteStoredFiles(deletedAssets)
+            }
         }
         audioLevelCancellable?.cancel()
         audioLevelCancellable = nil
@@ -2795,9 +2797,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
             pipelineHistory = pipelineHistoryStore.loadAllHistory()
         } catch {
-            if let transcriptFileName {
-                Self.deleteTranscriptFile(transcriptFileName)
-            }
+            Self.deleteStoredFiles(audioFileName: audioFileName, transcriptFileName: transcriptFileName)
             errorMessage = "Unable to save run history entry: \(error.localizedDescription)"
         }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -562,14 +562,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         let initialAccessibility = AXIsProcessTrusted()
         let initialScreenCapturePermission = CGPreflightScreenCaptureAccess()
-        var removedAudioFileNames: [String] = []
+        var removedStoredFiles: [DeletedPipelineHistoryAssets] = []
         do {
-            removedAudioFileNames = try pipelineHistoryStore.trim(to: maxPipelineHistoryCount)
+            removedStoredFiles = try pipelineHistoryStore.trim(to: maxPipelineHistoryCount)
         } catch {
             print("Failed to trim pipeline history during init: \(error)")
         }
-        for audioFileName in removedAudioFileNames {
-            Self.deleteAudioFile(audioFileName)
+        for removedAssets in removedStoredFiles {
+            Self.deleteStoredFiles(removedAssets)
         }
         let savedHistory = pipelineHistoryStore.loadAllHistory()
 
@@ -840,11 +840,24 @@ final class AppState: ObservableObject, @unchecked Sendable {
         try? FileManager.default.removeItem(at: fileURL)
     }
 
+    private static func deleteStoredFiles(audioFileName: String?, transcriptFileName: String?) {
+        if let audioFileName {
+            deleteAudioFile(audioFileName)
+        }
+        if let transcriptFileName {
+            deleteTranscriptFile(transcriptFileName)
+        }
+    }
+
+    private static func deleteStoredFiles(_ assets: DeletedPipelineHistoryAssets) {
+        deleteStoredFiles(audioFileName: assets.audioFileName, transcriptFileName: assets.transcriptFileName)
+    }
+
     func clearPipelineHistory() {
         do {
-            let removedAudioFileNames = try pipelineHistoryStore.clearAll()
-            for audioFileName in removedAudioFileNames {
-                Self.deleteAudioFile(audioFileName)
+            let removedStoredFiles = try pipelineHistoryStore.clearAll()
+            for removedAssets in removedStoredFiles {
+                Self.deleteStoredFiles(removedAssets)
             }
             pipelineHistory = []
         } catch {
@@ -855,8 +868,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     func deleteHistoryEntry(id: UUID) {
         guard let index = pipelineHistory.firstIndex(where: { $0.id == id }) else { return }
         do {
-            if let audioFileName = try pipelineHistoryStore.delete(id: id) {
-                Self.deleteAudioFile(audioFileName)
+            if let deletedAssets = try pipelineHistoryStore.delete(id: id) {
+                Self.deleteStoredFiles(deletedAssets)
             }
             pipelineHistory.remove(at: index)
         } catch {
@@ -1550,7 +1563,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         if let id = liveNoteID {
             liveNoteID = nil
             pipelineHistory.removeAll { $0.id == id }
-            try? pipelineHistoryStore.delete(id: id)
+            _ = try? pipelineHistoryStore.delete(id: id)
         }
         audioLevelCancellable?.cancel()
         audioLevelCancellable = nil
@@ -2682,7 +2695,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
         do {
             let removed = try pipelineHistoryStore.append(entry, maxCount: maxPipelineHistoryCount)
-            for f in removed { Self.deleteAudioFile(f) }
+            for removedAssets in removed {
+                Self.deleteStoredFiles(removedAssets)
+            }
             pipelineHistory = pipelineHistoryStore.loadAllHistory()
         } catch {
             liveNoteID = nil
@@ -2730,19 +2745,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
         intent: SessionIntent,
         audioFileName: String? = nil
     ) {
+        let existingID = liveNoteID
+        let existingEntry = existingID.flatMap { id in
+            pipelineHistory.first(where: { $0.id == id })
+        }
+        let previousTranscriptFileName = existingEntry?.transcriptFileName
         let transcriptFileName = Self.saveTranscriptFile(
             rawTranscript: rawTranscript,
             postProcessedTranscript: postProcessedTranscript
         )
-        let existingID = liveNoteID
         liveNoteID = nil
         let entry = PipelineHistoryItem(
             intent: intent.persistedIntent,
             selectedText: intent.persistedSelectedText,
             id: existingID ?? UUID(),
-            timestamp: existingID != nil
-                ? (pipelineHistory.first(where: { $0.id == existingID })?.timestamp ?? Date())
-                : Date(),
+            timestamp: existingEntry?.timestamp ?? Date(),
             rawTranscript: "",
             postProcessedTranscript: postProcessedTranscript,
             postProcessingPrompt: postProcessingPrompt,
@@ -2766,14 +2783,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
         do {
             if existingID != nil {
                 try pipelineHistoryStore.update(entry)
+                if let previousTranscriptFileName,
+                   previousTranscriptFileName != transcriptFileName {
+                    Self.deleteTranscriptFile(previousTranscriptFileName)
+                }
             } else {
-                let removedAudioFileNames = try pipelineHistoryStore.append(entry, maxCount: maxPipelineHistoryCount)
-                for audioFileName in removedAudioFileNames {
-                    Self.deleteAudioFile(audioFileName)
+                let removedStoredFiles = try pipelineHistoryStore.append(entry, maxCount: maxPipelineHistoryCount)
+                for removedAssets in removedStoredFiles {
+                    Self.deleteStoredFiles(removedAssets)
                 }
             }
             pipelineHistory = pipelineHistoryStore.loadAllHistory()
         } catch {
+            if let transcriptFileName {
+                Self.deleteTranscriptFile(transcriptFileName)
+            }
             errorMessage = "Unable to save run history entry: \(error.localizedDescription)"
         }
 

--- a/Sources/PipelineHistoryStore.swift
+++ b/Sources/PipelineHistoryStore.swift
@@ -1,6 +1,11 @@
 import Foundation
 import CoreData
 
+struct DeletedPipelineHistoryAssets {
+    let audioFileName: String?
+    let transcriptFileName: String?
+}
+
 final class PipelineHistoryStore {
     private let container: NSPersistentContainer
     private let isStoreLoaded: Bool
@@ -73,7 +78,7 @@ final class PipelineHistoryStore {
         return result
     }
 
-    func append(_ item: PipelineHistoryItem, maxCount: Int) throws -> [String] {
+    func append(_ item: PipelineHistoryItem, maxCount: Int) throws -> [DeletedPipelineHistoryAssets] {
         guard isStoreLoaded else { return [] }
         try insert(item)
         return try trim(to: maxCount)
@@ -116,17 +121,17 @@ final class PipelineHistoryStore {
         if let thrownError { throw thrownError }
     }
 
-    func delete(id: UUID) throws -> String? {
+    func delete(id: UUID) throws -> DeletedPipelineHistoryAssets? {
         guard isStoreLoaded else { return nil }
 
-        var deletedAudioFileName: String?
+        var deletedAssets: DeletedPipelineHistoryAssets?
         var thrownError: Error?
         container.viewContext.performAndWait {
             do {
                 let request = pipelineHistoryRequest()
                 request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
                 guard let entity = try container.viewContext.fetch(request).first else { return }
-                deletedAudioFileName = entity.audioFileName
+                deletedAssets = Self.deletedAssets(from: entity)
                 container.viewContext.delete(entity)
                 try saveContext()
             } catch {
@@ -134,20 +139,20 @@ final class PipelineHistoryStore {
             }
         }
         if let thrownError { throw thrownError }
-        return deletedAudioFileName
+        return deletedAssets
     }
 
-    func clearAll() throws -> [String] {
+    func clearAll() throws -> [DeletedPipelineHistoryAssets] {
         guard isStoreLoaded else { return [] }
 
-        var audioFileNames: [String] = []
+        var deletedAssets: [DeletedPipelineHistoryAssets] = []
         var thrownError: Error?
         container.viewContext.performAndWait {
             do {
                 let request = pipelineHistoryRequest()
                 request.sortDescriptors = [NSSortDescriptor(key: "timestamp", ascending: false)]
                 guard let entities = try? container.viewContext.fetch(request) else { return }
-                audioFileNames = entities.compactMap(\.audioFileName)
+                deletedAssets = entities.map(Self.deletedAssets(from:))
                 for entity in entities {
                     container.viewContext.delete(entity)
                 }
@@ -157,17 +162,17 @@ final class PipelineHistoryStore {
             }
         }
         if let thrownError { throw thrownError }
-        return audioFileNames
+        return deletedAssets
     }
 
-    func trim(to maxCount: Int) throws -> [String] {
+    func trim(to maxCount: Int) throws -> [DeletedPipelineHistoryAssets] {
         guard isStoreLoaded else { return [] }
         guard maxCount > 0 else {
-            let audioFileNames = try clearAll()
-            return audioFileNames
+            let deletedAssets = try clearAll()
+            return deletedAssets
         }
 
-        var audioFileNames: [String] = []
+        var deletedAssets: [DeletedPipelineHistoryAssets] = []
         var thrownError: Error?
         container.viewContext.performAndWait {
             do {
@@ -175,7 +180,7 @@ final class PipelineHistoryStore {
                 request.sortDescriptors = [NSSortDescriptor(key: "timestamp", ascending: false)]
                 guard let entities = try? container.viewContext.fetch(request), entities.count > maxCount else { return }
                 let dropped = entities[maxCount...]
-                audioFileNames = dropped.compactMap(\.audioFileName)
+                deletedAssets = dropped.map(Self.deletedAssets(from:))
                 for entity in dropped {
                     container.viewContext.delete(entity)
                 }
@@ -185,7 +190,7 @@ final class PipelineHistoryStore {
             }
         }
         if let thrownError { throw thrownError }
-        return audioFileNames
+        return deletedAssets
     }
 
     private func insert(_ item: PipelineHistoryItem) throws {
@@ -238,6 +243,13 @@ final class PipelineHistoryStore {
 
     private func pipelineHistoryRequest() -> NSFetchRequest<PipelineHistoryEntry> {
         NSFetchRequest<PipelineHistoryEntry>(entityName: "PipelineHistoryEntry")
+    }
+
+    private static func deletedAssets(from entity: PipelineHistoryEntry) -> DeletedPipelineHistoryAssets {
+        DeletedPipelineHistoryAssets(
+            audioFileName: entity.audioFileName,
+            transcriptFileName: entity.transcriptFileName
+        )
     }
 
     // Safe: loadPersistentStores calls back on a private queue, not the calling thread.


### PR DESCRIPTION
## Summary
- delete transcript files alongside audio when note history entries are removed, cleared, or trimmed
- return both audio and transcript filenames from `PipelineHistoryStore` cleanup paths so `AppState` can clean files consistently
- remove replaced transcript files after live-note updates and roll back newly created transcript files if persistence fails

## Test plan
- [x] `make all`
- [x] install `/Applications/Quill.app`, reset TCC, and relaunch the app
- [x] verify Quill DB/file storage consistency after orphan cleanup
- [x] create and delete a note in the app, then confirm DB and on-disk file counts stay in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)