### PR TITLE
Add optional notch-side recording overlay

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -22,6 +22,7 @@ struct PrecomputedMacro {
 
 enum SettingsTab: String, CaseIterable, Identifiable {
     case general
+    case appearance
     case prompts
     case macros
     case runLog
@@ -31,6 +32,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     var title: String {
         switch self {
         case .general: return "General"
+        case .appearance: return "Appearance"
         case .prompts: return "Prompts"
         case .macros: return "Voice Macros"
         case .runLog: return "Run Log"
@@ -40,6 +42,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .general: return "gearshape"
+        case .appearance: return "paintbrush"
         case .prompts: return "text.bubble"
         case .macros: return "music.mic"
         case .runLog: return "clock.arrow.circlepath"

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -252,6 +252,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let realtimeStreamingEnabledStorageKey = "realtime_streaming_enabled"
     private let realtimeStreamingModelStorageKey = "realtime_streaming_model"
     private let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
+    private let recordingOverlayLayoutStorageKey = "recording_overlay_layout"
     private let pendingMutedAudioRestoreStorageKey = "pending_muted_audio_restore"
     private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
     private let pressEnterAfterPasteDelay: TimeInterval = 0.08
@@ -466,6 +467,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 dictationAudioInterruptionEnabled,
                 forKey: dictationAudioInterruptionEnabledStorageKey
             )
+        }
+    }
+
+    @Published var recordingOverlayLayout: RecordingOverlayLayout {
+        didSet {
+            UserDefaults.standard.set(recordingOverlayLayout.rawValue, forKey: recordingOverlayLayoutStorageKey)
+            overlayManager.setRecordingOverlayLayout(recordingOverlayLayout)
         }
     }
 
@@ -769,6 +777,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let dictationAudioInterruptionEnabled = UserDefaults.standard.bool(
             forKey: dictationAudioInterruptionEnabledStorageKey
         )
+        let recordingOverlayLayout = RecordingOverlayLayout.find(
+            rawValue: UserDefaults.standard.string(forKey: recordingOverlayLayoutStorageKey)
+        )
         let isPressEnterVoiceCommandEnabled = UserDefaults.standard.object(forKey: pressEnterVoiceCommandStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: pressEnterVoiceCommandStorageKey)
@@ -856,6 +867,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.realtimeStreamingEnabled = realtimeStreamingEnabled
         self.realtimeStreamingModel = realtimeStreamingModel
         self.dictationAudioInterruptionEnabled = dictationAudioInterruptionEnabled
+        self.recordingOverlayLayout = recordingOverlayLayout
+        self.overlayManager.setRecordingOverlayLayout(recordingOverlayLayout)
         self.isPressEnterVoiceCommandEnabled = isPressEnterVoiceCommandEnabled
         self.alertSoundsEnabled = alertSoundsEnabled
         self.useLocalTranscription = useLocalTranscription

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -7,6 +7,7 @@ final class RecordingOverlayState: ObservableObject {
     @Published var phase: OverlayPhase = .recording
     @Published var audioLevel: Float = 0.0
     @Published var recordingTriggerMode: RecordingTriggerMode = .hold
+    @Published var recordingOverlayLayout: RecordingOverlayLayout = .centered
     @Published var isCommandMode = false
     @Published var showsTranscribingSpinner = false
     @Published var updateVersion: String = ""
@@ -18,6 +19,34 @@ enum OverlayPhase {
     case transcribing
     case feedback
     case updateAvailable
+}
+
+enum RecordingOverlayLayout: String, CaseIterable, Identifiable {
+    case centered
+    case notchSides
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .centered: return "Centered"
+        case .notchSides: return "Notch Sides"
+        }
+    }
+
+    var helpText: String {
+        switch self {
+        case .centered:
+            return "Show the recording overlay centered below the notch."
+        case .notchSides:
+            return "Show recording controls beside the notch when supported. Other states stay centered."
+        }
+    }
+
+    static func find(rawValue: String?) -> RecordingOverlayLayout {
+        guard let rawValue, let layout = RecordingOverlayLayout(rawValue: rawValue) else { return .centered }
+        return layout
+    }
 }
 
 // MARK: - Panel Helpers
