### PR TITLE
Fix stale transcribing overlay lifecycle

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1930,7 +1930,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         errorMessage = nil
         debugStatusMessage = "Cancelled"
         statusText = "Cancelled"
-        overlayManager.dismiss()
+        dismissTranscribingOverlay()
         tearDownRealtimeService()
         audioRecorder.cancelRecording()
         restoreAudioInterruptionIfNeeded()
@@ -1954,7 +1954,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         errorMessage = nil
         debugStatusMessage = "Cancelled"
         statusText = "Cancelled"
-        overlayManager.dismiss()
+        dismissTranscribingOverlay()
         cleanupRecorderIfIdle()
         if let audioFileName = job.audioFileName {
             Self.deleteAudioFile(audioFileName)
@@ -2089,9 +2089,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         os_log(.info, log: recordingLog, "startRecording() entered")
         guard !isRecording else { return }
 
-        // 전사 중이면 오버레이 소유권만 넘기고 전사는 백그라운드에서 계속 실행
+        // 전사 중이면 기존 transcribing overlay/indicator를 정리하고 소유권만 넘긴다.
         if isTranscribing {
-            overlayTranscriptionID = UUID()
+            dismissTranscribingOverlay(resetOverlayOwner: true)
             foregroundTranscriptionJobID = nil
         }
 
@@ -2280,7 +2280,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         audioRecorder.onRecordingFailure = nil
         audioLevelCancellable?.cancel()
         audioLevelCancellable = nil
-        overlayManager.dismiss()
+        dismissTranscribingOverlay()
     }
 
     private func applyAudioInterruptionIfNeeded() {
@@ -2485,7 +2485,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         shortcutSessionController.reset()
         errorMessage = formattedRecordingStartError(error)
         statusText = "Error"
-        overlayManager.dismiss()
+        dismissTranscribingOverlay()
         refreshAvailableMicrophonesIfNeeded()
     }
 
