### PR TITLE
Clean up orphaned stored files on launch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ ARCH ?= $(shell uname -m)
 ICON_SOURCE = Resources/AppIcon-Source.png
 ICON_ICNS = Resources/AppIcon.icns
 
+# Usage: make install CODESIGN_IDENTITY="Apple Development: you@example.com (TEAMID)"
 .PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run
 
 all: $(APP_EXECUTABLE_TARGET)
@@ -110,6 +111,7 @@ notarize:
 clean:
 	rm -rf $(BUILD_DIR)
 
+# Overwrite the installed app in place so macOS app permissions are preserved.
 install: all
 	@mkdir -p "/Applications/$(APP_NAME).app"
 	@ditto "$(APP_BUNDLE)" "/Applications/$(APP_NAME).app"

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -571,6 +571,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         for removedAssets in removedStoredFiles {
             Self.deleteStoredFiles(removedAssets)
         }
+        let referencedStoredFiles = pipelineHistoryStore.referencedStoredFiles()
+        Self.sweepOrphanStoredFiles(
+            referencedAudioFileNames: referencedStoredFiles.audioFileNames,
+            referencedTranscriptFileNames: referencedStoredFiles.transcriptFileNames
+        )
         let savedHistory = pipelineHistoryStore.loadAllHistory()
 
         let selectedMicrophoneID = UserDefaults.standard.string(forKey: selectedMicrophoneStorageKey) ?? "default"
@@ -799,6 +804,20 @@ final class AppState: ObservableObject, @unchecked Sendable {
             try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         }
         return dir
