### PR TITLE
Polish language settings behavior

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -110,6 +110,7 @@ private struct RetrySnapshot {
     let useLocalTranscription: Bool
     let customVocabulary: String
     let customSystemPrompt: String
+    let outputLanguage: String
     let postProcessingEnabled: Bool
     let localWhisperPath: String?
 }
@@ -230,6 +231,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let disableAutoPasteStorageKey = "disable_auto_paste"
     private let disablePostProcessingStorageKey = "disable_post_processing"
     private let transcriptionLanguageStorageKey = "transcription_language"
+    private let outputLanguageStorageKey = "output_language"
     private let localTranscriptionModelStorageKey = AppState.localTranscriptionModelStorageKeyName
     private let noteBrowserEnabledStorageKey = "note_browser_enabled"
     private let commandModeEnabledStorageKey = "command_mode_enabled"
@@ -553,6 +555,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var transcriptionLanguage: TranscriptionLanguage {
         didSet {
             UserDefaults.standard.set(transcriptionLanguage.code, forKey: transcriptionLanguageStorageKey)
+        }
+    }
+
+    @Published var outputLanguage: String {
+        didSet {
+            UserDefaults.standard.set(outputLanguage, forKey: outputLanguageStorageKey)
         }
     }
 
@@ -955,6 +963,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let transcriptionLanguage = TranscriptionLanguage.find(
             code: UserDefaults.standard.string(forKey: transcriptionLanguageStorageKey) ?? "ko"
         )
+        let outputLanguage = UserDefaults.standard.string(forKey: outputLanguageStorageKey) ?? ""
         let localTranscriptionModel = TranscriptionModel.find(
             id: UserDefaults.standard.string(forKey: localTranscriptionModelStorageKey) ?? TranscriptionModel.default.id
         )
@@ -1052,6 +1061,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.disablePostProcessing = disablePostProcessing
         self.noteBrowserEnabled = noteBrowserEnabled
         self.transcriptionLanguage = transcriptionLanguage
+        self.outputLanguage = outputLanguage
         self.localTranscriptionModel = localTranscriptionModel
         self.soundVolume = soundVolume
         self.voiceMacros = initialMacros
@@ -1693,6 +1703,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let capturedTranscriptionModel = transcriptionModel
         let capturedCustomVocabulary = customVocabulary
         let capturedCustomSystemPrompt = customSystemPrompt
+        let capturedOutputLanguage = outputLanguage
         let capturedPostProcessingEnabled = !disablePostProcessing
         let capturedPressEnterCommandEnabled = isPressEnterVoiceCommandEnabled
 
@@ -1731,6 +1742,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     postProcessingService: postProcessingService,
                     customVocabulary: capturedCustomVocabulary,
                     customSystemPrompt: capturedCustomSystemPrompt,
+                    outputLanguage: capturedOutputLanguage,
                     postProcessingEnabled: capturedPostProcessingEnabled
                 )
                 let processingStatus = Self.statusMessage(
@@ -1792,6 +1804,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         postProcessingService: PostProcessingService,
         customVocabulary: String,
         customSystemPrompt: String,
+        outputLanguage: String,
         postProcessingEnabled: Bool
     ) async -> (finalTranscript: String, outcome: TranscriptProcessingOutcome, prompt: String) {
         let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1809,7 +1822,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 transcript: trimmedRawTranscript,
                 context: context,
                 customVocabulary: customVocabulary,
-                customSystemPrompt: customSystemPrompt
+                customSystemPrompt: customSystemPrompt,
+                outputLanguage: outputLanguage
             )
             return (result.transcript, .postProcessingSucceeded, result.prompt)
         } catch {
@@ -1941,6 +1955,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             useLocalTranscription: configuration.useLocalTranscription,
             customVocabulary: item.customVocabulary,
             customSystemPrompt: item.customSystemPrompt,
+            outputLanguage: outputLanguage,
             postProcessingEnabled: item.usedPostProcessing,
             localWhisperPath: localWhisperPath.isEmpty ? nil : localWhisperPath
         )
@@ -2000,7 +2015,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     selectedText: selectedText,
                     voiceCommand: rawTranscript,
                     context: snapshot.restoredContext,
