### PR TITLE
Update Quill settings UX and branding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           plutil -replace CFBundleShortVersionString -string "${{ steps.version.outputs.version }}" Info.plist
           plutil -replace CFBundleVersion -string "${{ github.run_number }}" Info.plist
-          plutil -replace FreeFlowBuildTag -string "${{ steps.version.outputs.tag }}" Info.plist
+          plutil -replace QuillBuildTag -string "${{ steps.version.outputs.tag }}" Info.plist
 
       - name: Build release notes from changelog
         id: release_notes
@@ -46,7 +46,7 @@ jobs:
             echo
             echo "## Download"
             echo
-            echo "**[FreeFlow.dmg](https://github.com/zachlatta/freeflow/releases/download/${{ steps.version.outputs.tag }}/FreeFlow.dmg)** — Universal build for all Macs (Apple Silicon + Intel)."
+            echo "**[Quill.dmg](https://github.com/woosublee/freeflow/releases/download/${{ steps.version.outputs.tag }}/Quill.dmg)** — Universal build for all Macs (Apple Silicon + Intel)."
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -113,36 +113,36 @@ jobs:
 
       # --- Build universal ---
       - name: Build universal
-        run: make ARCH=universal APP_NAME=FreeFlow BUNDLE_ID=com.zachlatta.freeflow CODESIGN_IDENTITY="$CODESIGN_IDENTITY"
+        run: make ARCH=universal APP_NAME=Quill BUNDLE_ID=com.woosublee.quill CODESIGN_IDENTITY="$CODESIGN_IDENTITY"
 
       - name: Create universal DMG
-        run: make dmg ARCH=universal APP_NAME=FreeFlow BUNDLE_ID=com.zachlatta.freeflow CODESIGN_IDENTITY="$CODESIGN_IDENTITY"
+        run: make dmg ARCH=universal APP_NAME=Quill BUNDLE_ID=com.woosublee.quill CODESIGN_IDENTITY="$CODESIGN_IDENTITY"
 
       - name: Sign universal DMG
-        run: codesign --force --sign "$CODESIGN_IDENTITY" build/FreeFlow.dmg
+        run: codesign --force --sign "$CODESIGN_IDENTITY" build/Quill.dmg
 
       - name: Notarize universal DMG
         run: |
-          xcrun notarytool submit build/FreeFlow.dmg \
+          xcrun notarytool submit build/Quill.dmg \
             --keychain-profile "notarytool-profile" \
             --keychain "$KEYCHAIN_PATH" \
             --wait
-          xcrun stapler staple build/FreeFlow.dmg
+          xcrun stapler staple build/Quill.dmg
 
       - name: Save universal DMG
-        run: mv build/FreeFlow.dmg FreeFlow.dmg
+        run: mv build/Quill.dmg Quill.dmg
 
       # --- Release ---
       - name: Create Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           tag_name: ${{ steps.version.outputs.tag }}
-          name: FreeFlow ${{ steps.version.outputs.version }}
+          name: Quill ${{ steps.version.outputs.version }}
           body: ${{ steps.release_notes.outputs.body }}
           generate_release_notes: false
           make_latest: true
           files: |
-            FreeFlow.dmg
+            Quill.dmg
 
       # --- Cleanup ---
       - name: Cleanup signing artifacts

--- a/Info.plist
+++ b/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.woosublee.quill</string>
     <key>CFBundleVersion</key>
-    <string>0.3.0</string>
+    <string>1</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.3.0</string>
+    <string>0.0.1</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ ARCH ?= $(shell uname -m)
 
 # Pick the icon source based on which bundle we are building. Dev builds get
 # a distinct hammer-on-waveform icon so a developer's dock shows at a glance
-# which FreeFlow they are running when both are installed side by side.
-ifeq ($(APP_NAME),FreeFlow Dev)
+# which Quill build they are running when both are installed side by side.
+ifeq ($(APP_NAME),Quill Dev)
 ICON_SOURCE = Resources/AppIcon-Dev-Source.png
 ICON_ICNS = Resources/AppIcon-Dev.icns
 else
@@ -64,7 +64,13 @@ endif
 	@plutil -replace CFBundleIdentifier -string "$(BUNDLE_ID)" "$(CONTENTS)/Info.plist"
 	@cp $(ICON_ICNS) "$(RESOURCES)/"
 	@xattr -cr "$(APP_BUNDLE)"