@@ -128,6 +157,13 @@ final class RecordingOverlayManager {
         DispatchQueue.main.async {
             self.overlayState.recordingTriggerMode = mode
             self.updateOverlayLayout(animated: animated)
+        }
+    }
+
+    func setRecordingOverlayLayout(_ layout: RecordingOverlayLayout) {
+        DispatchQueue.main.async {
+            self.overlayState.recordingOverlayLayout = layout
+            self.updateOverlayLayout(animated: false)
         }
     }
 

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -92,6 +92,15 @@ final class RecordingOverlayManager {
     private var overlayWindow: NSPanel?
     private let overlayState = RecordingOverlayState()
     private var lockedOverlayWidth: CGFloat?
+    private let notchSideRegionWidth: CGFloat = 92
+    private let notchSidePanelHeight: CGFloat = 38
+    private let notchSideHorizontalInset: CGFloat = 8
+
+    private struct NotchSideGeometry {
+        let frame: NSRect
+        let leftContentFrame: CGRect
+        let rightContentFrame: CGRect
+    }
 
     var onStopButtonPressed: (() -> Void)?
     var onUpdateOverlayPressed: (() -> Void)?
@@ -111,6 +120,53 @@ final class RecordingOverlayManager {
     private var notchOverlap: CGFloat {
         guard let screen = NSScreen.main else { return 0 }
         return screen.frame.maxY - screen.visibleFrame.maxY
+    }
+
+    private var usesNotchSideRecordingLayout: Bool {
+        overlayState.recordingOverlayLayout == .notchSides
+            && overlayState.phase == .recording
+            && screenHasNotch
+            && notchSideGeometry != nil
+    }
+
+    private var notchSideGeometry: NotchSideGeometry? {
+        guard let screen = NSScreen.main, screenHasNotch else { return nil }
+        guard let leftArea = screen.auxiliaryTopLeftArea,
+              let rightArea = screen.auxiliaryTopRightArea else { return nil }
+
+        let availableSideWidth = min(leftArea.width, rightArea.width)
+        let contentWidth = min(notchSideRegionWidth, max(0, availableSideWidth - notchSideHorizontalInset * 2))
+        guard contentWidth >= 64 else { return nil }
+
+        let notchMinX = leftArea.maxX
+        let notchMaxX = rightArea.minX
+        guard notchMaxX > notchMinX else { return nil }
+
+        let panelMinX = leftArea.maxX - contentWidth - notchSideHorizontalInset
+        let panelMaxX = rightArea.minX + contentWidth + notchSideHorizontalInset
+        let height = notchSidePanelHeight + notchOverlap
+        let frame = NSRect(
+            x: panelMinX,
+            y: screen.frame.maxY - height,
+            width: panelMaxX - panelMinX,
+            height: height
+        )
+
+        let contentY = notchOverlap
+        let leftFrame = CGRect(
+            x: notchSideHorizontalInset,
+            y: contentY,
+            width: contentWidth,
+            height: notchSidePanelHeight
+        )
+        let rightFrame = CGRect(
+            x: frame.width - notchSideHorizontalInset - contentWidth,
+            y: contentY,
+            width: contentWidth,
+            height: notchSidePanelHeight
+        )
+
+        return NotchSideGeometry(frame: frame, leftContentFrame: leftFrame, rightContentFrame: rightFrame)
     }
 
     private var overlayAcceptsMouseEvents: Bool {
@@ -289,6 +345,12 @@ final class RecordingOverlayManager {
 
     private var overlayFrame: NSRect {
         guard let screen = NSScreen.main else { return .zero }
+        if let geometry = notchSideGeometry,
+           overlayState.recordingOverlayLayout == .notchSides,
+           overlayState.phase == .recording {
+            return geometry.frame
+        }
+
         let width = overlayWidth
         let overlap = screenHasNotch ? notchOverlap : 0
         let height: CGFloat = 38 + overlap

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -97,6 +97,64 @@ private func makeTransparentContent<V: View>(
     return hosting
 }
 
+struct RecordingOverlayGeometry {
+    struct NotchSideGeometry {
+        let frame: NSRect
+        let leftContentFrame: CGRect
+        let rightContentFrame: CGRect
+    }
+
+    static func notchSideGeometry(
+        screenFrame: CGRect,
+        visibleFrame: CGRect,
+        leftArea: CGRect,
+        rightArea: CGRect,
+        regionWidth: CGFloat,
+        panelHeight: CGFloat,
+        horizontalInset: CGFloat
+    ) -> NotchSideGeometry? {
+        let availableSideWidth = min(leftArea.width, rightArea.width)
+        let contentWidth = min(regionWidth, max(0, availableSideWidth - horizontalInset * 2))
+        guard contentWidth >= 64 else { return nil }
+
+        let notchMinX = leftArea.maxX
+        let notchMaxX = rightArea.minX
+        guard notchMaxX > notchMinX else { return nil }
+
+        let panelMinX = leftArea.maxX - contentWidth - horizontalInset
+        let panelMaxX = rightArea.minX + contentWidth + horizontalInset
+        let frame = NSRect(
+            x: panelMinX,
+            y: screenFrame.maxY - panelHeight,
+            width: panelMaxX - panelMinX,
+            height: panelHeight
+        )
+
+        let leftFrame = CGRect(
+            x: horizontalInset,
+            y: 0,
+            width: contentWidth,
+            height: panelHeight
+        )
+        let rightFrame = CGRect(
+            x: frame.width - horizontalInset - contentWidth,
+            y: 0,
+            width: contentWidth,
+            height: panelHeight
+        )
+
+        return NotchSideGeometry(frame: frame, leftContentFrame: leftFrame, rightContentFrame: rightFrame)
+    }
+
+    static func lockedTranscribingWidth(
+        currentPanelWidth: CGFloat,
+        centeredOverlayWidth: CGFloat,
+        wasNotchSideRecordingLayout: Bool
+    ) -> CGFloat {
+        wasNotchSideRecordingLayout ? centeredOverlayWidth : currentPanelWidth
+    }
+}
+
 // MARK: - Manager
 
 final class RecordingOverlayManager {
@@ -107,11 +165,7 @@ final class RecordingOverlayManager {
     private let notchSidePanelHeight: CGFloat = 38
     private let notchSideHorizontalInset: CGFloat = 8
 
-    private struct NotchSideGeometry {
-        let frame: NSRect
-        let leftContentFrame: CGRect
-        let rightContentFrame: CGRect
-    }
+    private typealias NotchSideGeometry = RecordingOverlayGeometry.NotchSideGeometry
 
     var onStopButtonPressed: (() -> Void)?
     var onUpdateOverlayPressed: (() -> Void)?
@@ -145,39 +199,15 @@ final class RecordingOverlayManager {
         guard let leftArea = screen.auxiliaryTopLeftArea,
               let rightArea = screen.auxiliaryTopRightArea else { return nil }
 
-        let availableSideWidth = min(leftArea.width, rightArea.width)
-        let contentWidth = min(notchSideRegionWidth, max(0, availableSideWidth - notchSideHorizontalInset * 2))
-        guard contentWidth >= 64 else { return nil }
-
-        let notchMinX = leftArea.maxX
-        let notchMaxX = rightArea.minX
-        guard notchMaxX > notchMinX else { return nil }
-
-        let panelMinX = leftArea.maxX - contentWidth - notchSideHorizontalInset
-        let panelMaxX = rightArea.minX + contentWidth + notchSideHorizontalInset
-        let height = notchSidePanelHeight + notchOverlap
-        let frame = NSRect(
-            x: panelMinX,
-            y: screen.frame.maxY - height,
-            width: panelMaxX - panelMinX,
-            height: height
+        return RecordingOverlayGeometry.notchSideGeometry(
+            screenFrame: screen.frame,
+            visibleFrame: screen.visibleFrame,
+            leftArea: leftArea,
+            rightArea: rightArea,
+            regionWidth: notchSideRegionWidth,
+            panelHeight: notchSidePanelHeight,
+            horizontalInset: notchSideHorizontalInset
         )
-
-        let contentY = notchOverlap
-        let leftFrame = CGRect(
-            x: notchSideHorizontalInset,
-            y: contentY,
-            width: contentWidth,
-            height: notchSidePanelHeight
-        )
-        let rightFrame = CGRect(
-            x: frame.width - notchSideHorizontalInset - contentWidth,
-            y: contentY,
-            width: contentWidth,
-            height: notchSidePanelHeight
-        )
-
-        return NotchSideGeometry(frame: frame, leftContentFrame: leftFrame, rightContentFrame: rightFrame)
     }
 
     private var overlayAcceptsMouseEvents: Bool {
@@ -317,7 +347,11 @@ final class RecordingOverlayManager {
     }
 
     private func setTranscribingPhase(showsTranscribingSpinner: Bool) {
-        lockedOverlayWidth = overlayWindow?.frame.width ?? overlayWidth
+        lockedOverlayWidth = RecordingOverlayGeometry.lockedTranscribingWidth(
+            currentPanelWidth: overlayWindow?.frame.width ?? overlayWidth,
+            centeredOverlayWidth: overlayWidth,
+            wasNotchSideRecordingLayout: usesNotchSideRecordingLayout
+        )
         overlayState.phase = .transcribing
         overlayState.showsTranscribingSpinner = showsTranscribingSpinner
         showOverlayPanel(animatedResize: true)

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -121,8 +121,8 @@ struct RecordingOverlayGeometry {
         let notchMaxX = rightArea.minX
         guard notchMaxX > notchMinX else { return nil }
 
-        let panelMinX = leftArea.maxX - contentWidth - horizontalInset
-        let panelMaxX = rightArea.minX + contentWidth + horizontalInset
+        let panelMinX = leftArea.maxX - contentWidth
+        let panelMaxX = rightArea.minX + contentWidth
         let frame = NSRect(
             x: panelMinX,
             y: screenFrame.maxY - panelHeight,
@@ -131,13 +131,13 @@ struct RecordingOverlayGeometry {
         )
 
         let leftFrame = CGRect(
-            x: horizontalInset,
+            x: 0,
             y: 0,
             width: contentWidth,
             height: panelHeight
         )
         let rightFrame = CGRect(
-            x: frame.width - horizontalInset - contentWidth,
+            x: frame.width - contentWidth,
             y: 0,
             width: contentWidth,
             height: panelHeight
@@ -147,11 +147,13 @@ struct RecordingOverlayGeometry {
     }
 
     static func lockedTranscribingWidth(
+        existingLockedWidth: CGFloat?,
         currentPanelWidth: CGFloat,
-        centeredOverlayWidth: CGFloat,
+        centeredTranscribingWidth: CGFloat,
         wasNotchSideRecordingLayout: Bool
     ) -> CGFloat {
-        wasNotchSideRecordingLayout ? centeredOverlayWidth : currentPanelWidth
+        if let existingLockedWidth { return existingLockedWidth }
+        return wasNotchSideRecordingLayout ? centeredTranscribingWidth : currentPanelWidth
     }
 }
 
@@ -348,8 +350,9 @@ final class RecordingOverlayManager {
 
     private func setTranscribingPhase(showsTranscribingSpinner: Bool) {
         lockedOverlayWidth = RecordingOverlayGeometry.lockedTranscribingWidth(
+            existingLockedWidth: lockedOverlayWidth,
             currentPanelWidth: overlayWindow?.frame.width ?? overlayWidth,
-            centeredOverlayWidth: overlayWidth,
+            centeredTranscribingWidth: centeredTranscribingOverlayWidth,
             wasNotchSideRecordingLayout: usesNotchSideRecordingLayout
         )
         overlayState.phase = .transcribing
@@ -422,6 +425,12 @@ final class RecordingOverlayManager {
         let x = screen.frame.midX - width / 2
         let y = screen.frame.maxY - height
         return NSRect(x: x, y: y, width: width, height: height)
+    }
+
+    private var centeredTranscribingOverlayWidth: CGFloat {
+        let defaultWidth: CGFloat = 92
+        guard screenHasNotch else { return defaultWidth }
+        return max(notchWidth, defaultWidth)
     }
 
     private var overlayWidth: CGFloat {
@@ -610,21 +619,18 @@ struct InitializingDotsView: View {
     }
 }
 
-private struct NotchSidePill<Content: View>: View {
-    let frame: CGRect
-    let content: Content
-
-    init(frame: CGRect, @ViewBuilder content: () -> Content) {
-        self.frame = frame
-        self.content = content()
-    }
-
+private struct NotchExtensionBackground: View {
     var body: some View {
-        content
-            .frame(width: frame.width, height: frame.height)
-            .background(Color.black)
-            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-            .position(x: frame.midX, y: frame.midY)
+        Color.black
+            .clipShape(
+                UnevenRoundedRectangle(
+                    topLeadingRadius: 0,
+                    bottomLeadingRadius: 12,
+                    bottomTrailingRadius: 12,
+                    topTrailingRadius: 0,
+                    style: .continuous
+                )
+            )
     }
 }
 
@@ -640,34 +646,36 @@ private struct NotchSideRecordingOverlayView: View {
 
     var body: some View {
         ZStack(alignment: .topLeading) {
-            NotchSidePill(frame: leftContentFrame) {
-                ZStack {
-                    WaveformView(audioLevel: state.audioLevel, showsActivityPulse: true)
-                        .padding(.horizontal, 12)
-                    if state.isCommandMode {
-                        HStack {
-                            CommandModeIndicator()
-                                .padding(.leading, 8)
-                            Spacer()
-                        }
-                    }
-                }
-            }
+            NotchExtensionBackground()
 
-            NotchSidePill(frame: rightContentFrame) {
-                ZStack {
-                    if showsStopButton {
-                        Button(action: onStopButtonPressed) {
-                            Image(systemName: "stop.fill")
-                                .font(.system(size: 9, weight: .bold))
-                                .foregroundStyle(.white)
-                                .frame(width: 20, height: 20)
-                                .background(Circle().fill(Color.red.opacity(0.92)))
-                        }
-                        .buttonStyle(.plain)
+            ZStack {
+                WaveformView(audioLevel: state.audioLevel, showsActivityPulse: true)
+                    .padding(.horizontal, 12)
+                if state.isCommandMode {
+                    HStack {
+                        CommandModeIndicator()
+                            .padding(.leading, 8)
+                        Spacer()
                     }
                 }
             }
+            .frame(width: leftContentFrame.width, height: leftContentFrame.height)
+            .position(x: leftContentFrame.midX, y: leftContentFrame.midY)
+
+            ZStack {
+                if showsStopButton {
+                    Button(action: onStopButtonPressed) {
+                        Image(systemName: "stop.fill")
+                            .font(.system(size: 9, weight: .bold))
+                            .foregroundStyle(.white)
+                            .frame(width: 20, height: 20)
+                            .background(Circle().fill(Color.red.opacity(0.92)))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .frame(width: rightContentFrame.width, height: rightContentFrame.height)
+            .position(x: rightContentFrame.midX, y: rightContentFrame.midY)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.audioLevel)

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -86,6 +86,17 @@ private func makeNotchContent<V: View>(
     return hosting
 }
 
+private func makeTransparentContent<V: View>(
+    width: CGFloat,
+    height: CGFloat,
+    rootView: V
+) -> NSView {
+    let hosting = NSHostingView(rootView: rootView.frame(width: width, height: height))
+    hosting.frame = NSRect(x: 0, y: 0, width: width, height: height)
+    hosting.autoresizingMask = [.width, .height]
+    return hosting
+}
+
 // MARK: - Manager
 
 final class RecordingOverlayManager {
@@ -313,7 +324,12 @@ final class RecordingOverlayManager {
     }
 
     private func makeOverlayContent(frame: NSRect) -> NSView {
-        makeNotchContent(
+        if let geometry = notchSideGeometry,
+           usesNotchSideRecordingLayout {
+            return makeNotchSideRecordingContent(frame: frame, geometry: geometry)
+        }
+
+        return makeNotchContent(
             width: frame.width,
             height: frame.height,
             cornerRadius: screenHasNotch ? 18 : 12,
@@ -327,6 +343,21 @@ final class RecordingOverlayManager {
                 }
             )
             .padding(.top, screenHasNotch ? notchOverlap : 0)
+        )
+    }
+
+    private func makeNotchSideRecordingContent(frame: NSRect, geometry: NotchSideGeometry) -> NSView {
+        makeTransparentContent(
+            width: frame.width,
+            height: frame.height,
+            rootView: NotchSideRecordingOverlayView(
+                state: overlayState,
+                leftContentFrame: geometry.leftContentFrame,
+                rightContentFrame: geometry.rightContentFrame,
+                onStopButtonPressed: { [weak self] in
+                    self?.onStopButtonPressed?()
+                }
+            )
         )
     }
 
@@ -542,6 +573,72 @@ struct InitializingDotsView: View {
             timer?.invalidate()
             timer = nil
         }
+    }
+}
+
+private struct NotchSidePill<Content: View>: View {
+    let frame: CGRect
+    let content: Content
+
+    init(frame: CGRect, @ViewBuilder content: () -> Content) {
+        self.frame = frame
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .frame(width: frame.width, height: frame.height)
+            .background(Color.black)
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .position(x: frame.midX, y: frame.midY)
+    }
+}
+
+private struct NotchSideRecordingOverlayView: View {
+    @ObservedObject var state: RecordingOverlayState
+    let leftContentFrame: CGRect
+    let rightContentFrame: CGRect
+    let onStopButtonPressed: () -> Void
+
+    private var showsStopButton: Bool {
+        state.recordingTriggerMode == .toggle
+    }
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            NotchSidePill(frame: leftContentFrame) {
+                ZStack {
+                    WaveformView(audioLevel: state.audioLevel, showsActivityPulse: true)
+                        .padding(.horizontal, 12)
+                    if state.isCommandMode {
+                        HStack {
+                            CommandModeIndicator()
+                                .padding(.leading, 8)
+                            Spacer()
+                        }
+                    }
+                }
+            }
+
+            NotchSidePill(frame: rightContentFrame) {
+                ZStack {
+                    if showsStopButton {
+                        Button(action: onStopButtonPressed) {
+                            Image(systemName: "stop.fill")
+                                .font(.system(size: 9, weight: .bold))
+                                .foregroundStyle(.white)
+                                .frame(width: 20, height: 20)
+                                .background(Circle().fill(Color.red.opacity(0.92)))
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.audioLevel)
+        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.recordingTriggerMode)
+        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.isCommandMode)
     }
 }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -440,6 +440,8 @@ struct SettingsView: View {
                 switch appState.selectedSettingsTab {
                 case .general, .none:
                     GeneralSettingsView()
+                case .appearance:
+                    AppearanceSettingsView()
                 case .prompts:
                     PromptsSettingsView()
                 case .macros:
@@ -453,13 +455,81 @@ struct SettingsView: View {
     }
 }
 
+// MARK: - Appearance Settings
+
+struct AppearanceSettingsView: View {
+    @EnvironmentObject var appState: AppState
+    @AppStorage("app_appearance") private var appAppearance: String = "system"
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                SettingsCard("App Appearance", icon: "circle.lefthalf.filled") {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Theme")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Picker("", selection: $appAppearance) {
+                            Text("System Setting").tag("system")
+                            Text("Light").tag("light")
+                            Text("Dark").tag("dark")
+                        }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+                        .onChange(of: appAppearance) { value in
+                            applyAppearance(value)
+                        }
+                    }
+                }
+
+                SettingsCard("Note Browser", icon: "note.text") {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Toggle("Enable Note Browser", isOn: $appState.noteBrowserEnabled)
+                        Text("Click the Dock icon to open Note Browser and browse your dictation history like notes.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                SettingsCard("Recording Overlay", icon: "rectangle.topthird.inset.filled") {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Layout")
+                            .font(.caption.weight(.semibold))
+
+                        Picker("Recording Overlay Layout", selection: $appState.recordingOverlayLayout) {
+                            ForEach(RecordingOverlayLayout.allCases) { layout in
+                                Text(layout.displayName).tag(layout)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+                        .accessibilityLabel("Recording Overlay Layout")
+
+                        Text(appState.recordingOverlayLayout.helpText)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .padding(24)
+        }
+    }
+
+    private func applyAppearance(_ value: String) {
+        switch value {
+        case "light":  NSApp.appearance = NSAppearance(named: .aqua)
+        case "dark":   NSApp.appearance = NSAppearance(named: .darkAqua)
+        default:       NSApp.appearance = nil
+        }
+    }
+}
+
 // MARK: - General Settings
 
 struct GeneralSettingsView: View {
     @EnvironmentObject var appState: AppState
     @Environment(\.openURL) private var openURL
     @AppStorage("show_menu_bar_icon") private var showMenuBarIcon = true
-    @AppStorage("app_appearance") private var appAppearance: String = "system"
     @State private var apiKeyInput: String = ""
     @State private var apiBaseURLInput: String = ""
     @State private var transcriptionAPIURLInput: String = ""
@@ -631,14 +701,8 @@ struct GeneralSettingsView: View {
                 .padding(.top, 4)
                 .padding(.bottom, 4)
 
-                SettingsCard("Appearance", icon: "paintbrush.fill") {
-                    appearanceSection
-                }
                 SettingsCard("App", icon: "power") {
                     startupSection
-                }
-                SettingsCard("Note Browser", icon: "note.text") {
-                    noteBrowserSection
                 }
                 // Quill releases are not distributed through the in-app updater yet.
                 // SettingsCard("Updates", icon: "arrow.triangle.2.circlepath") {
@@ -699,34 +763,6 @@ struct GeneralSettingsView: View {
         }
     }
 
-    // MARK: Appearance
-
-    private var appearanceSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Theme")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-            Picker("", selection: $appAppearance) {
-                Text("System Setting").tag("system")
-                Text("Light").tag("light")
-                Text("Dark").tag("dark")
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .onChange(of: appAppearance) { value in
-                applyAppearance(value)
-            }
-        }
-    }
-
-    private func applyAppearance(_ value: String) {
-        switch value {
-        case "light":  NSApp.appearance = NSAppearance(named: .aqua)
-        case "dark":   NSApp.appearance = NSAppearance(named: .darkAqua)
-        default:       NSApp.appearance = nil
-        }
-    }
-
     // MARK: Startup
 
     private var startupSection: some View {
@@ -748,17 +784,6 @@ struct GeneralSettingsView: View {
                     .font(.caption)
                 }
             }
-        }
-    }
-
-    // MARK: Note Browser
-
-    private var noteBrowserSection: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Toggle("Enable Note Browser", isOn: $appState.noteBrowserEnabled)
-            Text("Click the Dock icon to open Note Browser and browse your dictation history like notes.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
         }
     }
 
@@ -1143,26 +1168,6 @@ struct GeneralSettingsView: View {
                 )
 
                 Text("Applies before recording starts for both hold and tap shortcuts. Stopping still happens immediately.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Divider()
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Recording Overlay Layout")
-                    .font(.caption.weight(.semibold))
-
-                Picker("Recording Overlay Layout", selection: $appState.recordingOverlayLayout) {
-                    ForEach(RecordingOverlayLayout.allCases) { layout in
-                        Text(layout.displayName).tag(layout)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .accessibilityLabel("Recording Overlay Layout")
-
-                Text(appState.recordingOverlayLayout.helpText)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1146,6 +1146,26 @@ struct GeneralSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Recording Overlay Layout")
+                    .font(.caption.weight(.semibold))
+
+                Picker("Recording Overlay Layout", selection: $appState.recordingOverlayLayout) {
+                    ForEach(RecordingOverlayLayout.allCases) { layout in
+                        Text(layout.displayName).tag(layout)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .accessibilityLabel("Recording Overlay Layout")
+
+                Text(appState.recordingOverlayLayout.helpText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
     }
 

--- a/Tests/RecordingOverlayGeometryTests.swift
+++ b/Tests/RecordingOverlayGeometryTests.swift
@@ -6,6 +6,7 @@ struct RecordingOverlayGeometryTests {
     static func main() {
         testNotchSideContentStartsAtTopOfVisiblePill()
         testTranscribingWidthFallsBackToCenteredWidthAfterNotchSideRecording()
+        testTranscribingWidthKeepsExistingLockOnRepeatedTranscribingUpdate()
         print("RecordingOverlayGeometryTests passed")
     }
 
@@ -21,6 +22,10 @@ struct RecordingOverlayGeometryTests {
         )
 
         assert(geometry != nil)
+        assert(geometry?.frame.maxX == 922)
+        assert(geometry?.frame.minX == 590)
+        assert(geometry?.leftContentFrame.origin.x == 0)
+        assert(geometry?.rightContentFrame.maxX == geometry?.frame.width)
         assert(geometry?.leftContentFrame.origin.y == 0)
         assert(geometry?.rightContentFrame.origin.y == 0)
         assert(geometry?.frame.height == 38)
@@ -28,9 +33,21 @@ struct RecordingOverlayGeometryTests {
 
     private static func testTranscribingWidthFallsBackToCenteredWidthAfterNotchSideRecording() {
         let lockedWidth = RecordingOverlayGeometry.lockedTranscribingWidth(
+            existingLockedWidth: nil,
             currentPanelWidth: 348,
-            centeredOverlayWidth: 148,
+            centeredTranscribingWidth: 148,
             wasNotchSideRecordingLayout: true
+        )
+
+        assert(lockedWidth == 148)
+    }
+
+    private static func testTranscribingWidthKeepsExistingLockOnRepeatedTranscribingUpdate() {
+        let lockedWidth = RecordingOverlayGeometry.lockedTranscribingWidth(
+            existingLockedWidth: 148,
+            currentPanelWidth: 332,
+            centeredTranscribingWidth: 148,
+            wasNotchSideRecordingLayout: false
         )
 
         assert(lockedWidth == 148)

--- a/Tests/RecordingOverlayGeometryTests.swift
+++ b/Tests/RecordingOverlayGeometryTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import CoreGraphics
+
+@main
+struct RecordingOverlayGeometryTests {
+    static func main() {
+        testNotchSideContentStartsAtTopOfVisiblePill()
+        testTranscribingWidthFallsBackToCenteredWidthAfterNotchSideRecording()
+        print("RecordingOverlayGeometryTests passed")
+    }
+
+    private static func testNotchSideContentStartsAtTopOfVisiblePill() {
+        let geometry = RecordingOverlayGeometry.notchSideGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1512, height: 944),
+            leftArea: CGRect(x: 0, y: 944, width: 682, height: 38),
+            rightArea: CGRect(x: 830, y: 944, width: 682, height: 38),
+            regionWidth: 92,
+            panelHeight: 38,
+            horizontalInset: 8
+        )
+
+        assert(geometry != nil)
+        assert(geometry?.leftContentFrame.origin.y == 0)
+        assert(geometry?.rightContentFrame.origin.y == 0)
+        assert(geometry?.frame.height == 38)
+    }
+
+    private static func testTranscribingWidthFallsBackToCenteredWidthAfterNotchSideRecording() {
+        let lockedWidth = RecordingOverlayGeometry.lockedTranscribingWidth(
+            currentPanelWidth: 348,
+            centeredOverlayWidth: 148,
+            wasNotchSideRecordingLayout: true
+        )
+
+        assert(lockedWidth == 148)
+    }
+}

--- a/docs/superpowers/plans/2026-04-30-notch-side-recording-overlay.md
+++ b/docs/superpowers/plans/2026-04-30-notch-side-recording-overlay.md
@@ -1,0 +1,635 @@
+# Notch-side Recording Overlay Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional recording-only notch-side overlay layout that keeps Quill's existing centered overlay as the default and fallback.
+
+**Architecture:** Add a small persisted `RecordingOverlayLayout` setting in `AppState`, pass it into `RecordingOverlayManager`, and let the manager choose between the existing centered frame/content path and a new recording-only notch-side frame/content path. Keep transcribing, feedback, update, and concurrent transcription ownership flows unchanged.
+
+**Tech Stack:** Swift, SwiftUI, AppKit `NSPanel`/`NSScreen`, UserDefaults, Makefile-based macOS app build.
+
+---
+
+## File structure
+
+- `Sources/RecordingOverlay.swift`
+  - Add `RecordingOverlayLayout` enum.
+  - Store selected layout in `RecordingOverlayState` so layout updates are published consistently.
+  - Add notch-side geometry helpers inside `RecordingOverlayManager`.
+  - Keep existing centered `overlayFrame`, `overlayWidth`, and `RecordingOverlayView` behavior intact.
+  - Add a notch-side recording root view that renders equal-width left/right visible regions inside one transparent panel.
+
+- `Sources/AppState.swift`
+  - Add `recording_overlay_layout` UserDefaults key.
+  - Add `@Published var recordingOverlayLayout`.
+  - Load the setting in `init()` with default `.centered`.
+  - Pass the setting to `overlayManager` during init and whenever the setting changes.
+
+- `Sources/SettingsView.swift`
+  - Add a small picker for `Recording Overlay Layout`.
+  - Place it near shortcut/recording behavior settings, not in transcription model settings.
+  - Explain that `Notch Sides` applies only while recording on notch MacBooks.
+
+- `Tests/RecordingOverlayLayoutTests.swift`
+  - Add focused tests for enum raw-value decoding/fallback if test harness allows importing the source directly.
+  - If the project cannot compile tests independently, keep this task scoped to a parse/build verification and do not add brittle UI tests.
+
+---
+
+### Task 1: Add the overlay layout setting model
+
+**Files:**
+- Modify: `Sources/RecordingOverlay.swift`
+- Modify: `Sources/AppState.swift`
+
+- [ ] **Step 1: Add `RecordingOverlayLayout` enum near `OverlayPhase`**
+
+In `Sources/RecordingOverlay.swift`, add this enum after `OverlayPhase`:
+
+```swift
+enum RecordingOverlayLayout: String, CaseIterable, Identifiable {
+    case centered
+    case notchSides
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .centered: return "Centered"
+        case .notchSides: return "Notch Sides"
+        }
+    }
+
+    var helpText: String {
+        switch self {
+        case .centered:
+            return "Show the recording overlay centered below the notch."
+        case .notchSides:
+            return "Show recording controls beside the notch when supported. Other states stay centered."
+        }
+    }
+
+    static func find(rawValue: String?) -> RecordingOverlayLayout {
+        guard let rawValue, let layout = RecordingOverlayLayout(rawValue: rawValue) else { return .centered }
+        return layout
+    }
+}
+```
+
+- [ ] **Step 2: Add setting storage key to `AppState`**
+
+In `Sources/AppState.swift`, add the key near other private storage keys:
+
+```swift
+private let recordingOverlayLayoutStorageKey = "recording_overlay_layout"
+```
+
+Place it after `dictationAudioInterruptionEnabledStorageKey` and before `pendingMutedAudioRestoreStorageKey`.
+
+- [ ] **Step 3: Add published property to `AppState`**
+
+In `Sources/AppState.swift`, add this property near `dictationAudioInterruptionEnabled`:
+
+```swift
+@Published var recordingOverlayLayout: RecordingOverlayLayout {
+    didSet {
+        UserDefaults.standard.set(recordingOverlayLayout.rawValue, forKey: recordingOverlayLayoutStorageKey)
+        overlayManager.setRecordingOverlayLayout(recordingOverlayLayout)
+    }
+}
+```
+
+- [ ] **Step 4: Load the setting in `AppState.init()`**
+
+In `init()`, after loading `dictationAudioInterruptionEnabled`, add:
+
+```swift
+let recordingOverlayLayout = RecordingOverlayLayout.find(
+    rawValue: UserDefaults.standard.string(forKey: recordingOverlayLayoutStorageKey)
+)
+```
+
+Then assign it after `self.dictationAudioInterruptionEnabled = dictationAudioInterruptionEnabled`:
+
+```swift
+self.recordingOverlayLayout = recordingOverlayLayout
+self.overlayManager.setRecordingOverlayLayout(recordingOverlayLayout)
+```
+
+- [ ] **Step 5: Add the manager setter stub**
+
+In `Sources/RecordingOverlay.swift`, add a property to `RecordingOverlayState`:
+
+```swift
+@Published var recordingOverlayLayout: RecordingOverlayLayout = .centered
+```
+
+Then add this method inside `RecordingOverlayManager` after `setRecordingTriggerMode`:
+
+```swift
+func setRecordingOverlayLayout(_ layout: RecordingOverlayLayout) {
+    DispatchQueue.main.async {
+        self.overlayState.recordingOverlayLayout = layout
+        self.updateOverlayLayout(animated: false)
+    }
+}
+```
+
+- [ ] **Step 6: Parse-check the new setting model**
+
+Run:
+
+```bash
+swiftc -parse Sources/RecordingOverlay.swift Sources/AppState.swift
+```
+
+Expected: this may fail because these files reference types from other files when parsed together in isolation. If it fails due to unrelated missing symbols, continue to the full Makefile build in the next step. It must not fail due to `RecordingOverlayLayout` or `recordingOverlayLayout` being undefined.
+
+- [ ] **Step 7: Build with Makefile**
+
+Run:
+
+```bash
+make clean && make CODESIGN_IDENTITY="Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)"
+```
+
+Expected: build succeeds and prints `Built build/Quill.app`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/RecordingOverlay.swift Sources/AppState.swift
+git commit -m "Add recording overlay layout setting."
+```
+
+---
+
+### Task 2: Add Settings UI for the layout option
+
+**Files:**
+- Modify: `Sources/SettingsView.swift`
+
+- [ ] **Step 1: Locate recording/shortcut settings section**
+
+Search for the settings area that contains hold/toggle shortcut, shortcut start delay, or recording behavior controls:
+
+```bash
+git grep -n "shortcutStartDelay\|Hold Shortcut\|Toggle Shortcut\|Recording" Sources/SettingsView.swift
+```
+
+Use the section that already groups recording behavior. Do not put this control inside provider model settings.
+
+- [ ] **Step 2: Add picker UI**
+
+Add this block near other recording behavior controls:
+
+```swift
+VStack(alignment: .leading, spacing: 6) {
+    Text("Recording Overlay Layout")
+        .font(.caption.weight(.semibold))
+
+    Picker("Recording Overlay Layout", selection: $appState.recordingOverlayLayout) {
+        ForEach(RecordingOverlayLayout.allCases) { layout in
+            Text(layout.displayName).tag(layout)
+        }
+    }
+    .pickerStyle(.segmented)
+    .labelsHidden()
+    .accessibilityLabel("Recording Overlay Layout")
+
+    Text(appState.recordingOverlayLayout.helpText)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+}
+```
+
+If the surrounding section uses `SettingsCard` or `Divider()`, match that style exactly.
+
+- [ ] **Step 3: Build with Makefile**
+
+Run:
+
+```bash
+make clean && make CODESIGN_IDENTITY="Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)"
+```
+
+Expected: build succeeds and prints `Built build/Quill.app`.
+
+- [ ] **Step 4: Run the built app for Settings smoke test**
+
+Run:
+
+```bash
+open build/Quill.app
+```
+
+Expected: app launches. Open Settings manually and confirm the new picker appears and defaults to `Centered`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/SettingsView.swift
+git commit -m "Expose recording overlay layout setting."
+```
+
+---
+
+### Task 3: Implement notch-side recording geometry
+
+**Files:**
+- Modify: `Sources/RecordingOverlay.swift`
+
+- [ ] **Step 1: Add notch-side layout constants**
+
+Inside `RecordingOverlayManager`, near `lockedOverlayWidth`, add:
+
+```swift
+private let notchSideRegionWidth: CGFloat = 92
+private let notchSidePanelHeight: CGFloat = 38
+private let notchSideHorizontalInset: CGFloat = 8
+```
+
+- [ ] **Step 2: Add geometry struct**
+
+Inside `RecordingOverlayManager`, add this private struct near the constants:
+
+```swift
+private struct NotchSideGeometry {
+    let frame: NSRect
+    let leftContentFrame: CGRect
+    let rightContentFrame: CGRect
+}
+```
+
+- [ ] **Step 3: Add active-layout predicate**
+
+Inside `RecordingOverlayManager`, add:
+
+```swift
+private var usesNotchSideRecordingLayout: Bool {
+    overlayState.recordingOverlayLayout == .notchSides
+        && overlayState.phase == .recording
+        && screenHasNotch
+        && notchSideGeometry != nil
+}
+```
+
+- [ ] **Step 4: Add notch-side geometry helper**
+
+Inside `RecordingOverlayManager`, add:
+
+```swift
+private var notchSideGeometry: NotchSideGeometry? {
+    guard let screen = NSScreen.main, screenHasNotch else { return nil }
+    guard let leftArea = screen.auxiliaryTopLeftArea,
+          let rightArea = screen.auxiliaryTopRightArea else { return nil }
+
+    let availableSideWidth = min(leftArea.width, rightArea.width)
+    let contentWidth = min(notchSideRegionWidth, max(0, availableSideWidth - notchSideHorizontalInset * 2))
+    guard contentWidth >= 64 else { return nil }
+
+    let notchMinX = leftArea.maxX
+    let notchMaxX = rightArea.minX
+    guard notchMaxX > notchMinX else { return nil }
+
+    let panelMinX = leftArea.maxX - contentWidth - notchSideHorizontalInset
+    let panelMaxX = rightArea.minX + contentWidth + notchSideHorizontalInset
+    let height = notchSidePanelHeight + notchOverlap
+    let frame = NSRect(
+        x: panelMinX,
+        y: screen.frame.maxY - height,
+        width: panelMaxX - panelMinX,
+        height: height
+    )
+
+    let contentY = notchOverlap
+    let leftFrame = CGRect(
+        x: notchSideHorizontalInset,
+        y: contentY,
+        width: contentWidth,
+        height: notchSidePanelHeight
+    )
+    let rightFrame = CGRect(
+        x: frame.width - notchSideHorizontalInset - contentWidth,
+        y: contentY,
+        width: contentWidth,
+        height: notchSidePanelHeight
+    )
+
+    return NotchSideGeometry(frame: frame, leftContentFrame: leftFrame, rightContentFrame: rightFrame)
+}
+```
+
+- [ ] **Step 5: Route `overlayFrame` through notch-side geometry**
+
+At the top of `overlayFrame`, after `guard let screen = NSScreen.main else { return .zero }`, add:
+
+```swift
+if let geometry = notchSideGeometry,
+   overlayState.recordingOverlayLayout == .notchSides,
+   overlayState.phase == .recording {
+    return geometry.frame
+}
+```
+
+- [ ] **Step 6: Build with Makefile**
+
+Run:
+
+```bash
+make clean && make CODESIGN_IDENTITY="Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)"
+```
+
+Expected: build succeeds and prints `Built build/Quill.app`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/RecordingOverlay.swift
+git commit -m "Add notch-side recording overlay geometry."
+```
+
+---
+
+### Task 4: Render notch-side recording content
+
+**Files:**
+- Modify: `Sources/RecordingOverlay.swift`
+
+- [ ] **Step 1: Add a generic clear panel content helper**
+
+After `makeNotchContent`, add:
+
+```swift
+private func makeTransparentContent<V: View>(
+    width: CGFloat,
+    height: CGFloat,
+    rootView: V
+) -> NSView {
+    let hosting = NSHostingView(rootView: rootView.frame(width: width, height: height))
+    hosting.frame = NSRect(x: 0, y: 0, width: width, height: height)
+    hosting.autoresizingMask = [.width, .height]
+    return hosting
+}
+```
+
+- [ ] **Step 2: Add notch-side content route**
+
+At the top of `makeOverlayContent(frame:)`, add:
+
+```swift
+if let geometry = notchSideGeometry,
+   overlayState.recordingOverlayLayout == .notchSides,
+   overlayState.phase == .recording {
+    return makeNotchSideRecordingContent(frame: frame, geometry: geometry)
+}
+```
+
+- [ ] **Step 3: Add `makeNotchSideRecordingContent`**
+
+Inside `RecordingOverlayManager`, after `makeOverlayContent(frame:)`, add:
+
+```swift
+private func makeNotchSideRecordingContent(frame: NSRect, geometry: NotchSideGeometry) -> NSView {
+    makeTransparentContent(
+        width: frame.width,
+        height: frame.height,
+        rootView: NotchSideRecordingOverlayView(
+            state: overlayState,
+            leftContentFrame: geometry.leftContentFrame,
+            rightContentFrame: geometry.rightContentFrame,
+            onStopButtonPressed: { [weak self] in
+                self?.onStopButtonPressed?()
+            }
+        )
+    )
+}
+```
+
+- [ ] **Step 4: Add visible notch-side pill helper**
+
+Before `RecordingOverlayView`, add:
+
+```swift
+private struct NotchSidePill<Content: View>: View {
+    let frame: CGRect
+    let content: Content
+
+    init(frame: CGRect, @ViewBuilder content: () -> Content) {
+        self.frame = frame
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .frame(width: frame.width, height: frame.height)
+            .background(Color.black)
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .position(x: frame.midX, y: frame.midY)
+    }
+}
+```
+
+- [ ] **Step 5: Add notch-side recording view**
+
+Before `RecordingOverlayView`, add:
+
+```swift
+private struct NotchSideRecordingOverlayView: View {
+    @ObservedObject var state: RecordingOverlayState
+    let leftContentFrame: CGRect
+    let rightContentFrame: CGRect
+    let onStopButtonPressed: () -> Void
+
+    private var showsStopButton: Bool {
+        state.recordingTriggerMode == .toggle
+    }
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            NotchSidePill(frame: leftContentFrame) {
+                ZStack {
+                    WaveformView(audioLevel: state.audioLevel, showsActivityPulse: true)
+                        .padding(.horizontal, 12)
+                    if state.isCommandMode {
+                        HStack {
+                            CommandModeIndicator()
+                                .padding(.leading, 8)
+                            Spacer()
+                        }
+                    }
+                }
+            }
+
+            NotchSidePill(frame: rightContentFrame) {
+                ZStack {
+                    if showsStopButton {
+                        Button(action: onStopButtonPressed) {
+                            Image(systemName: "stop.fill")
+                                .font(.system(size: 9, weight: .bold))
+                                .foregroundStyle(.white)
+                                .frame(width: 20, height: 20)
+                                .background(Circle().fill(Color.red.opacity(0.92)))
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.audioLevel)
+        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.recordingTriggerMode)
+        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.isCommandMode)
+    }
+}
+```
+
+- [ ] **Step 6: Build with Makefile**
+
+Run:
+
+```bash
+make clean && make CODESIGN_IDENTITY="Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)"
+```
+
+Expected: build succeeds and prints `Built build/Quill.app`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/RecordingOverlay.swift
+git commit -m "Render notch-side recording overlay."
+```
+
+---
+
+### Task 5: Verify behavior in the built app
+
+**Files:**
+- No code changes expected unless verification finds a defect.
+
+- [ ] **Step 1: Launch the built app**
+
+Run:
+
+```bash
+open build/Quill.app
+```
+
+Expected: the built worktree app launches.
+
+- [ ] **Step 2: Verify default centered mode**
+
+Manual steps:
+
+1. Open Settings.
+2. Confirm `Recording Overlay Layout` is `Centered`.
+3. Start recording.
+4. Confirm the overlay appears in the existing centered/below-notch position.
+5. Stop recording.
+6. Confirm transcribing/processing remains centered.
+
+Expected: behavior matches current app.
+
+- [ ] **Step 3: Verify notch-side mode in hold recording**
+
+Manual steps:
+
+1. Set `Recording Overlay Layout` to `Notch Sides`.
+2. Start hold-mode recording.
+3. Confirm waveform appears on the left side of the notch.
+4. Confirm the right side has a balanced black pill but no stop button.
+5. Stop recording.
+6. Confirm transcribing/processing returns to the centered overlay.
+
+Expected: recording-only notch-side layout works and processing is centered.
+
+- [ ] **Step 4: Verify notch-side mode in toggle recording**
+
+Manual steps:
+
+1. Start toggle-mode recording.
+2. Confirm waveform appears on the left side of the notch.
+3. Confirm stop button appears on the right side.
+4. Click the stop button.
+5. Confirm recording stops and processing appears centered.
+
+Expected: stop button is clickable and does not regress toggle mode.
+
+- [ ] **Step 5: Verify concurrent transcription ownership**
+
+Manual steps:
+
+1. Use a transcription mode that takes long enough to process.
+2. Record and stop once.
+3. Start a second recording while the first transcription is still processing.
+4. Confirm the second recording controls the visible recording overlay.
+5. Confirm the first transcription completion does not dismiss or overwrite the second recording overlay.
+
+Expected: current `activeTranscriptionJobs` / `overlayTranscriptionID` behavior is preserved.
+
+- [ ] **Step 6: Commit verification fixes if needed**
+
+If verification required code changes, run the Makefile build again and commit:
+
+```bash
+git add Sources/RecordingOverlay.swift Sources/AppState.swift Sources/SettingsView.swift
+git commit -m "Fix notch-side overlay verification issues."
+```
+
+If no changes are needed, do not create an empty commit.
+
+---
+
+### Task 6: Prepare PR
+
+**Files:**
+- Existing commits only.
+
+- [ ] **Step 1: Review final diff**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline origin/main..HEAD
+git diff --stat origin/main...HEAD
+```
+
+Expected: worktree is on `issue-53-notch-side-overlay`, contains the design commit plus implementation commits, and has no uncommitted changes.
+
+- [ ] **Step 2: Push branch to origin**
+
+Run:
+
+```bash
+git push -u origin issue-53-notch-side-overlay
+```
+
+Expected: branch is pushed to `woosublee/freeflow`.
+
+- [ ] **Step 3: Create PR**
+
+Run:
+
+```bash
+gh pr create --repo woosublee/freeflow --base main --head issue-53-notch-side-overlay --title "Add optional notch-side recording overlay" --body "$(cat <<'EOF'
+## Summary
+- Add an optional recording overlay layout setting with existing centered behavior as the default.
+- Render recording waveform and toggle stop control beside the MacBook notch when Notch Sides is selected.
+- Keep transcribing, failure, update, and non-notch layouts on the existing centered path.
+
+## Test plan
+- [ ] Makefile build succeeds with the local Apple Development signing identity.
+- [ ] Launch `build/Quill.app` and verify default Centered layout.
+- [ ] Verify Notch Sides hold-mode recording.
+- [ ] Verify Notch Sides toggle stop button.
+- [ ] Verify transcribing/processing remains centered.
+- [ ] Verify concurrent recording/transcription overlay ownership.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR is created against `woosublee/freeflow:main`.

--- a/docs/superpowers/specs/2026-04-30-notch-side-recording-overlay-design.md
+++ b/docs/superpowers/specs/2026-04-30-notch-side-recording-overlay-design.md
@@ -1,0 +1,141 @@
+# Notch-side recording overlay design
+
+## Goal
+
+Reduce how often Quill's recording overlay blocks clicks in the active app by allowing the recording UI to use the MacBook notch's left and right top auxiliary areas instead of the current centered, below-notch overlay.
+
+This should be optional and easy to disable. The existing centered overlay remains the default behavior.
+
+## Scope
+
+This design applies only to the recording phase.
+
+- Recording on notch displays can use the new notch-side layout.
+- Initializing, transcribing/processing, failure feedback, and update-available overlays keep the existing centered layout.
+- Non-notch displays keep the existing centered layout.
+- Existing concurrent recording/transcription ownership behavior must remain unchanged.
+
+## User setting
+
+Add a persistent setting for recording overlay placement.
+
+Suggested storage key: `recording_overlay_layout`
+
+Supported values:
+
+- `centered` — existing centered overlay, default
+- `notchSides` — recording waveform on the left side of the notch and stop affordance on the right side
+
+Settings UI should expose this as a simple picker, for example:
+
+- Label: `Recording Overlay Layout`
+- Options: `Centered`, `Notch Sides`
+- Help text: `Notch Sides applies only while recording on MacBooks with a notch. Other states and displays use the centered overlay.`
+
+The default must be `centered` so disabling or reverting the feature restores the current behavior without migration risk.
+
+## Layout behavior
+
+### Centered layout
+
+The current implementation remains the fallback and default path:
+
+- Single centered `NSPanel`
+- Current `overlayFrame` and `overlayWidth` behavior
+- Existing below-notch vertical placement
+- Existing transcribing, feedback, and update content
+
+### Notch-side recording layout
+
+When all of the following are true, recording uses the notch-side layout:
+
+- setting is `notchSides`
+- overlay phase is `.recording`
+- the current screen has a notch/safe top area
+- both `auxiliaryTopLeftArea` and `auxiliaryTopRightArea` are available
+
+The layout uses one transparent panel spanning the top notch area. Visible content is split into balanced left and right regions:
+
+- Left region: recording waveform / command mode indicator if applicable
+- Right region: stop button in toggle mode
+- Hold mode: right region remains visually balanced but does not show a stop button
+
+Left and right visible regions should use the same width. Use the smaller available side width as the maximum cap so the layout is visually symmetric around the notch.
+
+The panel may span across the notch gap for simpler animation and layout. This may overlap menu bar hit-testing, but that is acceptable for this iteration because menu bar interaction during recording is not a primary workflow.
+
+## Screen and fallback rules
+
+Use `NSScreen` information already available in `RecordingOverlayManager`:
+
+- `safeAreaInsets.top` to infer notch/safe-area presence
+- `auxiliaryTopLeftArea` for the usable top-left area
+- `auxiliaryTopRightArea` for the usable top-right area
+
+If notch-side geometry is unavailable or too small, fall back to the centered layout.
+
+External displays and non-notch Macs must use the centered layout.
+
+`NSScreen.main` can remain the first implementation target. More precise active-screen selection can be handled separately if needed.
+
+## Architecture
+
+Keep the existing centered overlay code path intact and add a separate layout calculation path for recording-only notch-side placement.
+
+Recommended structure:
+
+- Add `RecordingOverlayLayout` enum.
+- Store selected layout in `AppState` via UserDefaults.
+- Pass the selected layout into `RecordingOverlayManager` before or during overlay display.
+- Add a helper that decides whether notch-side layout is active for the current state.
+- Add separate frame/content helpers for notch-side recording layout.
+- Leave transcribing and feedback helpers on the existing centered path.
+
+The implementation should avoid rewriting the entire overlay manager. The feature should be removable by deleting the setting, the notch-side layout helper, and the settings UI while leaving the centered path unchanged.
+
+## Interaction behavior
+
+Mouse-event behavior should match the existing intent:
+
+- Hold-mode recording overlay should not need to accept mouse events.
+- Toggle-mode recording overlay must allow the stop button to be clicked.
+- Update overlay keeps existing centered behavior and click handling.
+
+If using a single transparent panel causes too much menu bar click interception in practice, a follow-up can split the layout into two panels. That is not part of the initial implementation.
+
+## Concurrent transcription safety
+
+This feature must not change transcription ownership semantics.
+
+Do not change:
+
+- `activeTranscriptionJobs`
+- `foregroundTranscriptionJobID`
+- `overlayTranscriptionID`
+- `prepareTranscribingOverlay(for: overlayID, ...)`
+- transcribing completion/cancellation ownership checks
+
+Because the notch-side layout applies only to `.recording`, it should not allow background transcription jobs to control recording UI or dismiss the active overlay.
+
+## Testing and verification
+
+Required verification:
+
+1. Build with the Makefile-based build path.
+2. Run the built app, not just compile it.
+3. With default `Centered`, confirm the recording overlay behaves as before.
+4. Switch to `Notch Sides` and confirm recording waveform appears on the left side of the notch.
+5. In toggle recording mode, confirm the stop button appears on the right side and is clickable.
+6. Confirm hold recording mode does not show a stop button.
+7. Stop recording and confirm transcribing/processing uses the existing centered overlay.
+8. Confirm failure feedback still uses the existing centered overlay.
+9. If possible, verify external display or non-notch fallback uses the centered overlay.
+10. Start a new recording while an older transcription is still processing and confirm overlay ownership does not regress.
+
+## Out of scope
+
+- Replacing Quill's processing indicator design.
+- Integrating upstream `features/better-loader`.
+- Adding multiple visual themes for the recording waveform.
+- Multi-screen active-window-aware overlay placement.
+- Switching to two separate overlay panels in the first iteration.


### PR DESCRIPTION
## Summary
- Add an optional recording overlay layout setting with the existing centered behavior as the default.
- Render the recording waveform and toggle stop control as a notch-extension bar on MacBooks with a notch.
- Move appearance-related controls into a dedicated Appearance settings tab.

## Test plan
- [x] `swiftc -o /tmp/RecordingOverlayGeometryTests Tests/RecordingOverlayGeometryTests.swift Sources/RecordingOverlay.swift Sources/ShortcutCore/ShortcutModels.swift && /tmp/RecordingOverlayGeometryTests`
- [x] `make clean && make CODESIGN_IDENTITY="Apple Development: <local identity>"`
- [x] Launched `build/Quill.app` and manually verified Notch Sides recording overlay.
- [x] Manually verified transcribing overlay returns to the existing centered shape.
- [x] Manually verified Appearance settings tab placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)