-                    customVocabulary: snapshot.customVocabulary
+                    customVocabulary: snapshot.customVocabulary,
+                    outputLanguage: snapshot.outputLanguage
                 )
                 return (result.transcript, .commandModeSucceeded(invocation: invocation), result.prompt)
             } catch {
@@ -2023,7 +2039,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 transcript: trimmedRawTranscript,
                 context: snapshot.restoredContext,
                 customVocabulary: snapshot.customVocabulary,
-                customSystemPrompt: snapshot.customSystemPrompt
+                customSystemPrompt: snapshot.customSystemPrompt,
+                outputLanguage: snapshot.outputLanguage
             )
             return (result.transcript, .postProcessingSucceeded, result.prompt)
         } catch {
@@ -3498,7 +3515,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         context: AppContext,
         postProcessingService: PostProcessingService,
         customVocabulary: String,
-        customSystemPrompt: String
+        customSystemPrompt: String,
+        outputLanguage: String
     ) async -> (finalTranscript: String, outcome: TranscriptProcessingOutcome, prompt: String) {
         let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -3512,7 +3530,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     selectedText: selectedText,
                     voiceCommand: rawTranscript,
                     context: context,
-                    customVocabulary: customVocabulary
+                    customVocabulary: customVocabulary,
+                    outputLanguage: outputLanguage
                 )
                 return (result.transcript, .commandModeSucceeded(invocation: invocation), result.prompt)
             } catch {
@@ -3535,7 +3554,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 transcript: trimmedRawTranscript,
                 context: context,
                 customVocabulary: customVocabulary,
-                customSystemPrompt: customSystemPrompt
+                customSystemPrompt: customSystemPrompt,
+                outputLanguage: outputLanguage
             )
             return (result.transcript, .postProcessingSucceeded, result.prompt)
         } catch {
@@ -3638,6 +3658,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let capturedTranscriptionModel = transcriptionModel
         let capturedCustomVocabulary = customVocabulary
         let capturedCustomSystemPrompt = customSystemPrompt
+        let capturedOutputLanguage = outputLanguage
         let capturedLiveTranscriber = liveTranscriber
         let capturedPressEnterCommandEnabled = isPressEnterVoiceCommandEnabled
         liveTranscriber = nil
@@ -3740,7 +3761,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         context: appContext,
                         postProcessingService: postProcessingService,
                         customVocabulary: capturedCustomVocabulary,
-                        customSystemPrompt: capturedCustomSystemPrompt
+                        customSystemPrompt: capturedCustomSystemPrompt,
+                        outputLanguage: capturedOutputLanguage
                     )
                     try Task.checkCancellation()
                     let trimmedRawTranscript = parsedTranscript.transcript
@@ -3935,7 +3957,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         context: appContext,
                         postProcessingService: postProcessingService,
                         customVocabulary: capturedCustomVocabulary,