-	@codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" --entitlements Quill.entitlements "$(APP_BUNDLE)"
+	@rm -rf "$(BUILD_DIR)/codesign-staging"
+	@mkdir -p "$(BUILD_DIR)/codesign-staging"
+	@ditto --norsrc "$(APP_BUNDLE)" "$(BUILD_DIR)/codesign-staging/$(APP_NAME).app"
+	@codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" --entitlements Quill.entitlements "$(BUILD_DIR)/codesign-staging/$(APP_NAME).app"
+	@rm -rf "$(APP_BUNDLE)"
+	@ditto "$(BUILD_DIR)/codesign-staging/$(APP_NAME).app" "$(APP_BUNDLE)"
+	@rm -rf "$(BUILD_DIR)/codesign-staging"
 	@echo "Built $(APP_BUNDLE)"
 
 icon: $(ICON_ICNS)

--- a/README.md
+++ b/README.md
@@ -48,45 +48,45 @@ Then:
 ---
 
 <p align="center">
-  <img src="Resources/AppIcon-Source.png" width="128" height="128" alt="FreeFlow icon">
+  <img src="Resources/AppIcon-Source.png" width="128" height="128" alt="Quill icon">
 </p>
 
-<h1 align="center">FreeFlow</h1>
+<h1 align="center">Quill</h1>
 
 <p align="center">
   Free and open source alternative to <a href="https://wisprflow.ai">Wispr Flow</a>, <a href="https://superwhisper.com">Superwhisper</a>, and <a href="https://monologue.to">Monologue</a>.
 </p>
 
 <p align="center">
-  <a href="https://github.com/zachlatta/freeflow/releases/latest/download/FreeFlow.dmg"><b>⬇ Download FreeFlow.dmg</b></a><br>
+  <a href="https://github.com/woosublee/freeflow/releases/latest/download/Quill.dmg"><b>⬇ Download Quill.dmg</b></a><br>
   <sub>Works on all Macs (Apple Silicon + Intel)</sub>
 </p>
 
 ---
 
 <p align="center">
-  <img src="Resources/demo.gif" alt="FreeFlow demo" width="600">
+  <img src="Resources/demo.gif" alt="Quill demo" width="600">
 </p>
 
 <p align="center">
-  <i>Thank you to <a href="https://github.com/marcbodea">@marcbodea</a> for maintaining FreeFlow!</i>
+  <i>Thank you to <a href="https://github.com/marcbodea">@marcbodea</a> for maintaining the original FreeFlow project!</i>
 </p>
 
 ## Overview
 
