### PR TITLE
Simplify Google Calendar OAuth sign-in

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -22,6 +22,10 @@
     <string>13.0</string>
     <key>LSUIElement</key>
     <true/>
+    <key>GoogleCalendarOAuthClientID</key>
+    <string></string>
+    <key>GoogleCalendarOAuthClientSecret</key>
+    <string></string>
     <key>NSMicrophoneUsageDescription</key>
     <string>Quill needs microphone access to transcribe your speech.</string>
     <key>NSSpeechRecognitionUsageDescription</key>

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,13 @@ BUNDLE_ID ?= com.woosublee.quill
 BUILD_DIR = build
 APP_BUNDLE = $(BUILD_DIR)/$(APP_NAME).app
 CODESIGN_IDENTITY ?= Quill
+GOOGLE_CALENDAR_OAUTH_CLIENT_ID ?=
+GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET ?=
+-include $(HOME)/.config/quill/oauth.env
+-include .env
 CONTENTS = $(APP_BUNDLE)/Contents
 MACOS_DIR = $(CONTENTS)/MacOS
+BUILD_SETTINGS = $(BUILD_DIR)/.build-settings
 empty :=
 space := $(empty) $(empty)
 APP_EXECUTABLE = $(MACOS_DIR)/$(APP_NAME)
@@ -26,11 +31,16 @@ ICON_ICNS = Resources/AppIcon.icns
 endif
 
 # Usage: make install CODESIGN_IDENTITY="Apple Development: you@example.com (TEAMID)"
-.PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run test
+.PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run test FORCE
 
 all: $(APP_EXECUTABLE_TARGET)
 
-$(APP_EXECUTABLE_TARGET): $(SOURCES) Info.plist $(ICON_ICNS)
+$(BUILD_SETTINGS): FORCE
+	@mkdir -p "$(BUILD_DIR)"
+	@printf '%s\n%s\n%s\n%s\n' "$(APP_NAME)" "$(BUNDLE_ID)" "$(GOOGLE_CALENDAR_OAUTH_CLIENT_ID)" "$(GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET)" > "$@.tmp"
+	@if [ ! -f "$@" ] || ! cmp -s "$@.tmp" "$@"; then mv "$@.tmp" "$@"; else rm "$@.tmp"; fi
+
+$(APP_EXECUTABLE_TARGET): $(SOURCES) Info.plist $(ICON_ICNS) $(BUILD_SETTINGS)
 	@mkdir -p "$(MACOS_DIR)" "$(RESOURCES)"
 ifeq ($(ARCH),universal)
 	swiftc \
@@ -62,6 +72,8 @@ endif
 	@plutil -replace CFBundleDisplayName -string "$(APP_NAME)" "$(CONTENTS)/Info.plist"
 	@plutil -replace CFBundleExecutable -string "$(APP_NAME)" "$(CONTENTS)/Info.plist"
 	@plutil -replace CFBundleIdentifier -string "$(BUNDLE_ID)" "$(CONTENTS)/Info.plist"
+	@plutil -replace GoogleCalendarOAuthClientID -string "$(GOOGLE_CALENDAR_OAUTH_CLIENT_ID)" "$(CONTENTS)/Info.plist"
+	@plutil -replace GoogleCalendarOAuthClientSecret -string "$(GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET)" "$(CONTENTS)/Info.plist"
 	@cp $(ICON_ICNS) "$(RESOURCES)/"
 	@xattr -cr "$(APP_BUNDLE)"
 	@rm -rf "$(BUILD_DIR)/codesign-staging"
@@ -144,6 +156,8 @@ install-and-run: install
 
 run: all
 	open "$(APP_BUNDLE)"
+
+FORCE:
 
 test:
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/CalendarEventMatcher.swift Tests/CalendarEventMatcherTests.swift -o /tmp/CalendarEventMatcherTests

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -713,7 +713,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         guard !isGoogleCalendarBusy else { return }
         let oauthConfiguration = googleCalendarOAuthConfiguration
         guard oauthConfiguration.isConfigured else {
-            googleCalendarConnection.lastErrorMessage = "Google Calendar sign-in is not configured. Add a client ID in Advanced settings."
+            googleCalendarConnection.lastErrorMessage = "Google Calendar sign-in is not configured. Bundled credentials are used by default; to use custom credentials, add both a client ID and client secret in Advanced settings."
             return
         }
         let clientID = oauthConfiguration.clientID
