### PR TITLE
Merge upstream termination protection

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -573,6 +573,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var pendingShortcutStartTask: Task<Void, Never>?
     private var pendingShortcutStartMode: RecordingTriggerMode?
     private var realtimeService: RealtimeTranscriptionService?
+    private var automaticTerminationDisabled = false
     private var activeAudioInterruption: ActiveAudioInterruption?
     private var pendingOverlayDismissToken: UUID?
     private var shouldMonitorHotkeys = false
@@ -1624,6 +1625,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         tearDownRealtimeService()
         audioRecorder.cancelRecording()
         restoreAudioInterruptionIfNeeded()
+        endCriticalDictationActivity()
         refreshAvailableMicrophonesIfNeeded()
         if !isRecording && !isTranscribing && statusText == "Cancelled" {
             scheduleReadyStatusReset(after: 2, matching: ["Cancelled"])
@@ -1652,6 +1654,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             Self.deleteAudioFile(transcribingAudioFileName)
             self.transcribingAudioFileName = nil
         }
+        endCriticalDictationActivity()
         refreshAvailableMicrophonesIfNeeded()
         if !isRecording && !isTranscribing && statusText == "Cancelled" {
             scheduleReadyStatusReset(after: 2, matching: ["Cancelled"])
@@ -1968,8 +1971,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    private func beginCriticalDictationActivity() {
+        guard !automaticTerminationDisabled else { return }
+        ProcessInfo.processInfo.disableAutomaticTermination("FreeFlow dictation in progress")
+        automaticTerminationDisabled = true
+    }
+
+    private func endCriticalDictationActivity() {
+        guard automaticTerminationDisabled else { return }
+        ProcessInfo.processInfo.enableAutomaticTermination("FreeFlow dictation in progress")
+        automaticTerminationDisabled = false
+    }
+
     private func beginRecording(triggerMode: RecordingTriggerMode) {
         os_log(.info, log: recordingLog, "beginRecording() entered")
+        beginCriticalDictationActivity()
         clearPendingOverlayDismissToken()
         errorMessage = nil
 
@@ -2078,6 +2094,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         activeRecordingTriggerMode = nil
         currentSessionIntent = .dictation
         shortcutSessionController.reset()
+        endCriticalDictationActivity()
         errorMessage = formattedRecordingStartError(error)
         statusText = "Error"
         overlayManager.dismiss()
@@ -2346,6 +2363,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             guard let fileURL else {
                 self.isTranscribing = false
                 self.audioRecorder.cleanup()
+                self.endCriticalDictationActivity()
                 self.errorMessage = "No audio recorded"
                 self.statusText = "Error"
                 self.overlayManager.dismiss()
@@ -2384,6 +2402,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 self.transcribingAudioFileName = nil
                 activeRealtime?.cancel()
                 self.audioRecorder.cleanup()
+                self.endCriticalDictationActivity()
                 self.refreshAvailableMicrophonesIfNeeded()
                 return
             }
@@ -2462,6 +2481,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.transcribingAudioFileName = nil
                         self.lastTranscript = trimmedFinalTranscript
                         self.isTranscribing = false
+                        self.endCriticalDictationActivity()
                         self.debugStatusMessage = "Done"
                         let completionStatusText = self.preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
                         let enterOnlyStatusText = "Pressed Enter"
@@ -2515,6 +2535,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 } catch is CancellationError {
                     await MainActor.run {
                         self.transcriptionTask = nil
+                        self.endCriticalDictationActivity()
                     }
                 } catch {
                     let resolvedContext: AppContext
@@ -2531,6 +2552,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.transcribingAudioFileName = nil
                         self.errorMessage = error.localizedDescription
                         self.isTranscribing = false
+                        self.endCriticalDictationActivity()
                         self.statusText = "Error"
                         self.overlayManager.dismiss()
                         self.lastPostProcessedTranscript = ""
@@ -2762,6 +2784,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             restoreAudioInterruptionIfNeeded()
             shortcutSessionController.reset()
             activeRecordingTriggerMode = nil
+            endCriticalDictationActivity()
             statusText = "Screenshot Required"
             overlayManager.dismiss()
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1265,14 +1265,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func syncCriticalDictationActivity() {
+        let reason = "Quill dictation in progress"
         switch criticalDictationActivityState.update(
             isRecording: isRecording,
             activeTranscriptionJobCount: activeTranscriptionJobs.count
         ) {
         case .begin:
-            ProcessInfo.processInfo.disableAutomaticTermination("Quill dictation in progress")
+            ProcessInfo.processInfo.disableAutomaticTermination(reason)
         case .end:
-            ProcessInfo.processInfo.enableAutomaticTermination("Quill dictation in progress")
+            ProcessInfo.processInfo.enableAutomaticTermination(reason)
         case .none:
             break
         }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -736,6 +736,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var pendingShortcutStartTask: Task<Void, Never>?
     private var pendingShortcutStartMode: RecordingTriggerMode?
     private var realtimeService: RealtimeTranscriptionService?
+    private var criticalDictationActivityState = CriticalDictationActivityState()
     private var activeAudioInterruption: ActiveAudioInterruption?
     private var pendingOverlayDismissToken: UUID?
     private var shouldMonitorHotkeys = false
@@ -844,7 +845,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         for removedAssets in removedStoredFiles {
             Self.deleteStoredFiles(removedAssets)
         }
-        let savedHistory = pipelineHistoryStore.loadAllHistory()
+        let savedHistory = Self.markInterruptedRecoveryPlaceholders(
+            in: pipelineHistoryStore.loadAllHistory(),
+            store: pipelineHistoryStore
+        )
         let referencedAudioFileNames = Set(savedHistory.compactMap(\.audioFileName))
         let referencedTranscriptFileNames = Set(savedHistory.compactMap(\.transcriptFileName))
         Task.detached(priority: .background) {
@@ -1241,9 +1245,37 @@ final class AppState: ObservableObject, @unchecked Sendable {
         deleteStoredFiles(audioFileName: assets.audioFileName, transcriptFileName: assets.transcriptFileName)
     }
 
+    private static func markInterruptedRecoveryPlaceholders(
+        in history: [PipelineHistoryItem],
+        store: PipelineHistoryStore
+    ) -> [PipelineHistoryItem] {
+        history.map { item in
+            guard item.isIncompleteTranscription else { return item }
+            let updated = item.markInterruptedBeforeCompletion()
+            try? store.update(updated)
+            return updated
+        }
+    }
+
     @MainActor
     private func refreshTranscribingState() {
         isTranscribing = !activeTranscriptionJobs.isEmpty
+        syncCriticalDictationActivity()
+    }
+
+    @MainActor
+    private func syncCriticalDictationActivity() {
+        switch criticalDictationActivityState.update(
+            isRecording: isRecording,
+            activeTranscriptionJobCount: activeTranscriptionJobs.count
+        ) {
+        case .begin:
+            ProcessInfo.processInfo.disableAutomaticTermination("Quill dictation in progress")
+        case .end:
+            ProcessInfo.processInfo.enableAutomaticTermination("Quill dictation in progress")
+        case .none:
+            break
+        }
     }
 
     @MainActor
@@ -2336,6 +2368,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         tearDownRealtimeService()
         audioRecorder.cancelRecording()
         restoreAudioInterruptionIfNeeded()
+        syncCriticalDictationActivity()
         refreshAvailableMicrophonesIfNeeded()
         if !isRecording && !isTranscribing && statusText == "Cancelled" {
             scheduleReadyStatusReset(after: 2, matching: ["Cancelled"])
@@ -2863,6 +2896,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 return
             default:
                 isRecording = false
+                syncCriticalDictationActivity()
                 restoreAudioInterruptionIfNeeded()
                 activeRecordingTriggerMode = nil
                 currentSessionIntent = .dictation
@@ -2875,6 +2909,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         isRecording = true
+        syncCriticalDictationActivity()
         statusText = "Starting..."
         hasShownScreenshotPermissionAlert = false
 
@@ -3038,6 +3073,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         audioRecorder.cleanup()
         restoreAudioInterruptionIfNeeded()
         isRecording = false
+        syncCriticalDictationActivity()
         transcribingIndicatorTask?.cancel()
         transcribingIndicatorTask = nil
         refreshTranscribingState()
@@ -3575,7 +3611,22 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
             let savedAudioFile = Self.saveAudioFile(from: fileURL)
             let transcriptionFileURL = savedAudioFile?.fileURL ?? fileURL
-            self.updateTranscriptionJob(jobID) { $0.audioFileName = savedAudioFile?.fileName }
+            if let savedAudioFile {
+                let recoveryContext = sessionContext ?? self.fallbackContextAtStop()
+                self.createTranscriptionRecoveryPlaceholder(
+                    jobID: jobID,
+                    noteID: liveNoteID ?? jobID,
+                    startedAt: startedAt,
+                    sessionIntent: sessionIntent,
+                    context: recoveryContext,
+                    audioFileName: savedAudioFile.fileName,
+                    useLocalTranscription: capturedUseLocalTranscription,
+                    localTranscriptionModelID: capturedLocalTranscriptionModel.id,
+                    transcriptionLanguageCode: capturedTranscriptionLanguage.code
+                )
+            } else {
+                self.updateTranscriptionJob(jobID) { $0.audioFileName = nil }
+            }
             let activeRealtime = self.realtimeService
             self.realtimeService = nil
             self.audioRecorder.onPCM16Samples = nil
@@ -3824,6 +3875,61 @@ final class AppState: ObservableObject, @unchecked Sendable {
             if pipelineHistory.count > maxPipelineHistoryCount {
                 pipelineHistory.removeLast(pipelineHistory.count - maxPipelineHistoryCount)
             }
+        }
+    }
+
+    @MainActor
+    private func createTranscriptionRecoveryPlaceholder(
+        jobID: UUID,
+        noteID: UUID,
+        startedAt: Date,
+        sessionIntent: SessionIntent,
+        context: AppContext,
+        audioFileName: String,
+        useLocalTranscription: Bool,
+        localTranscriptionModelID: String,
+        transcriptionLanguageCode: String
+    ) {
+        let item = PipelineHistoryItem.transcriptionRecoveryPlaceholder(
+            id: noteID,
+            timestamp: startedAt,
+            intent: sessionIntent.persistedIntent,
+            selectedText: sessionIntent.persistedSelectedText,
+            capturedSelection: context.selectedText,
+            contextSummary: context.contextSummary,
+            contextSystemPrompt: context.contextSystemPrompt,
+            contextPrompt: context.contextPrompt,
+            contextScreenshotDataURL: context.screenshotDataURL,
+            contextScreenshotStatus: context.screenshotError ?? "available (\(context.screenshotMimeType ?? "image"))",
+            systemPrompt: Self.resolvedSystemPrompt(customSystemPrompt),
+            customVocabulary: customVocabulary,
+            customSystemPrompt: customSystemPrompt,
+            audioFileName: audioFileName,
+            usedLocalTranscription: useLocalTranscription,
+            usedContextCapture: !disableContextCapture,
+            usedPostProcessing: !disablePostProcessing,
+            transcriptionLanguageCode: transcriptionLanguageCode,
+            localTranscriptionModelID: localTranscriptionModelID,
+            contextAppName: context.appName,
+            contextBundleIdentifier: context.bundleIdentifier,
+            contextWindowTitle: context.windowTitle
+        )
+        do {
+            if pipelineHistory.contains(where: { $0.id == noteID }) {
+                try pipelineHistoryStore.update(item)
+                updatePipelineHistoryItem(item)
+            } else {
+                let removedStoredFiles = try appendPipelineHistoryItem(item)
+                for removedAssets in removedStoredFiles {
+                    Self.deleteStoredFiles(removedAssets)
+                }
+            }
+            updateTranscriptionJob(jobID) {
+                $0.liveNoteID = noteID
+                $0.audioFileName = audioFileName
+            }
+        } catch {
+            errorMessage = "Unable to save recovery entry: \(error.localizedDescription)"
         }
     }
 
@@ -4077,6 +4183,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             contextCaptureTask = nil
             capturedContext = nil
             isRecording = false
+            syncCriticalDictationActivity()
             restoreAudioInterruptionIfNeeded()
             shortcutSessionController.reset()
             activeRecordingTriggerMode = nil

--- a/Sources/CriticalDictationActivityState.swift
+++ b/Sources/CriticalDictationActivityState.swift
@@ -1,0 +1,23 @@
+struct CriticalDictationActivityState {
+    enum Transition {
+        case none
+        case begin
+        case end
+    }
+
+    private(set) var isActive = false
+
+    mutating func update(isRecording: Bool, activeTranscriptionJobCount: Int) -> Transition {
+        let shouldBeActive = isRecording || activeTranscriptionJobCount > 0
+        switch (isActive, shouldBeActive) {
+        case (false, true):
+            isActive = true
+            return .begin
+        case (true, false):
+            isActive = false
+            return .end
+        default:
+            return .none
+        }
+    }
+}

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -147,6 +147,7 @@ private func transcriptStatus(for item: PipelineHistoryItem, retrying: Set<UUID>
     if retrying.contains(item.id) { return .transcribing }
     if item.postProcessingStatus == "live-recording" { return .recording }
     if item.postProcessingStatus == "importing" { return .transcribing }
+    if item.postProcessingStatus == PipelineHistoryItem.transcriptionRecoveryPlaceholderStatus { return .transcribing }
     if item.postProcessingStatus.hasPrefix("Error:") { return .fail }
     return .done
 }

--- a/Sources/PipelineHistoryItem.swift
+++ b/Sources/PipelineHistoryItem.swift
@@ -7,6 +7,14 @@ enum PipelineHistoryItemIntent: String, Codable {
 }
 
 struct PipelineHistoryItem: Identifiable, Codable {
+    static let transcriptionRecoveryPlaceholderStatus = "transcription-interrupted"
+
+    var isIncompleteTranscription: Bool {
+        postProcessingStatus == Self.transcriptionRecoveryPlaceholderStatus
+            || postProcessingStatus == "importing"
+            || postProcessingStatus == "live-recording"
+    }
+
     let intent: PipelineHistoryItemIntent
     let selectedText: String?
     let capturedSelection: String?
@@ -94,5 +102,94 @@ struct PipelineHistoryItem: Identifiable, Codable {
         self.contextAppName = contextAppName
         self.contextBundleIdentifier = contextBundleIdentifier
         self.contextWindowTitle = contextWindowTitle
+    }
+
+    static func transcriptionRecoveryPlaceholder(
+        id: UUID = UUID(),
+        timestamp: Date,
+        intent: PipelineHistoryItemIntent,
+        selectedText: String?,
+        capturedSelection: String?,
+        contextSummary: String,
+        contextSystemPrompt: String?,
+        contextPrompt: String?,
+        contextScreenshotDataURL: String?,
+        contextScreenshotStatus: String,
+        systemPrompt: String?,
+        customVocabulary: String,
+        customSystemPrompt: String,
+        audioFileName: String,
+        usedLocalTranscription: Bool,
+        usedContextCapture: Bool,
+        usedPostProcessing: Bool,
+        transcriptionLanguageCode: String,
+        localTranscriptionModelID: String,
+        contextAppName: String?,
+        contextBundleIdentifier: String?,
+        contextWindowTitle: String?
+    ) -> PipelineHistoryItem {
+        PipelineHistoryItem(
+            intent: intent,
+            selectedText: selectedText,
+            capturedSelection: capturedSelection,
+            id: id,
+            timestamp: timestamp,
+            rawTranscript: "",
+            postProcessedTranscript: "",
+            postProcessingPrompt: nil,
+            systemPrompt: systemPrompt,
+            contextSummary: contextSummary,
+            contextSystemPrompt: contextSystemPrompt,
+            contextPrompt: contextPrompt,
+            contextScreenshotDataURL: contextScreenshotDataURL,
+            contextScreenshotStatus: contextScreenshotStatus,
+            postProcessingStatus: transcriptionRecoveryPlaceholderStatus,
+            debugStatus: "Transcription interrupted before completion",
+            customVocabulary: customVocabulary,
+            customSystemPrompt: customSystemPrompt,
+            audioFileName: audioFileName,
+            usedLocalTranscription: usedLocalTranscription,
+            usedContextCapture: usedContextCapture,
+            usedPostProcessing: usedPostProcessing,
+            transcriptionLanguageCode: transcriptionLanguageCode,
+            localTranscriptionModelID: localTranscriptionModelID,
+            transcriptFileName: nil,
+            contextAppName: contextAppName,
+            contextBundleIdentifier: contextBundleIdentifier,
+            contextWindowTitle: contextWindowTitle
+        )
+    }
+
+    func markInterruptedBeforeCompletion() -> PipelineHistoryItem {
+        PipelineHistoryItem(
+            intent: intent,
+            selectedText: selectedText,
+            capturedSelection: capturedSelection,
+            id: id,
+            timestamp: timestamp,
+            rawTranscript: rawTranscript,
+            postProcessedTranscript: postProcessedTranscript,
+            postProcessingPrompt: postProcessingPrompt,
+            systemPrompt: systemPrompt,
+            contextSummary: contextSummary,
+            contextSystemPrompt: contextSystemPrompt,
+            contextPrompt: contextPrompt,
+            contextScreenshotDataURL: contextScreenshotDataURL,
+            contextScreenshotStatus: contextScreenshotStatus,
+            postProcessingStatus: "Error: Interrupted before transcription completed",
+            debugStatus: "Interrupted before completion",
+            customVocabulary: customVocabulary,
+            customSystemPrompt: customSystemPrompt,
+            audioFileName: audioFileName,
+            usedLocalTranscription: usedLocalTranscription,
+            usedContextCapture: usedContextCapture,
+            usedPostProcessing: usedPostProcessing,
+            transcriptionLanguageCode: transcriptionLanguageCode,
+            localTranscriptionModelID: localTranscriptionModelID,
+            transcriptFileName: transcriptFileName,
+            contextAppName: contextAppName,
+            contextBundleIdentifier: contextBundleIdentifier,
+            contextWindowTitle: contextWindowTitle
+        )
     }
 }

--- a/Tests/CriticalDictationActivityStateTests.swift
+++ b/Tests/CriticalDictationActivityStateTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+@main
+struct CriticalDictationActivityStateTests {
+    static func main() {
+        testBeginsWhenRecordingStarts()
+        testStaysActiveWhenRecordingStopsButTranscriptionContinues()
+        testEndsWhenLastTranscriptionJobFinishes()
+        print("CriticalDictationActivityStateTests passed")
+    }
+
+    private static func testBeginsWhenRecordingStarts() {
+        var state = CriticalDictationActivityState()
+
+        let transition = state.update(isRecording: true, activeTranscriptionJobCount: 0)
+
+        assert(transition == .begin)
+        assert(state.isActive)
+    }
+
+    private static func testStaysActiveWhenRecordingStopsButTranscriptionContinues() {
+        var state = CriticalDictationActivityState()
+        _ = state.update(isRecording: true, activeTranscriptionJobCount: 0)
+
+        let transition = state.update(isRecording: false, activeTranscriptionJobCount: 1)
+
+        assert(transition == .none)
+        assert(state.isActive)
+    }
+
+    private static func testEndsWhenLastTranscriptionJobFinishes() {
+        var state = CriticalDictationActivityState()
+        _ = state.update(isRecording: false, activeTranscriptionJobCount: 1)
+
+        let transition = state.update(isRecording: false, activeTranscriptionJobCount: 0)
+
+        assert(transition == .end)
+        assert(!state.isActive)
+    }
+}

--- a/Tests/TranscriptionRecoveryPlaceholderTests.swift
+++ b/Tests/TranscriptionRecoveryPlaceholderTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+@main
+struct TranscriptionRecoveryPlaceholderTests {
+    static func main() {
+        testPlaceholderKeepsSavedAudioReferenceForRetryAfterInterruption()
+        testInterruptedPlaceholderBecomesFailedButKeepsAudioReference()
+        testImportingItemIsIncompleteAndBecomesFailedButKeepsAudioReference()
+        testLiveRecordingItemIsIncompleteAndBecomesFailedWithoutRetryAudio()
+        testCompletedItemIsNotIncomplete()
+        print("TranscriptionRecoveryPlaceholderTests passed")
+    }
+
+    private static func testPlaceholderKeepsSavedAudioReferenceForRetryAfterInterruption() {
+        let id = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let timestamp = Date(timeIntervalSince1970: 1_800_000_000)
+
+        let item = PipelineHistoryItem.transcriptionRecoveryPlaceholder(
+            id: id,
+            timestamp: timestamp,
+            intent: .commandManual,
+            selectedText: "original text",
+            capturedSelection: "captured text",
+            contextSummary: "Editing Notes",
+            contextSystemPrompt: "context system",
+            contextPrompt: "context prompt",
+            contextScreenshotDataURL: "data:image/jpeg;base64,abc",
+            contextScreenshotStatus: "available (image/jpeg)",
+            systemPrompt: "system",
+            customVocabulary: "terms",
+            customSystemPrompt: "custom",
+            audioFileName: "recording.wav",
+            usedLocalTranscription: true,
+            usedContextCapture: true,
+            usedPostProcessing: false,
+            transcriptionLanguageCode: "ko",
+            localTranscriptionModelID: "local-model",
+            contextAppName: "Notes",
+            contextBundleIdentifier: "com.apple.Notes",
+            contextWindowTitle: "Daily"
+        )
+
+        assert(item.id == id)
+        assert(item.timestamp == timestamp)
+        assert(item.intent == .commandManual)
+        assert(item.selectedText == "original text")
+        assert(item.capturedSelection == "captured text")
+        assert(item.audioFileName == "recording.wav")
+        assert(item.postProcessingStatus == PipelineHistoryItem.transcriptionRecoveryPlaceholderStatus)
+        assert(item.debugStatus == "Transcription interrupted before completion")
+        assert(item.rawTranscript.isEmpty)
+        assert(item.postProcessedTranscript.isEmpty)
+        assert(item.usedLocalTranscription)
+        assert(item.usedPostProcessing == false)
+        assert(item.transcriptionLanguageCode == "ko")
+        assert(item.localTranscriptionModelID == "local-model")
+        assert(item.contextAppName == "Notes")
+        assert(item.contextBundleIdentifier == "com.apple.Notes")
+        assert(item.contextWindowTitle == "Daily")
+    }
+
+    private static func testImportingItemIsIncompleteAndBecomesFailedButKeepsAudioReference() {
+        let item = makeHistoryItem(postProcessingStatus: "importing", audioFileName: "imported.m4a")
+
+        let interrupted = item.markInterruptedBeforeCompletion()
+
+        assert(item.isIncompleteTranscription)
+        assert(interrupted.audioFileName == "imported.m4a")
+        assert(interrupted.postProcessingStatus == "Error: Interrupted before transcription completed")
+        assert(interrupted.debugStatus == "Interrupted before completion")
+    }
+
+    private static func testLiveRecordingItemIsIncompleteAndBecomesFailedWithoutRetryAudio() {
+        let item = makeHistoryItem(postProcessingStatus: "live-recording", audioFileName: nil)
+
+        let interrupted = item.markInterruptedBeforeCompletion()
+
+        assert(item.isIncompleteTranscription)
+        assert(interrupted.audioFileName == nil)
+        assert(interrupted.postProcessingStatus == "Error: Interrupted before transcription completed")
+        assert(interrupted.debugStatus == "Interrupted before completion")
+    }
+
+    private static func testCompletedItemIsNotIncomplete() {
+        let item = makeHistoryItem(postProcessingStatus: "Post-processing succeeded", audioFileName: "recording.wav")
+
+        assert(!item.isIncompleteTranscription)
+    }
+
+    private static func makeHistoryItem(postProcessingStatus: String, audioFileName: String?) -> PipelineHistoryItem {
+        PipelineHistoryItem(
+            timestamp: Date(timeIntervalSince1970: 1_800_000_000),
+            rawTranscript: "raw",
+            postProcessedTranscript: "final",
+            postProcessingPrompt: nil,
+            contextSummary: "",
+            contextPrompt: nil,
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "No screenshot",
+            postProcessingStatus: postProcessingStatus,
+            debugStatus: "",
+            customVocabulary: "",
+            audioFileName: audioFileName,
+            usedContextCapture: false
+        )
+    }
+
+    private static func testInterruptedPlaceholderBecomesFailedButKeepsAudioReference() {
+        let item = PipelineHistoryItem.transcriptionRecoveryPlaceholder(
+            timestamp: Date(timeIntervalSince1970: 1_800_000_000),
+            intent: .dictation,
+            selectedText: nil,
+            capturedSelection: nil,
+            contextSummary: "",
+            contextSystemPrompt: nil,
+            contextPrompt: nil,
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "No screenshot",
+            systemPrompt: nil,
+            customVocabulary: "",
+            customSystemPrompt: "",
+            audioFileName: "recording.wav",
+            usedLocalTranscription: false,
+            usedContextCapture: false,
+            usedPostProcessing: true,
+            transcriptionLanguageCode: "auto",
+            localTranscriptionModelID: "mlx-community/whisper-large-v3-turbo",
+            contextAppName: nil,
+            contextBundleIdentifier: nil,
+            contextWindowTitle: nil
+        )
+
+        let interrupted = item.markInterruptedBeforeCompletion()
+
+        assert(interrupted.id == item.id)
+        assert(interrupted.audioFileName == "recording.wav")
+        assert(interrupted.postProcessingStatus == "Error: Interrupted before transcription completed")
+        assert(interrupted.debugStatus == "Interrupted before completion")
+        assert(interrupted.transcriptFileName == item.transcriptFileName)
+    }
+}


### PR DESCRIPTION
## Summary
- Merge upstream automatic termination protection and adapt it to Quill's multi-job recording/transcription lifecycle.
- Keep automatic termination disabled while recording or transcription jobs are active, and re-enable it only after all dictation work finishes.
- Persist retryable recovery placeholders for saved recording audio and mark interrupted in-progress items on launch.

## Test plan
- [x] `swiftc -parse-as-library Sources/CriticalDictationActivityState.swift Tests/CriticalDictationActivityStateTests.swift -o /tmp/CriticalDictationActivityStateTests && /tmp/CriticalDictationActivityStateTests`
- [x] `swiftc -parse-as-library Sources/PipelineHistoryItem.swift Tests/TranscriptionRecoveryPlaceholderTests.swift -o /tmp/TranscriptionRecoveryPlaceholderTests && /tmp/TranscriptionRecoveryPlaceholderTests`
- [x] `swiftc -parse-as-library Sources/AudioImportOptions.swift Tests/AudioImportOptionsTests.swift -o /tmp/AudioImportOptionsTests && /tmp/AudioImportOptionsTests`
- [x] `make all CODESIGN_IDENTITY="Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)"`
- [x] Launched `build/Quill.app` and confirmed the built app process starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)