### PR TITLE
Improve Google Calendar title suggestions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ICON_ICNS = Resources/AppIcon.icns
 endif
 
 # Usage: make install CODESIGN_IDENTITY="Apple Development: you@example.com (TEAMID)"
-.PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run
+.PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run test
 
 all: $(APP_EXECUTABLE_TARGET)
 
@@ -144,3 +144,13 @@ install-and-run: install
 
 run: all
 	open "$(APP_BUNDLE)"
+
+test:
+	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/CalendarEventMatcher.swift Tests/CalendarEventMatcherTests.swift -o /tmp/CalendarEventMatcherTests
+	@/tmp/CalendarEventMatcherTests
+	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/NoteTitleResolver.swift Tests/NoteTitleResolutionTests.swift -o /tmp/NoteTitleResolutionTests
+	@/tmp/NoteTitleResolutionTests
+	@swiftc -parse-as-library Sources/AppName.swift Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/TranscriptionModel.swift Sources/PipelineHistoryStore.swift Tests/PipelineHistoryCalendarMetadataTests.swift -o /tmp/PipelineHistoryCalendarMetadataTests
+	@/tmp/PipelineHistoryCalendarMetadataTests
+	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/GoogleCalendarTokenStore.swift Sources/GoogleCalendarAuthService.swift Sources/GoogleCalendarService.swift Tests/GoogleCalendarServiceTests.swift -o /tmp/GoogleCalendarServiceTests
+	@/tmp/GoogleCalendarServiceTests

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -229,6 +229,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         var task: Task<Void, Never>?
         var audioFileName: String?
         var liveNoteID: UUID?
