### PR TITLE
Add external audio import flow

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1353,7 +1353,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             contextPrompt: nil,
             contextScreenshotDataURL: nil,
             contextScreenshotStatus: "No screenshot",
-            postProcessingStatus: "live-recording",
+            postProcessingStatus: "importing",
             debugStatus: "Importing audio",
             customVocabulary: customVocabulary,
             customSystemPrompt: customSystemPrompt,
@@ -1372,6 +1372,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             _ = try pipelineHistoryStore.append(placeholder, maxCount: maxPipelineHistoryCount)
             pipelineHistory = pipelineHistoryStore.loadAllHistory()
         } catch {
+            Self.deleteAudioFile(savedAudioFile.fileName)
             errorMessage = "Unable to save imported audio note: \(error.localizedDescription)"
             return
         }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1171,7 +1171,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     static func fileSizeBytes(for fileURL: URL) -> Int64? {
-        (try? FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? NSNumber)?.int64Value
+        (try? fileURL.resourceValues(forKeys: [.fileSizeKey]))?.fileSize.map { Int64($0) }
     }
 
     static func saveAudioFile(from tempURL: URL) -> SavedAudioFile? {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1331,6 +1331,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let jobID = UUID()
         let noteID = UUID()
         let startedAt = Date()
+        let accessGranted = fileURL.startAccessingSecurityScopedResource()
+        defer {
+            if accessGranted {
+                fileURL.stopAccessingSecurityScopedResource()
+            }
+        }
         guard let savedAudioFile = Self.saveAudioFile(from: fileURL) else {
             errorMessage = "Unable to save the audio file. Check disk space or file permissions and try again."
             return

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1370,7 +1370,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         do {
             _ = try pipelineHistoryStore.append(placeholder, maxCount: maxPipelineHistoryCount)
-            pipelineHistory = pipelineHistoryStore.loadAllHistory()
+            pipelineHistory.insert(placeholder, at: 0)
+            if pipelineHistory.count > maxPipelineHistoryCount {
+                pipelineHistory.removeLast(pipelineHistory.count - maxPipelineHistoryCount)
+            }
         } catch {
             Self.deleteAudioFile(savedAudioFile.fileName)
             errorMessage = "Unable to save imported audio note: \(error.localizedDescription)"

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1405,7 +1405,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let capturedTranscriptionModel = transcriptionModel
         let capturedCustomVocabulary = customVocabulary
         let capturedCustomSystemPrompt = customSystemPrompt
-        let capturedDisablePostProcessing = disablePostProcessing
+        let capturedPostProcessingEnabled = !disablePostProcessing
+        let capturedPressEnterCommandEnabled = isPressEnterVoiceCommandEnabled
 
         let task = Task { [weak self] in
             guard let self else { return }
@@ -1434,7 +1435,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 let rawTranscript = try await transcriptionService.transcribe(fileURL: savedAudioFile.fileURL)
                 let parsedTranscript = Self.parseTranscriptCommands(
                     from: rawTranscript,
-                    pressEnterCommandEnabled: self.isPressEnterVoiceCommandEnabled
+                    pressEnterCommandEnabled: capturedPressEnterCommandEnabled
                 )
                 let result = await self.processImportedTranscript(
                     parsedTranscript.transcript,
@@ -1442,7 +1443,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     postProcessingService: postProcessingService,
                     customVocabulary: capturedCustomVocabulary,
                     customSystemPrompt: capturedCustomSystemPrompt,
-                    postProcessingEnabled: !capturedDisablePostProcessing
+                    postProcessingEnabled: capturedPostProcessingEnabled
                 )
                 let processingStatus = Self.statusMessage(
                     for: result.outcome,
@@ -1460,7 +1461,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         intent: .dictation,
                         audioFileName: savedAudioFile.fileName,
                         useLocalTranscriptionOverride: configuration.useLocalTranscription,
-                        localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id
+                        localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id,
+                        usedPostProcessingOverride: capturedPostProcessingEnabled
                     )
                     self.finishTranscriptionJob(jobID)
                 }
@@ -1477,7 +1479,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         intent: .dictation,
                         audioFileName: savedAudioFile.fileName,
                         useLocalTranscriptionOverride: configuration.useLocalTranscription,
-                        localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id
+                        localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id,
+                        usedPostProcessingOverride: capturedPostProcessingEnabled
                     )
                     self.finishTranscriptionJob(jobID)
                 }
@@ -1486,6 +1489,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         updateTranscriptionJob(jobID) { $0.task = task }
     }
 
+    @MainActor
     private func processImportedTranscript(
         _ rawTranscript: String,
         context: AppContext,
@@ -3251,6 +3255,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let capturedCustomVocabulary = customVocabulary
         let capturedCustomSystemPrompt = customSystemPrompt
         let capturedLiveTranscriber = liveTranscriber
+        let capturedPressEnterCommandEnabled = isPressEnterVoiceCommandEnabled
         liveTranscriber = nil
         audioRecorder.onPCM16Samples = nil
 
@@ -3330,7 +3335,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     }
                     let parsedTranscript = Self.parseTranscriptCommands(
                         from: rawTranscript,
-                        pressEnterCommandEnabled: self.isPressEnterVoiceCommandEnabled
+                        pressEnterCommandEnabled: capturedPressEnterCommandEnabled
                     )
                     try Task.checkCancellation()
                     let appContext: AppContext
@@ -3503,7 +3508,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     }
                     let parsedTranscript = Self.parseTranscriptCommands(
                         from: rawTranscript,
-                        pressEnterCommandEnabled: self.isPressEnterVoiceCommandEnabled
+                        pressEnterCommandEnabled: capturedPressEnterCommandEnabled
                     )
                     try Task.checkCancellation()
                     let appContext: AppContext
@@ -3710,7 +3715,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         intent: SessionIntent,
         audioFileName: String? = nil,
         useLocalTranscriptionOverride: Bool? = nil,
