### PR TITLE
Fix updateForegroundUI call syntax

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2720,15 +2720,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             shouldPersistRawDictationFallback = false
                         }
                         updateForegroundUI(
-                            rawTranscript: trimmedRawTranscript,
-                            finalTranscript: trimmedFinalTranscript,
-                            prompt: result.prompt,
-                            processingStatus: processingStatus,
-                            context: appContext,
-                            completionStatusText: completionStatusText,
-                            enterOnlyStatusText: enterOnlyStatusText,
-                            shouldPressEnterAfterPaste: shouldPressEnterAfterPaste,
-                            shouldPersistRawDictationFallback: shouldPersistRawDictationFallback
+                            trimmedRawTranscript,
+                            trimmedFinalTranscript,
+                            result.prompt,
+                            processingStatus,
+                            appContext,
+                            completionStatusText,
+                            enterOnlyStatusText,
+                            shouldPressEnterAfterPaste,
+                            shouldPersistRawDictationFallback
                         )
                         completeJob(jobID)
                     }


### PR DESCRIPTION
## Summary
- fix the `updateForegroundUI` call after it was converted from a local function to a closure
- remove outdated argument labels so `make install` builds successfully again

## Test plan
- [x] Confirm the app installs to `/Applications/Quill.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)