### PR TITLE
Add Apple live speech recognition permission UX

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2229,16 +2229,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
         speechRecognitionAuthorizationStatus == .authorized
     }
 
+    @MainActor
     func refreshSpeechRecognitionAuthorizationStatus() {
         speechRecognitionAuthorizationStatus = Self.currentSpeechRecognitionAuthorizationStatus()
     }
 
-    func requestSpeechRecognitionAccess(completion: ((Bool) -> Void)? = nil) {
+    @MainActor
+    func requestSpeechRecognitionAccess(completion: (@MainActor @Sendable (Bool) -> Void)? = nil) {
         let status = SFSpeechRecognizer.authorizationStatus()
         switch status {
         case .notDetermined:
             SFSpeechRecognizer.requestAuthorization { [weak self] status in
-                DispatchQueue.main.async {
+                Task { @MainActor [weak self] in
                     self?.speechRecognitionAuthorizationStatus = status
                     completion?(status == .authorized)
                 }
@@ -2256,13 +2258,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
     func showSpeechRecognitionPermissionAlert() {
-        guard Thread.isMainThread else {
-            DispatchQueue.main.async { [weak self] in
-                self?.showSpeechRecognitionPermissionAlert()
-            }
-            return
-        }
 
         let alert = NSAlert()
         alert.messageText = "Speech Recognition Permission Required"
@@ -2469,7 +2466,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     if granted {
                         self.errorMessage = nil
                         if triggerMode == .toggle {
-                            Task { [weak self] in
+                            Task { @MainActor [weak self] in
                                 guard let self else { return }
                                 guard await self.prepareRecordingStart(
                                     triggerMode: .toggle,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -5,6 +5,7 @@ import AVFoundation
 import ServiceManagement
 import ApplicationServices
 import ScreenCaptureKit
+import Speech
 import os.log
 private let recordingLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "Recording")
 
@@ -613,6 +614,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var lastContextSelectedText: String = ""
     @Published var lastContextLLMPrompt: String = ""
     @Published var hasScreenRecordingPermission = false
+    @Published var speechRecognitionAuthorizationStatus: SFSpeechRecognizerAuthorizationStatus = .notDetermined
     @Published var launchAtLogin: Bool {
         didSet { setLaunchAtLogin(launchAtLogin) }
     }
@@ -821,6 +823,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.selectedMicrophoneID = selectedMicrophoneID
         self.precomputeMacros()
 
+        speechRecognitionAuthorizationStatus = Self.currentSpeechRecognitionAuthorizationStatus()
         refreshAvailableMicrophones()
         installAudioDeviceObservers()
 
@@ -2214,6 +2217,27 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return true
     }
 
+    static func currentSpeechRecognitionAuthorizationStatus() -> SFSpeechRecognizerAuthorizationStatus {
+        SFSpeechRecognizer.authorizationStatus()
+    }
+
+    var hasSpeechRecognitionPermission: Bool {
+        speechRecognitionAuthorizationStatus == .authorized
+    }
+
+    func refreshSpeechRecognitionAuthorizationStatus() {
+        speechRecognitionAuthorizationStatus = Self.currentSpeechRecognitionAuthorizationStatus()
+    }
+
+    func requestSpeechRecognitionAccess(completion: ((Bool) -> Void)? = nil) {
+        SFSpeechRecognizer.requestAuthorization { [weak self] status in
+            DispatchQueue.main.async {
+                self?.speechRecognitionAuthorizationStatus = status
+                completion?(status == .authorized)
+            }
+        }
+    }
+
     private func ensureScreenCaptureAccess() -> Bool {
         let granted = hasScreenCapturePermission()
         hasScreenRecordingPermission = granted
@@ -2355,6 +2379,20 @@ final class AppState: ObservableObject, @unchecked Sendable {
         os_log(.info, log: recordingLog, "beginRecording() entered")
         clearPendingOverlayDismissToken()
         errorMessage = nil
+
+        if useLocalTranscription, localTranscriptionModel.isAppleSpeech {
+            refreshSpeechRecognitionAuthorizationStatus()
+            guard hasSpeechRecognitionPermission else {
+                isRecording = false
+                activeRecordingTriggerMode = nil
+                currentSessionIntent = .dictation
+                shortcutSessionController.reset()
+                errorMessage = "Speech Recognition permission is required for Apple Live transcription. Enable it in System Settings > Privacy & Security > Speech Recognition."
+                statusText = "No Speech Recognition"
+                requestSpeechRecognitionAccess()
+                return
+            }
+        }
 
         isRecording = true
         statusText = "Starting..."

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2234,11 +2234,47 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     func requestSpeechRecognitionAccess(completion: ((Bool) -> Void)? = nil) {
-        SFSpeechRecognizer.requestAuthorization { [weak self] status in
-            DispatchQueue.main.async {
-                self?.speechRecognitionAuthorizationStatus = status
-                completion?(status == .authorized)
+        let status = SFSpeechRecognizer.authorizationStatus()
+        switch status {
+        case .notDetermined:
+            SFSpeechRecognizer.requestAuthorization { [weak self] status in
+                DispatchQueue.main.async {
+                    self?.speechRecognitionAuthorizationStatus = status
+                    completion?(status == .authorized)
+                }
             }
+        case .denied, .restricted:
+            speechRecognitionAuthorizationStatus = status
+            openPrivacySettingsPane("Privacy_SpeechRecognition")
+            completion?(false)
+        case .authorized:
+            speechRecognitionAuthorizationStatus = status
+            completion?(true)
+        @unknown default:
+            speechRecognitionAuthorizationStatus = status
+            completion?(false)
+        }
+    }
+
+    func showSpeechRecognitionPermissionAlert() {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.showSpeechRecognitionPermissionAlert()
+            }
+            return
+        }
+
+        let alert = NSAlert()
+        alert.messageText = "Speech Recognition Permission Required"
+        alert.informativeText = "Quill cannot use Apple Live transcription without Speech Recognition access.\n\nGo to System Settings > Privacy & Security > Speech Recognition and enable Quill."
+        alert.alertStyle = .critical
+        alert.addButton(withTitle: "Open System Settings")
+        alert.addButton(withTitle: "Dismiss")
+        alert.icon = NSImage(systemSymbolName: "waveform.badge.mic", accessibilityDescription: nil)
+
+        let response = alert.runModal()
+        if response == .alertFirstButtonReturn {
+            openPrivacySettingsPane("Privacy_SpeechRecognition")
         }
     }
 
@@ -2460,6 +2496,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.activeRecordingTriggerMode = nil
                         self.currentSessionIntent = .dictation
                         self.shortcutSessionController.reset()
+                        self.showSpeechRecognitionPermissionAlert()
                     }
                 }
                 return
@@ -2471,6 +2508,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 shortcutSessionController.reset()
                 errorMessage = "Speech Recognition permission is required for Apple Live transcription. Enable it in System Settings > Privacy & Security > Speech Recognition."
                 statusText = "No Speech Recognition"
+                showSpeechRecognitionPermissionAlert()
                 return
             }
         }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -662,9 +662,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var shouldMonitorHotkeys = false
     private var isCapturingShortcut = false
     private var isAwaitingMicrophonePermission = false
+    private var isAwaitingSpeechRecognitionPermission = false
     private var pendingMicrophonePermissionTriggerMode: RecordingTriggerMode?
     private var pendingMicrophonePermissionSelectionSnapshot: AppSelectionSnapshot?
     private var pendingMicrophonePermissionManualCommandRequested: Bool?
+    private var pendingSpeechPermissionTriggerMode: RecordingTriggerMode?
+    private var pendingSpeechPermissionSelectionSnapshot: AppSelectionSnapshot?
+    private var pendingSpeechPermissionManualCommandRequested: Bool?
 
     init() {
         UserDefaults.standard.removeObject(forKey: "force_http2_transcription")
@@ -1817,7 +1821,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private func restartHotkeyMonitoring() {
-        guard shouldMonitorHotkeys, !isCapturingShortcut, !isAwaitingMicrophonePermission else {
+        guard shouldMonitorHotkeys, !isCapturingShortcut, !isAwaitingMicrophonePermission, !isAwaitingSpeechRecognitionPermission else {
             hotkeyManager.stop()
             return
         }
@@ -2238,6 +2242,27 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
+    private func prepareForSpeechRecognitionPermissionPrompt(
+        triggerMode: RecordingTriggerMode,
+        selectionSnapshot: AppSelectionSnapshot?,
+        manualCommandRequested: Bool?
+    ) {
+        isAwaitingSpeechRecognitionPermission = true
+        pendingSpeechPermissionTriggerMode = triggerMode
+        pendingSpeechPermissionSelectionSnapshot = selectionSnapshot
+        pendingSpeechPermissionManualCommandRequested = manualCommandRequested
+        hotkeyManager.stop()
+        shortcutSessionController.reset()
+        activeRecordingTriggerMode = nil
+        cancelRecordingInitializationTimer()
+        audioRecorder.onRecordingReady = nil
+        audioRecorder.onRecordingFailure = nil
+        audioLevelCancellable?.cancel()
+        audioLevelCancellable = nil
+        dismissTranscribingOverlay()
+    }
+
     private func ensureScreenCaptureAccess() -> Bool {
         let granted = hasScreenCapturePermission()
         hasScreenRecordingPermission = granted
@@ -2375,6 +2400,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
     private func beginRecording(triggerMode: RecordingTriggerMode) {
         os_log(.info, log: recordingLog, "beginRecording() entered")
         clearPendingOverlayDismissToken()
@@ -2382,14 +2408,66 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         if useLocalTranscription, localTranscriptionModel.isAppleSpeech {
             refreshSpeechRecognitionAuthorizationStatus()
-            guard hasSpeechRecognitionPermission else {
+            switch speechRecognitionAuthorizationStatus {
+            case .authorized:
+                break
+            case .notDetermined:
+                guard let triggerMode = activeRecordingTriggerMode else { return }
+                prepareForSpeechRecognitionPermissionPrompt(
+                    triggerMode: triggerMode,
+                    selectionSnapshot: pendingSelectionSnapshot ?? contextService.collectSelectionSnapshot(),
+                    manualCommandRequested: currentSessionIntent.isManualCommand
+                )
+                requestSpeechRecognitionAccess { [weak self] granted in
+                    guard let self else { return }
+                    let pendingTriggerMode = self.pendingSpeechPermissionTriggerMode
+                    let pendingSelectionSnapshot = self.pendingSpeechPermissionSelectionSnapshot
+                    let pendingManualCommandRequested = self.pendingSpeechPermissionManualCommandRequested
+                    self.pendingSpeechPermissionTriggerMode = nil
+                    self.pendingSpeechPermissionSelectionSnapshot = nil
+                    self.pendingSpeechPermissionManualCommandRequested = nil
+                    self.isAwaitingSpeechRecognitionPermission = false
+                    self.restartHotkeyMonitoring()
+
+                    guard let triggerMode = pendingTriggerMode else { return }
+                    if granted {
+                        self.errorMessage = nil
+                        if triggerMode == .toggle {
+                            Task { [weak self] in
+                                guard let self else { return }
+                                guard await self.prepareRecordingStart(
+                                    triggerMode: .toggle,
+                                    selectionSnapshot: pendingSelectionSnapshot,
+                                    manualCommandRequested: pendingManualCommandRequested
+                                ) else { return }
+                                self.shortcutSessionController.beginManual(mode: .toggle)
+                                self.applyAudioInterruptionIfNeeded()
+                                self.beginRecording(triggerMode: .toggle)
+                            }
+                        } else {
+                            self.currentSessionIntent = .dictation
+                            self.statusText = "Speech Recognition access granted. Press and hold again to record."
+                            self.scheduleReadyStatusReset(
+                                after: 2,
+                                matching: ["Speech Recognition access granted. Press and hold again to record."]
+                            )
+                        }
+                    } else {
+                        self.errorMessage = "Speech Recognition permission is required for Apple Live transcription. Enable it in System Settings > Privacy & Security > Speech Recognition."
+                        self.statusText = "No Speech Recognition"
+                        self.activeRecordingTriggerMode = nil
+                        self.currentSessionIntent = .dictation
+                        self.shortcutSessionController.reset()
+                    }
+                }
+                return
+            default:
                 isRecording = false
                 activeRecordingTriggerMode = nil
                 currentSessionIntent = .dictation
                 shortcutSessionController.reset()
                 errorMessage = "Speech Recognition permission is required for Apple Live transcription. Enable it in System Settings > Privacy & Security > Speech Recognition."
                 statusText = "No Speech Recognition"
-                requestSpeechRecognitionAccess()
                 return
             }
         }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2462,10 +2462,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     self.isAwaitingSpeechRecognitionPermission = false
                     self.restartHotkeyMonitoring()
 
-                    guard let triggerMode = pendingTriggerMode else { return }
+                    guard let resumedTriggerMode = pendingTriggerMode else { return }
                     if granted {
                         self.errorMessage = nil
-                        if triggerMode == .toggle {
+                        if resumedTriggerMode == .toggle {
                             Task { @MainActor [weak self] in
                                 guard let self else { return }
                                 guard await self.prepareRecordingStart(

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2415,7 +2415,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 guard let triggerMode = activeRecordingTriggerMode else { return }
                 prepareForSpeechRecognitionPermissionPrompt(
                     triggerMode: triggerMode,
-                    selectionSnapshot: pendingSelectionSnapshot ?? contextService.collectSelectionSnapshot(),
+                    selectionSnapshot: pendingSelectionSnapshot,
                     manualCommandRequested: currentSessionIntent.isManualCommand
                 )
                 requestSpeechRecognitionAccess { [weak self] granted in
@@ -2446,6 +2446,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             }
                         } else {
                             self.currentSessionIntent = .dictation
+                            self.restoreAudioInterruptionIfNeeded()
                             self.statusText = "Speech Recognition access granted. Press and hold again to record."
                             self.scheduleReadyStatusReset(
                                 after: 2,
@@ -2453,6 +2454,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             )
                         }
                     } else {
+                        self.restoreAudioInterruptionIfNeeded()
                         self.errorMessage = "Speech Recognition permission is required for Apple Live transcription. Enable it in System Settings > Privacy & Security > Speech Recognition."
                         self.statusText = "No Speech Recognition"
                         self.activeRecordingTriggerMode = nil
@@ -2463,6 +2465,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 return
             default:
                 isRecording = false
+                restoreAudioInterruptionIfNeeded()
                 activeRecordingTriggerMode = nil
                 currentSessionIntent = .dictation
                 shortcutSessionController.reset()

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1390,6 +1390,15 @@ struct GeneralSettingsView: View {
             )
 
             permissionRow(
+                title: "Speech Recognition",
+                icon: "waveform.badge.mic",
+                granted: appState.hasSpeechRecognitionPermission,
+                action: {
+                    appState.requestSpeechRecognitionAccess()
+                }
+            )
+
+            permissionRow(
                 title: "Screen Recording",
                 icon: "camera.viewfinder",
                 granted: appState.hasScreenRecordingPermission,

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -59,6 +59,7 @@ struct SetupView: View {
         case welcome = 0
         case apiKey
         case micPermission
+        case speechRecognition
         case accessibility
         case screenRecording
         case holdShortcut
@@ -232,6 +233,8 @@ struct SetupView: View {
             apiKeyStep
         case .micPermission:
             micPermissionStep
+        case .speechRecognition:
+            speechRecognitionStep
         case .accessibility:
             accessibilityStep
         case .screenRecording:
@@ -502,6 +505,47 @@ struct SetupView: View {
             .background(Color(nsColor: .controlBackgroundColor))
             .cornerRadius(8)
 
+        }
+    }
+
+    var speechRecognitionStep: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "waveform.badge.mic")
+                .font(.system(size: 60))
+                .foregroundStyle(.blue)
+
+            Text("Speech Recognition")
+                .font(.title)
+                .fontWeight(.bold)
+
+            Text("Apple Live transcription needs Speech Recognition permission in addition to microphone access.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack {
+                Image(systemName: "waveform.badge.mic")
+                    .frame(width: 24)
+                    .foregroundStyle(.blue)
+                Text("Speech Recognition")
+                Spacer()
+                if appState.hasSpeechRecognitionPermission {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Text("Granted")
+                        .foregroundStyle(.green)
+                } else {
+                    Button("Grant Access") {
+                        appState.requestSpeechRecognitionAccess()
+                    }
+                }
+            }
+            .padding(12)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .cornerRadius(8)
+        }
+        .onAppear {
+            appState.refreshSpeechRecognitionAuthorizationStatus()
         }
     }
 

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -1060,6 +1060,8 @@ struct SetupView: View {
         switch currentStep {
         case .micPermission:
             return micPermissionGranted
+        case .speechRecognition:
+            return appState.hasSpeechRecognitionPermission
         case .accessibility:
             return accessibilityGranted
         case .screenRecording:


### PR DESCRIPTION
Closes #39

## Summary
- surface Speech Recognition as an explicit permission in Setup and Settings
- track the current Speech Recognition authorization state in `AppState`
- block Apple Live recording start when Speech Recognition is unavailable and show a clear explanatory error

## Test plan
- [x] Run `make all CODESIGN_IDENTITY=\"Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)\"`
- [x] Run `make install CODESIGN_IDENTITY=\"Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)\"`
- [ ] Verify Setup shows a Speech Recognition permission row
- [ ] Verify Settings > Permissions shows a Speech Recognition row and status
- [ ] Verify Apple Live recording is blocked with a clear message when Speech Recognition permission is missing
- [ ] Verify Apple Live recording still starts normally when permission is granted

🤖 Generated with [Claude Code](https://claude.com/claude-code)