@@ -1285,7 +1285,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let oauthConfiguration = await MainActor.run {
             googleCalendarOAuthConfiguration
         }
-        guard oauthConfiguration.isConfigured else { return token }
+        guard oauthConfiguration.isConfigured else { return nil }
         if token.needsRefresh {
             token = try await GoogleCalendarAuthService.refreshToken(
                 clientID: oauthConfiguration.clientID,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -488,6 +488,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published private(set) var isGoogleCalendarBusy = false
     @Published private(set) var hasPendingGoogleCalendarOAuthConnection = false
 
+    private var builtInGoogleCalendarClientID: String {
+        Bundle.main.object(forInfoDictionaryKey: "GoogleCalendarOAuthClientID") as? String ?? ""
+    }
+
+    private var builtInGoogleCalendarClientSecret: String {
+        Bundle.main.object(forInfoDictionaryKey: "GoogleCalendarOAuthClientSecret") as? String ?? ""
+    }
+
     @Published var preserveClipboard: Bool {
         didSet {
             UserDefaults.standard.set(preserveClipboard, forKey: preserveClipboardStorageKey)
@@ -655,6 +663,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
+    var googleCalendarOAuthConfiguration: GoogleCalendarOAuthConfiguration {
+        GoogleCalendarOAuthConfiguration(
+            builtInClientID: builtInGoogleCalendarClientID,
+            builtInClientSecret: builtInGoogleCalendarClientSecret,
+            customClientID: googleCalendarClientID,
+            customClientSecret: googleCalendarClientSecret
+        )
+    }
+
+    @MainActor
     func disconnectGoogleCalendar() {
         cancelGoogleCalendarConnection()
         clearGoogleCalendarConnectionState()
@@ -693,12 +711,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @MainActor
     func connectGoogleCalendar() {
         guard !isGoogleCalendarBusy else { return }
-        let clientID = googleCalendarClientID.trimmingCharacters(in: .whitespacesAndNewlines)
-        let clientSecret = googleCalendarClientSecret.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !clientID.isEmpty else {
-            googleCalendarConnection.lastErrorMessage = "Enter a Google OAuth Desktop client ID first."
+        let oauthConfiguration = googleCalendarOAuthConfiguration
+        guard oauthConfiguration.isConfigured else {
+            googleCalendarConnection.lastErrorMessage = "Google Calendar sign-in is not configured. Add a client ID in Advanced settings."
             return
         }
+        let clientID = oauthConfiguration.clientID
+        let clientSecret = oauthConfiguration.clientSecret
         isGoogleCalendarBusy = true
         hasPendingGoogleCalendarOAuthConnection = true
         googleCalendarConnection.lastErrorMessage = nil
@@ -1263,17 +1282,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func validGoogleCalendarToken() async throws -> GoogleCalendarOAuthToken? {
         guard var token = GoogleCalendarTokenStore.load() else { return nil }
-        let clientCredentials = await MainActor.run {
-            (
-                googleCalendarClientID.trimmingCharacters(in: .whitespacesAndNewlines),
-                googleCalendarClientSecret.trimmingCharacters(in: .whitespacesAndNewlines)
-            )
+        let oauthConfiguration = await MainActor.run {
+            googleCalendarOAuthConfiguration
         }
-        guard !clientCredentials.0.isEmpty else { return token }
+        guard oauthConfiguration.isConfigured else { return token }
         if token.needsRefresh {
             token = try await GoogleCalendarAuthService.refreshToken(
-                clientID: clientCredentials.0,
-                clientSecret: clientCredentials.1,
+                clientID: oauthConfiguration.clientID,
+                clientSecret: oauthConfiguration.clientSecret,
                 token: token
             )
             try GoogleCalendarTokenStore.save(token)

--- a/Sources/CalendarIntegrationModels.swift
+++ b/Sources/CalendarIntegrationModels.swift
@@ -206,3 +206,43 @@ struct GoogleCalendarConnectionControls: Equatable {
         isConnected && !isBusy
     }
 }
+
+struct GoogleCalendarOAuthConfiguration: Equatable {
+    let builtInClientID: String
+    let builtInClientSecret: String
+    let customClientID: String
+    let customClientSecret: String
+
+    private var trimmedBuiltInClientID: String {
+        builtInClientID.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedBuiltInClientSecret: String {
+        builtInClientSecret.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedCustomClientID: String {
+        customClientID.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedCustomClientSecret: String {
+        customClientSecret.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var usesCustomCredentials: Bool {
+        !trimmedCustomClientID.isEmpty
+    }
+
+    var clientID: String {
+        usesCustomCredentials ? trimmedCustomClientID : trimmedBuiltInClientID
+    }
+
+    var clientSecret: String {
+        guard isConfigured else { return "" }
+        return usesCustomCredentials ? trimmedCustomClientSecret : trimmedBuiltInClientSecret
+    }
+
+    var isConfigured: Bool {
+        !clientID.isEmpty
+    }
+}

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -595,6 +595,7 @@ struct AppearanceSettingsView: View {
 
 struct CalendarSettingsView: View {
     @EnvironmentObject var appState: AppState
+    @State private var showsAdvancedGoogleCalendarSettings = false
 
     private var connectionControls: GoogleCalendarConnectionControls {
         appState.googleCalendarConnectionControls
@@ -621,19 +622,15 @@ struct CalendarSettingsView: View {
     private var googleCalendarSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             VStack(alignment: .leading, spacing: 6) {
-                Text("Google OAuth Desktop client ID")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                TextField("client-id.apps.googleusercontent.com", text: $appState.googleCalendarClientID)
-                    .textFieldStyle(.roundedBorder)
-                Text("Google OAuth client secret")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                SecureField("Optional for some Google OAuth clients", text: $appState.googleCalendarClientSecret)
-                    .textFieldStyle(.roundedBorder)
-                Text("Create a Google Cloud OAuth client for a desktop app, then paste its client ID. If Google reports that client_secret is missing, paste the client secret from the same credentials screen.")
+                Text("Connect your Google account to let Quill suggest note titles from matching calendar events.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                if !appState.googleCalendarOAuthConfiguration.isConfigured {
+                    Text("Google Calendar sign-in is not configured. Add a Google OAuth Desktop client ID in Advanced settings.")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
 
             HStack(spacing: 8) {
@@ -675,6 +672,27 @@ struct CalendarSettingsView: View {
                 }
                 .disabled(!connectionControls.allowsDisconnect)
             }
+
+            DisclosureGroup("Advanced OAuth credentials", isExpanded: $showsAdvancedGoogleCalendarSettings) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Use custom Google OAuth Desktop app credentials for development or personal testing. Leave these empty to use the built-in app configuration.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text("Google OAuth Desktop client ID")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    TextField("client-id.apps.googleusercontent.com", text: $appState.googleCalendarClientID)
+                        .textFieldStyle(.roundedBorder)
+                    Text("Google OAuth client secret")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    SecureField("Optional for some Google OAuth clients", text: $appState.googleCalendarClientSecret)
+                        .textFieldStyle(.roundedBorder)
+                }
+                .padding(.top, 6)
+            }
+            .font(.caption.weight(.semibold))
 
             if let error = appState.googleCalendarConnection.lastErrorMessage, !error.isEmpty {
                 Text(error)

--- a/Tests/GoogleCalendarServiceTests.swift
+++ b/Tests/GoogleCalendarServiceTests.swift
@@ -10,6 +10,9 @@ struct GoogleCalendarServiceTests {
         try await testLoopbackReceiverUsesAssignedPort()
         try await testTokenExchangeSurfacesGoogleErrorResponse()
         testClientSecretMissingMessageExplainsClientTypeMismatch()
+        testOAuthConfigurationUsesCustomCredentialsFirst()
+        testOAuthConfigurationFallsBackToBuiltInCredentials()
+        testOAuthConfigurationReportsMissingClientID()
         try await testTokenExchangeOmitsClientSecret()
         try await testTokenExchangeIncludesClientSecretWhenProvided()
         try await testRefreshTokenOmitsClientSecret()
@@ -120,6 +123,48 @@ struct GoogleCalendarServiceTests {
 
         assert(error.localizedDescription.contains("web OAuth client"))
         assert(error.localizedDescription.contains("Desktop app client"))
+    }
+
+    private static func testOAuthConfigurationUsesCustomCredentialsFirst() {
+        let configuration = GoogleCalendarOAuthConfiguration(
+            builtInClientID: "built-in.apps.googleusercontent.com",
+            builtInClientSecret: "built-in-secret",
+            customClientID: " custom.apps.googleusercontent.com ",
+            customClientSecret: " secret-value "
+        )
+
+        assert(configuration.clientID == "custom.apps.googleusercontent.com")
+        assert(configuration.clientSecret == "secret-value")
+        assert(configuration.usesCustomCredentials)
+        assert(configuration.isConfigured)
+    }
+
+    private static func testOAuthConfigurationFallsBackToBuiltInCredentials() {
+        let configuration = GoogleCalendarOAuthConfiguration(
+            builtInClientID: " built-in.apps.googleusercontent.com ",
+            builtInClientSecret: " built-in-secret ",
+            customClientID: " ",
+            customClientSecret: " secret-value "
+        )
+
+        assert(configuration.clientID == "built-in.apps.googleusercontent.com")
+        assert(configuration.clientSecret == "built-in-secret")
+        assert(!configuration.usesCustomCredentials)
+        assert(configuration.isConfigured)
+    }
+
+    private static func testOAuthConfigurationReportsMissingClientID() {
+        let configuration = GoogleCalendarOAuthConfiguration(
+            builtInClientID: " ",
+            builtInClientSecret: " built-in-secret ",
+            customClientID: " ",
+            customClientSecret: " secret-value "
+        )
+
+        assert(configuration.clientID.isEmpty)
+        assert(configuration.clientSecret == "")
+        assert(!configuration.usesCustomCredentials)
+        assert(!configuration.isConfigured)
     }
 
     private static func testTokenExchangeOmitsClientSecret() async throws {


### PR DESCRIPTION
## Summary
- Add bundled Google Calendar OAuth credential resolution with custom Advanced credentials still taking priority.
- Inject Google Calendar OAuth client ID and secret into the built app from local build settings without committing real values.
- Simplify Calendar settings so the default screen focuses on connecting Google Calendar, with custom OAuth fields hidden under Advanced.

## Google Cloud setup

Quill supports a normal Google sign-in style flow when `GoogleCalendarOAuthClientID` and `GoogleCalendarOAuthClientSecret` are present in the app bundle. To configure a build:

1. Create or select a Google Cloud project.
2. Enable the Google Calendar API.
3. Configure the OAuth consent screen.
4. Add scopes:
   - `https://www.googleapis.com/auth/calendar.calendarlist.readonly`
   - `https://www.googleapis.com/auth/calendar.events.readonly`
5. Create an OAuth client with application type `Desktop app`.
6. Store local build credentials outside the repo, for example in `~/.config/quill/oauth.env`:
   ```env
   GOOGLE_CALENDAR_OAUTH_CLIENT_ID=<client-id>.apps.googleusercontent.com
   GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET=<client-secret>
   ```
7. Build Quill normally; the Makefile reads the local env file and injects the values into the app bundle.
8. For Testing publishing status, add the Google account as a test user.

Advanced custom credentials remain available in Calendar settings for development and personal testing.

## Test plan
- [x] `make test`
- [x] `git diff --check`
- [x] Build `Quill Dev` with local OAuth env values and verify client ID/secret are injected without printing the secret.
- [x] Launch `Quill Dev` and confirm the process is running.
- [x] Manually verify Google Calendar OAuth succeeds with a Desktop OAuth client ID and secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 설정에서 고급 Google Calendar OAuth 자격증명 옵션을 접을 수 있는 토글 추가
  * 기본 제공 OAuth 자격증명과 사용자 정의 자격증명 모두 지원

* **버그 수정**
  * Google Calendar 인증 구성 처리 안정성 개선

* **테스트**
  * OAuth 자격증명 구성 검증 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->