-        localTranscriptionModelIDOverride: String? = nil
+        localTranscriptionModelIDOverride: String? = nil,
+        usedPostProcessingOverride: Bool? = nil
     ) {
         let existingID = activeTranscriptionJobs[jobID]?.liveNoteID
         let existingEntry = existingID.flatMap { id in
@@ -3748,7 +3754,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             audioFileName: audioFileName,
             usedLocalTranscription: useLocalTranscriptionOverride ?? useLocalTranscription,
             usedContextCapture: !disableContextCapture,
-            usedPostProcessing: !disablePostProcessing,
+            usedPostProcessing: usedPostProcessingOverride ?? !disablePostProcessing,
             transcriptionLanguageCode: transcriptionLanguage.code,
             localTranscriptionModelID: localTranscriptionModelIDOverride ?? localTranscriptionModel.id,
             transcriptFileName: transcriptFileName,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1369,10 +1369,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
 
         do {
-            _ = try pipelineHistoryStore.append(placeholder, maxCount: maxPipelineHistoryCount)
-            pipelineHistory.insert(placeholder, at: 0)
-            if pipelineHistory.count > maxPipelineHistoryCount {
-                pipelineHistory.removeLast(pipelineHistory.count - maxPipelineHistoryCount)
+            let removedStoredFiles = try appendPipelineHistoryItem(placeholder)
+            for removedAssets in removedStoredFiles {
+                Self.deleteStoredFiles(removedAssets)
             }
         } catch {
             Self.deleteAudioFile(savedAudioFile.fileName)
@@ -1462,7 +1461,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         audioFileName: savedAudioFile.fileName,
                         useLocalTranscriptionOverride: configuration.useLocalTranscription,
                         localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id,
-                        usedPostProcessingOverride: capturedPostProcessingEnabled
+                        usedContextCaptureOverride: false,
+                        usedPostProcessingOverride: capturedPostProcessingEnabled,
+                        transcriptionLanguageCodeOverride: capturedTranscriptionLanguage.code,
+                        customVocabularyOverride: capturedCustomVocabulary,
+                        customSystemPromptOverride: capturedCustomSystemPrompt
                     )
                     self.finishTranscriptionJob(jobID)
                 }
@@ -1480,7 +1483,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         audioFileName: savedAudioFile.fileName,
                         useLocalTranscriptionOverride: configuration.useLocalTranscription,
                         localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id,
-                        usedPostProcessingOverride: capturedPostProcessingEnabled
+                        usedContextCaptureOverride: false,
+                        usedPostProcessingOverride: capturedPostProcessingEnabled,
+                        transcriptionLanguageCodeOverride: capturedTranscriptionLanguage.code,
+                        customVocabularyOverride: capturedCustomVocabulary,
+                        customSystemPromptOverride: capturedCustomSystemPrompt
                     )
                     self.finishTranscriptionJob(jobID)
                 }
@@ -3704,6 +3711,28 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
+    private func appendPipelineHistoryItem(_ item: PipelineHistoryItem) throws -> [DeletedPipelineHistoryAssets] {
+        let removedStoredFiles = try pipelineHistoryStore.append(item, maxCount: maxPipelineHistoryCount)
+        pipelineHistory.insert(item, at: 0)
+        if pipelineHistory.count > maxPipelineHistoryCount {
+            pipelineHistory.removeLast(pipelineHistory.count - maxPipelineHistoryCount)
+        }
+        return removedStoredFiles
+    }
+
+    @MainActor
+    private func updatePipelineHistoryItem(_ item: PipelineHistoryItem) {
+        if let index = pipelineHistory.firstIndex(where: { $0.id == item.id }) {
+            pipelineHistory[index] = item
+        } else {
+            pipelineHistory.insert(item, at: 0)
+            if pipelineHistory.count > maxPipelineHistoryCount {
+                pipelineHistory.removeLast(pipelineHistory.count - maxPipelineHistoryCount)
+            }
+        }
+    }
+
+    @MainActor
     private func recordPipelineHistoryEntry(
         jobID: UUID,
         rawTranscript: String,
@@ -3716,7 +3745,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         audioFileName: String? = nil,
         useLocalTranscriptionOverride: Bool? = nil,
         localTranscriptionModelIDOverride: String? = nil,
-        usedPostProcessingOverride: Bool? = nil
+        usedContextCaptureOverride: Bool? = nil,
+        usedPostProcessingOverride: Bool? = nil,
+        transcriptionLanguageCodeOverride: String? = nil,
+        customVocabularyOverride: String? = nil,
+        customSystemPromptOverride: String? = nil
     ) {
         let existingID = activeTranscriptionJobs[jobID]?.liveNoteID
         let existingEntry = existingID.flatMap { id in
@@ -3749,13 +3782,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 ?? "available (\(context.screenshotMimeType ?? "image"))",
             postProcessingStatus: processingStatus,
             debugStatus: debugStatusMessage,
-            customVocabulary: customVocabulary,
-            customSystemPrompt: customSystemPrompt,
+            customVocabulary: customVocabularyOverride ?? customVocabulary,
+            customSystemPrompt: customSystemPromptOverride ?? customSystemPrompt,
             audioFileName: audioFileName,
             usedLocalTranscription: useLocalTranscriptionOverride ?? useLocalTranscription,
-            usedContextCapture: !disableContextCapture,
+            usedContextCapture: usedContextCaptureOverride ?? !disableContextCapture,
             usedPostProcessing: usedPostProcessingOverride ?? !disablePostProcessing,
-            transcriptionLanguageCode: transcriptionLanguage.code,
+            transcriptionLanguageCode: transcriptionLanguageCodeOverride ?? transcriptionLanguage.code,
             localTranscriptionModelID: localTranscriptionModelIDOverride ?? localTranscriptionModel.id,
             transcriptFileName: transcriptFileName,
             contextAppName: context.appName,
@@ -3770,12 +3803,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     Self.deleteTranscriptFile(previousTranscriptFileName)
                 }
             } else {
-                let removedStoredFiles = try pipelineHistoryStore.append(entry, maxCount: maxPipelineHistoryCount)
+                let removedStoredFiles = try appendPipelineHistoryItem(entry)
                 for removedAssets in removedStoredFiles {
                     Self.deleteStoredFiles(removedAssets)
                 }
             }