@@ -2823,8 +2823,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             if finalTranscript.isEmpty {
                 self.mcpLastRecordingFailed = true
                 self.statusText = shouldPressEnterAfterPaste ? enterOnlyStatusText : "Nothing to transcribe"
-                self.clearPendingOverlayDismissToken()
-                self.overlayManager.dismiss()
+                self.dismissTranscribingOverlay()
                 if shouldPressEnterAfterPaste {
                     self.pressEnterWhenShortcutReleased()
                 }
@@ -2832,8 +2831,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 if shouldPersistRawDictationFallback {
                     self.scheduleOverlayDismissAfterFailureIndicator(after: 2.5)
                 } else {
-                    self.clearPendingOverlayDismissToken()
-                    self.overlayManager.dismiss()
+                    self.dismissTranscribingOverlay()
                 }
                 if !self.disableAutoPaste {
                     let pendingClipboardRestore = self.writeTranscriptToPasteboard(finalTranscript)
@@ -2855,29 +2853,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
             Task { @MainActor in
                 guard let self else { return }
                 self.finishTranscriptionJob(id)
-                if self.overlayTranscriptionID == myOverlayID {
-                    self.transcribingIndicatorTask?.cancel()
-                    self.transcribingIndicatorTask = nil
-                }
+                self.cancelTranscribingIndicatorTask()
             }
         }
 
         if let transcriber = capturedLiveTranscriber, transcriber.handlesRecording {
             if overlayTranscriptionID == myOverlayID {
-                statusText = "Transcribing..."
-                debugStatusMessage = "Transcribing audio"
-                transcribingIndicatorTask?.cancel()
-                let indicatorDelay = transcribingIndicatorDelay
-                transcribingIndicatorTask = Task { [weak self] in
-                    do {
-                        try await Task.sleep(nanoseconds: UInt64(indicatorDelay * 1_000_000_000))
-                        guard self?.overlayTranscriptionID == myOverlayID else { return }
-                        await MainActor.run { [weak self] in
-                            guard self?.overlayTranscriptionID == myOverlayID else { return }
-                            self?.overlayManager.showTranscribing()
-                        }
-                    } catch {}
-                }
+                prepareTranscribingOverlay(for: myOverlayID, statusText: "Transcribing...", debugStatus: "Transcribing audio")
             }
             let task = Task { [weak self] in
                 guard let self else { return }
@@ -3019,7 +3001,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 if self.overlayTranscriptionID == myOverlayID {
                     self.errorMessage = "No audio recorded"
                     self.statusText = "Error"
-                    self.overlayManager.dismiss()
+                    self.dismissTranscribingOverlay()
                 }
                 self.mcpLastRecordingFailed = true
                 self.tearDownRealtimeService()
@@ -3037,20 +3019,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             self.audioRecorder.onPCM16Samples = nil
 
             if self.overlayTranscriptionID == myOverlayID {
-                self.statusText = "Transcribing..."
-                self.debugStatusMessage = "Transcribing audio"
-                self.transcribingIndicatorTask?.cancel()
-                let indicatorDelay = self.transcribingIndicatorDelay
-                self.transcribingIndicatorTask = Task { [weak self] in
-                    do {
-                        try await Task.sleep(nanoseconds: UInt64(indicatorDelay * 1_000_000_000))
-                        guard self?.overlayTranscriptionID == myOverlayID else { return }
-                        await MainActor.run { [weak self] in
-                            guard self?.overlayTranscriptionID == myOverlayID else { return }
-                            self?.overlayManager.showTranscribing()
-                        }
-                    } catch {}
-                }
+                self.prepareTranscribingOverlay(for: myOverlayID, statusText: "Transcribing...", debugStatus: "Transcribing audio")
             }
 
             let task = Task { [weak self] in
@@ -3520,7 +3489,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             shortcutSessionController.reset()
             activeRecordingTriggerMode = nil
             statusText = "Screenshot Required"
-            overlayManager.dismiss()
+            dismissTranscribingOverlay()
 
             playAlertSound(named: "Basso")
             showScreenshotPermissionAlert(message: message)
@@ -3596,11 +3565,43 @@ final class AppState: ObservableObject, @unchecked Sendable {
         debugOverlayTimer = nil
         isDebugOverlayActive = false
         clearPendingOverlayDismissToken()
-        overlayManager.dismiss()
+        dismissTranscribingOverlay()
     }
 
     private func clearPendingOverlayDismissToken() {
         pendingOverlayDismissToken = nil
+    }
+
+    private func cancelTranscribingIndicatorTask() {
+        transcribingIndicatorTask?.cancel()
+        transcribingIndicatorTask = nil
+    }
+
+    private func dismissTranscribingOverlay(resetOverlayOwner: Bool = false) {
+        cancelTranscribingIndicatorTask()
+        clearPendingOverlayDismissToken()
+        overlayManager.dismiss()
+        if resetOverlayOwner {
+            overlayTranscriptionID = UUID()
+        }
+    }
+
+    private func prepareTranscribingOverlay(for overlayID: UUID, statusText: String, debugStatus: String) {
+        guard overlayTranscriptionID == overlayID else { return }
+        self.statusText = statusText
+        self.debugStatusMessage = debugStatus
+        cancelTranscribingIndicatorTask()
+        let indicatorDelay = transcribingIndicatorDelay
+        transcribingIndicatorTask = Task { [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: UInt64(indicatorDelay * 1_000_000_000))
+                guard self?.overlayTranscriptionID == overlayID else { return }
+                await MainActor.run { [weak self] in
+                    guard self?.overlayTranscriptionID == overlayID else { return }
+                    self?.overlayManager.showTranscribing()
+                }
+            } catch {}
+        }
     }
 
     private func scheduleOverlayDismissAfterFailureIndicator(after delay: TimeInterval) {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1838,6 +1838,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     // MCP public interface
+    @MainActor
     func startRecordingFromMCP() {
         lastTranscript = ""
         mcpLastRecordingFailed = false
@@ -1972,6 +1973,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
     private func scheduleShortcutStart(mode: RecordingTriggerMode) {
         cancelPendingShortcutStart(resetMode: false)
         pendingManualCommandInvocation = hotkeyManager.currentPressedModifiers.contains(
@@ -2084,6 +2086,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         scheduleReadyStatusReset(after: 2, matching: ["Fix Edit Mode modifier"])
     }
 
+    @MainActor
     private func startRecording(triggerMode: RecordingTriggerMode) {
         let t0 = CFAbsoluteTimeGetCurrent()
         os_log(.info, log: recordingLog, "startRecording() entered")
@@ -2191,6 +2194,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return true
     }
 
+    @MainActor
     private func ensureMicrophoneAccess() -> Bool {
         let status = AVCaptureDevice.authorizationStatus(for: .audio)
         switch status {
@@ -2263,6 +2267,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
     private func prepareForMicrophonePermissionPrompt(
         triggerMode: RecordingTriggerMode,
         selectionSnapshot: AppSelectionSnapshot?,
@@ -2799,7 +2804,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         liveTranscriber = nil
         audioRecorder.onAudioBuffer = nil
 
-        let updateForegroundUI: @Sendable (
+        let updateForegroundUI: @MainActor @Sendable (
             String, String, String, String, AppContext, String, String, Bool, Bool
         ) -> Void = { [weak self] rawTranscript, finalTranscript, prompt, processingStatus, context, completionStatusText, enterOnlyStatusText, shouldPressEnterAfterPaste, shouldPersistRawDictationFallback in
             guard let self else { return }
@@ -2849,13 +2854,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
             self.scheduleReadyStatusReset(after: 3, matching: [completionStatusText, "Nothing to transcribe", enterOnlyStatusText])
         }
 
-        let completeJob: @Sendable (UUID, UUID) -> Void = { [weak self] id, overlayID in
-            Task { @MainActor in
-                guard let self else { return }
-                self.finishTranscriptionJob(id)
-                if self.overlayTranscriptionID == overlayID {
-                    self.cancelTranscribingIndicatorTask()
-                }
+        let completeJob: @MainActor @Sendable (UUID, UUID) -> Void = { [weak self] id, overlayID in
+            guard let self else { return }
+            self.finishTranscriptionJob(id)
+            if self.overlayTranscriptionID == overlayID {
+                self.cancelTranscribingIndicatorTask()
             }
         }
 
@@ -3464,6 +3467,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    @MainActor
     private func handleScreenshotCaptureIssue(_ message: String?) {
         guard let message, !message.isEmpty else {
             hasShownScreenshotPermissionAlert = false
@@ -3536,6 +3540,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         _ = alert.runModal()
     }
 
+    @MainActor
     func toggleDebugOverlay() {
         if isDebugOverlayActive {
             stopDebugOverlay()
@@ -3562,6 +3567,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
     private func stopDebugOverlay() {
         debugOverlayTimer?.invalidate()
         debugOverlayTimer = nil
@@ -3574,11 +3580,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         pendingOverlayDismissToken = nil
     }
 
+    @MainActor
     private func cancelTranscribingIndicatorTask() {
         transcribingIndicatorTask?.cancel()
         transcribingIndicatorTask = nil
     }
 
+    @MainActor
     private func dismissTranscribingOverlay(resetOverlayOwner: Bool = false) {
         cancelTranscribingIndicatorTask()
         clearPendingOverlayDismissToken()
@@ -3588,6 +3596,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
     private func prepareTranscribingOverlay(for overlayID: UUID, statusText: String, debugStatus: String) {
         guard overlayTranscriptionID == overlayID else { return }
         self.statusText = statusText

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -3607,10 +3607,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             do {
                 try await Task.sleep(nanoseconds: UInt64(indicatorDelay * 1_000_000_000))
                 guard self?.overlayTranscriptionID == overlayID else { return }
-                await MainActor.run { [weak self] in
-                    guard self?.overlayTranscriptionID == overlayID else { return }
-                    self?.overlayManager.showTranscribing()
-                }
+                self?.overlayManager.showTranscribing()
             } catch {}
         }
     }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2849,11 +2849,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
             self.scheduleReadyStatusReset(after: 3, matching: [completionStatusText, "Nothing to transcribe", enterOnlyStatusText])
         }
 
-        let completeJob: @Sendable (UUID) -> Void = { [weak self] id in
+        let completeJob: @Sendable (UUID, UUID) -> Void = { [weak self] id, overlayID in
             Task { @MainActor in
                 guard let self else { return }
                 self.finishTranscriptionJob(id)
-                self.cancelTranscribingIndicatorTask()
+                if self.overlayTranscriptionID == overlayID {
+                    self.cancelTranscribingIndicatorTask()
+                }
             }
         }
 
@@ -2938,11 +2940,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             parsedTranscript.shouldPressEnterAfterPaste,
                             shouldPersistRawDictationFallback
                         )
-                        completeJob(jobID)
+                        completeJob(jobID, myOverlayID)
                     }
                 } catch is CancellationError {
                     await MainActor.run {
-                        completeJob(jobID)
+                        completeJob(jobID, myOverlayID)
                     }
                 } catch {
                     let resolvedContext: AppContext
@@ -2973,7 +2975,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         )
                         self.cleanupRecorderIfIdle()
                         guard self.overlayTranscriptionID == myOverlayID else {
-                            completeJob(jobID)
+                            completeJob(jobID, myOverlayID)
                             return
                         }
                         self.errorMessage = error.localizedDescription
@@ -2987,7 +2989,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.lastContextScreenshotDataURL = resolvedContext.screenshotDataURL
                         self.lastContextScreenshotStatus = resolvedContext.screenshotError
                             ?? "available (\(resolvedContext.screenshotMimeType ?? "image"))"
-                        completeJob(jobID)
+                        completeJob(jobID, myOverlayID)
                     }
                 }
             }
@@ -3113,11 +3115,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             parsedTranscript.shouldPressEnterAfterPaste,
                             shouldPersistRawDictationFallback
                         )
-                        completeJob(jobID)
+                        completeJob(jobID, myOverlayID)
                     }
                 } catch is CancellationError {
                     await MainActor.run {
-                        completeJob(jobID)
+                        completeJob(jobID, myOverlayID)
                     }
                 } catch {
                     let resolvedContext: AppContext
@@ -3142,7 +3144,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         )
                         self.cleanupRecorderIfIdle()
                         guard self.overlayTranscriptionID == myOverlayID else {
-                            completeJob(jobID)
+                            completeJob(jobID, myOverlayID)
                             return
                         }
                         self.errorMessage = error.localizedDescription
@@ -3156,7 +3158,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.lastContextScreenshotDataURL = resolvedContext.screenshotDataURL
                         self.lastContextScreenshotStatus = resolvedContext.screenshotError
                             ?? "available (\(resolvedContext.screenshotMimeType ?? "image"))"
-                        completeJob(jobID)
+                        completeJob(jobID, myOverlayID)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- centralize transcribing overlay dismissal and delayed indicator scheduling in `AppState`
- clear stale transcribing overlay state when starting a new recording while transcription is still running
- apply the same overlay lifecycle rules to Apple live and file-based transcription stop/cancel/error paths

## Test plan
- [x] Run `make all CODESIGN_IDENTITY=\"Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)\"`
- [x] Run `make install CODESIGN_IDENTITY=\"Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)\"`
- [ ] Manually verify Apple live transcription overlay dismisses after stop
- [ ] Manually verify starting a new recording while transcribing clears the stale overlay
- [ ] Manually verify cancel/error/empty-result paths do not leave the transcribing overlay visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)