### PR TITLE
Align live transcription input pipeline

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1903,7 +1903,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         activeRecordingTriggerMode = nil
         audioRecorder.onRecordingReady = nil
         audioRecorder.onRecordingFailure = nil
-        audioRecorder.onAudioBuffer = nil
+        audioRecorder.onPCM16Samples = nil
         liveTranscriber?.cancel()
         liveTranscriber = nil
         if let id = currentRecordingLiveNoteID {
@@ -2384,8 +2384,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     try await transcriber.start(locale: transcriptionLanguage.sfSpeechLocale)
                     self.liveTranscriber = transcriber
                     if !transcriber.handlesRecording {
-                        self.audioRecorder.onAudioBuffer = { [weak transcriber] buffer in
-                            transcriber?.append(buffer)
+                        self.audioRecorder.onPCM16Samples = { [weak transcriber] data in
+                            transcriber?.appendPCM16(data)
                         }
                     }
 
@@ -2802,7 +2802,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let capturedCustomSystemPrompt = customSystemPrompt
         let capturedLiveTranscriber = liveTranscriber
         liveTranscriber = nil
-        audioRecorder.onAudioBuffer = nil
+        audioRecorder.onPCM16Samples = nil
 
         let updateForegroundUI: @MainActor @Sendable (
             String, String, String, String, AppContext, String, String, Bool, Bool

--- a/Sources/AppleSpeechLiveTranscriber.swift
+++ b/Sources/AppleSpeechLiveTranscriber.swift
@@ -14,7 +14,7 @@ protocol LiveTranscriber: AnyObject {
     /// finalize() 후 저장된 오디오 파일 URL (handlesRecording == true일 때만 유효)
     var recordedAudioURL: URL? { get }
     func start(locale: Locale) async throws
-    func append(_ sampleBuffer: CMSampleBuffer)
+    func appendPCM16(_ data: Data)
     func finalize() async throws -> String
     func cancel()
 }
@@ -36,10 +36,6 @@ final class AppleSpeechLiveTranscriber: LiveTranscriber {
     private(set) var recordedAudioURL: URL?
 
     private struct CachedPCMBufferState {
-        var sampleRate: Double = 0
-        var channelCount: AVAudioChannelCount = 0
-        var commonFormat: AVAudioCommonFormat = .otherFormat
-        var isInterleaved = false
         var format: AVAudioFormat?
         var buffer: AVAudioPCMBuffer?
     }
@@ -86,8 +82,8 @@ final class AppleSpeechLiveTranscriber: LiveTranscriber {
         }
     }
 
-    func append(_ sampleBuffer: CMSampleBuffer) {
-        guard let pcmBuffer = pcmBuffer(from: sampleBuffer) else { return }
+    func appendPCM16(_ data: Data) {
+        guard let pcmBuffer = pcmBuffer(fromPCM16: data) else { return }
         let didAppend = lock.withLock { () -> Bool in
             guard let recognitionRequest else { return false }
             recognitionRequest.append(pcmBuffer)
@@ -172,52 +168,36 @@ final class AppleSpeechLiveTranscriber: LiveTranscriber {
         }
     }
 
-    private func pcmBuffer(from sampleBuffer: CMSampleBuffer) -> AVAudioPCMBuffer? {
-        guard let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer) else {
-            return nil
-        }
-        let sampleFormat = AVAudioFormat(cmAudioFormatDescription: formatDescription)
-        let frameCount = AVAudioFrameCount(CMSampleBufferGetNumSamples(sampleBuffer))
-        guard frameCount > 0 else {
-            return nil
-        }
+    private func pcmBuffer(fromPCM16 data: Data) -> AVAudioPCMBuffer? {
+        let bytesPerFrame = MemoryLayout<Int16>.size
+        guard !data.isEmpty, data.count % bytesPerFrame == 0 else { return nil }
+        let frameCount = AVAudioFrameCount(data.count / bytesPerFrame)
+        guard frameCount > 0 else { return nil }
 
         let pcmBuffer: AVAudioPCMBuffer? = lock.withLock {
-            let shouldResetBuffer =
-                cachedPCMBufferState.sampleRate != sampleFormat.sampleRate ||
-                cachedPCMBufferState.channelCount != sampleFormat.channelCount ||
-                cachedPCMBufferState.commonFormat != sampleFormat.commonFormat ||
-                cachedPCMBufferState.isInterleaved != sampleFormat.isInterleaved
-            if shouldResetBuffer {
-                cachedPCMBufferState.sampleRate = sampleFormat.sampleRate
-                cachedPCMBufferState.channelCount = sampleFormat.channelCount
-                cachedPCMBufferState.commonFormat = sampleFormat.commonFormat
-                cachedPCMBufferState.isInterleaved = sampleFormat.isInterleaved
+            let sampleFormat = AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: 24_000,
+                channels: 1,
+                interleaved: true
+            )
+            guard let sampleFormat else { return nil }
+            if cachedPCMBufferState.format == nil {
                 cachedPCMBufferState.format = sampleFormat
-                cachedPCMBufferState.buffer = nil
-            }
-            guard let cachedFormat = cachedPCMBufferState.format else {
-                return nil
             }
             if cachedPCMBufferState.buffer == nil || cachedPCMBufferState.buffer?.frameCapacity ?? 0 < frameCount {
-                cachedPCMBufferState.buffer = AVAudioPCMBuffer(pcmFormat: cachedFormat, frameCapacity: frameCount)
+                cachedPCMBufferState.buffer = AVAudioPCMBuffer(pcmFormat: sampleFormat, frameCapacity: frameCount)
             }
             cachedPCMBufferState.buffer?.frameLength = frameCount
             return cachedPCMBufferState.buffer
         }
 
-        guard let pcmBuffer else {
+        guard let pcmBuffer, let channelData = pcmBuffer.int16ChannelData?[0] else {
             return nil
         }
-        let status = CMSampleBufferCopyPCMDataIntoAudioBufferList(
-            sampleBuffer,
-            at: 0,
-            frameCount: Int32(frameCount),
-            into: pcmBuffer.mutableAudioBufferList
-        )
-        guard status == noErr else {
-            os_log(.error, log: speechLog, "failed to copy CMSampleBuffer to PCM buffer status=%d", status)
-            return nil
+        data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return }
+            channelData.update(from: baseAddress.assumingMemoryBound(to: Int16.self), count: Int(frameCount))
         }
         return pcmBuffer
     }

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -94,7 +94,6 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
 
     var onRecordingReady: (() -> Void)?
     var onRecordingFailure: ((Error) -> Void)?
-    var onAudioBuffer: ((CMSampleBuffer) -> Void)?
     /// Fires on the sample-buffer queue with a 24 kHz mono PCM16 chunk for
     /// each incoming audio buffer (matching OpenAI Realtime's default PCM
     /// input rate). Set before ``startRecording`` to stream audio out-of-band
@@ -658,8 +657,6 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         from connection: AVCaptureConnection
     ) {
         guard _recording.withLock({ $0 }) else { return }
-
-        onAudioBuffer?(sampleBuffer)
 
         do {
             try appendSampleBufferToFile(sampleBuffer)


### PR DESCRIPTION
Closes #28

## Summary
- move Apple live transcription onto the shared PCM16 live input path
- remove the raw `onAudioBuffer` recorder hook
- keep file-based transcription unchanged while making live consumers use a more consistent recorder contract

## Current structure

```text
                           [ microphone input ]
                                  │
                                  ▼
                           ┌──────────────┐
                           │ AudioRecorder │
                           └──────────────┘
                                  │
              ┌───────────────────┼───────────────────┐
              │                   │                   │
              ▼                   ▼                   ▼
      [file save path]     [external realtime]    [Apple live]
              │                   │                   │
              │            onPCM16Samples         onAudioBuffer
              │              (PCM16 Data)       (CMSampleBuffer)
              │                   │                   │
              │                   ▼                   ▼
              │       RealtimeTranscription   AppleSpeechLiveTranscriber
              │            Service                    │
              │                   │             internal conversion:
              │                   │      CMSampleBuffer -> AVAudioPCMBuffer
              │                   ▼                   ▼
              │        external realtime API   SFSpeechAudioBufferRecognitionRequest
              │           (partial / final)               │
              │                                           │
              │                                 Apple live partial / final
              ▼
     stopAndTranscribe()
              │
              ▼
 TranscriptionService.transcribe(fileURL:)
              │
              ▼
         raw transcript
              │
              ▼
    PostProcessingService
              │
              ▼
        final transcript
              │
              ▼
      UI / paste / history
```

## Updated structure

```text
                           [ microphone input ]
                                  │
                                  ▼
                           ┌──────────────┐
                           │ AudioRecorder │
                           └──────────────┘
                                  │
              ┌───────────────────┴───────────────────┐
              │                                       │
              ▼                                       ▼
        [file save path]                  [shared live input path]
              │                                       │
              │                               shared live input
              │                                 (PCM16 Data)
              │                                       │
              │                ┌──────────────────────┴──────────────────────┐
              │                │                                             │
              ▼                ▼                                             ▼
     stopAndTranscribe()  ExternalRealtimeTranscriber              AppleSpeechLiveTranscriber
              │                │                                             │
              │                │                                   internal conversion:
              │                │                             PCM16 Data -> AVAudioPCMBuffer
              │                ▼                                             ▼
              │        external realtime API                    SFSpeechAudioBufferRecognitionRequest
              │          (partial / final)                                   │
              │                                                              │
              │                                                    Apple live partial / final
              ▼
 TranscriptionService.transcribe(fileURL:)
              │
              ▼
         raw transcript
              │
              ▼
    PostProcessingService
              │
              ▼
        final transcript
              │
              ▼
      UI / paste / history
```

## Test plan
- [x] Run `make all CODESIGN_IDENTITY=\"Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)\"`
- [x] Run `make install CODESIGN_IDENTITY=\"Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)\"`
- [x] Manually verify Apple live transcription still works
- [ ] Manually verify external realtime transcription when API credentials are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)