-            pipelineHistory = pipelineHistoryStore.loadAllHistory()
+            updatePipelineHistoryItem(entry)
         } catch {
             Self.deleteStoredFiles(audioFileName: audioFileName, transcriptFileName: transcriptFileName)
             errorMessage = "Unable to save run history entry: \(error.localizedDescription)"

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -20,13 +20,6 @@ struct PrecomputedMacro {
     let normalizedCommand: String
 }
 
-enum NoteBrowserTranscriptionMode {
-    case apiStandard
-    case apiRealtime
-    case localWhisper
-    case localAppleLive
-}
-
 enum SettingsTab: String, CaseIterable, Identifiable {
     case general
     case prompts
@@ -116,6 +109,12 @@ private struct PreservedPasteboardSnapshot {
 private struct PendingClipboardRestore {
     let snapshot: PreservedPasteboardSnapshot
     let expectedChangeCount: Int
+}
+
+struct AudioImportTranscriptionConfiguration {
+    let mode: NoteBrowserTranscriptionMode
+    let useLocalTranscription: Bool
+    let localTranscriptionModel: TranscriptionModel
 }
 
 private struct RetrySnapshot {
@@ -538,10 +537,59 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     var noteBrowserTranscriptionModeLabel: String {
+        label(for: currentNoteBrowserTranscriptionMode)
+    }
+
+    var currentNoteBrowserTranscriptionMode: NoteBrowserTranscriptionMode {
         if useLocalTranscription {
-            return localTranscriptionModel.isAppleSpeech ? "Local · Apple Live" : "Local · Whisper"
+            return localTranscriptionModel.isAppleSpeech ? .localAppleLive : .localWhisper
         }
-        return realtimeStreamingEnabled ? "API · Realtime" : "API · Standard"
+        return realtimeStreamingEnabled ? .apiRealtime : .apiStandard
+    }
+
+    func label(for mode: NoteBrowserTranscriptionMode) -> String {
+        switch mode {
+        case .apiStandard: return "API · Standard"
+        case .apiRealtime: return "API · Realtime"
+        case .localWhisper: return "Local · Whisper"
+        case .localAppleLive: return "Local · Apple Live"
+        }
+    }
+
+    func audioImportLabel(for mode: NoteBrowserTranscriptionMode) -> String {
+        switch mode {
+        case .apiStandard, .apiRealtime: return "API Standard"
+        case .localWhisper, .localAppleLive: return "Local Whisper"
+        }
+    }
+
+    var hasTranscriptionAPIKey: Bool {
+        !resolvedTranscriptionAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var hasInstalledLocalWhisperModel: Bool {
+        TranscriptionModel.all.contains { !$0.isAppleSpeech && $0.isInstalled }
+    }
+
+    @MainActor
+    func audioImportConfiguration(for mode: NoteBrowserTranscriptionMode) -> AudioImportTranscriptionConfiguration {
+        switch mode {
+        case .apiStandard, .apiRealtime:
+            return AudioImportTranscriptionConfiguration(
+                mode: mode,
+                useLocalTranscription: false,
+                localTranscriptionModel: localTranscriptionModel
+            )
+        case .localWhisper, .localAppleLive:
+            let model = localTranscriptionModel.isAppleSpeech
+                ? TranscriptionModel.all.first(where: { !$0.isAppleSpeech }) ?? localTranscriptionModel
+                : localTranscriptionModel
+            return AudioImportTranscriptionConfiguration(
+                mode: .localWhisper,
+                useLocalTranscription: true,
+                localTranscriptionModel: model
+            )
+        }
     }
 
     @MainActor
@@ -1122,8 +1170,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return try? String(contentsOf: fileURL, encoding: .utf8)
     }
 
+    static func fileSizeBytes(for fileURL: URL) -> Int64? {
+        (try? FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? NSNumber)?.int64Value
+    }
+
     static func saveAudioFile(from tempURL: URL) -> SavedAudioFile? {
-        let fileName = UUID().uuidString + ".wav"
+        let fileName = UUID().uuidString + "." + AudioImportOptions.storageExtension(for: tempURL.lastPathComponent)
         let destURL = audioStorageDirectory().appendingPathComponent(fileName)
         do {
             try? FileManager.default.removeItem(at: destURL)
@@ -1273,6 +1325,186 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
+    func importAudioFile(_ fileURL: URL, mode: NoteBrowserTranscriptionMode) {
+        let configuration = audioImportConfiguration(for: mode)
+        let jobID = UUID()
+        let noteID = UUID()
+        let startedAt = Date()
+        let savedAudioFile = Self.saveAudioFile(from: fileURL)
+        let transcriptionFileURL = savedAudioFile?.fileURL ?? fileURL
+        let placeholder = PipelineHistoryItem(
+            id: noteID,
+            timestamp: startedAt,
+            rawTranscript: "",
+            postProcessedTranscript: "",
+            postProcessingPrompt: nil,
+            systemPrompt: Self.resolvedSystemPrompt(customSystemPrompt),
+            contextSummary: "\(AudioImportOptions.importContextSummary(for: fileURL.lastPathComponent))",
+            contextPrompt: nil,
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "No screenshot",
+            postProcessingStatus: "live-recording",
+            debugStatus: "Importing audio",
+            customVocabulary: customVocabulary,
+            customSystemPrompt: customSystemPrompt,
+            audioFileName: savedAudioFile?.fileName,
+            usedLocalTranscription: configuration.useLocalTranscription,
+            usedContextCapture: false,
+            usedPostProcessing: !disablePostProcessing,
+            transcriptionLanguageCode: transcriptionLanguage.code,
+            localTranscriptionModelID: configuration.localTranscriptionModel.id,
+            contextAppName: nil,
+            contextBundleIdentifier: nil,
+            contextWindowTitle: nil
+        )
+
+        do {
+            _ = try pipelineHistoryStore.append(placeholder, maxCount: maxPipelineHistoryCount)
+            pipelineHistory = pipelineHistoryStore.loadAllHistory()
+        } catch {
+            errorMessage = "Unable to save imported audio note: \(error.localizedDescription)"
+            return
+        }
+
+        registerTranscriptionJob(
+            id: jobID,
+            startedAt: startedAt,
+            sessionIntent: .dictation,
+            sessionContext: nil,
+            contextTask: nil
+        )
+        updateTranscriptionJob(jobID) {
+            $0.liveNoteID = noteID
+            $0.audioFileName = savedAudioFile?.fileName
+        }
+
+        let postProcessingService = PostProcessingService(
+            apiKey: apiKey,
+            baseURL: apiBaseURL,
+            preferredModel: postProcessingModel,
+            preferredFallbackModel: postProcessingFallbackModel
+        )
+        let capturedApiKey = apiKey
+        let capturedApiBaseURL = resolvedTranscriptionBaseURL
+        let capturedLocalWhisperPath = localWhisperPath
+        let capturedTranscriptionLanguage = transcriptionLanguage
+        let capturedTranscriptionModel = transcriptionModel
+        let capturedCustomVocabulary = customVocabulary
+        let capturedCustomSystemPrompt = customSystemPrompt
+        let capturedDisablePostProcessing = disablePostProcessing
+
+        let task = Task { [weak self] in
+            guard let self else { return }
+            let importedContext = AppContext(
+                appName: nil,
+                bundleIdentifier: nil,
+                windowTitle: nil,
+                selectedText: nil,
+                currentActivity: "\(AudioImportOptions.importContextSummary(for: fileURL.lastPathComponent))",
+                contextSystemPrompt: nil,
+                contextPrompt: nil,
+                screenshotDataURL: nil,
+                screenshotMimeType: nil,
+                screenshotError: "No screenshot"
+            )
+            do {
+                let transcriptionService = try TranscriptionService(
+                    apiKey: capturedApiKey,
+                    baseURL: capturedApiBaseURL,
+                    useLocalTranscription: configuration.useLocalTranscription,
+                    localWhisperPath: capturedLocalWhisperPath.isEmpty ? nil : capturedLocalWhisperPath,
+                    transcriptionLanguage: capturedTranscriptionLanguage,
+                    localTranscriptionModel: configuration.localTranscriptionModel,
+                    transcriptionModel: capturedTranscriptionModel
+                )
+                let rawTranscript = try await transcriptionService.transcribe(fileURL: transcriptionFileURL)
+                let parsedTranscript = Self.parseTranscriptCommands(
+                    from: rawTranscript,
+                    pressEnterCommandEnabled: self.isPressEnterVoiceCommandEnabled
+                )
+                let result = await self.processImportedTranscript(
+                    parsedTranscript.transcript,
+                    context: importedContext,
+                    postProcessingService: postProcessingService,
+                    customVocabulary: capturedCustomVocabulary,
+                    customSystemPrompt: capturedCustomSystemPrompt,
+                    postProcessingEnabled: !capturedDisablePostProcessing
+                )
+                let processingStatus = Self.statusMessage(
+                    for: result.outcome,
+                    parsedTranscript: parsedTranscript
+                )
+                await MainActor.run {
+                    self.recordPipelineHistoryEntry(
+                        jobID: jobID,
+                        rawTranscript: parsedTranscript.transcript,
+                        postProcessedTranscript: result.finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
+                        postProcessingPrompt: result.prompt,
+                        systemPrompt: Self.resolvedSystemPrompt(capturedCustomSystemPrompt),
+                        context: importedContext,
+                        processingStatus: processingStatus,
+                        intent: .dictation,
+                        audioFileName: savedAudioFile?.fileName,
+                        useLocalTranscriptionOverride: configuration.useLocalTranscription,
+                        localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id
+                    )
+                    self.finishTranscriptionJob(jobID)
+                }
+            } catch {
+                await MainActor.run {
+                    self.recordPipelineHistoryEntry(
+                        jobID: jobID,
+                        rawTranscript: "",
+                        postProcessedTranscript: "",
+                        postProcessingPrompt: "",
+                        systemPrompt: Self.resolvedSystemPrompt(capturedCustomSystemPrompt),
+                        context: importedContext,
+                        processingStatus: "Error: \(error.localizedDescription)",
+                        intent: .dictation,
+                        audioFileName: savedAudioFile?.fileName,
+                        useLocalTranscriptionOverride: configuration.useLocalTranscription,
+                        localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id
+                    )
+                    self.finishTranscriptionJob(jobID)
+                }
+            }
+        }
+        updateTranscriptionJob(jobID) { $0.task = task }
+    }
+
+    private func processImportedTranscript(
+        _ rawTranscript: String,
+        context: AppContext,
+        postProcessingService: PostProcessingService,
+        customVocabulary: String,
+        customSystemPrompt: String,
+        postProcessingEnabled: Bool
+    ) async -> (finalTranscript: String, outcome: TranscriptProcessingOutcome, prompt: String) {
+        let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedRawTranscript.isEmpty else {
+            return ("", .skippedEmptyRawTranscript, "")
+        }
+        if let macro = findMatchingMacro(for: trimmedRawTranscript) {
+            return (macro.payload, .voiceMacro(command: macro.command), "")
+        }
+        guard postProcessingEnabled else {
+            return (rawTranscript, .postProcessingDisabled, "")
+        }
+        do {
+            let result = try await postProcessingService.postProcess(
+                transcript: trimmedRawTranscript,
+                context: context,
+                customVocabulary: customVocabulary,
+                customSystemPrompt: customSystemPrompt
+            )
+            return (result.transcript, .postProcessingSucceeded, result.prompt)
+        } catch {
+            return (trimmedRawTranscript, .postProcessingFailedFallback, "")
+        }
+    }
+
+    @MainActor
     func retryTranscription(item: PipelineHistoryItem) {
         guard !retryingItemIDs.contains(item.id) else { return }
 
@@ -1352,6 +1584,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
     private func makeRetrySnapshot(for item: PipelineHistoryItem) throws -> RetrySnapshot {
         guard let audioFileName = item.audioFileName else {
             throw TranscriptionError.submissionFailed("Audio file not found for retry.")
@@ -1361,6 +1594,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
         guard FileManager.default.fileExists(atPath: audioURL.path) else {
             throw TranscriptionError.submissionFailed("Audio file not found for retry.")
         }
+
+        let options = AudioImportOptions(
+            fileExtension: audioURL.pathExtension,
+            currentMode: currentNoteBrowserTranscriptionMode,
+            fileSizeBytes: Self.fileSizeBytes(for: audioURL),
+            hasAPIKey: hasTranscriptionAPIKey,
+            hasLocalWhisperModel: hasInstalledLocalWhisperModel
+        )
+        guard let retryMode = options.defaultMode else {
+            throw TranscriptionError.submissionFailed("사용 가능한 전사 방식이 없습니다. API key를 설정하거나 Local Whisper 모델을 설치한 뒤 다시 시도하세요.")
+        }
+        let configuration = audioImportConfiguration(for: retryMode)
 
         return RetrySnapshot(
             item: item,
@@ -1378,9 +1623,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 screenshotError: nil
             ),
             restoredIntent: SessionIntent.fromPersisted(intent: item.intent, selectedText: item.selectedText),
-            transcriptionLanguage: TranscriptionLanguage.find(code: item.transcriptionLanguageCode),
-            localTranscriptionModel: TranscriptionModel.find(id: item.localTranscriptionModelID),
-            useLocalTranscription: item.usedLocalTranscription,
+            transcriptionLanguage: transcriptionLanguage,
+            localTranscriptionModel: configuration.localTranscriptionModel,
+            useLocalTranscription: configuration.useLocalTranscription,
             customVocabulary: item.customVocabulary,
             customSystemPrompt: item.customSystemPrompt,
             postProcessingEnabled: item.usedPostProcessing,
@@ -3450,7 +3695,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         context: AppContext,
         processingStatus: String,
         intent: SessionIntent,
-        audioFileName: String? = nil
+        audioFileName: String? = nil,
+        useLocalTranscriptionOverride: Bool? = nil,
+        localTranscriptionModelIDOverride: String? = nil
     ) {
         let existingID = activeTranscriptionJobs[jobID]?.liveNoteID
         let existingEntry = existingID.flatMap { id in
@@ -3486,11 +3733,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
             customVocabulary: customVocabulary,
             customSystemPrompt: customSystemPrompt,
             audioFileName: audioFileName,
-            usedLocalTranscription: useLocalTranscription,
+            usedLocalTranscription: useLocalTranscriptionOverride ?? useLocalTranscription,
             usedContextCapture: !disableContextCapture,
             usedPostProcessing: !disablePostProcessing,
             transcriptionLanguageCode: transcriptionLanguage.code,
-            localTranscriptionModelID: localTranscriptionModel.id,
+            localTranscriptionModelID: localTranscriptionModelIDOverride ?? localTranscriptionModel.id,
             transcriptFileName: transcriptFileName,
             contextAppName: context.appName,
             contextBundleIdentifier: context.bundleIdentifier,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1332,7 +1332,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let noteID = UUID()
         let startedAt = Date()
         guard let savedAudioFile = Self.saveAudioFile(from: fileURL) else {
-            errorMessage = "오디오 파일을 저장할 수 없습니다. 디스크 공간 또는 파일 접근 권한을 확인한 뒤 다시 시도하세요."
+            errorMessage = "Unable to save the audio file. Check disk space or file permissions and try again."
             return
         }
         let importContextSummary = AudioImportOptions.importContextSummary(for: fileURL.lastPathComponent)
@@ -1606,7 +1606,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             hasLocalWhisperModel: hasInstalledLocalWhisperModel
         )
         guard let retryMode = options.defaultMode else {
-            throw TranscriptionError.submissionFailed("사용 가능한 전사 방식이 없습니다. API key를 설정하거나 Local Whisper 모델을 설치한 뒤 다시 시도하세요.")
+            throw TranscriptionError.submissionFailed("No transcription method is available. Configure an API key or install a Local Whisper model, then try again.")
         }
         let configuration = audioImportConfiguration(for: retryMode)
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1331,8 +1331,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let jobID = UUID()
         let noteID = UUID()
         let startedAt = Date()
-        let savedAudioFile = Self.saveAudioFile(from: fileURL)
-        let transcriptionFileURL = savedAudioFile?.fileURL ?? fileURL
+        guard let savedAudioFile = Self.saveAudioFile(from: fileURL) else {
+            errorMessage = "오디오 파일을 저장할 수 없습니다. 디스크 공간 또는 파일 접근 권한을 확인한 뒤 다시 시도하세요."
+            return
+        }
+        let importContextSummary = AudioImportOptions.importContextSummary(for: fileURL.lastPathComponent)
         let placeholder = PipelineHistoryItem(
             id: noteID,
             timestamp: startedAt,
@@ -1340,7 +1343,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             postProcessedTranscript: "",
             postProcessingPrompt: nil,
             systemPrompt: Self.resolvedSystemPrompt(customSystemPrompt),
-            contextSummary: "\(AudioImportOptions.importContextSummary(for: fileURL.lastPathComponent))",
+            contextSummary: importContextSummary,
             contextPrompt: nil,
             contextScreenshotDataURL: nil,
             contextScreenshotStatus: "No screenshot",
@@ -1348,7 +1351,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             debugStatus: "Importing audio",
             customVocabulary: customVocabulary,
             customSystemPrompt: customSystemPrompt,
-            audioFileName: savedAudioFile?.fileName,
+            audioFileName: savedAudioFile.fileName,
             usedLocalTranscription: configuration.useLocalTranscription,
             usedContextCapture: false,
             usedPostProcessing: !disablePostProcessing,
@@ -1376,7 +1379,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
         updateTranscriptionJob(jobID) {
             $0.liveNoteID = noteID
-            $0.audioFileName = savedAudioFile?.fileName
+            $0.audioFileName = savedAudioFile.fileName
         }
 
         let postProcessingService = PostProcessingService(
@@ -1401,7 +1404,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 bundleIdentifier: nil,
                 windowTitle: nil,
                 selectedText: nil,
-                currentActivity: "\(AudioImportOptions.importContextSummary(for: fileURL.lastPathComponent))",
+                currentActivity: importContextSummary,
                 contextSystemPrompt: nil,
                 contextPrompt: nil,
                 screenshotDataURL: nil,
@@ -1418,7 +1421,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     localTranscriptionModel: configuration.localTranscriptionModel,
                     transcriptionModel: capturedTranscriptionModel
                 )
-                let rawTranscript = try await transcriptionService.transcribe(fileURL: transcriptionFileURL)
+                let rawTranscript = try await transcriptionService.transcribe(fileURL: savedAudioFile.fileURL)
                 let parsedTranscript = Self.parseTranscriptCommands(
                     from: rawTranscript,
                     pressEnterCommandEnabled: self.isPressEnterVoiceCommandEnabled
@@ -1445,7 +1448,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         context: importedContext,
                         processingStatus: processingStatus,
                         intent: .dictation,
-                        audioFileName: savedAudioFile?.fileName,
+                        audioFileName: savedAudioFile.fileName,
                         useLocalTranscriptionOverride: configuration.useLocalTranscription,
                         localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id
                     )
@@ -1462,7 +1465,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         context: importedContext,
                         processingStatus: "Error: \(error.localizedDescription)",
                         intent: .dictation,
-                        audioFileName: savedAudioFile?.fileName,
+                        audioFileName: savedAudioFile.fileName,
                         useLocalTranscriptionOverride: configuration.useLocalTranscription,
                         localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id
                     )
@@ -1623,7 +1626,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 screenshotError: nil
             ),
             restoredIntent: SessionIntent.fromPersisted(intent: item.intent, selectedText: item.selectedText),
-            transcriptionLanguage: transcriptionLanguage,
+            transcriptionLanguage: TranscriptionLanguage.find(code: item.transcriptionLanguageCode),
             localTranscriptionModel: configuration.localTranscriptionModel,
             useLocalTranscription: configuration.useLocalTranscription,
             customVocabulary: item.customVocabulary,

--- a/Sources/AudioImportOptions.swift
+++ b/Sources/AudioImportOptions.swift
@@ -44,12 +44,12 @@ struct AudioImportOptions {
 
     var apiUnavailableReason: String {
         if !(fileSizeBytes.map({ $0 <= Self.apiUploadLimitBytes }) ?? true) {
-            return "25MB를 초과해 API 전사를 사용할 수 없습니다"
+            return "API transcription is unavailable for files over 25MB"
         }
         if !hasAPIKey {
-            return "API key가 설정되어 있지 않습니다"
+            return "API key is not configured"
         }
-        return "API 전사를 사용할 수 없습니다"
+        return "API transcription is unavailable"
     }
 
     var supportedModes: [NoteBrowserTranscriptionMode] {

--- a/Sources/AudioImportOptions.swift
+++ b/Sources/AudioImportOptions.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+enum NoteBrowserTranscriptionMode: CaseIterable, Equatable {
+    case apiStandard
+    case apiRealtime
+    case localWhisper
+    case localAppleLive
+}
+
+struct AudioImportOptions {
+    static let broadlySupportedExtensions: Set<String> = [
+        "flac", "mp3", "mp4", "mpeg", "mpga", "m4a", "ogg", "wav", "webm"
+    ]
+    static let apiUploadLimitBytes: Int64 = 25 * 1024 * 1024
+
+    static func storageExtension(for fileName: String) -> String {
+        let ext = URL(fileURLWithPath: fileName).pathExtension.lowercased()
+        return broadlySupportedExtensions.contains(ext) ? ext : "wav"
+    }
+
+    static func importContextSummary(for fileName: String) -> String {
+        ""
+    }
+
+    let fileExtension: String
+    let currentMode: NoteBrowserTranscriptionMode
+    let fileSizeBytes: Int64?
+    let hasAPIKey: Bool
+    let hasLocalWhisperModel: Bool
+
+    init(
+        fileExtension: String,
+        currentMode: NoteBrowserTranscriptionMode,
+        fileSizeBytes: Int64? = nil,
+        hasAPIKey: Bool = true,
+        hasLocalWhisperModel: Bool = true
+    ) {
+        self.fileExtension = fileExtension
+        self.currentMode = currentMode
+        self.fileSizeBytes = fileSizeBytes
+        self.hasAPIKey = hasAPIKey
+        self.hasLocalWhisperModel = hasLocalWhisperModel
+    }
+
+    var apiUnavailableReason: String {
+        if !(fileSizeBytes.map({ $0 <= Self.apiUploadLimitBytes }) ?? true) {
+            return "25MB를 초과해 API 전사를 사용할 수 없습니다"
+        }
+        if !hasAPIKey {
+            return "API key가 설정되어 있지 않습니다"
+        }
+        return "API 전사를 사용할 수 없습니다"
+    }
+
+    var supportedModes: [NoteBrowserTranscriptionMode] {
+        let normalizedExtension = fileExtension.lowercased()
+        guard Self.broadlySupportedExtensions.contains(normalizedExtension) else { return [] }
+
+        var modes: [NoteBrowserTranscriptionMode] = []
+        if hasAPIKey, fileSizeBytes.map({ $0 <= Self.apiUploadLimitBytes }) ?? true {
+            modes.append(.apiStandard)
+        }
+        if hasLocalWhisperModel {
+            modes.append(.localWhisper)
+        }
+        return modes
+    }
+
+    var defaultMode: NoteBrowserTranscriptionMode? {
+        let preferredMode: NoteBrowserTranscriptionMode
+        switch currentMode {
+        case .apiStandard, .apiRealtime:
+            preferredMode = .apiStandard
+        case .localWhisper, .localAppleLive:
+            preferredMode = .localWhisper
+        }
+        if supportedModes.contains(preferredMode) {
+            return preferredMode
+        }
+        return supportedModes.first
+    }
+}

--- a/Sources/AudioImportOptions.swift
+++ b/Sources/AudioImportOptions.swift
@@ -11,7 +11,7 @@ struct AudioImportOptions {
     static let broadlySupportedExtensions: Set<String> = [
         "flac", "mp3", "mp4", "mpeg", "mpga", "m4a", "ogg", "wav", "webm"
     ]
-    static let apiUploadLimitBytes: Int64 = 25 * 1024 * 1024
+    static let apiUploadLimitBytes: Int64 = 25_000_000
 
     static func storageExtension(for fileName: String) -> String {
         let ext = URL(fileURLWithPath: fileName).pathExtension.lowercased()

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -691,7 +691,8 @@ struct NoteBrowserView: View {
             .compactMap { UTType(filenameExtension: $0) }
         panel.prompt = "Choose"
         panel.message = "Choose an audio file. Supported formats: FLAC, MP3, MP4, MPEG, MPGA, M4A, OGG, WAV, WEBM"
-        if panel.runModal() == .OK, let url = panel.url {
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
             pendingAudioImport = PendingAudioImport(
                 fileURL: url,
                 currentMode: appState.currentNoteBrowserTranscriptionMode,

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -145,7 +145,7 @@ private enum TranscriptStatus {
 
 private func transcriptStatus(for item: PipelineHistoryItem, retrying: Set<UUID>) -> TranscriptStatus {
     if retrying.contains(item.id) { return .progress }
-    if item.postProcessingStatus == "live-recording" { return .progress }
+    if item.postProcessingStatus == "live-recording" || item.postProcessingStatus == "importing" { return .progress }
     if item.postProcessingStatus.hasPrefix("Error:") { return .fail }
     return .done
 }

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UserNotifications
 import AVFoundation
+import UniformTypeIdentifiers
 
 // MARK: - Cursor helper
 
@@ -335,6 +336,115 @@ final class NoteTitleStore: ObservableObject {
     }
 }
 
+// MARK: - Audio Import
+
+private struct PendingAudioImport: Identifiable {
+    let id = UUID()
+    let fileURL: URL
+    let currentMode: NoteBrowserTranscriptionMode
+    let hasAPIKey: Bool
+    let hasLocalWhisperModel: Bool
+
+    var options: AudioImportOptions {
+        AudioImportOptions(
+            fileExtension: fileURL.pathExtension,
+            currentMode: currentMode,
+            fileSizeBytes: fileSizeBytes,
+            hasAPIKey: hasAPIKey,
+            hasLocalWhisperModel: hasLocalWhisperModel
+        )
+    }
+
+    private var fileSizeBytes: Int64? {
+        AppState.fileSizeBytes(for: fileURL)
+    }
+}
+
+private struct AudioImportSheet: View {
+    let importRequest: PendingAudioImport
+    let onImport: (NoteBrowserTranscriptionMode) -> Void
+    let onCancel: () -> Void
+
+    @EnvironmentObject private var appState: AppState
+    @State private var selectedMode: NoteBrowserTranscriptionMode
+
+    init(
+        importRequest: PendingAudioImport,
+        onImport: @escaping (NoteBrowserTranscriptionMode) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.importRequest = importRequest
+        self.onImport = onImport
+        self.onCancel = onCancel
+        _selectedMode = State(initialValue: importRequest.options.defaultMode ?? .apiStandard)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("오디오 파일 가져오기")
+                    .font(.system(size: 18, weight: .semibold))
+                Text(importRequest.fileURL.lastPathComponent)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            if importRequest.options.supportedModes.isEmpty {
+                Text("사용 가능한 전사 방식이 없습니다. API key를 설정하거나 Local Whisper 모델을 설치한 뒤 다시 시도하세요.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("전사 방식")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                ForEach([NoteBrowserTranscriptionMode.apiStandard, .localWhisper], id: \.self) { mode in
+                    let isSupported = importRequest.options.supportedModes.contains(mode)
+                    Button {
+                        selectedMode = mode
+                    } label: {
+                        HStack {
+                            Image(systemName: selectedMode == mode ? "largecircle.fill.circle" : "circle")
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(appState.audioImportLabel(for: mode))
+                                if mode == .apiStandard && !isSupported {
+                                    Text(importRequest.options.apiUnavailableReason)
+                                        .font(.system(size: 10))
+                                        .foregroundStyle(.tertiary)
+                                } else if mode == .localWhisper && !isSupported {
+                                    Text("설치된 Local Whisper 모델이 없습니다")
+                                        .font(.system(size: 10))
+                                        .foregroundStyle(.tertiary)
+                                }
+                            }
+                            Spacer()
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!isSupported)
+                    .opacity(isSupported ? 1 : 0.45)
+                }
+            }
+
+            HStack {
+                Button("취소") { onCancel() }
+                    .keyboardShortcut(.cancelAction)
+                Spacer()
+                Button("전사하기") { onImport(selectedMode) }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(importRequest.options.supportedModes.isEmpty || !importRequest.options.supportedModes.contains(selectedMode))
+            }
+        }
+        .padding(24)
+        .frame(width: 420)
+    }
+}
+
 // MARK: - Note Browser View
 
 struct NoteBrowserView: View {
@@ -344,6 +454,7 @@ struct NoteBrowserView: View {
     @State private var selectedItemID: UUID?
     @State private var searchText = ""
     @State private var knownHistoryIDs: Set<UUID> = []
+    @State private var pendingAudioImport: PendingAudioImport?
 
     private var filteredHistory: [PipelineHistoryItem] {
         guard !searchText.isEmpty else { return appState.pipelineHistory }
@@ -367,6 +478,15 @@ struct NoteBrowserView: View {
             if selectedItemID == nil {
                 selectedItemID = appState.pipelineHistory.first?.id
             }
+        }
+        .sheet(item: $pendingAudioImport) { importRequest in
+            AudioImportSheet(importRequest: importRequest) { mode in
+                pendingAudioImport = nil
+                appState.importAudioFile(importRequest.fileURL, mode: mode)
+            } onCancel: {
+                pendingAudioImport = nil
+            }
+            .environmentObject(appState)
         }
         .onReceive(appState.$pipelineHistory) { newHistory in
             let ids = newHistory.map(\.id)
@@ -402,6 +522,19 @@ struct NoteBrowserView: View {
                         .background(Color.primary.opacity(0.08), in: Capsule())
                 }
                 Spacer()
+                Button {
+                    showAudioImportPicker()
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 12, weight: .bold))
+                        .frame(width: 24, height: 24)
+                        .background(Color.primary.opacity(0.06), in: Circle())
+                }
+                .buttonStyle(.plain)
+                .help("오디오 파일 가져오기")
+                .disabled(appState.isRecording)
+                .overrideCursor(.arrow)
+
                 // Record button
                 Button {
                     appState.toggleRecording()
@@ -531,6 +664,26 @@ struct NoteBrowserView: View {
             Rectangle()
                 .fill(Color.primary.opacity(0.07))
                 .frame(width: 0.5)
+        }
+    }
+
+    private func showAudioImportPicker() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = Array(AudioImportOptions.broadlySupportedExtensions)
+            .sorted()
+            .compactMap { UTType(filenameExtension: $0) }
+        panel.prompt = "선택"
+        panel.message = "오디오 파일을 선택하세요. 지원 형식: FLAC, MP3, MP4, MPEG, MPGA, M4A, OGG, WAV, WEBM"
+        if panel.runModal() == .OK, let url = panel.url {
+            pendingAudioImport = PendingAudioImport(
+                fileURL: url,
+                currentMode: appState.currentNoteBrowserTranscriptionMode,
+                hasAPIKey: appState.hasTranscriptionAPIKey,
+                hasLocalWhisperModel: appState.hasInstalledLocalWhisperModel
+            )
         }
     }
 

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -188,7 +188,8 @@ final class ObsidianExportManager: ObservableObject {
 
                 let iso = ISO8601DateFormatter()
                 iso.formatOptions = [.withInternetDateTime]
-                let audioEmbed = audioSrcURL != nil ? "\n![[\(fileName).wav]]\n" : ""
+                let audioFileName = audioSrcURL.map { fileName + "." + $0.pathExtension }
+                let audioEmbed = audioFileName.map { "\n![[\($0)]]\n" } ?? ""
 
                 let markdown: String
                 if useGemini {
@@ -226,8 +227,9 @@ source: Quill
                 try markdown.write(to: mdURL, atomically: true, encoding: .utf8)
 
                 if let srcURL = audioSrcURL,
+                   let audioFileName,
                    FileManager.default.fileExists(atPath: srcURL.path) {
-                    let dstURL = vaultURL.appendingPathComponent(fileName + ".wav")
+                    let dstURL = vaultURL.appendingPathComponent(audioFileName)
                     try? FileManager.default.removeItem(at: dstURL)
                     try FileManager.default.copyItem(at: srcURL, to: dstURL)
                 }

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -359,7 +359,7 @@ private struct PendingAudioImport: Identifiable {
         self.hasAPIKey = hasAPIKey
         self.hasLocalWhisperModel = hasLocalWhisperModel
         let accessGranted = fileURL.startAccessingSecurityScopedResource()
-        self.fileSizeBytes = AppState.fileSizeBytes(for: fileURL)
+        self.fileSizeBytes = accessGranted ? AppState.fileSizeBytes(for: fileURL) : nil
         if accessGranted {
             fileURL.stopAccessingSecurityScopedResource()
         }

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -382,7 +382,7 @@ private struct AudioImportSheet: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
             VStack(alignment: .leading, spacing: 6) {
-                Text("오디오 파일 가져오기")
+                Text("Import Audio File")
                     .font(.system(size: 18, weight: .semibold))
                 Text(importRequest.fileURL.lastPathComponent)
                     .font(.system(size: 12))
@@ -392,14 +392,14 @@ private struct AudioImportSheet: View {
             }
 
             if importRequest.options.supportedModes.isEmpty {
-                Text("사용 가능한 전사 방식이 없습니다. API key를 설정하거나 Local Whisper 모델을 설치한 뒤 다시 시도하세요.")
+                Text("No transcription method is available. Configure an API key or install a Local Whisper model, then try again.")
                     .font(.system(size: 12))
                     .foregroundStyle(.red)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
             VStack(alignment: .leading, spacing: 8) {
-                Text("전사 방식")
+                Text("Transcription Method")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(.secondary)
                 ForEach([NoteBrowserTranscriptionMode.apiStandard, .localWhisper], id: \.self) { mode in
@@ -416,7 +416,7 @@ private struct AudioImportSheet: View {
                                         .font(.system(size: 10))
                                         .foregroundStyle(.tertiary)
                                 } else if mode == .localWhisper && !isSupported {
-                                    Text("설치된 Local Whisper 모델이 없습니다")
+                                    Text("No Local Whisper model is installed")
                                         .font(.system(size: 10))
                                         .foregroundStyle(.tertiary)
                                 }
@@ -431,10 +431,10 @@ private struct AudioImportSheet: View {
             }
 
             HStack {
-                Button("취소") { onCancel() }
+                Button("Cancel") { onCancel() }
                     .keyboardShortcut(.cancelAction)
                 Spacer()
-                Button("전사하기") { onImport(selectedMode) }
+                Button("Transcribe") { onImport(selectedMode) }
                     .keyboardShortcut(.defaultAction)
                     .buttonStyle(.borderedProminent)
                     .disabled(importRequest.options.supportedModes.isEmpty || !importRequest.options.supportedModes.contains(selectedMode))
@@ -531,7 +531,7 @@ struct NoteBrowserView: View {
                         .background(Color.primary.opacity(0.06), in: Circle())
                 }
                 .buttonStyle(.plain)
-                .help("오디오 파일 가져오기")
+                .help("Import audio file")
                 .disabled(appState.isRecording)
                 .overrideCursor(.arrow)
 
@@ -675,8 +675,8 @@ struct NoteBrowserView: View {
         panel.allowedContentTypes = Array(AudioImportOptions.broadlySupportedExtensions)
             .sorted()
             .compactMap { UTType(filenameExtension: $0) }
-        panel.prompt = "선택"
-        panel.message = "오디오 파일을 선택하세요. 지원 형식: FLAC, MP3, MP4, MPEG, MPGA, M4A, OGG, WAV, WEBM"
+        panel.prompt = "Choose"
+        panel.message = "Choose an audio file. Supported formats: FLAC, MP3, MP4, MPEG, MPGA, M4A, OGG, WAV, WEBM"
         if panel.runModal() == .OK, let url = panel.url {
             pendingAudioImport = PendingAudioImport(
                 fileURL: url,

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -344,6 +344,24 @@ private struct PendingAudioImport: Identifiable {
     let currentMode: NoteBrowserTranscriptionMode
     let hasAPIKey: Bool
     let hasLocalWhisperModel: Bool
+    let fileSizeBytes: Int64?
+
+    init(
+        fileURL: URL,
+        currentMode: NoteBrowserTranscriptionMode,
+        hasAPIKey: Bool,
+        hasLocalWhisperModel: Bool
+    ) {
+        self.fileURL = fileURL
+        self.currentMode = currentMode
+        self.hasAPIKey = hasAPIKey
+        self.hasLocalWhisperModel = hasLocalWhisperModel
+        let accessGranted = fileURL.startAccessingSecurityScopedResource()
+        self.fileSizeBytes = AppState.fileSizeBytes(for: fileURL)
+        if accessGranted {
+            fileURL.stopAccessingSecurityScopedResource()
+        }
+    }
 
     var options: AudioImportOptions {
         AudioImportOptions(
@@ -353,10 +371,6 @@ private struct PendingAudioImport: Identifiable {
             hasAPIKey: hasAPIKey,
             hasLocalWhisperModel: hasLocalWhisperModel
         )
-    }
-
-    private var fileSizeBytes: Int64? {
-        AppState.fileSizeBytes(for: fileURL)
     }
 }
 

--- a/Tests/AudioImportOptionsTests.swift
+++ b/Tests/AudioImportOptionsTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+@main
+struct AudioImportOptionsTests {
+    static func main() {
+        testAPIStandardSupportsAllImportExtensions()
+        testAPIRealtimeFallsBackToAPIStandardForImport()
+        testLocalCurrentModeDefaultsToLocalWhisper()
+        testAPIKeyMissingFallsBackToLocalWhisper()
+        testNoAvailableBackendReturnsNoDefault()
+        testStorageExtensionPreservesSupportedImportExtension()
+        testStorageExtensionFallsBackToWavForUnknownExtension()
+        testImportedAudioContextSummaryIsEmpty()
+        testAPIStandardDisabledAboveTwentyFiveMegabytes()
+        testLocalWhisperStillEnabledAboveTwentyFiveMegabytes()
+        print("AudioImportOptionsTests passed")
+    }
+
+    private static func testAPIStandardSupportsAllImportExtensions() {
+        let options = AudioImportOptions(
+            fileExtension: "webm",
+            currentMode: .apiStandard,
+            hasAPIKey: true,
+            hasLocalWhisperModel: true
+        )
+
+        assert(options.defaultMode == .apiStandard)
+        assert(options.supportedModes.contains(.apiStandard))
+        assert(!options.supportedModes.contains(.apiRealtime))
+        assert(options.supportedModes.contains(.localWhisper))
+        assert(!options.supportedModes.contains(.localAppleLive))
+    }
+
+    private static func testAPIRealtimeFallsBackToAPIStandardForImport() {
+        let options = AudioImportOptions(
+            fileExtension: "mp3",
+            currentMode: .apiRealtime,
+            hasAPIKey: true,
+            hasLocalWhisperModel: true
+        )
+
+        assert(options.defaultMode == .apiStandard)
+    }
+
+    private static func testLocalCurrentModeDefaultsToLocalWhisper() {
+        let options = AudioImportOptions(
+            fileExtension: "m4a",
+            currentMode: .localAppleLive,
+            hasAPIKey: true,
+            hasLocalWhisperModel: true
+        )
+
+        assert(options.defaultMode == .localWhisper)
+        assert(options.supportedModes == [.apiStandard, .localWhisper])
+    }
+
+    private static func testAPIKeyMissingFallsBackToLocalWhisper() {
+        let options = AudioImportOptions(
+            fileExtension: "mp3",
+            currentMode: .apiStandard,
+            hasAPIKey: false,
+            hasLocalWhisperModel: true
+        )
+
+        assert(!options.supportedModes.contains(.apiStandard))
+        assert(options.defaultMode == .localWhisper)
+    }
+
+    private static func testNoAvailableBackendReturnsNoDefault() {
+        let options = AudioImportOptions(
+            fileExtension: "mp3",
+            currentMode: .apiStandard,
+            hasAPIKey: false,
+            hasLocalWhisperModel: false
+        )
+
+        assert(options.supportedModes.isEmpty)
+        assert(options.defaultMode == nil)
+    }
+
+    private static func testStorageExtensionPreservesSupportedImportExtension() {
+        assert(AudioImportOptions.storageExtension(for: "meeting.MP3") == "mp3")
+        assert(AudioImportOptions.storageExtension(for: "clip.webm") == "webm")
+    }
+
+    private static func testStorageExtensionFallsBackToWavForUnknownExtension() {
+        assert(AudioImportOptions.storageExtension(for: "audio.xyz") == "wav")
+        assert(AudioImportOptions.storageExtension(for: "audio") == "wav")
+    }
+
+    private static func testImportedAudioContextSummaryIsEmpty() {
+        assert(AudioImportOptions.importContextSummary(for: "새로운.m4a") == "")
+    }
+
+    private static func testAPIStandardDisabledAboveTwentyFiveMegabytes() {
+        let options = AudioImportOptions(
+            fileExtension: "mp3",
+            currentMode: .apiStandard,
+            fileSizeBytes: AudioImportOptions.apiUploadLimitBytes + 1,
+            hasAPIKey: true,
+            hasLocalWhisperModel: true
+        )
+
+        assert(!options.supportedModes.contains(.apiStandard))
+        assert(options.defaultMode == .localWhisper)
+    }
+
+    private static func testLocalWhisperStillEnabledAboveTwentyFiveMegabytes() {
+        let options = AudioImportOptions(
+            fileExtension: "mp3",
+            currentMode: .localWhisper,
+            fileSizeBytes: AudioImportOptions.apiUploadLimitBytes + 1,
+            hasAPIKey: true,
+            hasLocalWhisperModel: true
+        )
+
+        assert(options.supportedModes.contains(.localWhisper))
+    }
+}


### PR DESCRIPTION
## Summary
- Add a Note Browser import button and dialog for creating notes from existing audio files.
- Support API Standard and Local Whisper import/retry selection with API key, local model, and 25MB upload-limit handling.
- Preserve supported source audio extensions and add regression tests for import backend selection.

## Test plan
- [x] swiftc Sources/AudioImportOptions.swift Tests/AudioImportOptionsTests.swift -o /tmp/AudioImportOptionsTests && /tmp/AudioImportOptionsTests
- [ ] Manual app verification with an imported audio file

🤖 Generated with [Claude Code](https://claude.com/claude-code)