-                        customSystemPrompt: capturedCustomSystemPrompt
+                        customSystemPrompt: capturedCustomSystemPrompt,
+                        outputLanguage: capturedOutputLanguage
                     )
                     try Task.checkCancellation()
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -799,11 +799,24 @@ struct GeneralSettingsView: View {
     @State private var customVocabularyInput: String = ""
     @State private var micPermissionGranted = false
     @State private var showMutedHint = false
+    @State private var advancedProviderSettingsExpanded = false
     @State private var copiedBuildInfo = false
     @State private var copiedBuildInfoResetWorkItem: DispatchWorkItem?
     @StateObject private var githubCache = GitHubMetadataCache.shared
     @ObservedObject private var updateManager = UpdateManager.shared
     private let upstreamRepoURL = URL(string: "https://github.com/zachlatta/freeflow")!
+
+    private static let outputLanguageOptions: [(label: String, value: String)] = [
+        ("Same as spoken language", ""),
+        ("English", "English"),
+        ("한국어", "Korean"),
+        ("日本語", "Japanese"),
+        ("中文", "Chinese"),
+        ("Español", "Spanish"),
+        ("Français", "French"),
+        ("Deutsch", "German"),
+        ("Português", "Portuguese"),
+    ]
 
     private var appDisplayName: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
@@ -969,6 +982,9 @@ struct GeneralSettingsView: View {
                 // }
                 SettingsCard("Transcription", icon: "waveform.badge.magnifyingglass") {
                     transcriptionSection
+                }
+                SettingsCard("Language", icon: "globe") {
+                    languageSettings
                 }
                 SettingsCard("Dictation Shortcuts", icon: "keyboard.fill") {
                     hotkeySection
@@ -1270,19 +1286,6 @@ struct GeneralSettingsView: View {
             }
 
             VStack(alignment: .leading, spacing: 4) {
-                Text("Transcription Language")
-                    .font(.caption.weight(.semibold))
-                Picker("", selection: $appState.transcriptionLanguage) {
-                    ForEach(TranscriptionLanguage.all) { lang in
-                        Text(lang.displayName).tag(lang)
-                    }
-                }
-                .labelsHidden()
-                .pickerStyle(.menu)
-                .frame(maxWidth: 200, alignment: .leading)
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
                 Text("mlx_whisper Path (optional)")
                     .font(.caption.weight(.semibold))
                 Text("Leave empty to use the default path (~/.local/bin/mlx_whisper).")
@@ -1330,14 +1333,74 @@ struct GeneralSettingsView: View {
                     .font(.caption)
             }
 
-            ProviderSettingsFields(
-                apiBaseURLInput: $apiBaseURLInput,
-                transcriptionAPIURLInput: $transcriptionAPIURLInput,
-                transcriptionAPIKeyInput: $transcriptionAPIKeyInput,
-                showsModelDescription: false,
-                showsTranscriptionLanguage: true
-            )
+            DisclosureGroup(isExpanded: $advancedProviderSettingsExpanded) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Divider()
+                    ProviderSettingsFields(
+                        apiBaseURLInput: $apiBaseURLInput,
+                        transcriptionAPIURLInput: $transcriptionAPIURLInput,
+                        transcriptionAPIKeyInput: $transcriptionAPIKeyInput,
+                        showsModelDescription: false,
+                        showsTranscriptionLanguage: false
+                    )
+                }
+            } label: {
+                HStack {
+                    Text("Advanced Provider Settings")
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    advancedProviderSettingsExpanded.toggle()
+                }
+            }
+            .padding(.top, 4)
         }
+    }
+
+    private var languageSettings: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 8) {
+                Picker("Transcription Language", selection: $appState.transcriptionLanguage) {
+                    ForEach(TranscriptionLanguage.all) { lang in
+                        Text(lang.displayName).tag(lang)
+                    }
+                }
+                .pickerStyle(.menu)
+                .frame(maxWidth: 240, alignment: .leading)
+
+                Text("Spoken language hint for speech recognition. Auto Detect works for most users.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 8) {
+                Picker("Output Language", selection: $appState.outputLanguage) {
+                    ForEach(Self.outputLanguageOptions, id: \.value) { option in
+                        Text(option.label).tag(option.value)
+                    }
+                }
+                .pickerStyle(.menu)
+                .frame(minWidth: 280, maxWidth: 320, alignment: .leading)
+                .disabled(appState.disablePostProcessing || appState.useLocalTranscription)
+
+                Text(outputLanguageHelpText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var outputLanguageHelpText: String {
+        if appState.useLocalTranscription {
+            return "Use API Provider transcription to choose a final output language."
+        }
+        if appState.disablePostProcessing {
+            return "Enable post-processing to choose a final output language."
+        }
+        return "Final transcript language for post-processing."
     }
 
     private var sharedTranscriptionBehaviors: some View {


### PR DESCRIPTION
## Summary
- Move transcription language into a dedicated Language card alongside output language.
- Wire output language into post-processing, Edit Mode transforms, imports, and retry paths.
- Disable output language when post-processing or API provider transcription is unavailable in the current settings structure.

## Test plan
- [x] make test
- [x] make all APP_NAME=\"Quill Dev\" BUNDLE_ID=\"com.woosublee.quill.dev\" CODESIGN_IDENTITY=\"<local Apple Development identity>\"
- [x] Launch Quill Dev and inspect the Language settings card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 출력 언어 설정 옵션 추가
  * 음성 인식 및 출력 언어를 별도로 선택할 수 있도록 개선

* **UI 개선**
  * 언어 설정 영역 재구성
  * 고급 제공자 설정 섹션 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->