-FreeFlow is a free Mac dictation app inspired by [Wispr Flow](https://wisprflow.ai/), [Superwhisper](https://superwhisper.com/), and [Monologue](https://www.monologue.to/). It gives you fast AI transcription, context-aware cleanup, and voice-driven text editing without a monthly subscription.
+Quill is a free Mac dictation app inspired by [Wispr Flow](https://wisprflow.ai/), [Superwhisper](https://superwhisper.com/), and [Monologue](https://www.monologue.to/). It gives you fast AI transcription, context-aware cleanup, and voice-driven text editing without a monthly subscription.
 
 ## Quick Start
 
-1. Download the app from above or [click here](https://github.com/zachlatta/freeflow/releases/latest/download/FreeFlow.dmg)
+1. Download the app from above or [click here](https://github.com/woosublee/freeflow/releases/latest/download/Quill.dmg)
 2. Get a free Groq API key from [groq.com](https://groq.com/)
 3. Hold `Fn` to talk, or tap `Command-Fn` to start and stop dictation, and have whatever you say pasted into the current text field
 
 ## Features
 
 - **Custom shortcuts:** Customize both hold-to-talk and toggle dictation shortcuts. If your toggle shortcut extends your hold shortcut, you can start in hold mode and press the extra modifier keys to latch into tap mode without stopping the recording.
-- **Context-aware cleanup:** FreeFlow can read nearby app context so names, terms, and phrases are spelled correctly when you dictate into email, terminals, docs, and other apps.
-- **Custom vocabulary:** Add names, jargon, and project-specific words that FreeFlow should preserve during cleanup.
+- **Context-aware cleanup:** Quill can read nearby app context so names, terms, and phrases are spelled correctly when you dictate into email, terminals, docs, and other apps.
+- **Custom vocabulary:** Add names, jargon, and project-specific words that Quill should preserve during cleanup.
 - **OpenAI-compatible providers:** Use Groq by default, or configure a custom model and API URL in settings.
 
 ## Edit Mode
@@ -95,7 +95,7 @@ Edit Mode lets you highlight existing text and transform it with a spoken instru
 
 ## Privacy
 
-There is no FreeFlow server, so FreeFlow does not store or retain your data. The only information that leaves your computer are API calls to your configured transcription and LLM provider.
+There is no Quill server, so Quill does not store or retain your data. The only information that leaves your computer are API calls to your configured transcription and LLM provider.
 
 ## Custom Cleanup
 
@@ -129,13 +129,13 @@ Then your response would be ONLY the cleaned up text, so here your response is O
 
 **Why does this use Groq instead of a local transcription model?**
 
-I love this idea, and originally planned to build FreeFlow using local models, but to have post-processing (that's where you get correctly spelled names when replying to emails / etc), you need to have a local LLM too.
+I love this idea, and originally planned to build Quill using local models, but to have post-processing (that's where you get correctly spelled names when replying to emails / etc), you need to have a local LLM too.
 
 If you do that, the total pipeline takes too long for the UX to be good (5-10 seconds per transcription instead of <1s). I also had concerns around battery life.
 
 Some day!
 
-**Update:** You can now use a custom model with FreeFlow by configuring the LLM API URL in the FreeFlow settings to use Ollama. Thank you @taciturnaxolotl!
+**Update:** You can now use a custom model with Quill by configuring the LLM API URL in the Quill settings to use Ollama. Thank you @taciturnaxolotl!
 
 ## License
 

--- a/Sources/App.swift
+++ b/Sources/App.swift
@@ -2,7 +2,7 @@ import AppKit
 import SwiftUI
 
 @main
-struct FreeFlowApp: App {
+struct QuillApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @AppStorage("show_menu_bar_icon") private var showMenuBarIcon = true
 
@@ -29,7 +29,7 @@ struct MenuBarLabel: View {
     @EnvironmentObject var appState: AppState
 
     private var isDevBundle: Bool {
-        (Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String) == "FreeFlow Dev"
+        (Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String) == "Quill Dev"
     }
 
     private var iconName: String {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -87,9 +87,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             appState.startHotkeyMonitoring()
             appState.startAccessibilityPolling()
-            Task { @MainActor in
-                UpdateManager.shared.startPeriodicChecks()
-            }
+            // Quill releases are not distributed through the in-app updater yet.
+            // Task { @MainActor in
+            //     UpdateManager.shared.startPeriodicChecks()
+            // }
 
             if !AXIsProcessTrusted() {
                 appState.showAccessibilityAlert()
@@ -253,9 +254,10 @@ private func showNoteBrowserWindow() {
         updateActivationPolicy()
         appState.startHotkeyMonitoring()
         appState.startAccessibilityPolling()
-        Task { @MainActor in
-            UpdateManager.shared.startPeriodicChecks()
-        }
+        // Quill releases are not distributed through the in-app updater yet.
+        // Task { @MainActor in
+        //     UpdateManager.shared.startPeriodicChecks()
+        // }
 
         if !AXIsProcessTrusted() {
             Task { @MainActor in

--- a/Sources/AppName.swift
+++ b/Sources/AppName.swift
@@ -2,5 +2,5 @@ import Foundation
 
 enum AppName {
     static let displayName: String =
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "FreeFlow"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "Quill"
 }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -7,7 +7,7 @@ import ApplicationServices
 import ScreenCaptureKit
 import Speech
 import os.log
-private let recordingLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "Recording")
+private let recordingLog = OSLog(subsystem: "com.woosublee.quill", category: "Recording")
 
 struct VoiceMacro: Codable, Identifiable, Equatable {
     var id: UUID = UUID()

--- a/Sources/AppleSpeechLiveTranscriber.swift
+++ b/Sources/AppleSpeechLiveTranscriber.swift
@@ -3,7 +3,7 @@ import CoreMedia
 import os.log
 import Speech
 
-private let speechLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "AppleSpeech")
+private let speechLog = OSLog(subsystem: "com.woosublee.quill", category: "AppleSpeech")
 
 // 실시간 전사를 지원하는 모든 백엔드가 따르는 프로토콜
 protocol LiveTranscriber: AnyObject {

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -3,7 +3,7 @@ import CoreMedia
 import Foundation
 import os.log
 
-private let recordingLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "Recording")
+private let recordingLog = OSLog(subsystem: "com.woosublee.quill", category: "Recording")
 
 struct AudioDevice: Identifiable {
     let id: String
@@ -79,8 +79,8 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     private let _bufferCount = OSAllocatedUnfairLock(initialState: 0)
     private let fileWriteErrorLock = OSAllocatedUnfairLock(initialState: ())
     private var watchdogTimer: DispatchSourceTimer?
-    private let sessionQueue = DispatchQueue(label: "com.zachlatta.freeflow.capture.session")
-    private let sampleBufferQueue = DispatchQueue(label: "com.zachlatta.freeflow.capture.samples")
+    private let sessionQueue = DispatchQueue(label: "com.woosublee.quill.capture.session")
+    private let sampleBufferQueue = DispatchQueue(label: "com.woosublee.quill.capture.samples")
     private var activeAudioFile: AVAudioFile?
     private var activeAudioFormat: AVAudioFormat?
     private var recordedFrameCount: AVAudioFramePosition = 0

--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -1,7 +1,7 @@
 import Cocoa
 import os.log
 
-private let shortcutLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "Shortcuts")
+private let shortcutLog = OSLog(subsystem: "com.woosublee.quill", category: "Shortcuts")
 
 enum GlobalShortcutBackendError: LocalizedError {
     case eventTapUnavailable

--- a/Sources/KeychainStorage.swift
+++ b/Sources/KeychainStorage.swift
@@ -2,7 +2,7 @@ import Foundation
 import Security
 
 enum AppSettingsStorage {
-    private static let bundleID = Bundle.main.bundleIdentifier ?? "com.zachlatta.freeflow"
+    private static let bundleID = Bundle.main.bundleIdentifier ?? "com.woosublee.quill"
 
     private static var storageDirectory: URL {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!

--- a/Sources/RealtimeTranscriptionService.swift
+++ b/Sources/RealtimeTranscriptionService.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os.log
 
-private let realtimeLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "RealtimeTranscription")
+private let realtimeLog = OSLog(subsystem: "com.woosublee.quill", category: "RealtimeTranscription")
 
 enum RealtimeTranscriptionError: LocalizedError {
     case invalidBaseURL(String)
@@ -32,7 +32,7 @@ final class RealtimeTranscriptionService {
     private var task: URLSessionWebSocketTask?
     private var receiveTask: Task<Void, Never>?
 
-    private let stateQueue = DispatchQueue(label: "com.zachlatta.freeflow.realtime.state")
+    private let stateQueue = DispatchQueue(label: "com.woosublee.quill.realtime.state")
     private var finalText: String = ""
     private var partialText: String = ""
     private var finalContinuation: CheckedContinuation<String, Error>?

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -474,7 +474,7 @@ struct GeneralSettingsView: View {
     @State private var copiedBuildInfoResetWorkItem: DispatchWorkItem?
     @StateObject private var githubCache = GitHubMetadataCache.shared
     @ObservedObject private var updateManager = UpdateManager.shared
-    private let freeflowRepoURL = URL(string: "https://github.com/zachlatta/freeflow")!
+    private let upstreamRepoURL = URL(string: "https://github.com/zachlatta/freeflow")!
 
     private var appDisplayName: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
@@ -487,7 +487,7 @@ struct GeneralSettingsView: View {
     }
 
     private var appBuildNumber: String {
-        Bundle.main.object(forInfoDictionaryKey: "FreeFlowBuildTag") as? String
+        Bundle.main.object(forInfoDictionaryKey: "QuillBuildTag") as? String
             ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
             ?? "unknown"
     }
@@ -543,7 +543,7 @@ struct GeneralSettingsView: View {
                             .clipShape(Circle())
 
                             Button {
-                                openURL(freeflowRepoURL)
+                                openURL(upstreamRepoURL)
                             } label: {
                                 Text("zachlatta/freeflow")
                                     .font(.system(.caption, design: .monospaced).weight(.medium))
@@ -570,7 +570,7 @@ struct GeneralSettingsView: View {
                             .background(Capsule().fill(Color.yellow.opacity(0.14)))
 
                             Button {
-                                openURL(freeflowRepoURL)
+                                openURL(upstreamRepoURL)
                             } label: {
                                 HStack(spacing: 4) {
                                     Image(systemName: "star")
@@ -640,9 +640,10 @@ struct GeneralSettingsView: View {
                 SettingsCard("Note Browser", icon: "note.text") {
                     noteBrowserSection
                 }
-                SettingsCard("Updates", icon: "arrow.triangle.2.circlepath") {
-                    updatesSection
-                }
+                // Quill releases are not distributed through the in-app updater yet.
+                // SettingsCard("Updates", icon: "arrow.triangle.2.circlepath") {
+                //     updatesSection
+                // }
                 SettingsCard("Transcription", icon: "waveform.badge.magnifyingglass") {
                     transcriptionSection
                 }
@@ -1687,7 +1688,7 @@ struct PromptsSettingsView: View {
 
         let context = AppContext(
             appName: "Quill Settings",
-            bundleIdentifier: "com.zachlatta.freeflow",
+            bundleIdentifier: "com.woosublee.quill",
             windowTitle: "System Prompt Test",
             selectedText: nil,
             currentActivity: "User is testing the system prompt in Quill settings.",

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -58,6 +58,7 @@ struct ProviderSettingsFields: View {
     @State private var contextModelDraft: String = ""
 
     let showsModelDescription: Bool
+    let showsTranscriptionLanguage: Bool
 
     private func commitAPIBaseURL() {
         let trimmed = apiBaseURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -259,19 +260,21 @@ struct ProviderSettingsFields: View {
                     .foregroundStyle(.secondary)
             }
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Transcription Language")
-                    .font(.caption.weight(.semibold))
-                Picker("", selection: $appState.transcriptionLanguage) {
-                    ForEach(TranscriptionLanguage.all) { option in
-                        Text(option.displayName).tag(option)
+            if showsTranscriptionLanguage {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Transcription Language")
+                        .font(.caption.weight(.semibold))
+                    Picker("", selection: $appState.transcriptionLanguage) {
+                        ForEach(TranscriptionLanguage.all) { option in
+                            Text(option.displayName).tag(option)
+                        }
                     }
+                    .accessibilityLabel("Transcription Language")
+                    .labelsHidden()
+                    Text("Hint to the transcription model. Auto Detect works for most users. Pick a specific language if you see wrong-script characters appear in the output.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
-                .accessibilityLabel("Transcription Language")
-                .labelsHidden()
-                Text("Hint to the transcription model. Auto Detect works for most users. Pick a specific language if you see wrong-script characters appear in the output.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
 
             VStack(alignment: .leading, spacing: 6) {
@@ -461,7 +464,6 @@ struct GeneralSettingsView: View {
     @State private var apiBaseURLInput: String = ""
     @State private var transcriptionAPIURLInput: String = ""
     @State private var transcriptionAPIKeyInput: String = ""
-    @State private var advancedProviderSettingsExpanded = false
     @State private var isValidatingKey = false
     @State private var keyValidationError: String?
     @State private var keyValidationSuccess = false
@@ -635,11 +637,14 @@ struct GeneralSettingsView: View {
                 SettingsCard("App", icon: "power") {
                     startupSection
                 }
+                SettingsCard("Note Browser", icon: "note.text") {
+                    noteBrowserSection
+                }
                 SettingsCard("Updates", icon: "arrow.triangle.2.circlepath") {
                     updatesSection
                 }
-                SettingsCard("API Key", icon: "key.fill") {
-                    apiKeySection
+                SettingsCard("Transcription", icon: "waveform.badge.magnifyingglass") {
+                    transcriptionSection
                 }
                 SettingsCard("Dictation Shortcuts", icon: "keyboard.fill") {
                     hotkeySection
@@ -697,13 +702,13 @@ struct GeneralSettingsView: View {
 
     private var appearanceSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("테마")
+            Text("Theme")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
             Picker("", selection: $appAppearance) {
-                Text("시스템 설정 따름").tag("system")
-                Text("라이트 모드").tag("light")
-                Text("다크 모드").tag("dark")
+                Text("System Setting").tag("system")
+                Text("Light").tag("light")
+                Text("Dark").tag("dark")
             }
             .pickerStyle(.segmented)
             .labelsHidden()
@@ -728,20 +733,6 @@ struct GeneralSettingsView: View {
             Toggle("Launch Quill at login", isOn: $appState.launchAtLogin)
             Toggle("Show menu bar icon", isOn: $showMenuBarIcon)
 
-            HStack(alignment: .center, spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Note Browser")
-                        .font(.caption.weight(.semibold))
-                    Text("독 아이콘을 클릭하면 노트 브라우저가 열립니다. 받아쓰기 기록을 노트 앱처럼 탐색할 수 있습니다.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer(minLength: 0)
-                Toggle("", isOn: $appState.noteBrowserEnabled)
-                    .toggleStyle(.checkbox)
-                    .labelsHidden()
-            }
-
             if SMAppService.mainApp.status == .requiresApproval {
                 HStack(spacing: 6) {
                     Image(systemName: "exclamationmark.triangle.fill")
@@ -756,6 +747,17 @@ struct GeneralSettingsView: View {
                     .font(.caption)
                 }
             }
+        }
+    }
+
+    // MARK: Note Browser
+
+    private var noteBrowserSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Toggle("Enable Note Browser", isOn: $appState.noteBrowserEnabled)
+            Text("Click the Dock icon to open Note Browser and browse your dictation history like notes.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -927,10 +929,92 @@ struct GeneralSettingsView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: resetWorkItem)
     }
 
-    // MARK: API Key
+    // MARK: Transcription
 
-    private var apiKeySection: some View {
-        VStack(alignment: .leading, spacing: 10) {
+    private var transcriptionSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Transcription Mode")
+                    .font(.caption.weight(.semibold))
+
+                Picker("Transcription Mode", selection: $appState.useLocalTranscription) {
+                    Text("Local").tag(true)
+                    Text("API Provider").tag(false)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+
+                Text(appState.useLocalTranscription
+                    ? "Run speech recognition on this Mac and configure only local transcription options."
+                    : "Use your configured OpenAI-compatible provider and configure only provider-specific options.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Divider()
+
+            if appState.useLocalTranscription {
+                localTranscriptionSettings
+            } else {
+                apiProviderTranscriptionSettings
+            }
+
+            Divider()
+
+            sharedTranscriptionBehaviors
+        }
+    }
+
+    private var localTranscriptionSettings: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Local Options")
+                    .font(.caption.weight(.semibold))
+
+                ForEach(TranscriptionModel.all) { model in
+                    ModelRowView(
+                        model: model,
+                        isSelected: appState.localTranscriptionModel == model,
+                        whisperBin: appState.localWhisperPath.isEmpty
+                            ? "\(FileManager.default.homeDirectoryForCurrentUser.path)/.local/bin/mlx_whisper"
+                            : appState.localWhisperPath
+                    ) {
+                        appState.localTranscriptionModel = model
+                    }
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Transcription Language")
+                    .font(.caption.weight(.semibold))
+                Picker("", selection: $appState.transcriptionLanguage) {
+                    ForEach(TranscriptionLanguage.all) { lang in
+                        Text(lang.displayName).tag(lang)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .frame(maxWidth: 200, alignment: .leading)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("mlx_whisper Path (optional)")
+                    .font(.caption.weight(.semibold))
+                Text("Leave empty to use the default path (~/.local/bin/mlx_whisper).")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextField("~/.local/bin/mlx_whisper", text: $appState.localWhisperPath)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(.body, design: .monospaced))
+            }
+        }
+    }
+
+    private var apiProviderTranscriptionSettings: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("API Provider Options")
+                .font(.caption.weight(.semibold))
+
             Text("Quill uses the configured transcription model with your selected OpenAI-compatible provider.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -961,145 +1045,45 @@ struct GeneralSettingsView: View {
                     .font(.caption)
             }
 
-            DisclosureGroup(isExpanded: $advancedProviderSettingsExpanded) {
-                VStack(alignment: .leading, spacing: 12) {
-                    Divider()
-                    ProviderSettingsFields(
-                        apiBaseURLInput: $apiBaseURLInput,
-                        transcriptionAPIURLInput: $transcriptionAPIURLInput,
-                        transcriptionAPIKeyInput: $transcriptionAPIKeyInput,
-                        showsModelDescription: false
-                    )
-                }
-            } label: {
-                HStack {
-                    Text("Advanced Provider Settings")
-                    Spacer()
-                }
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    advancedProviderSettingsExpanded.toggle()
-                }
+            ProviderSettingsFields(
+                apiBaseURLInput: $apiBaseURLInput,
+                transcriptionAPIURLInput: $transcriptionAPIURLInput,
+                transcriptionAPIKeyInput: $transcriptionAPIKeyInput,
+                showsModelDescription: false,
+                showsTranscriptionLanguage: true
+            )
+        }
+    }
+
+    private var sharedTranscriptionBehaviors: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Shared Behaviors")
+                .font(.caption.weight(.semibold))
+
+            VStack(alignment: .leading, spacing: 6) {
+                Toggle("Disable Post-Processing", isOn: $appState.disablePostProcessing)
+                Text("Skip LLM cleanup. Raw transcript is used as-is. No API call is made for post-processing.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Divider()
 
-            HStack(alignment: .center, spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Use Local Transcription (mlx-whisper)")
-                        .font(.caption.weight(.semibold))
-                    Text("Runs whisper-large-v3 locally on your Mac. No file size limit. Requires mlx-whisper installed via pipx.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer(minLength: 0)
-
-                Toggle("", isOn: $appState.useLocalTranscription)
-                    .toggleStyle(.checkbox)
-                    .labelsHidden()
-            }
-
-            if appState.useLocalTranscription {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Transcription Model")
-                        .font(.caption.weight(.semibold))
-                    ForEach(TranscriptionModel.all) { model in
-                        ModelRowView(
-                            model: model,
-                            isSelected: appState.localTranscriptionModel == model,
-                            whisperBin: appState.localWhisperPath.isEmpty
-                                ? "\(FileManager.default.homeDirectoryForCurrentUser.path)/.local/bin/mlx_whisper"
-                                : appState.localWhisperPath
-                        ) {
-                            appState.localTranscriptionModel = model
-                        }
-                    }
-                }
-            }
-
-            if appState.useLocalTranscription {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Transcription Language")
-                        .font(.caption.weight(.semibold))
-                    Picker("", selection: $appState.transcriptionLanguage) {
-                        ForEach(TranscriptionLanguage.all) { lang in
-                            Text(lang.displayName).tag(lang)
-                        }
-                    }
-                    .labelsHidden()
-                    .pickerStyle(.menu)
-                    .frame(maxWidth: 200, alignment: .leading)
-                }
-            }
-
-            if appState.useLocalTranscription {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("mlx_whisper Path (optional)")
-                        .font(.caption.weight(.semibold))
-                    Text("Leave empty to use the default path (~/.local/bin/mlx_whisper).")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    TextField("~/.local/bin/mlx_whisper", text: $appState.localWhisperPath)
-                        .textFieldStyle(.roundedBorder)
-                        .font(.system(.body, design: .monospaced))
-                }
+            VStack(alignment: .leading, spacing: 6) {
+                Toggle("Disable Auto Paste", isOn: $appState.disableAutoPaste)
+                Text("Transcription will be copied to clipboard only. Paste manually when needed.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Divider()
 
-            HStack(alignment: .center, spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Disable Post-Processing")
-                        .font(.caption.weight(.semibold))
-                    Text("Skip LLM cleanup. Raw transcript is used as-is. No API call is made for post-processing.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer(minLength: 0)
-
-                Toggle("", isOn: $appState.disablePostProcessing)
-                    .toggleStyle(.checkbox)
-                    .labelsHidden()
+            VStack(alignment: .leading, spacing: 6) {
+                Toggle("Disable Context Capture", isOn: $appState.disableContextCapture)
+                Text("Skip screen recording and app context detection. Transcription will not adapt to the current app. Screen Recording permission is not required.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
-
-            Divider()
-
-            HStack(alignment: .center, spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Disable Auto Paste")
-                        .font(.caption.weight(.semibold))
-                    Text("Transcription will be copied to clipboard only. Paste manually when needed.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer(minLength: 0)
-
-                Toggle("", isOn: $appState.disableAutoPaste)
-                    .toggleStyle(.checkbox)
-                    .labelsHidden()
-            }
-
-            Divider()
-
-            HStack(alignment: .center, spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Disable Context Capture")
-                        .font(.caption.weight(.semibold))
-                    Text("Skip screen recording and app context detection. Transcription will not adapt to the current app. Screen Recording permission is not required.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer(minLength: 0)
-
-                Toggle("", isOn: $appState.disableContextCapture)
-                    .toggleStyle(.checkbox)
-                    .labelsHidden()
-            }
-            .padding(.top, 4)
         }
     }
 

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -55,7 +55,7 @@ struct SetupView: View {
     var onComplete: () -> Void
     @EnvironmentObject var appState: AppState
     @Environment(\.openURL) private var openURL
-    private let freeflowRepoURL = URL(string: "https://github.com/zachlatta/freeflow")!
+    private let upstreamRepoURL = URL(string: "https://github.com/zachlatta/freeflow")!
     private enum SetupStep: Int, CaseIterable {
         case welcome = 0
         case apiKey
@@ -290,7 +290,7 @@ struct SetupView: View {
                     .clipShape(Circle())
 
                     Button {
-                        openURL(freeflowRepoURL)
+                        openURL(upstreamRepoURL)
                     } label: {
                         Text("zachlatta/freeflow")
                             .font(.system(.caption, design: .monospaced).weight(.medium))
@@ -317,7 +317,7 @@ struct SetupView: View {
                     .background(Capsule().fill(Color.yellow.opacity(0.14)))
 
                     Button {
-                        openURL(freeflowRepoURL)
+                        openURL(upstreamRepoURL)
                     } label: {
                         HStack(spacing: 4) {
                             Image(systemName: "star")

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -30,7 +30,8 @@ private struct SetupProviderSettingsSheet: View {
                     apiBaseURLInput: $apiBaseURLInput,
                     transcriptionAPIURLInput: $transcriptionAPIURLInput,
                     transcriptionAPIKeyInput: $transcriptionAPIKeyInput,
-                    showsModelDescription: true
+                    showsModelDescription: true,
+                    showsTranscriptionLanguage: true
                 )
                 .padding(20)
             }

--- a/Sources/TestCaseExporter.swift
+++ b/Sources/TestCaseExporter.swift
@@ -40,7 +40,7 @@ struct TestCaseExporter {
         let timestamp = isoTimestamp(from: item.timestamp)
         let panel = NSSavePanel()
         panel.allowedContentTypes = [UTType.zip]
-        panel.nameFieldStringValue = "freeflow-case-\(timestamp).zip"
+        panel.nameFieldStringValue = "quill-case-\(timestamp).zip"
         panel.title = "Export Test Case"
         panel.message = "Choose where to save the test case ZIP."
         panel.begin { response in
@@ -75,7 +75,7 @@ struct TestCaseExporter {
     ) throws {
         let fm = FileManager.default
         let tempDir = fm.temporaryDirectory
-            .appendingPathComponent("freeflow-case-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("quill-case-\(UUID().uuidString)", isDirectory: true)
         defer { try? fm.removeItem(at: tempDir) }
 
         do {

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -4,7 +4,7 @@ import Foundation
 import Speech
 import os.log
 
-private let transcriptionLog = OSLog(subsystem: "com.zachlatta.freeflow", category: "Transcription")
+private let transcriptionLog = OSLog(subsystem: "com.woosublee.quill", category: "Transcription")
 
 class TranscriptionService {
     private let apiKey: String

--- a/Sources/UpdateManager.swift
+++ b/Sources/UpdateManager.swift
@@ -186,7 +186,7 @@ final class UpdateManager: ObservableObject {
         set { UserDefaults.standard.set(newValue, forKey: "updateLastPostTranscriptionReminderDate") }
     }
 
-    private let releasesURL = URL(string: "https://api.github.com/repos/zachlatta/freeflow/releases?per_page=100")!
+    private let releasesURL = URL(string: "https://api.github.com/repos/woosublee/freeflow/releases?per_page=100")!
     private let stabilityBufferDays: TimeInterval = 3
     private let checkIntervalSeconds: TimeInterval = 7 * 24 * 60 * 60 // 7 days
     private let postTranscriptionReminderInterval: TimeInterval = 24 * 60 * 60 // 1 day
@@ -231,7 +231,7 @@ final class UpdateManager: ObservableObject {
     // MARK: - Check for Updates
 
     func checkForUpdates(userInitiated: Bool) async {
-        let currentBuildTag = Bundle.main.infoDictionary?["FreeFlowBuildTag"] as? String
+        let currentBuildTag = Bundle.main.infoDictionary?["QuillBuildTag"] as? String
         let currentVersionString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
 
         // Dev builds (no embedded tag): skip auto-checks, but allow manual checks
@@ -621,7 +621,7 @@ final class UpdateManager: ObservableObject {
 
     private func performUpdate(downloadURL: URL, expectedSize: Int) async {
         let fm = FileManager.default
-        let tempDir = fm.temporaryDirectory.appendingPathComponent("freeflow-update-\(UUID().uuidString)")
+        let tempDir = fm.temporaryDirectory.appendingPathComponent("quill-update-\(UUID().uuidString)")
 
         do {
             try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -630,7 +630,7 @@ final class UpdateManager: ObservableObject {
             return
         }
 
-        let dmgPath = tempDir.appendingPathComponent("FreeFlow.dmg")
+        let dmgPath = tempDir.appendingPathComponent("Quill.dmg")
 
         // MARK: Download phase
         updateStatus = .downloading
@@ -732,7 +732,7 @@ final class UpdateManager: ObservableObject {
             }
 
             // Copy app to staging directory
-            let stagingDir = fm.temporaryDirectory.appendingPathComponent("freeflow-staged-\(UUID().uuidString)")
+            let stagingDir = fm.temporaryDirectory.appendingPathComponent("quill-staged-\(UUID().uuidString)")
             try fm.createDirectory(at: stagingDir, withIntermediateDirectories: true)
             let stagedApp = stagingDir.appendingPathComponent(appBundle.lastPathComponent)
             try fm.copyItem(at: appBundle, to: stagedApp)


### PR DESCRIPTION
## Summary
- Restructure Settings so transcription mode is chosen first, with Local/API Provider options shown conditionally.
- Move shared transcription behaviors into their own section and separate Note Browser from startup settings.
- Align remaining app branding, release metadata, versioning, and package naming around Quill while preserving upstream references.

## Test plan
- [x] `make clean && make all CODESIGN_IDENTITY="Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)" && make install CODESIGN_IDENTITY="Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)"`
- [x] Launched `/Applications/Quill.app`
- [x] Confirmed remaining FreeFlow/freeflow strings are upstream or repo references

🤖 Generated with [Claude Code](https://claude.com/claude-code)