+    }
+
+    private static func sweepOrphanStoredFiles(referencedAudioFileNames: Set<String>, referencedTranscriptFileNames: Set<String>) {
+        let fileManager = FileManager.default
+        if let audioFiles = try? fileManager.contentsOfDirectory(atPath: audioStorageDirectory().path) {
+            for fileName in audioFiles where !referencedAudioFileNames.contains(fileName) {
+                deleteAudioFile(fileName)
+            }
+        }
+        if let transcriptFiles = try? fileManager.contentsOfDirectory(atPath: transcriptStorageDirectory().path) {
+            for fileName in transcriptFiles where !referencedTranscriptFileNames.contains(fileName) {
+                deleteTranscriptFile(fileName)
+            }
+        }
     }
 
     static func saveTranscriptFile(rawTranscript: String, postProcessedTranscript: String) -> String? {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -571,12 +571,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
         for removedAssets in removedStoredFiles {
             Self.deleteStoredFiles(removedAssets)
         }
-        let referencedStoredFiles = pipelineHistoryStore.referencedStoredFiles()
-        Self.sweepOrphanStoredFiles(
-            referencedAudioFileNames: referencedStoredFiles.audioFileNames,
-            referencedTranscriptFileNames: referencedStoredFiles.transcriptFileNames
-        )
         let savedHistory = pipelineHistoryStore.loadAllHistory()
+        let referencedAudioFileNames = Set(savedHistory.compactMap(\.audioFileName))
+        let referencedTranscriptFileNames = Set(savedHistory.compactMap(\.transcriptFileName))
+        Task.detached(priority: .background) {
+            Self.sweepOrphanStoredFiles(
+                referencedAudioFileNames: referencedAudioFileNames,
+                referencedTranscriptFileNames: referencedTranscriptFileNames
+            )
+        }
 
         let selectedMicrophoneID = UserDefaults.standard.string(forKey: selectedMicrophoneStorageKey) ?? "default"
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -811,14 +811,26 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private static func sweepOrphanStoredFiles(referencedAudioFileNames: Set<String>, referencedTranscriptFileNames: Set<String>) {
         let fileManager = FileManager.default
-        if let audioFiles = try? fileManager.contentsOfDirectory(atPath: audioStorageDirectory().path) {
+        let now = Date()
+        let gracePeriod: TimeInterval = 300
+        let audioDirectory = audioStorageDirectory()
+        if let audioFiles = try? fileManager.contentsOfDirectory(atPath: audioDirectory.path) {
             for fileName in audioFiles where !referencedAudioFileNames.contains(fileName) {
-                deleteAudioFile(fileName)
+                let fileURL = audioDirectory.appendingPathComponent(fileName)
+                guard let attributes = try? fileManager.attributesOfItem(atPath: fileURL.path),
+                      let modificationDate = attributes[.modificationDate] as? Date,
+                      now.timeIntervalSince(modificationDate) > gracePeriod else { continue }
+                try? fileManager.removeItem(at: fileURL)
             }
         }
-        if let transcriptFiles = try? fileManager.contentsOfDirectory(atPath: transcriptStorageDirectory().path) {
+        let transcriptDirectory = transcriptStorageDirectory()
+        if let transcriptFiles = try? fileManager.contentsOfDirectory(atPath: transcriptDirectory.path) {
             for fileName in transcriptFiles where !referencedTranscriptFileNames.contains(fileName) {
-                deleteTranscriptFile(fileName)
+                let fileURL = transcriptDirectory.appendingPathComponent(fileName)
+                guard let attributes = try? fileManager.attributesOfItem(atPath: fileURL.path),
+                      let modificationDate = attributes[.modificationDate] as? Date,
+                      now.timeIntervalSince(modificationDate) > gracePeriod else { continue }
+                try? fileManager.removeItem(at: fileURL)
             }
         }
     }

--- a/Sources/PipelineHistoryStore.swift
+++ b/Sources/PipelineHistoryStore.swift
@@ -193,27 +193,6 @@ final class PipelineHistoryStore {
         return deletedAssets
     }
 
-    func referencedStoredFiles() -> (audioFileNames: Set<String>, transcriptFileNames: Set<String>) {
-        guard isStoreLoaded else { return ([], []) }
-
-        var audioFileNames = Set<String>()
-        var transcriptFileNames = Set<String>()
-        container.viewContext.performAndWait {
-            let request = pipelineHistoryRequest()
-            request.includesPropertyValues = true
-            guard let entities = try? container.viewContext.fetch(request) else { return }
-            for entity in entities {
-                if let audioFileName = entity.audioFileName {
-                    audioFileNames.insert(audioFileName)
-                }
-                if let transcriptFileName = entity.transcriptFileName {
-                    transcriptFileNames.insert(transcriptFileName)
-                }
-            }
-        }
-        return (audioFileNames, transcriptFileNames)
-    }
-
     private func insert(_ item: PipelineHistoryItem) throws {
         guard isStoreLoaded else { return }
 

--- a/Sources/PipelineHistoryStore.swift
+++ b/Sources/PipelineHistoryStore.swift
@@ -193,6 +193,27 @@ final class PipelineHistoryStore {
         return deletedAssets
     }
 
+    func referencedStoredFiles() -> (audioFileNames: Set<String>, transcriptFileNames: Set<String>) {
+        guard isStoreLoaded else { return ([], []) }
+
+        var audioFileNames = Set<String>()
+        var transcriptFileNames = Set<String>()
+        container.viewContext.performAndWait {
+            let request = pipelineHistoryRequest()
+            request.includesPropertyValues = true
+            guard let entities = try? container.viewContext.fetch(request) else { return }
+            for entity in entities {
+                if let audioFileName = entity.audioFileName {
+                    audioFileNames.insert(audioFileName)
+                }
+                if let transcriptFileName = entity.transcriptFileName {
+                    transcriptFileNames.insert(transcriptFileName)
+                }
+            }
+        }
+        return (audioFileNames, transcriptFileNames)
+    }
+
     private func insert(_ item: PipelineHistoryItem) throws {
         guard isStoreLoaded else { return }
 


### PR DESCRIPTION
## Summary
- sweep unreferenced audio and transcript files once during app startup
- reuse loaded history file references and perform the sweep in a background task
- document Makefile signing override usage and note that install overwrites in place to preserve app permissions

## Test plan
- [x] Build and install with `make install CODESIGN_IDENTITY=\"Apple Development: you@example.com (TEAMID)\"`
- [x] Relaunch `/Applications/Quill.app` without resetting permissions
- [x] Compare stored files against `PipelineHistory.sqlite` before and after cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)