+        var recordingStartedAt: Date?
+        var recordingEndedAt: Date?
+        var isImportedAudio: Bool
     }
 
     private enum ActiveAudioInterruption {
@@ -275,6 +278,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let realtimeStreamingModelStorageKey = "realtime_streaming_model"
     private let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
     private let recordingOverlayLayoutStorageKey = "recording_overlay_layout"
+    private let googleCalendarClientIDStorageKey = "google_calendar_client_id"
+    private let googleCalendarClientSecretStorageKey = "google_calendar_client_secret"
+    private let googleCalendarSelectedIDsStorageKey = "google_calendar_selected_ids"
     private let pendingMutedAudioRestoreStorageKey = "pending_muted_audio_restore"
     private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
     private let pressEnterAfterPasteDelay: TimeInterval = 0.08
@@ -499,6 +505,27 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @Published var googleCalendarClientID: String {
+        didSet {
+            let trimmed = googleCalendarClientID.trimmingCharacters(in: .whitespacesAndNewlines)
+            UserDefaults.standard.set(trimmed, forKey: googleCalendarClientIDStorageKey)
+            guard trimmed != oldValue.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
+            clearGoogleCalendarConnectionState()
+        }
+    }
+
+    @Published var googleCalendarClientSecret: String {
+        didSet {
+            persistOptionalAPIValue(googleCalendarClientSecret, account: googleCalendarClientSecretStorageKey)
+            guard googleCalendarClientSecret.trimmingCharacters(in: .whitespacesAndNewlines) != oldValue.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
+            clearGoogleCalendarConnectionState()
+        }
+    }
+
+    @Published private(set) var googleCalendarConnection = GoogleCalendarConnectionState.disconnected
+    @Published private(set) var availableGoogleCalendars: [GoogleCalendarInfo] = []
+    @Published private(set) var isGoogleCalendarBusy = false
+
     @Published var preserveClipboard: Bool {
         didSet {
             UserDefaults.standard.set(preserveClipboard, forKey: preserveClipboardStorageKey)
@@ -644,6 +671,94 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
+    func setGoogleCalendarSelected(_ calendarID: String, isSelected: Bool) {
+        var selected = googleCalendarConnection.selectedCalendarIDs
+        if isSelected {
+            selected.insert(calendarID)
+        } else {
+            selected.remove(calendarID)
+        }
+        googleCalendarConnection.selectedCalendarIDs = selected
+        Self.saveStringSet(selected, forKey: googleCalendarSelectedIDsStorageKey)
+    }
+
+    @MainActor
+    func disconnectGoogleCalendar() {
+        clearGoogleCalendarConnectionState()
+    }
+
+    private func clearGoogleCalendarConnectionState() {
+        GoogleCalendarTokenStore.delete()
+        availableGoogleCalendars = []
+        googleCalendarConnection = .disconnected
+        UserDefaults.standard.removeObject(forKey: googleCalendarSelectedIDsStorageKey)
+    }
+
+    @MainActor
+    func refreshGoogleCalendars() {
+        guard googleCalendarConnection.isConnected else { return }
+        Task { [weak self] in
+            await self?.loadGoogleCalendars()
+        }
+    }
+
+    @MainActor
+    func connectGoogleCalendar() {
+        guard !isGoogleCalendarBusy else { return }
+        let clientID = googleCalendarClientID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let clientSecret = googleCalendarClientSecret.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !clientID.isEmpty else {
+            googleCalendarConnection.lastErrorMessage = "Enter a Google OAuth Desktop client ID first."
+            return
+        }
+        isGoogleCalendarBusy = true
+        googleCalendarConnection.lastErrorMessage = nil
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let pkce = GoogleCalendarAuthService.makePKCEPair()
+                let state = UUID().uuidString
+                let receiver = try GoogleCalendarAuthService.LoopbackReceiver(state: state)
+                defer { receiver.cancel() }
+                receiver.start()
+                let callbackURL = try await receiver.waitForCallbackURL()
+                await MainActor.run {
+                    GoogleCalendarAuthService.openAuthorizationPage(
+                        clientID: clientID,
+                        callbackURL: callbackURL,
+                        codeChallenge: pkce.challenge,
+                        state: state
+                    )
+                }
+                let code = try await receiver.waitForCode()
+                let token = try await GoogleCalendarAuthService.exchangeCode(
+                    clientID: clientID,
+                    clientSecret: clientSecret,
+                    code: code,
+                    codeVerifier: pkce.verifier,
+                    redirectURI: callbackURL.absoluteString
+                )
+                try GoogleCalendarTokenStore.save(token)
+                await MainActor.run {
+                    self.googleCalendarConnection = GoogleCalendarConnectionState(
+                        isConnected: true,
+                        accountEmail: token.accountEmail,
+                        selectedCalendarIDs: [],
+                        lastErrorMessage: nil
+                    )
+                    Self.saveStringSet([], forKey: self.googleCalendarSelectedIDsStorageKey)
+                }
+                await self.loadGoogleCalendars(force: true)
+            } catch {
+                await MainActor.run {
+                    self.googleCalendarConnection.lastErrorMessage = error.localizedDescription
+                    self.isGoogleCalendarBusy = false
+                }
+            }
+        }
+    }
+
     @Published var soundVolume: Float {
         didSet {
             UserDefaults.standard.set(soundVolume, forKey: soundVolumeStorageKey)
@@ -714,6 +829,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var transcribingIndicatorTask: Task<Void, Never>?
     private var liveTranscriber: (any LiveTranscriber)?
     private var currentRecordingLiveNoteID: UUID?
+    private var activeRecordingStartedAt: Date?
     private var isCancelConfirmationShowing = false
     private var overlayTranscriptionID: UUID = UUID()
     private var foregroundTranscriptionJobID: UUID?
@@ -805,6 +921,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let recordingOverlayLayout = RecordingOverlayLayout.find(
             rawValue: UserDefaults.standard.string(forKey: recordingOverlayLayoutStorageKey)
         )
+        let googleCalendarClientID = UserDefaults.standard.string(forKey: googleCalendarClientIDStorageKey) ?? ""
+        let googleCalendarClientSecret = Self.loadOptionalStoredAPIValue(account: googleCalendarClientSecretStorageKey)
+        let selectedGoogleCalendarIDs = Self.loadStringSet(forKey: googleCalendarSelectedIDsStorageKey)
+        let storedCalendarToken = GoogleCalendarTokenStore.load()
         let isPressEnterVoiceCommandEnabled = UserDefaults.standard.object(forKey: pressEnterVoiceCommandStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: pressEnterVoiceCommandStorageKey)
@@ -896,6 +1016,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.realtimeStreamingModel = realtimeStreamingModel
         self.dictationAudioInterruptionEnabled = dictationAudioInterruptionEnabled
         self.recordingOverlayLayout = recordingOverlayLayout
+        self.googleCalendarClientID = googleCalendarClientID
+        self.googleCalendarClientSecret = googleCalendarClientSecret
+        self.googleCalendarConnection = GoogleCalendarConnectionState(
+            isConnected: storedCalendarToken != nil,
+            accountEmail: storedCalendarToken?.accountEmail,
+            selectedCalendarIDs: selectedGoogleCalendarIDs,
+            lastErrorMessage: nil
+        )
         self.overlayManager.setRecordingOverlayLayout(recordingOverlayLayout)
         self.isPressEnterVoiceCommandEnabled = isPressEnterVoiceCommandEnabled
         self.alertSoundsEnabled = alertSoundsEnabled
@@ -1105,6 +1233,25 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return stored.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private static func loadStringSet(forKey key: String) -> Set<String> {
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let values = try? JSONDecoder().decode([String].self, from: data) else {
+            return []
+        }
+        return Set(values)
+    }
+
+    private static func saveStringSet(_ values: Set<String>, forKey key: String) {
+        let sorted = values.sorted()
+        if sorted.isEmpty {
+            UserDefaults.standard.removeObject(forKey: key)
+            return
+        }
+        if let data = try? JSONEncoder().encode(sorted) {
+            UserDefaults.standard.set(data, forKey: key)
+        }
+    }
+
     private var resolvedTranscriptionBaseURL: String {
         let trimmed = transcriptionAPIURL.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? apiBaseURL : trimmed
@@ -1113,6 +1260,47 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var resolvedTranscriptionAPIKey: String {
         let trimmed = transcriptionAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? apiKey : trimmed
+    }
+
+    private func validGoogleCalendarToken() async throws -> GoogleCalendarOAuthToken? {
+        guard var token = GoogleCalendarTokenStore.load() else { return nil }
+        let clientCredentials = await MainActor.run {
+            (
+                googleCalendarClientID.trimmingCharacters(in: .whitespacesAndNewlines),
+                googleCalendarClientSecret.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        }
+        guard !clientCredentials.0.isEmpty else { return token }
+        if token.needsRefresh {
+            token = try await GoogleCalendarAuthService.refreshToken(
+                clientID: clientCredentials.0,
+                clientSecret: clientCredentials.1,
+                token: token
+            )
+            try GoogleCalendarTokenStore.save(token)
+        }
+        return token
+    }
+
+    @MainActor
+    private func loadGoogleCalendars(force: Bool = false) async {
+        guard force || !isGoogleCalendarBusy else { return }
+        isGoogleCalendarBusy = true
+        defer { isGoogleCalendarBusy = false }
+        do {
+            guard let token = try await validGoogleCalendarToken() else {
+                googleCalendarConnection = .disconnected
+                availableGoogleCalendars = []
+                return
+            }
+            let calendars = try await GoogleCalendarService().fetchCalendars(accessToken: token.accessToken)
+            availableGoogleCalendars = calendars
+            googleCalendarConnection.isConnected = true
+            googleCalendarConnection.accountEmail = token.accountEmail
+            googleCalendarConnection.lastErrorMessage = nil
+        } catch {
+            googleCalendarConnection.lastErrorMessage = error.localizedDescription
+        }
     }
 
     func makeTranscriptionService() throws -> TranscriptionService {
@@ -1285,7 +1473,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         startedAt: Date,
         sessionIntent: SessionIntent,
         sessionContext: AppContext?,
-        contextTask: Task<AppContext?, Never>?
+        contextTask: Task<AppContext?, Never>?,
+        recordingStartedAt: Date? = nil,
+        recordingEndedAt: Date? = nil,
+        isImportedAudio: Bool = false
     ) {
         activeTranscriptionJobs[id] = TranscriptionJob(
             id: id,
@@ -1295,7 +1486,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
             contextTask: contextTask,
             task: nil,
             audioFileName: nil,
-            liveNoteID: nil
+            liveNoteID: nil,
+            recordingStartedAt: recordingStartedAt,
+            recordingEndedAt: recordingEndedAt,
+            isImportedAudio: isImportedAudio
         )
         foregroundTranscriptionJobID = id
         refreshTranscribingState()
@@ -1367,6 +1561,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
             selectedText: item.selectedText,
             id: item.id,
             timestamp: item.timestamp,
+            recordingStartedAt: item.recordingStartedAt,
+            recordingEndedAt: item.recordingEndedAt,
+            calendarMatch: item.calendarMatch,
             rawTranscript: item.rawTranscript,
             postProcessedTranscript: text,
             postProcessingPrompt: item.postProcessingPrompt,
@@ -1416,6 +1613,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let placeholder = PipelineHistoryItem(
             id: noteID,
             timestamp: startedAt,
+            recordingStartedAt: nil,
+            recordingEndedAt: nil,
+            calendarMatch: nil,
             rawTranscript: "",
             postProcessedTranscript: "",
             postProcessingPrompt: nil,
@@ -1455,7 +1655,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
             startedAt: startedAt,
             sessionIntent: .dictation,
             sessionContext: nil,
-            contextTask: nil
+            contextTask: nil,
+            recordingStartedAt: nil,
+            recordingEndedAt: nil,
+            isImportedAudio: true
         )
         updateTranscriptionJob(jobID) {
             $0.liveNoteID = noteID
@@ -1741,6 +1944,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
             selectedText: snapshot.item.selectedText,
             id: snapshot.item.id,
             timestamp: snapshot.item.timestamp,
+            recordingStartedAt: snapshot.item.recordingStartedAt,
+            recordingEndedAt: snapshot.item.recordingEndedAt,
+            calendarMatch: snapshot.item.calendarMatch,
             rawTranscript: rawTranscript,
             postProcessedTranscript: postProcessedTranscript,
             postProcessingPrompt: postProcessingPrompt,
@@ -2360,6 +2566,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         contextCaptureTask?.cancel()
         contextCaptureTask = nil
         capturedContext = nil
+        activeRecordingStartedAt = nil
         currentSessionIntent = .dictation
         isRecording = false
         errorMessage = nil
@@ -2832,6 +3039,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
+    private func markRecordingStarted(_ date: Date) {
+        guard isRecording, activeRecordingTriggerMode != nil else { return }
+        activeRecordingStartedAt = date
+    }
+
+    @MainActor
     private func beginRecording(triggerMode: RecordingTriggerMode) {
         os_log(.info, log: recordingLog, "beginRecording() entered")
         clearPendingOverlayDismissToken()
@@ -3002,9 +3215,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     let t0 = CFAbsoluteTimeGetCurrent()
                     if transcriber.handlesRecording {
                         // AVAudioEngine이 transcriber.start()에서 이미 시작됨 — 녹음 UI만 트리거
+                        let actualRecordingStartedAt = Date()
+                        await MainActor.run {
+                            self.markRecordingStarted(actualRecordingStartedAt)
+                        }
                         self.audioRecorder.onRecordingReady?()
                     } else {
                         try self.audioRecorder.startRecording(deviceUID: deviceUID)
+                        let actualRecordingStartedAt = Date()
+                        await MainActor.run {
+                            self.markRecordingStarted(actualRecordingStartedAt)
+                        }
                         os_log(.info, log: recordingLog, "audioRecorder.startRecording() done: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
                     }
                     await MainActor.run {
@@ -3032,8 +3253,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 let t0 = CFAbsoluteTimeGetCurrent()
                 do {
                     try self.audioRecorder.startRecording(deviceUID: deviceUID)
+                    let actualRecordingStartedAt = Date()
                     os_log(.info, log: recordingLog, "audioRecorder.startRecording() done: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
                     DispatchQueue.main.async {
+                        self.markRecordingStarted(actualRecordingStartedAt)
                         guard self.isRecording, self.activeRecordingTriggerMode != nil else { return }
                         self.startContextCapture()
                         self.audioLevelCancellable = self.audioRecorder.$audioLevel
@@ -3063,6 +3286,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         contextCaptureTask?.cancel()
         contextCaptureTask = nil
         capturedContext = nil
+        activeRecordingStartedAt = nil
         if let liveNoteID = currentRecordingLiveNoteID {
             currentRecordingLiveNoteID = nil
             pipelineHistory.removeAll { $0.id == liveNoteID }
@@ -3350,13 +3574,19 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let jobID = currentRecordingLiveNoteID ?? UUID()
         let liveNoteID = currentRecordingLiveNoteID
         currentRecordingLiveNoteID = nil
-        let startedAt = Date()
+        let recordingStartedAt = activeRecordingStartedAt
+        let recordingEndedAt = Date()
+        activeRecordingStartedAt = nil
+        let startedAt = recordingEndedAt
         registerTranscriptionJob(
             id: jobID,
             startedAt: startedAt,
             sessionIntent: sessionIntent,
             sessionContext: sessionContext,
-            contextTask: inFlightContextTask
+            contextTask: inFlightContextTask,
+            recordingStartedAt: recordingStartedAt,
+            recordingEndedAt: recordingEndedAt,
+            isImportedAudio: false
         )
         updateTranscriptionJob(jobID) { $0.liveNoteID = liveNoteID }
         capturedContext = nil
@@ -3511,6 +3741,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     default:
                         shouldPersistRawDictationFallback = false
                     }
+                    let calendarMatch = await self.calendarMatchForHistoryItem(jobID: jobID)
                     await MainActor.run {
                         self.recordPipelineHistoryEntry(
                             jobID: jobID,
@@ -3521,7 +3752,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             context: appContext,
                             processingStatus: processingStatus,
                             intent: sessionIntent,
-                            audioFileName: savedAudioFile?.fileName
+                            audioFileName: savedAudioFile?.fileName,
+                            calendarMatch: calendarMatch
                         )
                         self.cleanupRecorderIfIdle()
                         let completionStatusText = self.preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
@@ -3557,6 +3789,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         try? FileManager.default.removeItem(at: url)
                         return saved
                     }
+                    let calendarMatch = await self.calendarMatchForHistoryItem(jobID: jobID)
                     await MainActor.run {
                         self.updateTranscriptionJob(jobID) { $0.audioFileName = errorAudioFile?.fileName }
                         self.recordPipelineHistoryEntry(
@@ -3568,7 +3801,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             context: resolvedContext,
                             processingStatus: "Error: \(error.localizedDescription)",
                             intent: sessionIntent,
-                            audioFileName: errorAudioFile?.fileName
+                            audioFileName: errorAudioFile?.fileName,
+                            calendarMatch: calendarMatch
                         )
                         self.cleanupRecorderIfIdle()
                         guard self.overlayTranscriptionID == myOverlayID else {
@@ -3614,6 +3848,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             let transcriptionFileURL = savedAudioFile?.fileURL ?? fileURL
             if let savedAudioFile {
                 let recoveryContext = sessionContext ?? self.fallbackContextAtStop()
+                let activeJob = self.activeTranscriptionJobs[jobID]
                 self.createTranscriptionRecoveryPlaceholder(
                     jobID: jobID,
                     noteID: liveNoteID ?? jobID,
@@ -3623,7 +3858,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     audioFileName: savedAudioFile.fileName,
                     useLocalTranscription: capturedUseLocalTranscription,
                     localTranscriptionModelID: capturedLocalTranscriptionModel.id,
-                    transcriptionLanguageCode: capturedTranscriptionLanguage.code
+                    transcriptionLanguageCode: capturedTranscriptionLanguage.code,
+                    recordingStartedAt: activeJob?.recordingStartedAt,
+                    recordingEndedAt: activeJob?.recordingEndedAt
                 )
             } else {
                 self.updateTranscriptionJob(jobID) { $0.audioFileName = nil }
@@ -3700,6 +3937,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     default:
                         shouldPersistRawDictationFallback = false
                     }
+                    let calendarMatch = await self.calendarMatchForHistoryItem(jobID: jobID)
 
                     await MainActor.run {
                         self.recordPipelineHistoryEntry(
@@ -3711,7 +3949,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             context: appContext,
                             processingStatus: processingStatus,
                             intent: sessionIntent,
-                            audioFileName: savedAudioFile?.fileName
+                            audioFileName: savedAudioFile?.fileName,
+                            calendarMatch: calendarMatch
                         )
                         self.cleanupRecorderIfIdle()
                         let completionStatusText = self.preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
@@ -3742,6 +3981,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     } else {
                         resolvedContext = self.fallbackContextAtStop()
                     }
+                    let calendarMatch = await self.calendarMatchForHistoryItem(jobID: jobID)
                     await MainActor.run {
                         self.recordPipelineHistoryEntry(
                             jobID: jobID,
@@ -3752,7 +3992,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             context: resolvedContext,
                             processingStatus: "Error: \(error.localizedDescription)",
                             intent: sessionIntent,
-                            audioFileName: savedAudioFile?.fileName
+                            audioFileName: savedAudioFile?.fileName,
+                            calendarMatch: calendarMatch
                         )
                         self.cleanupRecorderIfIdle()
                         guard self.overlayTranscriptionID == myOverlayID else {
@@ -3782,9 +4023,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @MainActor
     private func createLiveNote(jobID: UUID, noteID: UUID) {
         updateTranscriptionJob(jobID) { $0.liveNoteID = noteID }
+        let job = activeTranscriptionJobs[jobID]
         let entry = PipelineHistoryItem(
             id: noteID,
             timestamp: Date(),
+            recordingStartedAt: job?.recordingStartedAt,
+            recordingEndedAt: job?.recordingEndedAt,
+            calendarMatch: nil,
             rawTranscript: "",
             postProcessedTranscript: "",
             postProcessingPrompt: nil,
@@ -3823,6 +4068,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
             capturedSelection: existing.capturedSelection,
             id: existing.id,
             timestamp: existing.timestamp,
+            recordingStartedAt: existing.recordingStartedAt,
+            recordingEndedAt: existing.recordingEndedAt,
+            calendarMatch: existing.calendarMatch,
             rawTranscript: existing.rawTranscript,
             postProcessedTranscript: text,
             postProcessingPrompt: existing.postProcessingPrompt,
@@ -3889,11 +4137,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
         audioFileName: String,
         useLocalTranscription: Bool,
         localTranscriptionModelID: String,
-        transcriptionLanguageCode: String
+        transcriptionLanguageCode: String,
+        recordingStartedAt: Date?,
+        recordingEndedAt: Date?
     ) {
         let item = PipelineHistoryItem.transcriptionRecoveryPlaceholder(
             id: noteID,
             timestamp: startedAt,
+            recordingStartedAt: recordingStartedAt,
+            recordingEndedAt: recordingEndedAt,
             intent: sessionIntent.persistedIntent,
             selectedText: sessionIntent.persistedSelectedText,
             capturedSelection: context.selectedText,
@@ -3934,6 +4186,44 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    private func calendarMatchForHistoryItem(jobID: UUID) async -> CalendarEventMatch? {
+        guard let job = await MainActor.run(body: { activeTranscriptionJobs[jobID] }),
+              !job.isImportedAudio,
+              let recordingStartedAt = job.recordingStartedAt,
+              let recordingEndedAt = job.recordingEndedAt,
+              recordingEndedAt > recordingStartedAt else {
+            return nil
+        }
+        let selectedCalendarIDs = await MainActor.run { googleCalendarConnection.selectedCalendarIDs }
+        guard !selectedCalendarIDs.isEmpty else { return nil }
+        do {
+            guard let token = try await validGoogleCalendarToken() else { return nil }
+            let events = await GoogleCalendarService().fetchEventsSkippingFailures(
+                accessToken: token.accessToken,
+                calendarIDs: Array(selectedCalendarIDs),
+                timeMin: recordingStartedAt,
+                timeMax: recordingEndedAt
+            )
+            guard let event = CalendarEventMatcher.bestMatch(
+                recordingStartedAt: recordingStartedAt,
+                recordingEndedAt: recordingEndedAt,
+                events: events
+            ) else {
+                return nil
+            }
+            return event.match(
+                accountID: token.accountEmail,
+                source: .overlapSuggestion,
+                titleState: .suggested
+            )
+        } catch {
+            await MainActor.run {
+                googleCalendarConnection.lastErrorMessage = error.localizedDescription
+            }
+            return nil
+        }
+    }
+
     @MainActor
     private func recordPipelineHistoryEntry(
         jobID: UUID,
@@ -3951,7 +4241,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         usedPostProcessingOverride: Bool? = nil,
         transcriptionLanguageCodeOverride: String? = nil,
         customVocabularyOverride: String? = nil,
-        customSystemPromptOverride: String? = nil
+        customSystemPromptOverride: String? = nil,
+        calendarMatch: CalendarEventMatch? = nil
     ) {
         let existingID = activeTranscriptionJobs[jobID]?.liveNoteID
         let existingEntry = existingID.flatMap { id in
@@ -3972,6 +4263,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
             capturedSelection: context.selectedText,
             id: existingID ?? UUID(),
             timestamp: existingEntry?.timestamp ?? activeTranscriptionJobs[jobID]?.startedAt ?? Date(),
+            recordingStartedAt: activeTranscriptionJobs[jobID]?.recordingStartedAt ?? existingEntry?.recordingStartedAt,
+            recordingEndedAt: activeTranscriptionJobs[jobID]?.recordingEndedAt ?? existingEntry?.recordingEndedAt,
+            calendarMatch: calendarMatch ?? existingEntry?.calendarMatch,
             rawTranscript: rawTranscript,
             postProcessedTranscript: postProcessedTranscript,
             postProcessingPrompt: postProcessingPrompt,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -20,45 +20,6 @@ struct PrecomputedMacro {
     let normalizedCommand: String
 }
 
-enum SettingsTab: String, CaseIterable, Identifiable {
-    case general
-    case appearance
-    case prompts
-    case macros
-    case runLog
-    case debug
-
-    var id: String { rawValue }
-
-    static var visibleCases: [SettingsTab] {
-        allCases.filter { tab in
-            tab != .debug || AppBuild.isDevBundle
-        }
-    }
-
-    var title: String {
-        switch self {
-        case .general: return "General"
-        case .appearance: return "Appearance"
-        case .prompts: return "Prompts"
-        case .macros: return "Voice Macros"
-        case .runLog: return "Run Log"
-        case .debug: return "Debug"
-        }
-    }
-
-    var icon: String {
-        switch self {
-        case .general: return "gearshape"
-        case .appearance: return "paintbrush"
-        case .prompts: return "text.bubble"
-        case .macros: return "music.mic"
-        case .runLog: return "clock.arrow.circlepath"
-        case .debug: return "wrench.and.screwdriver"
-        }
-    }
-}
-
 enum AppBuild {
     static var isDevBundle: Bool {
         isDevBundleName(Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String)
@@ -525,6 +486,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published private(set) var googleCalendarConnection = GoogleCalendarConnectionState.disconnected
     @Published private(set) var availableGoogleCalendars: [GoogleCalendarInfo] = []
     @Published private(set) var isGoogleCalendarBusy = false
+    @Published private(set) var hasPendingGoogleCalendarOAuthConnection = false
 
     @Published var preserveClipboard: Bool {
         didSet {
@@ -684,8 +646,26 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
+    var googleCalendarConnectionControls: GoogleCalendarConnectionControls {
+        GoogleCalendarConnectionControls(
+            isConnected: googleCalendarConnection.isConnected,
+            isBusy: isGoogleCalendarBusy,
+            hasPendingOAuthConnection: hasPendingGoogleCalendarOAuthConnection
+        )
+    }
+
+    @MainActor
     func disconnectGoogleCalendar() {
+        cancelGoogleCalendarConnection()
         clearGoogleCalendarConnectionState()
+    }
+
+    @MainActor
+    func cancelGoogleCalendarConnection() {
+        googleCalendarConnectionTask?.cancel()
+        googleCalendarConnectionTask = nil
+        hasPendingGoogleCalendarOAuthConnection = false
+        isGoogleCalendarBusy = false
     }
 
     private func clearGoogleCalendarConnectionState() {
@@ -697,9 +677,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func refreshGoogleCalendars() {
-        guard googleCalendarConnection.isConnected else { return }
         Task { [weak self] in
-            await self?.loadGoogleCalendars()
+            await self?.loadGoogleCalendars(force: true)
+        }
+    }
+
+    @MainActor
+    func loadStoredGoogleCalendarConnection() {
+        guard !isGoogleCalendarBusy else { return }
+        Task { [weak self] in
+            await self?.loadGoogleCalendars(force: true)
         }
     }
 
@@ -713,8 +700,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return
         }
         isGoogleCalendarBusy = true
+        hasPendingGoogleCalendarOAuthConnection = true
         googleCalendarConnection.lastErrorMessage = nil
-        Task { [weak self] in
+        googleCalendarConnectionTask = Task { [weak self] in
             guard let self else { return }
             do {
                 let pkce = GoogleCalendarAuthService.makePKCEPair()
@@ -748,12 +736,22 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         lastErrorMessage: nil
                     )
                     Self.saveStringSet([], forKey: self.googleCalendarSelectedIDsStorageKey)
+                    self.hasPendingGoogleCalendarOAuthConnection = false
+                    self.googleCalendarConnectionTask = nil
                 }
                 await self.loadGoogleCalendars(force: true)
+            } catch is CancellationError {
+                await MainActor.run {
+                    self.hasPendingGoogleCalendarOAuthConnection = false
+                    self.isGoogleCalendarBusy = false
+                    self.googleCalendarConnectionTask = nil
+                }
             } catch {
                 await MainActor.run {
                     self.googleCalendarConnection.lastErrorMessage = error.localizedDescription
+                    self.hasPendingGoogleCalendarOAuthConnection = false
                     self.isGoogleCalendarBusy = false
+                    self.googleCalendarConnectionTask = nil
                 }
             }
         }
@@ -837,6 +835,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var contextService: AppContextService
     private var contextCaptureTask: Task<AppContext?, Never>?
     private var capturedContext: AppContext?
+    private var googleCalendarConnectionTask: Task<Void, Never>?
     private var hasShownScreenshotPermissionAlert = false
     private var isEscapeCancelAlertPresented = false
     private var shouldTerminateAfterTranscription = false

--- a/Sources/CalendarEventMatcher.swift
+++ b/Sources/CalendarEventMatcher.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+enum CalendarEventMatcher {
+    static func bestMatch(recordingStartedAt: Date?, recordingEndedAt: Date?, events: [GoogleCalendarEvent]) -> GoogleCalendarEvent? {
+        guard let recordingStartedAt, let recordingEndedAt, recordingEndedAt > recordingStartedAt else {
+            return nil
+        }
+        return events
+            .filter { !$0.isAllDay && $0.hasUsableTitle && $0.end > $0.start }
+            .compactMap { event -> Candidate? in
+                let overlapStart = max(recordingStartedAt, event.start)
+                let overlapEnd = min(recordingEndedAt, event.end)
+                let overlap = overlapEnd.timeIntervalSince(overlapStart)
+                guard overlap > 0 else { return nil }
+                return Candidate(event: event, overlap: overlap, startDistance: abs(event.start.timeIntervalSince(recordingStartedAt)))
+            }
+            .sorted { lhs, rhs in
+                if lhs.overlap != rhs.overlap {
+                    return lhs.overlap > rhs.overlap
+                }
+                if lhs.startDistance != rhs.startDistance {
+                    return lhs.startDistance < rhs.startDistance
+                }
+                if lhs.event.start != rhs.event.start {
+                    return lhs.event.start < rhs.event.start
+                }
+                if lhs.event.calendarID != rhs.event.calendarID {
+                    return lhs.event.calendarID < rhs.event.calendarID
+                }
+                return lhs.event.id < rhs.event.id
+            }
+            .first?
+            .event
+    }
+
+    private struct Candidate {
+        let event: GoogleCalendarEvent
+        let overlap: TimeInterval
+        let startDistance: TimeInterval
+    }
+}

--- a/Sources/CalendarIntegrationModels.swift
+++ b/Sources/CalendarIntegrationModels.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+enum CalendarMatchSource: String, Codable, Equatable {
+    case overlapSuggestion = "overlap_suggestion"
+    case calendarNotification = "calendar_notification"
+}
+
+enum CalendarTitleState: String, Codable, Equatable {
+    case suggested
+    case applied
+}
+
+struct CalendarEventAttendee: Codable, Equatable {
+    let displayName: String?
+    let email: String?
+    let responseStatus: String?
+    let isOptional: Bool
+    let isSelf: Bool
+
+    init(displayName: String? = nil, email: String? = nil, responseStatus: String? = nil, isOptional: Bool = false, isSelf: Bool = false) {
+        self.displayName = displayName
+        self.email = email
+        self.responseStatus = responseStatus
+        self.isOptional = isOptional
+        self.isSelf = isSelf
+    }
+}
+
+struct CalendarEventMatch: Codable, Equatable {
+    let accountID: String?
+    let calendarID: String
+    let eventID: String
+    let title: String
+    let start: Date
+    let end: Date
+    let attendees: [CalendarEventAttendee]
+    let matchSource: CalendarMatchSource
+    let titleState: CalendarTitleState
+
+    init(accountID: String? = nil, calendarID: String, eventID: String, title: String, start: Date, end: Date, attendees: [CalendarEventAttendee] = [], matchSource: CalendarMatchSource, titleState: CalendarTitleState) {
+        self.accountID = accountID
+        self.calendarID = calendarID
+        self.eventID = eventID
+        self.title = title
+        self.start = start
+        self.end = end
+        self.attendees = attendees
+        self.matchSource = matchSource
+        self.titleState = titleState
+    }
+
+    var suggestedTitle: String? {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    var appliedTitle: String? {
+        guard titleState == .applied else { return nil }
+        return suggestedTitle
+    }
+
+    func applyingTitle() -> CalendarEventMatch {
+        CalendarEventMatch(accountID: accountID, calendarID: calendarID, eventID: eventID, title: title, start: start, end: end, attendees: attendees, matchSource: matchSource, titleState: .applied)
+    }
+}
+
+struct GoogleCalendarInfo: Identifiable, Codable, Equatable {
+    let id: String
+    let summary: String
+    let summaryOverride: String?
+    let primary: Bool
+    let accessRole: String?
+
+    var displayName: String {
+        let override = summaryOverride?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !override.isEmpty { return override }
+        let trimmed = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? id : trimmed
+    }
+}
+
+struct GoogleCalendarEvent: Identifiable, Equatable {
+    let id: String
+    let calendarID: String
+    let title: String
+    let start: Date
+    let end: Date
+    let isAllDay: Bool
+    let attendees: [CalendarEventAttendee]
+
+    var hasUsableTitle: Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    func match(accountID: String?, source: CalendarMatchSource, titleState: CalendarTitleState) -> CalendarEventMatch {
+        CalendarEventMatch(accountID: accountID, calendarID: calendarID, eventID: id, title: title, start: start, end: end, attendees: attendees, matchSource: source, titleState: titleState)
+    }
+}
+
+struct GoogleCalendarConnectionState: Codable, Equatable {
+    var isConnected: Bool
+    var accountEmail: String?
+    var selectedCalendarIDs: Set<String>
+    var lastErrorMessage: String?
+
+    static let disconnected = GoogleCalendarConnectionState(isConnected: false, accountEmail: nil, selectedCalendarIDs: [], lastErrorMessage: nil)
+}

--- a/Sources/CalendarIntegrationModels.swift
+++ b/Sources/CalendarIntegrationModels.swift
@@ -1,5 +1,45 @@
 import Foundation
 
+enum SettingsTab: String, CaseIterable, Identifiable {
+    case general
+    case appearance
+    case calendar
+    case prompts
+    case macros
+    case runLog
+    case debug
+
+    var id: String { rawValue }
+
+    static var orderedCases: [SettingsTab] {
+        [.general, .appearance, .calendar, .prompts, .macros, .runLog, .debug]
+    }
+
+    var title: String {
+        switch self {
+        case .general: return "General"
+        case .appearance: return "Appearance"
+        case .calendar: return "Calendar"
+        case .prompts: return "Prompts"
+        case .macros: return "Voice Macros"
+        case .runLog: return "Run Log"
+        case .debug: return "Debug"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .general: return "gearshape"
+        case .appearance: return "paintbrush"
+        case .calendar: return "calendar"
+        case .prompts: return "text.bubble"
+        case .macros: return "music.mic"
+        case .runLog: return "clock.arrow.circlepath"
+        case .debug: return "wrench.and.screwdriver"
+        }
+    }
+}
+
 enum CalendarMatchSource: String, Codable, Equatable {
     case overlapSuggestion = "overlap_suggestion"
     case calendarNotification = "calendar_notification"
@@ -77,6 +117,44 @@ struct GoogleCalendarInfo: Identifiable, Codable, Equatable {
         let trimmed = summary.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? id : trimmed
     }
+
+    var displaySortRank: Int {
+        if primary { return 0 }
+        switch accessRole {
+        case "owner", "writer": return 1
+        default: return 2
+        }
+    }
+}
+
+struct GoogleCalendarDisplayGroup: Equatable {
+    let title: String
+    let calendars: [GoogleCalendarInfo]
+}
+
+extension Array where Element == GoogleCalendarInfo {
+    func sortedForQuillDisplay() -> [GoogleCalendarInfo] {
+        sorted { lhs, rhs in
+            if lhs.displaySortRank != rhs.displaySortRank {
+                return lhs.displaySortRank < rhs.displaySortRank
+            }
+            let nameComparison = lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName)
+            if nameComparison != .orderedSame {
+                return nameComparison == .orderedAscending
+            }
+            return lhs.id.localizedCaseInsensitiveCompare(rhs.id) == .orderedAscending
+        }
+    }
+
+    func groupedForQuillDisplay() -> [GoogleCalendarDisplayGroup] {
+        let sorted = sortedForQuillDisplay()
+        let myCalendars = sorted.filter { $0.displaySortRank < 2 }
+        let sharedCalendars = sorted.filter { $0.displaySortRank == 2 }
+        return [
+            GoogleCalendarDisplayGroup(title: "My calendars", calendars: myCalendars),
+            GoogleCalendarDisplayGroup(title: "Shared calendars", calendars: sharedCalendars)
+        ].filter { !$0.calendars.isEmpty }
+    }
 }
 
 struct GoogleCalendarEvent: Identifiable, Equatable {
@@ -104,4 +182,27 @@ struct GoogleCalendarConnectionState: Codable, Equatable {
     var lastErrorMessage: String?
 
     static let disconnected = GoogleCalendarConnectionState(isConnected: false, accountEmail: nil, selectedCalendarIDs: [], lastErrorMessage: nil)
+}
+
+struct GoogleCalendarConnectionControls: Equatable {
+    let isConnected: Bool
+    let isBusy: Bool
+    let hasPendingOAuthConnection: Bool
+
+    var primaryActionTitle: String {
+        if hasPendingOAuthConnection { return "Cancel" }
+        return isConnected ? "Reconnect" : "Connect"
+    }
+
+    var allowsPrimaryAction: Bool {
+        hasPendingOAuthConnection || !isBusy
+    }
+
+    var allowsRefresh: Bool {
+        isConnected && !isBusy
+    }
+
+    var allowsDisconnect: Bool {
+        isConnected && !isBusy
+    }
 }

--- a/Sources/GoogleCalendarAuthService.swift
+++ b/Sources/GoogleCalendarAuthService.swift
@@ -1,0 +1,456 @@
+#if canImport(AppKit)
+import AppKit
+#endif
+import CryptoKit
+import Foundation
+import Network
+import Security
+
+struct GoogleCalendarTokenResponse: Decodable {
+    let accessToken: String
+    let expiresIn: TimeInterval
+    let refreshToken: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case expiresIn = "expires_in"
+        case refreshToken = "refresh_token"
+    }
+}
+
+struct GoogleCalendarErrorResponse: Decodable {
+    let error: String
+    let errorDescription: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+    }
+}
+
+struct GoogleCalendarAuthService {
+    private static let formURLEncodedAllowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+
+    struct PKCEPair: Equatable {
+        let verifier: String
+        let challenge: String
+    }
+
+    struct SecureRandomError: LocalizedError {
+        let status: OSStatus
+
+        var errorDescription: String? {
+            "Secure random generation failed with status \(status)"
+        }
+    }
+
+    typealias Transport = (URLRequest, Data?) async throws -> (Data, URLResponse)
+
+    static let scopes = [
+        "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+        "https://www.googleapis.com/auth/calendar.events.readonly"
+    ]
+
+    static func makePKCEPair() -> PKCEPair {
+        do {
+            return try makePKCEPair(randomBytes: secureRandomBytes)
+        } catch {
+            preconditionFailure("Failed to generate secure random bytes for Google Calendar OAuth PKCE")
+        }
+    }
+
+    static func makePKCEPair(randomBytes: (Int) throws -> Data) throws -> PKCEPair {
+        let verifier = base64URLEncoded(try randomBytes(32))
+        return PKCEPair(verifier: verifier, challenge: challenge(for: verifier))
+    }
+
+    static func challenge(for verifier: String) -> String {
+        let digest = SHA256.hash(data: Data(verifier.utf8))
+        return base64URLEncoded(Data(digest))
+    }
+
+    static func authorizationURL(
+        clientID: String,
+        callbackURL: URL,
+        codeChallenge: String,
+        state: String
+    ) -> URL {
+        var components = URLComponents(string: "https://accounts.google.com/o/oauth2/v2/auth")!
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "redirect_uri", value: callbackURL.absoluteString),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "scope", value: scopes.joined(separator: " ")),
+            URLQueryItem(name: "access_type", value: "offline"),
+            URLQueryItem(name: "prompt", value: "consent"),
+            URLQueryItem(name: "code_challenge", value: codeChallenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "state", value: state)
+        ]
+        return components.url!
+    }
+
+    #if canImport(AppKit)
+    static func openAuthorizationPage(
+        clientID: String,
+        callbackURL: URL,
+        codeChallenge: String,
+        state: String
+    ) {
+        NSWorkspace.shared.open(
+            authorizationURL(
+                clientID: clientID,
+                callbackURL: callbackURL,
+                codeChallenge: codeChallenge,
+                state: state
+            )
+        )
+    }
+    #endif
+
+    final class LoopbackReceiver: @unchecked Sendable {
+        private var listener: NWListener?
+        private var codeContinuation: CheckedContinuation<String, Error>?
+        private var callbackURLContinuation: CheckedContinuation<URL, Error>?
+        private var pendingResult: Result<String, Error>?
+        private var callbackURL: URL?
+        private var timeoutWorkItem: DispatchWorkItem?
+        private var isStarted = false
+        private var didComplete = false
+        private let state: String
+        private let lock = NSLock()
+        private let queue = DispatchQueue(label: "GoogleCalendarAuthService.LoopbackReceiver")
+
+        init(state: String) throws {
+            self.state = state
+            listener = try NWListener(using: .tcp, on: .any)
+        }
+
+        func start(timeoutSeconds: TimeInterval = 120) {
+            guard !isStarted else { return }
+            isStarted = true
+            listener?.stateUpdateHandler = { [weak self] state in
+                switch state {
+                case .ready:
+                    guard let self, let port = self.listener?.port, port.rawValue != 0 else {
+                        self?.complete(.failure(OAuthError.requestFailed))
+                        return
+                    }
+                    self.markReady(port: port)
+                case .failed, .cancelled:
+                    self?.complete(.failure(OAuthError.requestFailed))
+                default:
+                    break
+                }
+            }
+            listener?.newConnectionHandler = { [weak self] connection in
+                self?.handle(connection)
+            }
+            let timeoutWorkItem = DispatchWorkItem { [weak self] in
+                self?.complete(.failure(OAuthError.requestFailed))
+            }
+            self.timeoutWorkItem = timeoutWorkItem
+            queue.asyncAfter(deadline: .now() + timeoutSeconds, execute: timeoutWorkItem)
+            listener?.start(queue: queue)
+        }
+
+        func waitForCallbackURL() async throws -> URL {
+            try Task.checkCancellation()
+            return try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    switch registerCallbackURL(continuation) {
+                    case .success(let callbackURL):
+                        continuation.resume(returning: callbackURL)
+                    case .failure(let error):
+                        continuation.resume(throwing: error)
+                    case nil:
+                        break
+                    }
+                }
+            } onCancel: { [weak self] in
+                self?.cancel()
+            }
+        }
+
+        func waitForCode() async throws -> String {
+            try Task.checkCancellation()
+            return try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    switch registerCode(continuation) {
+                    case .success(let code):
+                        continuation.resume(returning: code)
+                    case .failure(let error):
+                        continuation.resume(throwing: error)
+                    case nil:
+                        break
+                    }
+                }
+            } onCancel: { [weak self] in
+                self?.cancel()
+            }
+        }
+
+        func cancel() {
+            let continuations: (CheckedContinuation<String, Error>?, CheckedContinuation<URL, Error>?) = lock.withLock {
+                guard !didComplete else { return (nil, nil) }
+                didComplete = true
+                let codeContinuation = self.codeContinuation
+                let callbackURLContinuation = self.callbackURLContinuation
+                self.codeContinuation = nil
+                self.callbackURLContinuation = nil
+                pendingResult = nil
+                return (codeContinuation, callbackURLContinuation)
+            }
+            cleanup()
+            continuations.0?.resume(throwing: CancellationError())
+            continuations.1?.resume(throwing: CancellationError())
+        }
+
+        private func registerCallbackURL(_ continuation: CheckedContinuation<URL, Error>) -> Result<URL, Error>? {
+            lock.withLock {
+                if let callbackURL {
+                    return .success(callbackURL)
+                }
+                if didComplete {
+                    return .failure(OAuthError.requestFailed)
+                }
+                callbackURLContinuation = continuation
+                return nil
+            }
+        }
+
+        private func registerCode(_ continuation: CheckedContinuation<String, Error>) -> Result<String, Error>? {
+            lock.withLock {
+                if let pendingResult {
+                    self.pendingResult = nil
+                    return pendingResult
+                }
+                if didComplete {
+                    return .failure(OAuthError.requestFailed)
+                }
+                codeContinuation = continuation
+                return nil
+            }
+        }
+
+        private func markReady(port: NWEndpoint.Port) {
+            let callbackURL = URL(string: "http://127.0.0.1:\(port.rawValue)/oauth2callback")!
+            let continuation: CheckedContinuation<URL, Error>? = lock.withLock {
+                guard !didComplete else { return nil }
+                self.callbackURL = callbackURL
+                let continuation = callbackURLContinuation
+                callbackURLContinuation = nil
+                return continuation
+            }
+            continuation?.resume(returning: callbackURL)
+        }
+
+        private func handle(_ connection: NWConnection) {
+            connection.start(queue: queue)
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 4096) { [weak self] data, _, _, _ in
+                guard let self else { return }
+                guard let data,
+                      let request = String(data: data, encoding: .utf8),
+                      let firstLine = request.components(separatedBy: "\r\n").first,
+                      let url = Self.url(from: firstLine),
+                      let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                      let queryItems = components.queryItems,
+                      let code = Self.singleValue(named: "code", in: queryItems),
+                      let callbackState = Self.singleValue(named: "state", in: queryItems),
+                      callbackState == state,
+                      !code.isEmpty else {
+                    sendResponse("400 Bad Request", body: "Google Calendar sign-in failed.", on: connection)
+                    complete(.failure(OAuthError.requestFailed))
+                    return
+                }
+                sendResponse("200 OK", body: "You can return to Quill.", on: connection)
+                complete(.success(code))
+            }
+        }
+
+        private func complete(_ result: Result<String, Error>) {
+            let continuations: (CheckedContinuation<String, Error>?, CheckedContinuation<URL, Error>?) = lock.withLock {
+                guard !didComplete else { return (nil, nil) }
+                didComplete = true
+                let codeContinuation = self.codeContinuation
+                let callbackURLContinuation = self.callbackURLContinuation
+                self.codeContinuation = nil
+                self.callbackURLContinuation = nil
+                if codeContinuation == nil {
+                    pendingResult = result
+                }
+                return (codeContinuation, callbackURLContinuation)
+            }
+            cleanup()
+            if let callbackURLContinuation = continuations.1 {
+                switch result {
+                case .success:
+                    callbackURLContinuation.resume(throwing: OAuthError.requestFailed)
+                case .failure(let error):
+                    callbackURLContinuation.resume(throwing: error)
+                }
+            }
+            guard let codeContinuation = continuations.0 else { return }
+            switch result {
+            case .success(let code):
+                codeContinuation.resume(returning: code)
+            case .failure(let error):
+                codeContinuation.resume(throwing: error)
+            }
+        }
+
+        private func cleanup() {
+            timeoutWorkItem?.cancel()
+            timeoutWorkItem = nil
+            listener?.cancel()
+            listener = nil
+        }
+
+        private func sendResponse(_ status: String, body: String, on connection: NWConnection) {
+            let response = "HTTP/1.1 \(status)\r\nContent-Type: text/html\r\n\r\n<html><body>\(body)</body></html>"
+            connection.send(content: Data(response.utf8), completion: .contentProcessed { _ in
+                connection.cancel()
+            })
+        }
+
+        private static func singleValue(named name: String, in items: [URLQueryItem]) -> String? {
+            let values = items.filter { $0.name == name }
+            guard values.count == 1 else { return nil }
+            return values[0].value
+        }
+
+        private static func url(from requestLine: String) -> URL? {
+            let parts = requestLine.split(separator: " ")
+            guard parts.count >= 2 else { return nil }
+            return URL(string: "http://127.0.0.1\(parts[1])")
+        }
+    }
+
+    static func token(from response: GoogleCalendarTokenResponse, existingRefreshToken: String? = nil) -> GoogleCalendarOAuthToken {
+        GoogleCalendarOAuthToken(
+            accessToken: response.accessToken,
+            refreshToken: response.refreshToken ?? existingRefreshToken,
+            expiresAt: Date().addingTimeInterval(response.expiresIn),
+            accountEmail: nil
+        )
+    }
+
+    static func exchangeCode(
+        clientID: String,
+        clientSecret: String,
+        code: String,
+        codeVerifier: String,
+        redirectURI: String,
+        transport: @escaping Transport = defaultTransport
+    ) async throws -> GoogleCalendarOAuthToken {
+        var body = [
+            "client_id": clientID,
+            "code": code,
+            "code_verifier": codeVerifier,
+            "redirect_uri": redirectURI,
+            "grant_type": "authorization_code"
+        ]
+        addClientSecret(clientSecret, to: &body)
+        let response = try await tokenRequest(body: body, transport: transport)
+        return token(from: response)
+    }
+
+    static func refreshToken(
+        clientID: String,
+        clientSecret: String,
+        token: GoogleCalendarOAuthToken,
+        transport: @escaping Transport = defaultTransport
+    ) async throws -> GoogleCalendarOAuthToken {
+        guard let refreshToken = token.refreshToken else {
+            throw OAuthError.missingRefreshToken
+        }
+        var body = [
+            "client_id": clientID,
+            "refresh_token": refreshToken,
+            "grant_type": "refresh_token"
+        ]
+        addClientSecret(clientSecret, to: &body)
+        let response = try await tokenRequest(body: body, transport: transport)
+        var refreshed = self.token(from: response, existingRefreshToken: refreshToken)
+        refreshed.accountEmail = token.accountEmail
+        return refreshed
+    }
+
+    private static func addClientSecret(_ clientSecret: String, to body: inout [String: String]) {
+        let trimmed = clientSecret.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        body["client_secret"] = trimmed
+    }
+
+    private static func tokenRequest(
+        body: [String: String],
+        transport: @escaping Transport
+    ) async throws -> GoogleCalendarTokenResponse {
+        var request = URLRequest(url: URL(string: "https://oauth2.googleapis.com/token")!)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        let bodyString = body.map { key, value in
+            "\(percentEncode(key))=\(percentEncode(value))"
+        }.joined(separator: "&")
+        let (data, response) = try await transport(request, Data(bodyString.utf8))
+        guard let http = response as? HTTPURLResponse else {
+            throw OAuthError.requestFailed
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            if let errorResponse = try? JSONDecoder().decode(GoogleCalendarErrorResponse.self, from: data) {
+                throw OAuthError.response(errorResponse.error, errorResponse.errorDescription)
+            }
+            throw OAuthError.requestFailed
+        }
+        return try JSONDecoder().decode(GoogleCalendarTokenResponse.self, from: data)
+    }
+
+    private static func defaultTransport(_ request: URLRequest, _ body: Data?) async throws -> (Data, URLResponse) {
+        var request = request
+        request.httpBody = body
+        return try await URLSession.shared.data(for: request)
+    }
+
+    private static func percentEncode(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: formURLEncodedAllowed) ?? value
+    }
+
+    enum OAuthError: LocalizedError {
+        case missingRefreshToken
+        case requestFailed
+        case response(String, String?)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingRefreshToken:
+                return "Google Calendar refresh token is missing."
+            case .requestFailed:
+                return "Google Calendar OAuth request failed."
+            case .response(let error, let description):
+                if error == "invalid_request", description == "client_secret is missing" {
+                    return "Google Calendar OAuth failed: this client ID is being treated as a web OAuth client. Create a Google OAuth Desktop app client and paste that client ID, then reconnect."
+                }
+                guard let description, !description.isEmpty else {
+                    return "Google Calendar OAuth failed: \(error)"
+                }
+                return "Google Calendar OAuth failed: \(error) — \(description)"
+            }
+        }
+    }
+
+    private static func secureRandomBytes(count: Int) throws -> Data {
+        var bytes = [UInt8](repeating: 0, count: count)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            throw SecureRandomError(status: status)
+        }
+        return Data(bytes)
+    }
+
+    private static func base64URLEncoded(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/Sources/GoogleCalendarService.swift
+++ b/Sources/GoogleCalendarService.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+struct GoogleCalendarService {
+    typealias Transport = (URLRequest) async throws -> (Data, URLResponse)
+
+    private let transport: Transport
+    private let baseURL = URL(string: "https://www.googleapis.com/calendar/v3")!
+    private static let calendarIDPathAllowed: CharacterSet = {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "/")
+        return allowed
+    }()
+
+    private let decoder: JSONDecoder
+    private let encoderDateFormatter: ISO8601DateFormatter
+
+    init(transport: @escaping Transport = { request in try await URLSession.shared.data(for: request) }) {
+        self.transport = transport
+        decoder = JSONDecoder()
+        encoderDateFormatter = ISO8601DateFormatter()
+        encoderDateFormatter.formatOptions = [.withInternetDateTime]
+    }
+
+    func fetchCalendars(accessToken: String) async throws -> [GoogleCalendarInfo] {
+        var components = URLComponents(url: baseURL.appendingPathComponent("users/me/calendarList"), resolvingAgainstBaseURL: false)!
+        components.queryItems = [
+            URLQueryItem(name: "showDeleted", value: "false"),
+            URLQueryItem(name: "fields", value: "items(id,summary,summaryOverride,primary,accessRole)")
+        ]
+        let response: CalendarListResponse = try await send(url: components.url!, accessToken: accessToken)
+        return response.calendars
+    }
+
+    func fetchEvents(
+        accessToken: String,
+        calendarID: String,
+        timeMin: Date,
+        timeMax: Date
+    ) async throws -> [GoogleCalendarEvent] {
+        let encodedCalendarID = calendarID.addingPercentEncoding(withAllowedCharacters: Self.calendarIDPathAllowed) ?? calendarID
+        var components = URLComponents(string: "\(baseURL.absoluteString)/calendars/\(encodedCalendarID)/events")!
+        components.queryItems = [
+            URLQueryItem(name: "timeMin", value: encoderDateFormatter.string(from: timeMin)),
+            URLQueryItem(name: "timeMax", value: encoderDateFormatter.string(from: timeMax)),
+            URLQueryItem(name: "singleEvents", value: "true"),
+            URLQueryItem(name: "orderBy", value: "startTime"),
+            URLQueryItem(name: "showDeleted", value: "false"),
+            URLQueryItem(name: "fields", value: "items(id,summary,start,end,attendees(displayName,email,responseStatus,optional,self))")
+        ]
+        let response: EventsResponse = try await send(url: components.url!, accessToken: accessToken)
+        return response.items.compactMap { $0.event(calendarID: calendarID) }
+    }
+
+    func fetchEventsSkippingFailures(
+        accessToken: String,
+        calendarIDs: [String],
+        timeMin: Date,
+        timeMax: Date
+    ) async -> [GoogleCalendarEvent] {
+        var events: [GoogleCalendarEvent] = []
+        for calendarID in calendarIDs {
+            do {
+                let calendarEvents = try await fetchEvents(
+                    accessToken: accessToken,
+                    calendarID: calendarID,
+                    timeMin: timeMin,
+                    timeMax: timeMax
+                )
+                events.append(contentsOf: calendarEvents)
+            } catch {
+                continue
+            }
+        }
+        return events
+    }
+
+    private func send<Response: Decodable>(url: URL, accessToken: String) async throws -> Response {
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        let (data, response) = try await transport(request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw CalendarAPIError.requestFailed
+        }
+        return try decoder.decode(Response.self, from: data)
+    }
+
+    enum CalendarAPIError: Error {
+        case requestFailed
+    }
+
+    private struct CalendarListResponse: Decodable {
+        let items: [CalendarInfoResponse]
+
+        var calendars: [GoogleCalendarInfo] {
+            items.map(\.calendar)
+        }
+    }
+
+    private struct CalendarInfoResponse: Decodable {
+        let id: String
+        let summary: String
+        let summaryOverride: String?
+        let primary: Bool?
+        let accessRole: String?
+
+        var calendar: GoogleCalendarInfo {
+            GoogleCalendarInfo(
+                id: id,
+                summary: summary,
+                summaryOverride: summaryOverride,
+                primary: primary ?? false,
+                accessRole: accessRole
+            )
+        }
+    }
+
+    private struct EventsResponse: Decodable {
+        let items: [EventResponse]
+    }
+
+    private struct EventResponse: Decodable {
+        let id: String
+        let summary: String?
+        let start: EventDateTime
+        let end: EventDateTime
+        let attendees: [AttendeeResponse]?
+
+        func event(calendarID: String) -> GoogleCalendarEvent? {
+            guard let startDate = start.resolvedDate,
+                  let endDate = end.resolvedDate else {
+                return nil
+            }
+            return GoogleCalendarEvent(
+                id: id,
+                calendarID: calendarID,
+                title: summary ?? "",
+                start: startDate,
+                end: endDate,
+                isAllDay: start.date != nil || end.date != nil,
+                attendees: attendees?.map { $0.attendee } ?? []
+            )
+        }
+    }
+
+    private struct EventDateTime: Decodable {
+        private static let dateTimeFormatter: ISO8601DateFormatter = {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime]
+            return formatter
+        }()
+
+        private static let fractionalDateTimeFormatter: ISO8601DateFormatter = {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return formatter
+        }()
+
+        private static let allDayDateFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.calendar = Calendar(identifier: .gregorian)
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(secondsFromGMT: 0)
+            formatter.dateFormat = "yyyy-MM-dd"
+            return formatter
+        }()
+
+        let date: String?
+        let dateTime: String?
+
+        var resolvedDate: Date? {
+            if let dateTime {
+                return Self.dateTimeFormatter.date(from: dateTime) ?? Self.fractionalDateTimeFormatter.date(from: dateTime)
+            }
+            if let date {
+                return Self.allDayDateFormatter.date(from: date)
+            }
+            return nil
+        }
+    }
+
+    private struct AttendeeResponse: Decodable {
+        let displayName: String?
+        let email: String?
+        let responseStatus: String?
+        let optional: Bool?
+        let selfValue: Bool?
+
+        private enum CodingKeys: String, CodingKey {
+            case displayName
+            case email
+            case responseStatus
+            case optional
+            case selfValue = "self"
+        }
+
+        var attendee: CalendarEventAttendee {
+            CalendarEventAttendee(
+                displayName: displayName,
+                email: email,
+                responseStatus: responseStatus,
+                isOptional: optional ?? false,
+                isSelf: selfValue ?? false
+            )
+        }
+    }
+}

--- a/Sources/GoogleCalendarService.swift
+++ b/Sources/GoogleCalendarService.swift
@@ -28,7 +28,7 @@ struct GoogleCalendarService {
             URLQueryItem(name: "fields", value: "items(id,summary,summaryOverride,primary,accessRole)")
         ]
         let response: CalendarListResponse = try await send(url: components.url!, accessToken: accessToken)
-        return response.calendars
+        return response.calendars.sortedForQuillDisplay()
     }
 
     func fetchEvents(

--- a/Sources/GoogleCalendarTokenStore.swift
+++ b/Sources/GoogleCalendarTokenStore.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Security
+
+struct GoogleCalendarOAuthToken: Codable, Equatable {
+    var accessToken: String
+    var refreshToken: String?
+    var expiresAt: Date
+    var accountEmail: String?
+
+    var needsRefresh: Bool {
+        Date().addingTimeInterval(60) >= expiresAt
+    }
+}
+
+enum GoogleCalendarTokenStore {
+    private static let service = (Bundle.main.bundleIdentifier ?? "com.woosublee.quill") + ".google-calendar"
+    private static let account = "oauth-token"
+
+    static func load() -> GoogleCalendarOAuthToken? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess,
+              let data = result as? Data else {
+            return nil
+        }
+        return try? JSONDecoder().decode(GoogleCalendarOAuthToken.self, from: data)
+    }
+
+    static func save(_ token: GoogleCalendarOAuthToken) throws {
+        let data = try JSONEncoder().encode(token)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        let update: [String: Any] = [kSecValueData as String: data]
+        let status = SecItemUpdate(query as CFDictionary, update as CFDictionary)
+        if status == errSecSuccess { return }
+        if status == errSecItemNotFound {
+            var insert = query
+            insert[kSecValueData as String] = data
+            let insertStatus = SecItemAdd(insert as CFDictionary, nil)
+            guard insertStatus == errSecSuccess else {
+                throw KeychainError(status: insertStatus)
+            }
+            return
+        }
+        throw KeychainError(status: status)
+    }
+
+    static func delete() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    struct KeychainError: LocalizedError {
+        let status: OSStatus
+
+        var errorDescription: String? {
+            "Keychain operation failed with status \(status)"
+        }
+    }
+}

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -328,7 +328,12 @@ final class NoteTitleStore: ObservableObject {
 
     func setTitle(_ title: String, for id: UUID) {
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty { titles.removeValue(forKey: id) } else { titles[id] = trimmed }
+        if trimmed.isEmpty {
+            guard titles.removeValue(forKey: id) != nil else { return }
+        } else {
+            guard titles[id] != trimmed else { return }
+            titles[id] = trimmed
+        }
         save()
     }
 
@@ -480,7 +485,8 @@ struct NoteBrowserView: View {
         return appState.pipelineHistory.filter {
             $0.postProcessedTranscript.lowercased().contains(q) ||
             $0.contextSummary.lowercased().contains(q) ||
-            (titleStore.title(for: $0.id) ?? "").lowercased().contains(q)
+            (titleStore.title(for: $0.id) ?? "").lowercased().contains(q) ||
+            ($0.calendarMatch?.title ?? "").lowercased().contains(q)
         }
     }
 
@@ -927,34 +933,17 @@ private struct NoteListRow: View {
     }
 
     private var displayTitle: String {
-        if let custom = customTitle, !custom.isEmpty { return custom }
-        return autoTitle
+        NoteTitleResolver.displayTitle(for: item, customTitle: customTitle, isTranscribing: status == .transcribing)
     }
 
     private var autoTitle: String {
-        let content = normalizedContent
-        if content.isEmpty {
-            switch status {
-            case .fail:
-                return "Transcription failed"
-            case .recording:
-                return "Recording..."
-            case .transcribing:
-                return "Transcribing..."
-            case .done:
-                return "(No content)"
-            }
-        }
-        let firstLine = content.components(separatedBy: .newlines)
-            .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? content
-        let trimmed = firstLine.trimmingCharacters(in: .whitespaces)
-        return trimmed.count <= 60 ? trimmed : String(trimmed.prefix(60))
+        NoteTitleResolver.automaticTitle(for: item, isTranscribing: status == .transcribing)
     }
 
     private var notePreview: String {
         if status == .fail { return item.postProcessingStatus.replacingOccurrences(of: "Error: ", with: "") }
         let content = normalizedContent
-        if customTitle != nil {
+        if customTitle != nil || item.calendarMatch?.appliedTitle != nil {
             return String(content.prefix(100))
         }
         guard content.count > autoTitle.count else { return "" }
@@ -984,6 +973,14 @@ private struct NoteDetailView: View {
     private var isLiveRecording: Bool { item.postProcessingStatus == "live-recording" }
     private var canRetry: Bool { item.audioFileName != nil }
     private var displayContent: String { loadedContent ?? item.postProcessedTranscript }
+
+    private var suggestedCalendarTitle: String? {
+        guard titleStore.title(for: item.id) == nil,
+              item.calendarMatch?.titleState == .suggested else {
+            return nil
+        }
+        return item.calendarMatch?.suggestedTitle
+    }
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -1075,6 +1072,23 @@ private struct NoteDetailView: View {
                 titleDraft = titleStore.title(for: item.id) ?? ""
             }
             .overrideCursor(.iBeam)
+
+            if let suggestedCalendarTitle {
+                HStack(spacing: 8) {
+                    Image(systemName: "calendar")
+                        .font(.system(size: 11, weight: .medium))
+                    Text("Calendar suggested title: \(suggestedCalendarTitle)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    Button("Apply") {
+                        titleDraft = suggestedCalendarTitle
+                        titleStore.setTitle(suggestedCalendarTitle, for: item.id)
+                    }
+                    .buttonStyle(.borderless)
+                }
+                .padding(.top, 2)
+            }
 
             // Audio player (오디오 파일이 있을 때만 표시)
             if let audioFileName = item.audioFileName {

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -982,6 +982,14 @@ private struct NoteDetailView: View {
         return item.calendarMatch?.suggestedTitle
     }
 
+    private var suggestedCalendarAppliedTitle: String? {
+        guard let suggestedCalendarTitle else { return nil }
+        return NoteTitleResolver.calendarAppliedTitle(
+            suggestedTitle: suggestedCalendarTitle,
+            recordingStartedAt: item.timestamp
+        )
+    }
+
     var body: some View {
         ZStack(alignment: .bottom) {
             VStack(spacing: 0) {
@@ -1073,20 +1081,41 @@ private struct NoteDetailView: View {
             }
             .overrideCursor(.iBeam)
 
-            if let suggestedCalendarTitle {
-                HStack(spacing: 8) {
+            if let suggestedCalendarTitle, let suggestedCalendarAppliedTitle {
+                HStack(spacing: 10) {
                     Image(systemName: "calendar")
-                        .font(.system(size: 11, weight: .medium))
-                    Text("Calendar suggested title: \(suggestedCalendarTitle)")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                    Button("Apply") {
-                        titleDraft = suggestedCalendarTitle
-                        titleStore.setTitle(suggestedCalendarTitle, for: item.id)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.blue)
+                        .frame(width: 24, height: 24)
+                        .background(Color.blue.opacity(0.12), in: RoundedRectangle(cornerRadius: 7))
+
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text("Calendar suggested title")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .fixedSize()
+                        Text(suggestedCalendarTitle)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
                     }
-                    .buttonStyle(.borderless)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Button("Apply") {
+                        titleDraft = suggestedCalendarAppliedTitle
+                        titleStore.setTitle(suggestedCalendarAppliedTitle, for: item.id)
+                    }
+                    .font(.caption.weight(.semibold))
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
                 }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(Color.blue.opacity(colorScheme == .dark ? 0.12 : 0.06), in: RoundedRectangle(cornerRadius: 10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(Color.blue.opacity(0.16), lineWidth: 1)
+                )
                 .padding(.top, 2)
             }
 

--- a/Sources/NoteTitleResolver.swift
+++ b/Sources/NoteTitleResolver.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum NoteTitleResolver {
+    static func displayTitle(for item: PipelineHistoryItem, customTitle: String?, isTranscribing: Bool = false) -> String {
+        if let customTitle {
+            let trimmed = customTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { return trimmed }
+        }
+        if let applied = item.calendarMatch?.appliedTitle {
+            return applied
+        }
+        return automaticTitle(for: item, isTranscribing: isTranscribing)
+    }
+
+    static func automaticTitle(for item: PipelineHistoryItem, isTranscribing: Bool = false) -> String {
+        let content = item.postProcessedTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        if content.isEmpty {
+            if isTranscribing { return "Transcribing..." }
+            if item.postProcessingStatus.hasPrefix("Error:") { return "Transcription failed" }
+            if item.postProcessingStatus == "live-recording" { return "Recording..." }
+            if item.postProcessingStatus == PipelineHistoryItem.transcriptionRecoveryPlaceholderStatus || item.postProcessingStatus == "importing" { return "Transcribing..." }
+            return "(No content)"
+        }
+        let firstLine = content.components(separatedBy: .newlines).first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? content
+        let trimmed = firstLine.trimmingCharacters(in: .whitespaces)
+        return trimmed.count <= 60 ? trimmed : String(trimmed.prefix(60))
+    }
+}

--- a/Sources/NoteTitleResolver.swift
+++ b/Sources/NoteTitleResolver.swift
@@ -1,6 +1,18 @@
 import Foundation
 
 enum NoteTitleResolver {
+    private static let calendarTitleDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    static func calendarAppliedTitle(suggestedTitle: String, recordingStartedAt: Date) -> String {
+        "\(calendarTitleDateFormatter.string(from: recordingStartedAt)) \(suggestedTitle)"
+    }
+
     static func displayTitle(for item: PipelineHistoryItem, customTitle: String?, isTranscribing: Bool = false) -> String {
         if let customTitle {
             let trimmed = customTitle.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/PipelineHistoryItem.swift
+++ b/Sources/PipelineHistoryItem.swift
@@ -20,6 +20,9 @@ struct PipelineHistoryItem: Identifiable, Codable {
     let capturedSelection: String?
     let id: UUID
     let timestamp: Date
+    let recordingStartedAt: Date?
+    let recordingEndedAt: Date?
+    let calendarMatch: CalendarEventMatch?
     let rawTranscript: String
     let postProcessedTranscript: String
     let postProcessingPrompt: String?
@@ -50,6 +53,9 @@ struct PipelineHistoryItem: Identifiable, Codable {
         capturedSelection: String? = nil,
         id: UUID = UUID(),
         timestamp: Date,
+        recordingStartedAt: Date? = nil,
+        recordingEndedAt: Date? = nil,
+        calendarMatch: CalendarEventMatch? = nil,
         rawTranscript: String,
         postProcessedTranscript: String,
         postProcessingPrompt: String?,
@@ -79,6 +85,9 @@ struct PipelineHistoryItem: Identifiable, Codable {
         self.capturedSelection = capturedSelection
         self.id = id
         self.timestamp = timestamp
+        self.recordingStartedAt = recordingStartedAt
+        self.recordingEndedAt = recordingEndedAt
+        self.calendarMatch = calendarMatch
         self.rawTranscript = rawTranscript
         self.postProcessedTranscript = postProcessedTranscript
         self.postProcessingPrompt = postProcessingPrompt
@@ -107,6 +116,9 @@ struct PipelineHistoryItem: Identifiable, Codable {
     static func transcriptionRecoveryPlaceholder(
         id: UUID = UUID(),
         timestamp: Date,
+        recordingStartedAt: Date? = nil,
+        recordingEndedAt: Date? = nil,
+        calendarMatch: CalendarEventMatch? = nil,
         intent: PipelineHistoryItemIntent,
         selectedText: String?,
         capturedSelection: String?,
@@ -134,6 +146,9 @@ struct PipelineHistoryItem: Identifiable, Codable {
             capturedSelection: capturedSelection,
             id: id,
             timestamp: timestamp,
+            recordingStartedAt: recordingStartedAt,
+            recordingEndedAt: recordingEndedAt,
+            calendarMatch: calendarMatch,
             rawTranscript: "",
             postProcessedTranscript: "",
             postProcessingPrompt: nil,
@@ -167,6 +182,9 @@ struct PipelineHistoryItem: Identifiable, Codable {
             capturedSelection: capturedSelection,
             id: id,
             timestamp: timestamp,
+            recordingStartedAt: recordingStartedAt,
+            recordingEndedAt: recordingEndedAt,
+            calendarMatch: calendarMatch,
             rawTranscript: rawTranscript,
             postProcessedTranscript: postProcessedTranscript,
             postProcessingPrompt: postProcessingPrompt,

--- a/Sources/PipelineHistoryStore.swift
+++ b/Sources/PipelineHistoryStore.swift
@@ -10,9 +10,21 @@ final class PipelineHistoryStore {
     private let container: NSPersistentContainer
     private let isStoreLoaded: Bool
 
-    init() {
+    convenience init() {
+        self.init(inMemory: false)
+    }
+
+    init(inMemory: Bool) {
         let model = Self.makeModel()
         container = NSPersistentContainer(name: "PipelineHistory", managedObjectModel: model)
+
+        if inMemory {
+            let description = NSPersistentStoreDescription()
+            description.type = NSInMemoryStoreType
+            container.persistentStoreDescriptions = [description]
+            isStoreLoaded = Self.loadPersistentStoresSynchronously(container: container) == nil
+            return
+        }
 
         var storeURL: URL?
         if let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
@@ -96,6 +108,9 @@ final class PipelineHistoryStore {
                 entity.intent = item.intent.rawValue
                 entity.selectedText = item.selectedText
                 entity.capturedSelection = item.capturedSelection
+                entity.recordingStartedAt = item.recordingStartedAt
+                entity.recordingEndedAt = item.recordingEndedAt
+                entity.calendarMatchJSON = Self.encodeCalendarMatch(item.calendarMatch)
                 entity.rawTranscript = item.rawTranscript
                 entity.postProcessedTranscript = item.postProcessedTranscript
                 entity.postProcessingPrompt = item.postProcessingPrompt
@@ -212,6 +227,9 @@ final class PipelineHistoryStore {
                 entity.selectedText = item.selectedText
                 entity.capturedSelection = item.capturedSelection
                 entity.timestamp = item.timestamp
+                entity.recordingStartedAt = item.recordingStartedAt
+                entity.recordingEndedAt = item.recordingEndedAt
+                entity.calendarMatchJSON = Self.encodeCalendarMatch(item.calendarMatch)
                 entity.rawTranscript = item.rawTranscript
                 entity.postProcessedTranscript = item.postProcessedTranscript
                 entity.postProcessingPrompt = item.postProcessingPrompt
@@ -297,6 +315,16 @@ final class PipelineHistoryStore {
         }
     }
 
+    private static func encodeCalendarMatch(_ match: CalendarEventMatch?) -> String? {
+        guard let match, let data = try? JSONEncoder().encode(match) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func decodeCalendarMatch(_ json: String?) -> CalendarEventMatch? {
+        guard let json, let data = json.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(CalendarEventMatch.self, from: data)
+    }
+
     private static func makeHistoryItem(from entity: PipelineHistoryEntry) -> PipelineHistoryItem {
         PipelineHistoryItem(
             intent: PipelineHistoryItemIntent(rawValue: entity.intent ?? "") ?? .dictation,
@@ -304,6 +332,9 @@ final class PipelineHistoryStore {
             capturedSelection: entity.capturedSelection,
             id: entity.id,
             timestamp: entity.timestamp ?? Date(),
+            recordingStartedAt: entity.recordingStartedAt,
+            recordingEndedAt: entity.recordingEndedAt,
+            calendarMatch: decodeCalendarMatch(entity.calendarMatchJSON),
             rawTranscript: entity.rawTranscript ?? "",
             postProcessedTranscript: entity.postProcessedTranscript ?? "",
             postProcessingPrompt: entity.postProcessingPrompt,
@@ -343,6 +374,9 @@ final class PipelineHistoryStore {
             makeAttribute(name: "capturedSelection", type: .stringAttributeType, isOptional: true),
             makeAttribute(name: "id", type: .UUIDAttributeType, isOptional: false),
             makeAttribute(name: "timestamp", type: .dateAttributeType, isOptional: false),
+            makeAttribute(name: "recordingStartedAt", type: .dateAttributeType, isOptional: true),
+            makeAttribute(name: "recordingEndedAt", type: .dateAttributeType, isOptional: true),
+            makeAttribute(name: "calendarMatchJSON", type: .stringAttributeType, isOptional: true),
             makeAttribute(name: "rawTranscript", type: .stringAttributeType, isOptional: false),
             makeAttribute(name: "postProcessedTranscript", type: .stringAttributeType, isOptional: false),
             makeAttribute(name: "postProcessingPrompt", type: .stringAttributeType, isOptional: true),
@@ -394,6 +428,9 @@ final class PipelineHistoryEntry: NSManagedObject {
     @NSManaged var selectedText: String?
     @NSManaged var capturedSelection: String?
     @NSManaged var timestamp: Date?
+    @NSManaged var recordingStartedAt: Date?
+    @NSManaged var recordingEndedAt: Date?
+    @NSManaged var calendarMatchJSON: String?
     @NSManaged var rawTranscript: String?
     @NSManaged var postProcessedTranscript: String?
     @NSManaged var postProcessingPrompt: String?

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -410,7 +410,7 @@ struct SettingsView: View {
     var body: some View {
         HStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 2) {
-                ForEach(SettingsTab.visibleCases) { tab in
+                ForEach(SettingsTab.orderedCases.filter { $0 != .debug || AppBuild.isDevBundle }) { tab in
                     Button {
                         appState.selectedSettingsTab = tab
                     } label: {
@@ -444,6 +444,8 @@ struct SettingsView: View {
                     PromptsSettingsView()
                 case .macros:
                     VoiceMacrosSettingsView()
+                case .calendar:
+                    CalendarSettingsView()
                 case .runLog:
                     RunLogView()
                 case .debug:
@@ -585,6 +587,180 @@ struct AppearanceSettingsView: View {
         case "light":  NSApp.appearance = NSAppearance(named: .aqua)
         case "dark":   NSApp.appearance = NSAppearance(named: .darkAqua)
         default:       NSApp.appearance = nil
+        }
+    }
+}
+
+// MARK: - Calendar Settings
+
+struct CalendarSettingsView: View {
+    @EnvironmentObject var appState: AppState
+
+    private var connectionControls: GoogleCalendarConnectionControls {
+        appState.googleCalendarConnectionControls
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Calendar")
+                    .font(.largeTitle.bold())
+
+                SettingsCard("Google Calendar", icon: "calendar") {
+                    googleCalendarSection
+                }
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .onAppear {
+            appState.loadStoredGoogleCalendarConnection()
+        }
+    }
+
+    private var googleCalendarSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Google OAuth Desktop client ID")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                TextField("client-id.apps.googleusercontent.com", text: $appState.googleCalendarClientID)
+                    .textFieldStyle(.roundedBorder)
+                Text("Google OAuth client secret")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                SecureField("Optional for some Google OAuth clients", text: $appState.googleCalendarClientSecret)
+                    .textFieldStyle(.roundedBorder)
+                Text("Create a Google Cloud OAuth client for a desktop app, then paste its client ID. If Google reports that client_secret is missing, paste the client secret from the same credentials screen.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 8) {
+                if appState.googleCalendarConnection.isConnected {
+                    Label("Connected", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    if let email = appState.googleCalendarConnection.accountEmail, !email.isEmpty {
+                        Text(email)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Label("Not connected", systemImage: "xmark.circle")
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if appState.isGoogleCalendarBusy {
+                    ProgressView().scaleEffect(0.7)
+                }
+            }
+
+            HStack {
+                Button(connectionControls.primaryActionTitle) {
+                    if appState.hasPendingGoogleCalendarOAuthConnection {
+                        appState.cancelGoogleCalendarConnection()
+                    } else {
+                        appState.connectGoogleCalendar()
+                    }
+                }
+                .disabled(!connectionControls.allowsPrimaryAction)
+
+                Button("Refresh Calendars") {
+                    appState.refreshGoogleCalendars()
+                }
+                .disabled(!connectionControls.allowsRefresh)
+
+                Button("Disconnect") {
+                    appState.disconnectGoogleCalendar()
+                }
+                .disabled(!connectionControls.allowsDisconnect)
+            }
+
+            if let error = appState.googleCalendarConnection.lastErrorMessage, !error.isEmpty {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if appState.googleCalendarConnection.isConnected {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Calendars used for note title suggestions")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    if appState.availableGoogleCalendars.isEmpty {
+                        Text("No calendars loaded. Click Refresh Calendars after connecting.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        VStack(alignment: .leading, spacing: 14) {
+                            ForEach(appState.availableGoogleCalendars.groupedForQuillDisplay(), id: \.title) { group in
+                                calendarGroupSection(group)
+                            }
+                        }
+                    }
+                    Text("No calendars are selected by default. Quill only reads events from calendars you explicitly select.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func calendarGroupSection(_ group: GoogleCalendarDisplayGroup) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Text(group.title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+                    .kerning(0.4)
+                Text("\(group.calendars.count)")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.secondary.opacity(0.12), in: Capsule())
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(group.calendars) { calendar in
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Toggle(
+                            calendar.displayName,
+                            isOn: Binding(
+                                get: { appState.googleCalendarConnection.selectedCalendarIDs.contains(calendar.id) },
+                                set: { appState.setGoogleCalendarSelected(calendar.id, isSelected: $0) }
+                            )
+                        )
+                        .toggleStyle(.checkbox)
+
+                        Text(calendarDisplayKind(calendar))
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.secondary.opacity(0.12), in: Capsule())
+                    }
+                }
+            }
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(nsColor: .textBackgroundColor).opacity(0.35), in: RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color.primary.opacity(0.06), lineWidth: 1)
+            )
+        }
+    }
+
+    private func calendarDisplayKind(_ calendar: GoogleCalendarInfo) -> String {
+        if calendar.primary { return "Primary" }
+        switch calendar.accessRole {
+        case "owner", "writer": return "My calendar"
+        default: return "Shared"
         }
     }
 }
@@ -775,9 +951,6 @@ struct GeneralSettingsView: View {
                 // }
                 SettingsCard("Transcription", icon: "waveform.badge.magnifyingglass") {
                     transcriptionSection
-                }
-                SettingsCard("Calendar", icon: "calendar") {
-                    googleCalendarSection
                 }
                 SettingsCard("Dictation Shortcuts", icon: "keyboard.fill") {
                     hotkeySection
@@ -1200,100 +1373,6 @@ struct GeneralSettingsView: View {
                     keyValidationSuccess = true
                 } else {
                     keyValidationError = "Validation failed. Please check your API key and provider settings, then try again."
-                }
-            }
-        }
-    }
-
-    // MARK: Calendar
-
-    private var googleCalendarSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Google OAuth Desktop client ID")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                TextField("client-id.apps.googleusercontent.com", text: $appState.googleCalendarClientID)
-                    .textFieldStyle(.roundedBorder)
-                Text("Google OAuth client secret")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                SecureField("Optional for some Google OAuth clients", text: $appState.googleCalendarClientSecret)
-                    .textFieldStyle(.roundedBorder)
-                Text("Create a Google Cloud OAuth client for a desktop app, then paste its client ID. If Google reports that client_secret is missing, paste the client secret from the same credentials screen.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            HStack(spacing: 8) {
-                if appState.googleCalendarConnection.isConnected {
-                    Label("Connected", systemImage: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
-                    if let email = appState.googleCalendarConnection.accountEmail, !email.isEmpty {
-                        Text(email)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                } else {
-                    Label("Not connected", systemImage: "xmark.circle")
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                if appState.isGoogleCalendarBusy {
-                    ProgressView().scaleEffect(0.7)
-                }
-            }
-
-            HStack {
-                Button(appState.googleCalendarConnection.isConnected ? "Reconnect" : "Connect") {
-                    appState.connectGoogleCalendar()
-                }
-                .disabled(appState.isGoogleCalendarBusy)
-
-                Button("Refresh Calendars") {
-                    appState.refreshGoogleCalendars()
-                }
-                .disabled(!appState.googleCalendarConnection.isConnected || appState.isGoogleCalendarBusy)
-
-                Button("Disconnect") {
-                    appState.disconnectGoogleCalendar()
-                }
-                .disabled(!appState.googleCalendarConnection.isConnected || appState.isGoogleCalendarBusy)
-            }
-
-            if let error = appState.googleCalendarConnection.lastErrorMessage, !error.isEmpty {
-                Text(error)
-                    .font(.caption)
-                    .foregroundStyle(.red)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            if appState.googleCalendarConnection.isConnected {
-                Divider()
-
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Calendars used for note title suggestions")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                    if appState.availableGoogleCalendars.isEmpty {
-                        Text("No calendars loaded. Click Refresh Calendars after connecting.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    } else {
-                        ForEach(appState.availableGoogleCalendars) { calendar in
-                            Toggle(
-                                calendar.displayName,
-                                isOn: Binding(
-                                    get: { appState.googleCalendarConnection.selectedCalendarIDs.contains(calendar.id) },
-                                    set: { appState.setGoogleCalendarSelected(calendar.id, isSelected: $0) }
-                                )
-                            )
-                            .toggleStyle(.checkbox)
-                        }
-                    }
-                    Text("No calendars are selected by default. Quill only reads events from calendars you explicitly select.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
                 }
             }
         }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -776,6 +776,9 @@ struct GeneralSettingsView: View {
                 SettingsCard("Transcription", icon: "waveform.badge.magnifyingglass") {
                     transcriptionSection
                 }
+                SettingsCard("Calendar", icon: "calendar") {
+                    googleCalendarSection
+                }
                 SettingsCard("Dictation Shortcuts", icon: "keyboard.fill") {
                     hotkeySection
                 }
@@ -1197,6 +1200,100 @@ struct GeneralSettingsView: View {
                     keyValidationSuccess = true
                 } else {
                     keyValidationError = "Validation failed. Please check your API key and provider settings, then try again."
+                }
+            }
+        }
+    }
+
+    // MARK: Calendar
+
+    private var googleCalendarSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Google OAuth Desktop client ID")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                TextField("client-id.apps.googleusercontent.com", text: $appState.googleCalendarClientID)
+                    .textFieldStyle(.roundedBorder)
+                Text("Google OAuth client secret")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                SecureField("Optional for some Google OAuth clients", text: $appState.googleCalendarClientSecret)
+                    .textFieldStyle(.roundedBorder)
+                Text("Create a Google Cloud OAuth client for a desktop app, then paste its client ID. If Google reports that client_secret is missing, paste the client secret from the same credentials screen.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 8) {
+                if appState.googleCalendarConnection.isConnected {
+                    Label("Connected", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    if let email = appState.googleCalendarConnection.accountEmail, !email.isEmpty {
+                        Text(email)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Label("Not connected", systemImage: "xmark.circle")
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if appState.isGoogleCalendarBusy {
+                    ProgressView().scaleEffect(0.7)
+                }
+            }
+
+            HStack {
+                Button(appState.googleCalendarConnection.isConnected ? "Reconnect" : "Connect") {
+                    appState.connectGoogleCalendar()
+                }
+                .disabled(appState.isGoogleCalendarBusy)
+
+                Button("Refresh Calendars") {
+                    appState.refreshGoogleCalendars()
+                }
+                .disabled(!appState.googleCalendarConnection.isConnected || appState.isGoogleCalendarBusy)
+
+                Button("Disconnect") {
+                    appState.disconnectGoogleCalendar()
+                }
+                .disabled(!appState.googleCalendarConnection.isConnected || appState.isGoogleCalendarBusy)
+            }
+
+            if let error = appState.googleCalendarConnection.lastErrorMessage, !error.isEmpty {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if appState.googleCalendarConnection.isConnected {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Calendars used for note title suggestions")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    if appState.availableGoogleCalendars.isEmpty {
+                        Text("No calendars loaded. Click Refresh Calendars after connecting.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(appState.availableGoogleCalendars) { calendar in
+                            Toggle(
+                                calendar.displayName,
+                                isOn: Binding(
+                                    get: { appState.googleCalendarConnection.selectedCalendarIDs.contains(calendar.id) },
+                                    set: { appState.setGoogleCalendarSelected(calendar.id, isSelected: $0) }
+                                )
+                            )
+                            .toggleStyle(.checkbox)
+                        }
+                    }
+                    Text("No calendars are selected by default. Quill only reads events from calendars you explicitly select.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
             }
         }

--- a/Tests/CalendarEventMatcherTests.swift
+++ b/Tests/CalendarEventMatcherTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+@main
+struct CalendarEventMatcherTests {
+    static func main() {
+        testChoosesLongestPositiveOverlap()
+        testExcludesZeroOverlapEvents()
+        testExcludesAllDayEvents()
+        testTieBreaksByStartClosestToRecordingStart()
+        testTieBreaksExactTimingByCalendarAndEventID()
+        testExcludesInvalidEventIntervals()
+        testInvalidRecordingIntervalReturnsNil()
+        testExcludesTitlelessEvents()
+        print("CalendarEventMatcherTests passed")
+    }
+
+    private static func testChoosesLongestPositiveOverlap() {
+        let recordingStart = Date(timeIntervalSince1970: 1_000)
+        let recordingEnd = Date(timeIntervalSince1970: 1_600)
+        let short = event(id: "short", title: "Short", start: 900, end: 1_100)
+        let long = event(id: "long", title: "Long", start: 1_100, end: 1_700)
+        let matched = CalendarEventMatcher.bestMatch(recordingStartedAt: recordingStart, recordingEndedAt: recordingEnd, events: [short, long])
+        assert(matched?.id == "long")
+    }
+
+    private static func testExcludesZeroOverlapEvents() {
+        let matched = CalendarEventMatcher.bestMatch(
+            recordingStartedAt: Date(timeIntervalSince1970: 1_000),
+            recordingEndedAt: Date(timeIntervalSince1970: 1_600),
+            events: [event(id: "before", title: "Before", start: 100, end: 999), event(id: "after", title: "After", start: 1_600, end: 1_900)]
+        )
+        assert(matched == nil)
+    }
+
+    private static func testExcludesAllDayEvents() {
+        let matched = CalendarEventMatcher.bestMatch(
+            recordingStartedAt: Date(timeIntervalSince1970: 1_000),
+            recordingEndedAt: Date(timeIntervalSince1970: 1_600),
+            events: [event(id: "holiday", title: "Holiday", start: 0, end: 86_400, isAllDay: true), event(id: "meeting", title: "Meeting", start: 1_100, end: 1_500)]
+        )
+        assert(matched?.id == "meeting")
+    }
+
+    private static func testTieBreaksByStartClosestToRecordingStart() {
+        let matched = CalendarEventMatcher.bestMatch(
+            recordingStartedAt: Date(timeIntervalSince1970: 1_000),
+            recordingEndedAt: Date(timeIntervalSince1970: 1_600),
+            events: [event(id: "far", title: "Far", start: 700, end: 1_200), event(id: "near", title: "Near", start: 900, end: 1_200)]
+        )
+        assert(matched?.id == "near")
+    }
+
+    private static func testTieBreaksExactTimingByCalendarAndEventID() {
+        let recordingStart = Date(timeIntervalSince1970: 1_000)
+        let recordingEnd = Date(timeIntervalSince1970: 1_600)
+        let laterCalendar = event(id: "event", calendarID: "b-calendar", title: "Meeting", start: 900, end: 1_500)
+        let earlierCalendar = event(id: "event", calendarID: "a-calendar", title: "Meeting", start: 900, end: 1_500)
+        let calendarMatched = CalendarEventMatcher.bestMatch(recordingStartedAt: recordingStart, recordingEndedAt: recordingEnd, events: [laterCalendar, earlierCalendar])
+        assert(calendarMatched?.calendarID == "a-calendar")
+
+        let laterEventID = event(id: "b-event", title: "Meeting", start: 900, end: 1_500)
+        let earlierEventID = event(id: "a-event", title: "Meeting", start: 900, end: 1_500)
+        let eventMatched = CalendarEventMatcher.bestMatch(recordingStartedAt: recordingStart, recordingEndedAt: recordingEnd, events: [laterEventID, earlierEventID])
+        assert(eventMatched?.id == "a-event")
+    }
+
+    private static func testExcludesInvalidEventIntervals() {
+        let matched = CalendarEventMatcher.bestMatch(
+            recordingStartedAt: Date(timeIntervalSince1970: 1_000),
+            recordingEndedAt: Date(timeIntervalSince1970: 1_600),
+            events: [
+                event(id: "zero", title: "Zero", start: 1_100, end: 1_100),
+                event(id: "negative", title: "Negative", start: 1_400, end: 1_300),
+                event(id: "valid", title: "Valid", start: 1_100, end: 1_500),
+            ]
+        )
+        assert(matched?.id == "valid")
+    }
+
+    private static func testInvalidRecordingIntervalReturnsNil() {
+        let zeroLengthMatched = CalendarEventMatcher.bestMatch(
+            recordingStartedAt: Date(timeIntervalSince1970: 1_000),
+            recordingEndedAt: Date(timeIntervalSince1970: 1_000),
+            events: [event(id: "meeting", title: "Meeting", start: 900, end: 1_100)]
+        )
+        assert(zeroLengthMatched == nil)
+
+        let negativeLengthMatched = CalendarEventMatcher.bestMatch(
+            recordingStartedAt: Date(timeIntervalSince1970: 1_100),
+            recordingEndedAt: Date(timeIntervalSince1970: 1_000),
+            events: [event(id: "meeting", title: "Meeting", start: 900, end: 1_200)]
+        )
+        assert(negativeLengthMatched == nil)
+
+        let missingStartMatched = CalendarEventMatcher.bestMatch(
+            recordingStartedAt: nil,
+            recordingEndedAt: Date(timeIntervalSince1970: 1_000),
+            events: [event(id: "meeting", title: "Meeting", start: 900, end: 1_200)]
+        )
+        assert(missingStartMatched == nil)
+
+        let missingEndMatched = CalendarEventMatcher.bestMatch(
+            recordingStartedAt: Date(timeIntervalSince1970: 1_000),
+            recordingEndedAt: nil,
+            events: [event(id: "meeting", title: "Meeting", start: 900, end: 1_200)]
+        )
+        assert(missingEndMatched == nil)
+    }
+
+    private static func testExcludesTitlelessEvents() {
+        let matched = CalendarEventMatcher.bestMatch(
+            recordingStartedAt: Date(timeIntervalSince1970: 1_000),
+            recordingEndedAt: Date(timeIntervalSince1970: 1_600),
+            events: [event(id: "blank", title: "   ", start: 900, end: 1_700), event(id: "named", title: "Named", start: 1_100, end: 1_500)]
+        )
+        assert(matched?.id == "named")
+    }
+
+    private static func event(id: String, calendarID: String = "calendar", title: String, start: TimeInterval, end: TimeInterval, isAllDay: Bool = false) -> GoogleCalendarEvent {
+        GoogleCalendarEvent(id: id, calendarID: calendarID, title: title, start: Date(timeIntervalSince1970: start), end: Date(timeIntervalSince1970: end), isAllDay: isAllDay, attendees: [])
+    }
+}

--- a/Tests/GoogleCalendarServiceTests.swift
+++ b/Tests/GoogleCalendarServiceTests.swift
@@ -15,6 +15,11 @@ struct GoogleCalendarServiceTests {
         try await testRefreshTokenOmitsClientSecret()
         try await testRefreshTokenIncludesClientSecretWhenProvided()
         try await testCalendarListDecodesSelectableCalendars()
+        testCalendarsSortPrimaryOwnedThenSharedByDisplayName()
+        testCalendarsGroupMyCalendarsBeforeSharedCalendars()
+        testConnectionControlsShowCancelDuringOAuthConnection()
+        testConnectionControlsAllowForcedRefreshForStoredToken()
+        testSettingsTabsPlaceCalendarAfterAppearance()
         try await testEventsDecodeMinimalFieldsAndExcludeAllDayLaterInMatcher()
         try await testFetchEventsEncodesCalendarIDAsSinglePathSegment()
         try await testEventsDecodeFractionalSecondDateTimes()
@@ -209,6 +214,66 @@ struct GoogleCalendarServiceTests {
         assert(calendars[0].primary)
         assert(calendars[1].displayName == "Team")
         assert(!calendars[1].primary)
+    }
+
+    private static func testCalendarsSortPrimaryOwnedThenSharedByDisplayName() {
+        let calendars = [
+            GoogleCalendarInfo(id: "team", summary: "Team", summaryOverride: nil, primary: false, accessRole: "reader"),
+            GoogleCalendarInfo(id: "owned-z", summary: "Zebra", summaryOverride: nil, primary: false, accessRole: "owner"),
+            GoogleCalendarInfo(id: "primary", summary: "Personal", summaryOverride: nil, primary: true, accessRole: "owner"),
+            GoogleCalendarInfo(id: "owned-a", summary: "Alpha", summaryOverride: nil, primary: false, accessRole: "writer"),
+            GoogleCalendarInfo(id: "shared-a", summary: "Alpha Shared", summaryOverride: nil, primary: false, accessRole: "reader")
+        ]
+
+        let sorted = calendars.sortedForQuillDisplay()
+
+        assert(sorted.map(\.id) == ["primary", "owned-a", "owned-z", "shared-a", "team"])
+    }
+
+    private static func testCalendarsGroupMyCalendarsBeforeSharedCalendars() {
+        let calendars = [
+            GoogleCalendarInfo(id: "team", summary: "Team", summaryOverride: nil, primary: false, accessRole: "reader"),
+            GoogleCalendarInfo(id: "owned", summary: "Work", summaryOverride: nil, primary: false, accessRole: "owner"),
+            GoogleCalendarInfo(id: "primary", summary: "Personal", summaryOverride: nil, primary: true, accessRole: "owner")
+        ]
+
+        let groups = calendars.groupedForQuillDisplay()
+
+        assert(groups.count == 2)
+        assert(groups[0].title == "My calendars")
+        assert(groups[0].calendars.map(\.id) == ["primary", "owned"])
+        assert(groups[1].title == "Shared calendars")
+        assert(groups[1].calendars.map(\.id) == ["team"])
+    }
+
+    private static func testConnectionControlsShowCancelDuringOAuthConnection() {
+        let controls = GoogleCalendarConnectionControls(
+            isConnected: false,
+            isBusy: true,
+            hasPendingOAuthConnection: true
+        )
+
+        assert(controls.primaryActionTitle == "Cancel")
+        assert(controls.allowsPrimaryAction)
+        assert(!controls.allowsRefresh)
+        assert(!controls.allowsDisconnect)
+    }
+
+    private static func testConnectionControlsAllowForcedRefreshForStoredToken() {
+        let controls = GoogleCalendarConnectionControls(
+            isConnected: true,
+            isBusy: false,
+            hasPendingOAuthConnection: false
+        )
+
+        assert(controls.primaryActionTitle == "Reconnect")
+        assert(controls.allowsPrimaryAction)
+        assert(controls.allowsRefresh)
+        assert(controls.allowsDisconnect)
+    }
+
+    private static func testSettingsTabsPlaceCalendarAfterAppearance() {
+        assert(SettingsTab.orderedCases.prefix(3) == [.general, .appearance, .calendar])
     }
 
     private static func testEventsDecodeMinimalFieldsAndExcludeAllDayLaterInMatcher() async throws {

--- a/Tests/GoogleCalendarServiceTests.swift
+++ b/Tests/GoogleCalendarServiceTests.swift
@@ -1,0 +1,354 @@
+import CryptoKit
+import Foundation
+
+@main
+struct GoogleCalendarServiceTests {
+    static func main() async throws {
+        testPKCEVerifierAndChallengeAreURLSafe()
+        try testPKCEPairPropagatesRandomProviderFailure()
+        testAuthorizationURLContainsReadOnlyScopesAndPKCEChallenge()
+        try await testLoopbackReceiverUsesAssignedPort()
+        try await testTokenExchangeSurfacesGoogleErrorResponse()
+        testClientSecretMissingMessageExplainsClientTypeMismatch()
+        try await testTokenExchangeOmitsClientSecret()
+        try await testTokenExchangeIncludesClientSecretWhenProvided()
+        try await testRefreshTokenOmitsClientSecret()
+        try await testRefreshTokenIncludesClientSecretWhenProvided()
+        try await testCalendarListDecodesSelectableCalendars()
+        try await testEventsDecodeMinimalFieldsAndExcludeAllDayLaterInMatcher()
+        try await testFetchEventsEncodesCalendarIDAsSinglePathSegment()
+        try await testEventsDecodeFractionalSecondDateTimes()
+        try await testFetchEventsSkipsFailedCalendars()
+        print("GoogleCalendarServiceTests passed")
+    }
+
+    private static func testPKCEVerifierAndChallengeAreURLSafe() {
+        let pair = GoogleCalendarAuthService.makePKCEPair()
+
+        assert(pair.verifier.count >= 43)
+        assert(pair.challenge.count >= 43)
+        assert(!pair.verifier.contains("+"))
+        assert(!pair.verifier.contains("/"))
+        assert(!pair.verifier.contains("="))
+        assert(!pair.challenge.contains("+"))
+        assert(!pair.challenge.contains("/"))
+        assert(!pair.challenge.contains("="))
+        assert(pair.challenge == expectedChallenge(for: pair.verifier))
+    }
+
+    private static func testPKCEPairPropagatesRandomProviderFailure() throws {
+        struct RandomFailure: Error {}
+
+        do {
+            _ = try GoogleCalendarAuthService.makePKCEPair { _ in throw RandomFailure() }
+            assertionFailure("Expected random provider failure")
+        } catch is RandomFailure {
+        }
+    }
+
+    private static func testAuthorizationURLContainsReadOnlyScopesAndPKCEChallenge() {
+        let callbackURL = URL(string: "http://127.0.0.1:49152/oauth2callback")!
+        let url = GoogleCalendarAuthService.authorizationURL(
+            clientID: "client-id.apps.googleusercontent.com",
+            callbackURL: callbackURL,
+            codeChallenge: "challenge-value",
+            state: "state-value"
+        )
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        let query = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+
+        assert(components.scheme == "https")
+        assert(components.host == "accounts.google.com")
+        assert(components.path == "/o/oauth2/v2/auth")
+        assert(query["client_id"] == "client-id.apps.googleusercontent.com")
+        assert(query["redirect_uri"] == callbackURL.absoluteString)
+        assert(query["response_type"] == "code")
+        assert(query["code_challenge"] == "challenge-value")
+        assert(query["code_challenge_method"] == "S256")
+        assert(query["access_type"] == "offline")
+        assert(query["prompt"] == "consent")
+        assert(query["state"] == "state-value")
+        assert(query["scope"]?.contains("https://www.googleapis.com/auth/calendar.calendarlist.readonly") == true)
+        assert(query["scope"]?.contains("https://www.googleapis.com/auth/calendar.events.readonly") == true)
+    }
+
+    private static func testLoopbackReceiverUsesAssignedPort() async throws {
+        let receiver = try GoogleCalendarAuthService.LoopbackReceiver(state: "state-value")
+        defer { receiver.cancel() }
+        receiver.start()
+
+        let callbackURL = try await receiver.waitForCallbackURL()
+
+        assert(callbackURL.host == "127.0.0.1")
+        assert(callbackURL.port != nil)
+        assert(callbackURL.port != 0)
+    }
+
+    private static func testTokenExchangeSurfacesGoogleErrorResponse() async throws {
+        do {
+            _ = try await GoogleCalendarAuthService.exchangeCode(
+                clientID: "client-id.apps.googleusercontent.com",
+                clientSecret: "",
+                code: "bad-code",
+                codeVerifier: "verifier",
+                redirectURI: "http://127.0.0.1:49152/oauth2callback"
+            ) { request, body in
+                assert(request.httpMethod == "POST")
+                assert(String(data: body ?? Data(), encoding: .utf8)?.contains("grant_type=authorization_code") == true)
+                let data = Data("""
+                {
+                  "error": "invalid_grant",
+                  "error_description": "Bad Request"
+                }
+                """.utf8)
+                return (data, HTTPURLResponse(url: request.url!, statusCode: 400, httpVersion: nil, headerFields: nil)!)
+            }
+            assertionFailure("Expected token exchange to surface Google error")
+        } catch let error as GoogleCalendarAuthService.OAuthError {
+            assert(error.localizedDescription.contains("invalid_grant"))
+            assert(error.localizedDescription.contains("Bad Request"))
+        }
+    }
+
+    private static func testClientSecretMissingMessageExplainsClientTypeMismatch() {
+        let error = GoogleCalendarAuthService.OAuthError.response("invalid_request", "client_secret is missing")
+
+        assert(error.localizedDescription.contains("web OAuth client"))
+        assert(error.localizedDescription.contains("Desktop app client"))
+    }
+
+    private static func testTokenExchangeOmitsClientSecret() async throws {
+        let token = try await GoogleCalendarAuthService.exchangeCode(
+            clientID: "client-id.apps.googleusercontent.com",
+            clientSecret: "",
+            code: "code-value",
+            codeVerifier: "verifier",
+            redirectURI: "http://127.0.0.1:49152/oauth2callback"
+        ) { request, body in
+            let bodyString = String(data: body ?? Data(), encoding: .utf8) ?? ""
+            assert(bodyString.contains("client_id=client-id.apps.googleusercontent.com"))
+            assert(!bodyString.contains("client_secret"))
+            assert(bodyString.contains("grant_type=authorization_code"))
+            return (Data(tokenJSON.utf8), HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+
+        assert(token.accessToken == "access-token")
+        assert(token.refreshToken == "refresh-token")
+    }
+
+    private static func testTokenExchangeIncludesClientSecretWhenProvided() async throws {
+        _ = try await GoogleCalendarAuthService.exchangeCode(
+            clientID: "client-id.apps.googleusercontent.com",
+            clientSecret: "client-secret",
+            code: "code-value",
+            codeVerifier: "verifier",
+            redirectURI: "http://127.0.0.1:49152/oauth2callback"
+        ) { request, body in
+            let bodyString = String(data: body ?? Data(), encoding: .utf8) ?? ""
+            assert(bodyString.contains("client_secret=client-secret"))
+            return (Data(tokenJSON.utf8), HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+    }
+
+    private static func testRefreshTokenOmitsClientSecret() async throws {
+        let existingToken = GoogleCalendarOAuthToken(
+            accessToken: "old-access-token",
+            refreshToken: "refresh-token",
+            expiresAt: Date(timeIntervalSince1970: 0),
+            accountEmail: "ada@example.com"
+        )
+
+        let token = try await GoogleCalendarAuthService.refreshToken(
+            clientID: "client-id.apps.googleusercontent.com",
+            clientSecret: "",
+            token: existingToken
+        ) { request, body in
+            let bodyString = String(data: body ?? Data(), encoding: .utf8) ?? ""
+            assert(bodyString.contains("client_id=client-id.apps.googleusercontent.com"))
+            assert(!bodyString.contains("client_secret"))
+            assert(bodyString.contains("refresh_token=refresh-token"))
+            assert(bodyString.contains("grant_type=refresh_token"))
+            return (Data(refreshedTokenJSON.utf8), HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+
+        assert(token.accessToken == "new-access-token")
+        assert(token.refreshToken == "refresh-token")
+        assert(token.accountEmail == "ada@example.com")
+    }
+
+    private static func testRefreshTokenIncludesClientSecretWhenProvided() async throws {
+        let existingToken = GoogleCalendarOAuthToken(
+            accessToken: "old-access-token",
+            refreshToken: "refresh-token",
+            expiresAt: Date(timeIntervalSince1970: 0),
+            accountEmail: "ada@example.com"
+        )
+
+        _ = try await GoogleCalendarAuthService.refreshToken(
+            clientID: "client-id.apps.googleusercontent.com",
+            clientSecret: "client-secret",
+            token: existingToken
+        ) { request, body in
+            let bodyString = String(data: body ?? Data(), encoding: .utf8) ?? ""
+            assert(bodyString.contains("client_secret=client-secret"))
+            return (Data(refreshedTokenJSON.utf8), HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+    }
+
+    private static func testCalendarListDecodesSelectableCalendars() async throws {
+        let service = GoogleCalendarService { request in
+            assert(request.url?.absoluteString.contains("/users/me/calendarList") == true)
+            return (Data(calendarListJSON.utf8), HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+
+        let calendars = try await service.fetchCalendars(accessToken: "token")
+
+        assert(calendars.count == 2)
+        assert(calendars[0].id == "primary")
+        assert(calendars[0].displayName == "Work")
+        assert(calendars[0].primary)
+        assert(calendars[1].displayName == "Team")
+        assert(!calendars[1].primary)
+    }
+
+    private static func testEventsDecodeMinimalFieldsAndExcludeAllDayLaterInMatcher() async throws {
+        let service = GoogleCalendarService { request in
+            assert(request.url?.absoluteString.contains("singleEvents=true") == true)
+            return (Data(eventsJSON.utf8), HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+
+        let events = try await service.fetchEvents(
+            accessToken: "token",
+            calendarID: "calendar-id",
+            timeMin: Date(timeIntervalSince1970: 1_000),
+            timeMax: Date(timeIntervalSince1970: 2_000)
+        )
+
+        assert(events.count == 2)
+        assert(events[0].id == "timed")
+        assert(events[0].calendarID == "calendar-id")
+        assert(events[0].title == "Timed Meeting")
+        assert(events[0].attendees.first?.email == "ada@example.com")
+        assert(events[0].isAllDay == false)
+        assert(events[1].id == "all-day")
+        assert(events[1].isAllDay == true)
+    }
+
+    private static func testFetchEventsEncodesCalendarIDAsSinglePathSegment() async throws {
+        let service = GoogleCalendarService { request in
+            assert(request.url?.absoluteString.contains("/calendars/team%2Fcalendar/events") == true)
+            return (Data(eventsJSON.utf8), HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+
+        _ = try await service.fetchEvents(
+            accessToken: "token",
+            calendarID: "team/calendar",
+            timeMin: Date(timeIntervalSince1970: 1_000),
+            timeMax: Date(timeIntervalSince1970: 2_000)
+        )
+    }
+
+    private static func testEventsDecodeFractionalSecondDateTimes() async throws {
+        let service = GoogleCalendarService { request in
+            return (Data(fractionalEventsJSON.utf8), HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+
+        let events = try await service.fetchEvents(
+            accessToken: "token",
+            calendarID: "calendar-id",
+            timeMin: Date(timeIntervalSince1970: 1_000),
+            timeMax: Date(timeIntervalSince1970: 2_000)
+        )
+
+        assert(events.count == 1)
+        assert(events[0].start == Date(timeIntervalSince1970: 1_800_000_000))
+        assert(events[0].end == Date(timeIntervalSince1970: 1_800_003_600))
+    }
+
+    private static func testFetchEventsSkipsFailedCalendars() async throws {
+        let service = GoogleCalendarService { request in
+            let url = request.url!.absoluteString
+            if url.contains("bad-calendar") {
+                return (Data("{}".utf8), HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!)
+            }
+            return (Data(eventsJSON.utf8), HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+
+        let events = await service.fetchEventsSkippingFailures(
+            accessToken: "token",
+            calendarIDs: ["bad-calendar", "good-calendar"],
+            timeMin: Date(timeIntervalSince1970: 1_000),
+            timeMax: Date(timeIntervalSince1970: 2_000)
+        )
+
+        assert(events.count == 2)
+        assert(events.allSatisfy { $0.calendarID == "good-calendar" })
+    }
+
+    private static func expectedChallenge(for verifier: String) -> String {
+        let digest = SHA256.hash(data: Data(verifier.utf8))
+        return Data(digest).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private static let tokenJSON = """
+    {
+      "access_token": "access-token",
+      "refresh_token": "refresh-token",
+      "expires_in": 3600
+    }
+    """
+
+    private static let refreshedTokenJSON = """
+    {
+      "access_token": "new-access-token",
+      "expires_in": 3600
+    }
+    """
+
+    private static let calendarListJSON = """
+    {
+      "items": [
+        { "id": "primary", "summary": "Personal", "summaryOverride": "Work", "primary": true, "accessRole": "owner" },
+        { "id": "team@example.com", "summary": "Team", "accessRole": "reader" }
+      ]
+    }
+    """
+
+    private static let eventsJSON = """
+    {
+      "items": [
+        {
+          "id": "timed",
+          "summary": "Timed Meeting",
+          "start": { "dateTime": "1970-01-01T00:16:40Z" },
+          "end": { "dateTime": "1970-01-01T00:33:20Z" },
+          "attendees": [
+            { "displayName": "Ada", "email": "ada@example.com", "responseStatus": "accepted", "optional": false, "self": false }
+          ]
+        },
+        {
+          "id": "all-day",
+          "summary": "Holiday",
+          "start": { "date": "1970-01-01" },
+          "end": { "date": "1970-01-02" }
+        }
+      ]
+    }
+    """
+
+    private static let fractionalEventsJSON = """
+    {
+      "items": [
+        {
+          "id": "fractional",
+          "summary": "Fractional Meeting",
+          "start": { "dateTime": "2027-01-15T08:00:00.000Z" },
+          "end": { "dateTime": "2027-01-15T09:00:00.000Z" }
+        }
+      ]
+    }
+    """
+}

--- a/Tests/NoteTitleResolutionTests.swift
+++ b/Tests/NoteTitleResolutionTests.swift
@@ -9,6 +9,7 @@ struct NoteTitleResolutionTests {
         testFallbackUsedWhenNoContentOrAppliedCalendarTitle()
         testTranscribingFallbackWinsOverFailedEmptyContent()
         testAppliedCalendarTitleKeepsWinningWhileTranscribing()
+        testCalendarAppliedTitleIncludesRecordingDate()
         print("NoteTitleResolutionTests passed")
     }
 
@@ -46,6 +47,15 @@ struct NoteTitleResolutionTests {
         let item = item(transcript: "", calendarMatch: match(title: "Calendar title", titleState: .applied), postProcessingStatus: "Error: Previous failure")
         let title = NoteTitleResolver.displayTitle(for: item, customTitle: nil, isTranscribing: true)
         assert(title == "Calendar title")
+    }
+
+    private static func testCalendarAppliedTitleIncludesRecordingDate() {
+        let recordingStartedAt = Date(timeIntervalSince1970: 1_746_422_400)
+        let title = NoteTitleResolver.calendarAppliedTitle(
+            suggestedTitle: "Team Standup",
+            recordingStartedAt: recordingStartedAt
+        )
+        assert(title == "2025-05-05 Team Standup")
     }
 
     private static func item(transcript: String, calendarMatch: CalendarEventMatch?, postProcessingStatus: String = "Post-processing succeeded") -> PipelineHistoryItem {

--- a/Tests/NoteTitleResolutionTests.swift
+++ b/Tests/NoteTitleResolutionTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+@main
+struct NoteTitleResolutionTests {
+    static func main() {
+        testCustomTitleWins()
+        testAppliedCalendarTitleWinsOverTranscriptTitle()
+        testSuggestedCalendarTitleDoesNotOverrideTranscriptTitle()
+        testFallbackUsedWhenNoContentOrAppliedCalendarTitle()
+        testTranscribingFallbackWinsOverFailedEmptyContent()
+        testAppliedCalendarTitleKeepsWinningWhileTranscribing()
+        print("NoteTitleResolutionTests passed")
+    }
+
+    private static func testCustomTitleWins() {
+        let item = item(transcript: "Transcript title", calendarMatch: match(title: "Calendar title", titleState: .applied))
+        let title = NoteTitleResolver.displayTitle(for: item, customTitle: "Manual title")
+        assert(title == "Manual title")
+    }
+
+    private static func testAppliedCalendarTitleWinsOverTranscriptTitle() {
+        let item = item(transcript: "Transcript title", calendarMatch: match(title: "Calendar title", titleState: .applied))
+        let title = NoteTitleResolver.displayTitle(for: item, customTitle: nil)
+        assert(title == "Calendar title")
+    }
+
+    private static func testSuggestedCalendarTitleDoesNotOverrideTranscriptTitle() {
+        let item = item(transcript: "Transcript title", calendarMatch: match(title: "Calendar title", titleState: .suggested))
+        let title = NoteTitleResolver.displayTitle(for: item, customTitle: nil)
+        assert(title == "Transcript title")
+    }
+
+    private static func testFallbackUsedWhenNoContentOrAppliedCalendarTitle() {
+        let item = item(transcript: "", calendarMatch: nil)
+        let title = NoteTitleResolver.displayTitle(for: item, customTitle: nil)
+        assert(title == "(No content)")
+    }
+
+    private static func testTranscribingFallbackWinsOverFailedEmptyContent() {
+        let item = item(transcript: "", calendarMatch: nil, postProcessingStatus: "Error: Previous failure")
+        let title = NoteTitleResolver.displayTitle(for: item, customTitle: nil, isTranscribing: true)
+        assert(title == "Transcribing...")
+    }
+
+    private static func testAppliedCalendarTitleKeepsWinningWhileTranscribing() {
+        let item = item(transcript: "", calendarMatch: match(title: "Calendar title", titleState: .applied), postProcessingStatus: "Error: Previous failure")
+        let title = NoteTitleResolver.displayTitle(for: item, customTitle: nil, isTranscribing: true)
+        assert(title == "Calendar title")
+    }
+
+    private static func item(transcript: String, calendarMatch: CalendarEventMatch?, postProcessingStatus: String = "Post-processing succeeded") -> PipelineHistoryItem {
+        PipelineHistoryItem(
+            timestamp: Date(timeIntervalSince1970: 1),
+            calendarMatch: calendarMatch,
+            rawTranscript: transcript,
+            postProcessedTranscript: transcript,
+            postProcessingPrompt: nil,
+            contextSummary: "",
+            contextPrompt: nil,
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "No screenshot",
+            postProcessingStatus: postProcessingStatus,
+            debugStatus: "Done",
+            customVocabulary: ""
+        )
+    }
+
+    private static func match(title: String, titleState: CalendarTitleState) -> CalendarEventMatch {
+        CalendarEventMatch(calendarID: "calendar", eventID: "event", title: title, start: Date(timeIntervalSince1970: 1), end: Date(timeIntervalSince1970: 2), matchSource: .overlapSuggestion, titleState: titleState)
+    }
+}

--- a/Tests/PipelineHistoryCalendarMetadataTests.swift
+++ b/Tests/PipelineHistoryCalendarMetadataTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+@main
+struct PipelineHistoryCalendarMetadataTests {
+    static func main() throws {
+        try testCalendarMetadataRoundTripsThroughPipelineHistoryItemCodable()
+        testCalendarMetadataCopyHelpersPreserveFields()
+        try testLegacyEncodedHistoryItemDecodesMissingCalendarMetadataAsNil()
+        try testCalendarMetadataPersistsThroughPipelineHistoryStore()
+        print("PipelineHistoryCalendarMetadataTests passed")
+    }
+
+    private static func testCalendarMetadataRoundTripsThroughPipelineHistoryItemCodable() throws {
+        let start = Date(timeIntervalSince1970: 1_800)
+        let end = Date(timeIntervalSince1970: 2_400)
+        let item = PipelineHistoryItem(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000057")!,
+            timestamp: Date(timeIntervalSince1970: 1_700),
+            recordingStartedAt: start,
+            recordingEndedAt: end,
+            calendarMatch: CalendarEventMatch(
+                accountID: "user@example.com",
+                calendarID: "calendar-1",
+                eventID: "event-1",
+                title: "Design Review",
+                start: start,
+                end: end,
+                attendees: [CalendarEventAttendee(displayName: "Ada Lovelace", email: "ada@example.com", responseStatus: "accepted", isOptional: false, isSelf: false)],
+                matchSource: .overlapSuggestion,
+                titleState: .suggested
+            ),
+            rawTranscript: "raw",
+            postProcessedTranscript: "processed",
+            postProcessingPrompt: nil,
+            contextSummary: "",
+            contextPrompt: nil,
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "No screenshot",
+            postProcessingStatus: "Post-processing succeeded",
+            debugStatus: "Done",
+            customVocabulary: ""
+        )
+        let data = try JSONEncoder().encode(item)
+        let decoded = try JSONDecoder().decode(PipelineHistoryItem.self, from: data)
+        assert(decoded.recordingStartedAt == start)
+        assert(decoded.recordingEndedAt == end)
+        assert(decoded.calendarMatch?.title == "Design Review")
+        assert(decoded.calendarMatch?.attendees.first?.email == "ada@example.com")
+        assert(decoded.calendarMatch?.titleState == .suggested)
+    }
+
+    private static func testCalendarMetadataCopyHelpersPreserveFields() {
+        let start = Date(timeIntervalSince1970: 3_000)
+        let end = Date(timeIntervalSince1970: 3_600)
+        let match = CalendarEventMatch(accountID: "user@example.com", calendarID: "calendar-2", eventID: "event-2", title: "Planning", start: start, end: end, matchSource: .overlapSuggestion, titleState: .suggested)
+        let placeholder = PipelineHistoryItem.transcriptionRecoveryPlaceholder(
+            timestamp: start,
+            recordingStartedAt: start,
+            recordingEndedAt: end,
+            calendarMatch: match,
+            intent: .dictation,
+            selectedText: nil,
+            capturedSelection: nil,
+            contextSummary: "",
+            contextSystemPrompt: nil,
+            contextPrompt: nil,
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "No screenshot",
+            systemPrompt: nil,
+            customVocabulary: "",
+            customSystemPrompt: "",
+            audioFileName: "audio.wav",
+            usedLocalTranscription: false,
+            usedContextCapture: false,
+            usedPostProcessing: true,
+            transcriptionLanguageCode: "ko",
+            localTranscriptionModelID: "mlx-community/whisper-large-v3-turbo",
+            contextAppName: nil,
+            contextBundleIdentifier: nil,
+            contextWindowTitle: nil
+        )
+        let interrupted = placeholder.markInterruptedBeforeCompletion()
+        assert(interrupted.recordingStartedAt == start)
+        assert(interrupted.recordingEndedAt == end)
+        assert(interrupted.calendarMatch == match)
+    }
+
+    private static func testLegacyEncodedHistoryItemDecodesMissingCalendarMetadataAsNil() throws {
+        let legacy = LegacyPipelineHistoryItem(
+            intent: .dictation,
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000059")!,
+            timestamp: Date(timeIntervalSince1970: 4_000),
+            rawTranscript: "raw",
+            postProcessedTranscript: "processed",
+            contextSummary: "",
+            contextScreenshotStatus: "No screenshot",
+            postProcessingStatus: "Post-processing succeeded",
+            debugStatus: "Done",
+            customVocabulary: "",
+            customSystemPrompt: "",
+            usedLocalTranscription: false,
+            usedContextCapture: true,
+            usedPostProcessing: true,
+            transcriptionLanguageCode: "ko",
+            localTranscriptionModelID: "mlx-community/whisper-large-v3-turbo"
+        )
+        let data = try JSONEncoder().encode(legacy)
+        let decoded = try JSONDecoder().decode(PipelineHistoryItem.self, from: data)
+        assert(decoded.recordingStartedAt == nil)
+        assert(decoded.recordingEndedAt == nil)
+        assert(decoded.calendarMatch == nil)
+    }
+
+    private static func testCalendarMetadataPersistsThroughPipelineHistoryStore() throws {
+        let store = PipelineHistoryStore(inMemory: true)
+        let recordingStart = Date(timeIntervalSince1970: 5_000)
+        let recordingEnd = Date(timeIntervalSince1970: 5_900)
+        let match = CalendarEventMatch(
+            accountID: "user@example.com",
+            calendarID: "calendar-3",
+            eventID: "event-3",
+            title: "Roadmap",
+            start: recordingStart,
+            end: recordingEnd,
+            attendees: [CalendarEventAttendee(displayName: "Grace Hopper", email: "grace@example.com", responseStatus: "tentative", isOptional: true, isSelf: false)],
+            matchSource: .overlapSuggestion,
+            titleState: .suggested
+        )
+        let item = PipelineHistoryItem(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000058")!,
+            timestamp: Date(timeIntervalSince1970: 4_900),
+            recordingStartedAt: recordingStart,
+            recordingEndedAt: recordingEnd,
+            calendarMatch: match,
+            rawTranscript: "raw",
+            postProcessedTranscript: "processed",
+            postProcessingPrompt: nil,
+            contextSummary: "",
+            contextPrompt: nil,
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "No screenshot",
+            postProcessingStatus: "Post-processing succeeded",
+            debugStatus: "Done",
+            customVocabulary: ""
+        )
+        _ = try store.append(item, maxCount: 10)
+        let loaded = store.loadAllHistory()
+        assert(loaded.count == 1)
+        assert(loaded[0].recordingStartedAt == recordingStart)
+        assert(loaded[0].recordingEndedAt == recordingEnd)
+        assert(loaded[0].calendarMatch == match)
+    }
+
+    private struct LegacyPipelineHistoryItem: Encodable {
+        let intent: PipelineHistoryItemIntent
+        let id: UUID
+        let timestamp: Date
+        let rawTranscript: String
+        let postProcessedTranscript: String
+        let contextSummary: String
+        let contextScreenshotStatus: String
+        let postProcessingStatus: String
+        let debugStatus: String
+        let customVocabulary: String
+        let customSystemPrompt: String
+        let usedLocalTranscription: Bool
+        let usedContextCapture: Bool
+        let usedPostProcessing: Bool
+        let transcriptionLanguageCode: String
+        let localTranscriptionModelID: String
+    }
+}

--- a/docs/superpowers/specs/2026-05-04-google-calendar-meeting-title-design.md
+++ b/docs/superpowers/specs/2026-05-04-google-calendar-meeting-title-design.md
@@ -1,0 +1,250 @@
+# Google Calendar meeting note title design
+
+## Summary
+
+Add Google Calendar integration so Quill can use calendar events as optional meeting-note metadata. The first implementation connects one Google account, lets the user choose which calendars to use, matches selected calendar events against recording intervals, and surfaces matched event titles as note title suggestions. Calendar data must not be fed into dictation post-processing context.
+
+## Goals
+
+- Add explicit persisted recording start and stop timestamps.
+- Connect Google Calendar through a native desktop OAuth flow with PKCE.
+- Let the user choose the calendars used for matching.
+- Match selected calendar events to recording intervals by overlap duration.
+- Store matched event metadata needed for note titles, future reminders, and attendee-aware note metadata.
+- Keep calendar integration suggestion-oriented unless a future calendar reminder explicitly starts the recording.
+
+## Non-goals
+
+- Calendar-based recording reminders in the first implementation.
+- Calendar event editing.
+- Multi-account Google support in the first implementation.
+- Hosted backend support.
+- Feeding calendar event details into LLM post-processing context.
+- Storing event descriptions, locations, meeting links, attachments, or attendee comments.
+
+## User experience
+
+### Settings
+
+Add a Calendar section to Settings.
+
+- Show Google Calendar connection state.
+- Provide Connect and Disconnect actions.
+- Provide a calendar list refresh action.
+- Show the connected account identity when available.
+- Show calendars as checkboxes.
+- Select no calendars by default after connection.
+- Use only explicitly selected calendars for event matching.
+
+The first version supports one connected Google account. The settings shape should still be compatible with a future multi-account model by treating selected calendars as account-scoped calendar IDs internally.
+
+### Note titles
+
+Calendar title behavior depends on how the recording started.
+
+- Future calendar-notification recordings: the event is an explicit user-selected recording source, so the event title may be applied automatically.
+- Normal shortcut, menu, or MCP recordings: a time-overlapping event is only a suggested title.
+- User-edited titles always win and are never overwritten by calendar metadata.
+- If Calendar is disconnected, no calendars are selected, no interval exists, or no matching event exists, existing transcript-based title and fallback behavior remains unchanged.
+
+Suggested titles should be shown in the note detail UI with an Apply action. Applying a suggested calendar title stores it as the note's user-confirmed title so later calendar changes do not unexpectedly alter the note title.
+
+## Data model
+
+Add optional fields to persisted pipeline history items.
+
+- `recordingStartedAt: Date?`
+  - The actual microphone recording start time.
+  - Not the shortcut/request time or permission-check start time.
+- `recordingEndedAt: Date?`
+  - The time the user requested recording stop.
+  - Not the audio-file-ready or transcription-complete time.
+- `calendarMatch: CalendarEventMatch?`
+  - `accountID: String?`
+  - `calendarID: String`
+  - `eventID: String`
+  - `title: String`
+  - `start: Date`
+  - `end: Date`
+  - `attendees: [CalendarEventAttendee]`
+  - `matchSource: CalendarMatchSource`
+  - `titleState: CalendarTitleState`
+
+`CalendarMatchSource` values:
+
+- `overlapSuggestion`
+- `calendarNotification`
+
+`CalendarTitleState` values:
+
+- `suggested`
+- `applied`
+
+`CalendarEventAttendee` stores a minimal snapshot.
+
+- `displayName: String?`
+- `email: String?`
+- `responseStatus: String?`
+- `isOptional: Bool`
+- `isSelf: Bool`
+
+Do not store event description, location, Meet links, attachments, or attendee comments. Existing history entries must load with all new fields unset. Imported audio remains excluded from calendar matching unless a reliable recording interval exists.
+
+Nested calendar match metadata should be persisted as Codable JSON on the history item rather than as separate Core Data entities. The metadata is a point-in-time snapshot attached to a note, and separate entities would add migration and query complexity without helping the first feature.
+
+## Services
+
+### `GoogleCalendarAuthService`
+
+Responsible for Google OAuth.
+
+- Generate PKCE verifier and challenge.
+- Build the authorization URL.
+- Open the user's browser for consent.
+- Receive a local loopback callback with the authorization code.
+- Exchange the code and verifier for access and refresh tokens.
+- Refresh access tokens as needed.
+- Delete tokens when the user disconnects.
+
+Prefer loopback callback over a custom URL scheme for the first implementation because it avoids app URL scheme registration and fits native desktop OAuth.
+
+### `GoogleCalendarService`
+
+Responsible for Calendar API reads.
+
+- Fetch the user's calendar list.
+- Fetch events for selected calendar IDs over a recording interval.
+- Use read-only scopes only.
+- Use `singleEvents=true` so recurring meetings are evaluated as individual instances.
+- Request only fields needed for matching and metadata.
+- Exclude all-day events.
+- Exclude private or otherwise unusable events that do not expose a title.
+- Decode attendees only into the minimal snapshot fields.
+
+### `CalendarEventMatcher`
+
+Responsible for deterministic matching.
+
+- Take a recording start/end interval and candidate events.
+- Ignore candidates with no positive overlap.
+- Choose the event with the longest overlap duration.
+- If overlap duration ties, choose the event whose start is closest to the recording start.
+- Return no match if no usable candidate remains.
+
+## Recording and note flow
+
+1. Capture `recordingStartedAt` when microphone recording actually begins.
+2. Capture `recordingEndedAt` when the user requests stop.
+3. Continue audio save and transcription even if Calendar is unavailable.
+4. When creating the final history item, attempt calendar matching only if:
+   - Calendar is connected,
+   - at least one calendar is selected,
+   - both recording timestamps exist, and
+   - the item is not imported audio without a reliable interval.
+5. Fetch events from selected calendars for the recording interval.
+6. Match by overlap duration.
+7. Store `calendarMatch` if a match exists.
+8. Set `titleState` to `suggested` for normal recordings.
+9. Reserve `calendarNotification` + `applied` for the future reminder-start flow.
+
+Calendar API failures must not block note creation or transcription completion.
+
+## Title display priority
+
+Use this priority order when rendering note titles:
+
+1. User-confirmed custom title.
+2. Applied calendar title.
+3. Existing transcript-based automatic title.
+4. Existing fallback title.
+
+Suggested calendar titles do not automatically change the rendered title. They appear as a suggestion with an Apply action. Apply writes the title through the existing user-title path so the user has explicit control.
+
+## OAuth, scopes, and storage
+
+Use a native desktop OAuth client with PKCE.
+
+- Store OAuth tokens in macOS Keychain.
+- Store selected calendar IDs and non-secret connection metadata outside Keychain.
+- On disconnect, delete Keychain token items and clear selected calendar IDs.
+- On refresh failure or revoked access, mark Calendar disconnected and skip matching.
+
+Request only read-only Google Calendar scopes needed to list calendars and read event details. The preferred narrow scope pair is:
+
+- `https://www.googleapis.com/auth/calendar.calendarlist.readonly` for calendar list selection.
+- `https://www.googleapis.com/auth/calendar.events.readonly` for reading event title, time, and attendee snapshots.
+
+If the narrow pair proves insufficient during manual OAuth verification, use `https://www.googleapis.com/auth/calendar.readonly` as the read-only fallback. Do not request event write scopes.
+
+## Error handling
+
+Calendar integration is auxiliary.
+
+- Not connected: skip matching.
+- No selected calendars: skip matching and show setup guidance in Settings.
+- Access token expired: refresh and retry.
+- Refresh failure or revoked access: disconnect Calendar state and skip matching.
+- One calendar fails: skip that calendar and use events from calendars that succeeded.
+- All calendar requests fail: complete the note without a suggestion.
+- All-day events: exclude.
+- Titleless events: exclude.
+- Missing recording interval: skip matching.
+
+A last Calendar error can be shown in Settings for troubleshooting, but the recording flow should not surface blocking alerts for calendar failures.
+
+## Testing
+
+### Unit tests
+
+Add tests for `CalendarEventMatcher`.
+
+- Selects the candidate with the longest positive overlap.
+- Excludes zero-overlap events.
+- Excludes all-day events.
+- Applies the tie-break by start-time distance to recording start.
+- Excludes titleless events.
+
+Add persistence tests for history metadata.
+
+- Existing history entries load when new optional fields are absent.
+- Recording start/end timestamps persist and reload.
+- Calendar match metadata persists and reloads.
+- Minimal attendee snapshots persist and reload.
+
+Add title behavior tests.
+
+- User custom title overrides calendar titles.
+- Applied calendar title is used before transcript-based auto title.
+- Suggested calendar title does not override the displayed title.
+- Applying a suggestion stores a user-confirmed title.
+
+### Service boundary tests
+
+Use fake transports for Calendar API and OAuth boundaries.
+
+- Calendar list responses decode into selectable calendars.
+- Event responses decode only required fields.
+- Partial calendar request failures do not fail the whole matching attempt.
+- Token refresh failure marks Calendar disconnected.
+
+### Manual verification
+
+Use a Google Cloud OAuth desktop client in Testing mode with the owner account as a test user.
+
+- Connect Google Calendar from Settings.
+- Verify no calendars are selected by default.
+- Select a calendar and record during a timed meeting event.
+- Confirm the event appears as a suggested title for normal recording.
+- Apply the suggestion and confirm the title stays user-controlled.
+- Confirm all-day events do not become suggestions.
+- Disconnect Calendar and confirm matching is skipped.
+
+## Future reminder extension
+
+The design keeps space for calendar-based recording prompts without implementing them now.
+
+- Selected calendars can later gain reminder settings.
+- `calendarMatch.accountID/calendarID/eventID` can identify the event that launched a recording.
+- `matchSource = calendarNotification` can distinguish explicit reminder-start recordings from inferred overlap suggestions.
+- `titleState = applied` can be used when a user starts recording from a calendar notification.
+- Attendee snapshots can later support note metadata or export frontmatter, still without feeding calendar details into LLM post-processing by default.


### PR DESCRIPTION
## Summary
- Add Google Calendar-driven note title suggestions and apply titles with the recording date prefix.
- Move Calendar into its own Settings tab, place it after Appearance, and group calendars into My calendars and Shared calendars.
- Improve Calendar connection controls with cancelable OAuth reconnects and stored-token calendar loading.

## Test plan
- [x] `make test`
- [x] `make all APP_NAME="Quill Dev" BUNDLE_ID="com.woosublee.quill.dev" CODESIGN_IDENTITY="Apple Development: ..."`
- [x] `make run APP_NAME="Quill Dev" BUNDLE_ID="com.woosublee.quill.dev" CODESIGN_IDENTITY="Apple Development: ..."`

## Follow-up
- #60 tracks replacing manual Google OAuth client credential entry with a simpler Google account sign-in flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)