### PR TITLE
Add Note Browser transcription mode switcher

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -543,6 +543,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return realtimeStreamingEnabled ? "API · Realtime" : "API · Standard"
     }
 
+    @MainActor
     func setNoteBrowserTranscriptionMode(_ mode: NoteBrowserTranscriptionMode) {
         switch mode {
         case .apiStandard:

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -19,6 +19,13 @@ struct PrecomputedMacro {
     let normalizedCommand: String
 }
 
+enum NoteBrowserTranscriptionMode {
+    case apiStandard
+    case apiRealtime
+    case localWhisper
+    case localAppleLive
+}
+
 enum SettingsTab: String, CaseIterable, Identifiable {
     case general
     case prompts
@@ -534,6 +541,28 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return localTranscriptionModel.isAppleSpeech ? "Local · Apple Live" : "Local · Whisper"
         }
         return realtimeStreamingEnabled ? "API · Realtime" : "API · Standard"
+    }
+
+    func setNoteBrowserTranscriptionMode(_ mode: NoteBrowserTranscriptionMode) {
+        switch mode {
+        case .apiStandard:
+            useLocalTranscription = false
+            realtimeStreamingEnabled = false
+        case .apiRealtime:
+            useLocalTranscription = false
+            realtimeStreamingEnabled = true
+        case .localWhisper:
+            useLocalTranscription = true
+            realtimeStreamingEnabled = false
+            if localTranscriptionModel.isAppleSpeech,
+               let nonAppleModel = TranscriptionModel.all.first(where: { !$0.isAppleSpeech }) {
+                localTranscriptionModel = nonAppleModel
+            }
+        case .localAppleLive:
+            useLocalTranscription = true
+            realtimeStreamingEnabled = false
+            localTranscriptionModel = .find(id: "apple-speech")
+        }
     }
 
     @Published var soundVolume: Float {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -529,6 +529,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    var noteBrowserTranscriptionModeLabel: String {
+        if useLocalTranscription {
+            return localTranscriptionModel.isAppleSpeech ? "Local · Apple Live" : "Local · Whisper"
+        }
+        return realtimeStreamingEnabled ? "API · Realtime" : "API · Standard"
+    }
+
     @Published var soundVolume: Float {
         didSet {
             UserDefaults.standard.set(soundVolume, forKey: soundVolumeStorageKey)

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -455,13 +455,11 @@ struct NoteBrowserView: View {
                         }
                     }
                 } label: {
-                    HStack(spacing: 6) {
-                        Text(appState.noteBrowserTranscriptionModeLabel)
-                            .font(.system(size: 11, weight: .semibold))
-                    }
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
-                    .background(Color.primary.opacity(0.06), in: Capsule())
+                    Text(appState.noteBrowserTranscriptionModeLabel)
+                        .font(.system(size: 11, weight: .semibold))
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(Color.primary.opacity(0.06), in: Capsule())
                 }
                 .menuStyle(.borderlessButton)
                 .fixedSize()

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -440,27 +440,18 @@ struct NoteBrowserView: View {
                 Menu {
                     Section("API") {
                         Button("Standard") {
-                            appState.useLocalTranscription = false
-                            appState.realtimeStreamingEnabled = false
+                            appState.setNoteBrowserTranscriptionMode(.apiStandard)
                         }
                         Button("Realtime") {
-                            appState.useLocalTranscription = false
-                            appState.realtimeStreamingEnabled = true
+                            appState.setNoteBrowserTranscriptionMode(.apiRealtime)
                         }
                     }
                     Section("Local") {
                         Button("Whisper") {
-                            appState.useLocalTranscription = true
-                            appState.realtimeStreamingEnabled = false
-                            if appState.localTranscriptionModel.isAppleSpeech,
-                               let nonAppleModel = TranscriptionModel.all.first(where: { !$0.isAppleSpeech }) {
-                                appState.localTranscriptionModel = nonAppleModel
-                            }
+                            appState.setNoteBrowserTranscriptionMode(.localWhisper)
                         }
                         Button("Apple Live") {
-                            appState.useLocalTranscription = true
-                            appState.realtimeStreamingEnabled = false
-                            appState.localTranscriptionModel = .find(id: "apple-speech")
+                            appState.setNoteBrowserTranscriptionMode(.localAppleLive)
                         }
                     }
                 } label: {
@@ -474,6 +465,7 @@ struct NoteBrowserView: View {
                 }
                 .menuStyle(.borderlessButton)
                 .fixedSize()
+                .disabled(appState.isRecording || appState.isTranscribing)
             }
             .padding(.horizontal, 12)
             .padding(.bottom, 8)

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -428,6 +428,56 @@ struct NoteBrowserView: View {
             .padding(.top, 14)
             .padding(.bottom, 10)
 
+            HStack(spacing: 8) {
+                Text("Transcription")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .textCase(.uppercase)
+                    .kerning(0.4)
+
+                Spacer()
+
+                Menu {
+                    Section("API") {
+                        Button("Standard") {
+                            appState.useLocalTranscription = false
+                            appState.realtimeStreamingEnabled = false
+                        }
+                        Button("Realtime") {
+                            appState.useLocalTranscription = false
+                            appState.realtimeStreamingEnabled = true
+                        }
+                    }
+                    Section("Local") {
+                        Button("Whisper") {
+                            appState.useLocalTranscription = true
+                            appState.realtimeStreamingEnabled = false
+                            if appState.localTranscriptionModel.isAppleSpeech,
+                               let nonAppleModel = TranscriptionModel.all.first(where: { !$0.isAppleSpeech }) {
+                                appState.localTranscriptionModel = nonAppleModel
+                            }
+                        }
+                        Button("Apple Live") {
+                            appState.useLocalTranscription = true
+                            appState.realtimeStreamingEnabled = false
+                            appState.localTranscriptionModel = .find(id: "apple-speech")
+                        }
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Text(appState.noteBrowserTranscriptionModeLabel)
+                            .font(.system(size: 11, weight: .semibold))
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(Color.primary.opacity(0.06), in: Capsule())
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+            }
+            .padding(.horizontal, 12)
+            .padding(.bottom, 8)
+
             // Search bar
             HStack(spacing: 6) {
                 Image(systemName: "magnifyingglass")


### PR DESCRIPTION
## Summary
- show the current transcription mode in the Note Browser sidebar
- add a grouped quick-switch menu for API Standard, API Realtime, Local Whisper, and Local Apple Live
- keep the existing Note Browser layout while making mode switching easier without going through Settings

## Test plan
- [x] Run `make all CODESIGN_IDENTITY=\"Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)\"`
- [x] Run `make install CODESIGN_IDENTITY=\"Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)\"`
- [ ] Manually verify the current mode label matches the active AppState combination
- [ ] Manually verify switching between API Standard / API Realtime / Local Whisper / Local Apple Live works as expected
- [ ] Manually verify existing sidebar controls (record button, search, list selection) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)