### PR TITLE
Add calendar recording reminders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,3 +168,5 @@ test:
 	@/tmp/PipelineHistoryCalendarMetadataTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/GoogleCalendarTokenStore.swift Sources/GoogleCalendarAuthService.swift Sources/GoogleCalendarService.swift Tests/GoogleCalendarServiceTests.swift -o /tmp/GoogleCalendarServiceTests
 	@/tmp/GoogleCalendarServiceTests
+	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/AppNotificationManager.swift Sources/CalendarRecordingReminderScheduler.swift Tests/CalendarRecordingReminderSchedulerTests.swift -o /tmp/CalendarRecordingReminderSchedulerTests
+	@/tmp/CalendarRecordingReminderSchedulerTests

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -42,7 +42,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        ObsidianExportManager.shared.requestNotificationPermission()
+        AppNotificationManager.shared.install()
+        AppNotificationManager.shared.setCalendarReminderHandler { [weak self] in
+            self?.appState.startRecordingFromCalendarReminder()
+        }
 
         // 저장된 appearance 설정 적용
         let savedAppearance = UserDefaults.standard.string(forKey: "app_appearance") ?? "system"
@@ -98,6 +101,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             startMCPServer()
+            appState.startCalendarRecordingReminderScheduling()
         }
 
     }
@@ -297,6 +301,9 @@ private func showNoteBrowserWindow() {
         updateActivationPolicy()
         appState.startHotkeyMonitoring()
         appState.startAccessibilityPolling()
+        Task { @MainActor in
+            appState.startCalendarRecordingReminderScheduling()
+        }
         // Quill releases are not distributed through the in-app updater yet.
         // Task { @MainActor in
         //     UpdateManager.shared.startPeriodicChecks()

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -294,6 +294,7 @@ private func showNoteBrowserWindow() {
         NSApp.activate(ignoringOtherApps: true)
     }
 
+    @MainActor
     func completeSetup() {
         appState.hasCompletedSetup = true
         setupWindow?.close()
@@ -301,9 +302,7 @@ private func showNoteBrowserWindow() {
         updateActivationPolicy()
         appState.startHotkeyMonitoring()
         appState.startAccessibilityPolling()
-        Task { @MainActor in
-            appState.startCalendarRecordingReminderScheduling()
-        }
+        appState.startCalendarRecordingReminderScheduling()
         // Quill releases are not distributed through the in-app updater yet.
         // Task { @MainActor in
         //     UpdateManager.shared.startPeriodicChecks()

--- a/Sources/AppNotificationManager.swift
+++ b/Sources/AppNotificationManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UserNotifications
 
+@MainActor
 final class AppNotificationManager: NSObject, UNUserNotificationCenterDelegate {
     static let shared = AppNotificationManager()
 

--- a/Sources/AppNotificationManager.swift
+++ b/Sources/AppNotificationManager.swift
@@ -57,6 +57,14 @@ final class AppNotificationManager: NSObject, UNUserNotificationCenterDelegate {
         }
     }
 
+    func deliveredNotificationRequestIdentifiers() async -> [String] {
+        await withCheckedContinuation { continuation in
+            notificationCenter.getDeliveredNotifications { notifications in
+                continuation.resume(returning: notifications.map(\.request.identifier))
+            }
+        }
+    }
+
     func sendImmediateNotification(title: String, body: String, sound: UNNotificationSound?) async {
         let content = UNMutableNotificationContent()
         content.title = title
@@ -75,10 +83,10 @@ final class AppNotificationManager: NSObject, UNUserNotificationCenterDelegate {
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
-        guard CalendarRecordingReminderScheduler.isCalendarReminderIdentifier(notification.request.identifier) else {
-            return []
+        if CalendarRecordingReminderScheduler.isCalendarReminderIdentifier(notification.request.identifier) {
+            return [.banner, .sound]
         }
-        return [.banner, .sound]
+        return notification.request.content.sound == nil ? [.banner] : [.banner, .sound]
     }
 
     func userNotificationCenter(

--- a/Sources/AppNotificationManager.swift
+++ b/Sources/AppNotificationManager.swift
@@ -66,18 +66,25 @@ final class AppNotificationManager: NSObject, UNUserNotificationCenterDelegate {
         }
     }
 
-    func sendImmediateNotification(title: String, body: String, sound: UNNotificationSound?) async {
+    @discardableResult
+    func sendImmediateNotification(title: String, body: String, sound: UNNotificationSound?) async -> Bool {
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
         content.sound = sound
         let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
-        await sendImmediateNotification(request)
+        return await sendImmediateNotification(request)
     }
 
-    func sendImmediateNotification(_ request: UNNotificationRequest) async {
-        guard await canShowAlerts() else { return }
-        try? await add(request)
+    @discardableResult
+    func sendImmediateNotification(_ request: UNNotificationRequest) async -> Bool {
+        guard await canShowAlerts() else { return false }
+        do {
+            try await add(request)
+            return true
+        } catch {
+            return false
+        }
     }
 
     func userNotificationCenter(

--- a/Sources/AppNotificationManager.swift
+++ b/Sources/AppNotificationManager.swift
@@ -1,0 +1,95 @@
+import Foundation
+import UserNotifications
+
+final class AppNotificationManager: NSObject, UNUserNotificationCenterDelegate {
+    static let shared = AppNotificationManager()
+
+    private let notificationCenter: UNUserNotificationCenter
+    private var calendarReminderHandler: (() -> Void)?
+
+    private override init() {
+        notificationCenter = .current()
+        super.init()
+    }
+
+    func install() {
+        notificationCenter.delegate = self
+    }
+
+    func setCalendarReminderHandler(_ handler: @escaping () -> Void) {
+        calendarReminderHandler = handler
+    }
+
+    func notificationSettings() async -> UNNotificationSettings {
+        await withCheckedContinuation { continuation in
+            notificationCenter.getNotificationSettings { settings in
+                continuation.resume(returning: settings)
+            }
+        }
+    }
+
+    func requestAuthorization() async -> Bool {
+        await withCheckedContinuation { continuation in
+            notificationCenter.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+                continuation.resume(returning: granted)
+            }
+        }
+    }
+
+    func canShowAlerts() async -> Bool {
+        let settings = await notificationSettings()
+        return settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional
+    }
+
+    func add(_ request: UNNotificationRequest) async throws {
+        try await notificationCenter.add(request)
+    }
+
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: identifiers)
+    }
+
+    func pendingNotificationRequestIdentifiers() async -> [String] {
+        await withCheckedContinuation { continuation in
+            notificationCenter.getPendingNotificationRequests { requests in
+                continuation.resume(returning: requests.map(\.identifier))
+            }
+        }
+    }
+
+    func sendImmediateNotification(title: String, body: String, sound: UNNotificationSound?) async {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = sound
+        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+        await sendImmediateNotification(request)
+    }
+
+    func sendImmediateNotification(_ request: UNNotificationRequest) async {
+        guard await canShowAlerts() else { return }
+        try? await add(request)
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        guard CalendarRecordingReminderScheduler.isCalendarReminderIdentifier(notification.request.identifier) else {
+            return []
+        }
+        return [.banner, .sound]
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        guard CalendarRecordingReminderScheduler.isCalendarReminderIdentifier(response.notification.request.identifier) else {
+            return
+        }
+        await MainActor.run {
+            calendarReminderHandler?()
+        }
+    }
+}

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -244,6 +244,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let googleCalendarClientIDStorageKey = "google_calendar_client_id"
     private let googleCalendarClientSecretStorageKey = "google_calendar_client_secret"
     private let googleCalendarSelectedIDsStorageKey = "google_calendar_selected_ids"
+    private let calendarRecordingRemindersEnabledStorageKey = "calendar_recording_reminders_enabled"
+    private let calendarRecordingReminderLeadMinutesStorageKey = "calendar_recording_reminder_lead_minutes"
+    private let calendarRecordingReminderRefreshIntervalMinutesStorageKey = "calendar_recording_reminder_refresh_interval_minutes"
     private let pendingMutedAudioRestoreStorageKey = "pending_muted_audio_restore"
     private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
     private let pressEnterAfterPasteDelay: TimeInterval = 0.08
@@ -490,6 +493,40 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published private(set) var isGoogleCalendarBusy = false
     @Published private(set) var hasPendingGoogleCalendarOAuthConnection = false
 
+    @Published var calendarRecordingRemindersEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(calendarRecordingRemindersEnabled, forKey: calendarRecordingRemindersEnabledStorageKey)
+            scheduleCalendarRecordingReminderRefreshFromPropertyChange()
+        }
+    }
+
+    @Published var calendarRecordingReminderLeadMinutes: Int {
+        didSet {
+            let normalized = CalendarRecordingReminderScheduler.normalizedLeadMinutes(calendarRecordingReminderLeadMinutes)
+            if normalized != calendarRecordingReminderLeadMinutes {
+                calendarRecordingReminderLeadMinutes = normalized
+                return
+            }
+            UserDefaults.standard.set(calendarRecordingReminderLeadMinutes, forKey: calendarRecordingReminderLeadMinutesStorageKey)
+            scheduleCalendarRecordingReminderRefreshFromPropertyChange()
+        }
+    }
+
+    @Published var calendarRecordingReminderRefreshIntervalMinutes: Int {
+        didSet {
+            let normalized = CalendarRecordingReminderScheduler.normalizedRefreshIntervalMinutes(calendarRecordingReminderRefreshIntervalMinutes)
+            if normalized != calendarRecordingReminderRefreshIntervalMinutes {
+                calendarRecordingReminderRefreshIntervalMinutes = normalized
+                return
+            }
+            UserDefaults.standard.set(calendarRecordingReminderRefreshIntervalMinutes, forKey: calendarRecordingReminderRefreshIntervalMinutesStorageKey)
+            scheduleCalendarRecordingReminderRefreshFromPropertyChange()
+        }
+    }
+
+    @Published private(set) var isRefreshingCalendarRecordingReminders = false
+    @Published private(set) var calendarRecordingReminderStatusMessage: String?
+
     private var builtInGoogleCalendarClientID: String {
         Bundle.main.object(forInfoDictionaryKey: "GoogleCalendarOAuthClientID") as? String ?? ""
     }
@@ -659,6 +696,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
         googleCalendarConnection.selectedCalendarIDs = selected
         Self.saveStringSet(selected, forKey: googleCalendarSelectedIDsStorageKey)
+        scheduleCalendarRecordingReminderRefresh()
     }
 
     @MainActor
@@ -699,6 +737,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         availableGoogleCalendars = []
         googleCalendarConnection = .disconnected
         UserDefaults.standard.removeObject(forKey: googleCalendarSelectedIDsStorageKey)
+        calendarRecordingReminderScheduler.stop()
     }
 
     @MainActor
@@ -863,6 +902,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var contextCaptureTask: Task<AppContext?, Never>?
     private var capturedContext: AppContext?
     private var googleCalendarConnectionTask: Task<Void, Never>?
+    private lazy var calendarRecordingReminderScheduler = CalendarRecordingReminderScheduler { [weak self] timeMin, timeMax in
+        guard let self else { return [] }
+        return try await self.fetchCalendarRecordingReminderEvents(timeMin: timeMin, timeMax: timeMax)
+    }
     private var hasShownScreenshotPermissionAlert = false
     private var isEscapeCancelAlertPresented = false
     private var shouldTerminateAfterTranscription = false
@@ -951,6 +994,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let googleCalendarClientSecret = Self.loadOptionalStoredAPIValue(account: googleCalendarClientSecretStorageKey)
         let selectedGoogleCalendarIDs = Self.loadStringSet(forKey: googleCalendarSelectedIDsStorageKey)
         let storedCalendarToken = GoogleCalendarTokenStore.load()
+        let calendarRecordingRemindersEnabled = UserDefaults.standard.bool(forKey: calendarRecordingRemindersEnabledStorageKey)
+        let storedCalendarRecordingReminderLeadMinutes = UserDefaults.standard.object(forKey: calendarRecordingReminderLeadMinutesStorageKey) != nil
+            ? UserDefaults.standard.integer(forKey: calendarRecordingReminderLeadMinutesStorageKey)
+            : CalendarRecordingReminderScheduler.defaultLeadMinutes
+        let calendarRecordingReminderLeadMinutes = CalendarRecordingReminderScheduler.normalizedLeadMinutes(storedCalendarRecordingReminderLeadMinutes)
+        let storedCalendarRecordingReminderRefreshIntervalMinutes = UserDefaults.standard.object(forKey: calendarRecordingReminderRefreshIntervalMinutesStorageKey) != nil
+            ? UserDefaults.standard.integer(forKey: calendarRecordingReminderRefreshIntervalMinutesStorageKey)
+            : CalendarRecordingReminderScheduler.defaultRefreshIntervalMinutes
+        let calendarRecordingReminderRefreshIntervalMinutes = CalendarRecordingReminderScheduler.normalizedRefreshIntervalMinutes(storedCalendarRecordingReminderRefreshIntervalMinutes)
         let isPressEnterVoiceCommandEnabled = UserDefaults.standard.object(forKey: pressEnterVoiceCommandStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: pressEnterVoiceCommandStorageKey)
@@ -1051,6 +1103,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
             selectedCalendarIDs: selectedGoogleCalendarIDs,
             lastErrorMessage: nil
         )
+        self.calendarRecordingRemindersEnabled = calendarRecordingRemindersEnabled
+        self.calendarRecordingReminderLeadMinutes = calendarRecordingReminderLeadMinutes
+        self.calendarRecordingReminderRefreshIntervalMinutes = calendarRecordingReminderRefreshIntervalMinutes
         self.overlayManager.setRecordingOverlayLayout(recordingOverlayLayout)
         self.isPressEnterVoiceCommandEnabled = isPressEnterVoiceCommandEnabled
         self.alertSoundsEnabled = alertSoundsEnabled
@@ -1307,6 +1362,81 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return token
     }
 
+    private func fetchCalendarRecordingReminderEvents(timeMin: Date, timeMax: Date) async throws -> [GoogleCalendarEvent] {
+        let selectedCalendarIDs = await MainActor.run { googleCalendarConnection.selectedCalendarIDs }
+        guard !selectedCalendarIDs.isEmpty else { return [] }
+        guard let token = try await validGoogleCalendarToken() else { return [] }
+        return await GoogleCalendarService().fetchEventsSkippingFailures(
+            accessToken: token.accessToken,
+            calendarIDs: Array(selectedCalendarIDs),
+            timeMin: timeMin,
+            timeMax: timeMax
+        )
+    }
+
+    @MainActor
+    func startCalendarRecordingReminderScheduling() {
+        scheduleCalendarRecordingReminderRefresh()
+    }
+
+    @MainActor
+    func stopCalendarRecordingReminderScheduling() {
+        calendarRecordingReminderScheduler.stop()
+    }
+
+    @MainActor
+    func refreshCalendarRecordingRemindersNow() {
+        guard calendarRecordingRemindersEnabled,
+              googleCalendarConnection.isConnected,
+              !googleCalendarConnection.selectedCalendarIDs.isEmpty else {
+            calendarRecordingReminderScheduler.stop()
+            calendarRecordingReminderStatusMessage = "Connect Google Calendar, select calendars, and enable reminders first."
+            return
+        }
+        guard !isRefreshingCalendarRecordingReminders else { return }
+        isRefreshingCalendarRecordingReminders = true
+        calendarRecordingReminderStatusMessage = "Refreshing reminders..."
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let count = try await self.calendarRecordingReminderScheduler.rescheduleNow(
+                    leadMinutes: self.calendarRecordingReminderLeadMinutes
+                )
+                await MainActor.run {
+                    self.calendarRecordingReminderStatusMessage = count == 1
+                        ? "Scheduled 1 meeting reminder."
+                        : "Scheduled \(count) meeting reminders."
+                    self.isRefreshingCalendarRecordingReminders = false
+                }
+            } catch {
+                await MainActor.run {
+                    self.calendarRecordingReminderStatusMessage = "Unable to refresh reminders: \(error.localizedDescription)"
+                    self.isRefreshingCalendarRecordingReminders = false
+                }
+            }
+        }
+    }
+
+    private func scheduleCalendarRecordingReminderRefreshFromPropertyChange() {
+        Task { @MainActor in
+            self.scheduleCalendarRecordingReminderRefresh()
+        }
+    }
+
+    @MainActor
+    private func scheduleCalendarRecordingReminderRefresh() {
+        guard calendarRecordingRemindersEnabled,
+              googleCalendarConnection.isConnected,
+              !googleCalendarConnection.selectedCalendarIDs.isEmpty else {
+            calendarRecordingReminderScheduler.stop()
+            return
+        }
+        calendarRecordingReminderScheduler.start(
+            leadMinutes: calendarRecordingReminderLeadMinutes,
+            refreshIntervalMinutes: calendarRecordingReminderRefreshIntervalMinutes
+        )
+    }
+
     @MainActor
     private func loadGoogleCalendars(force: Bool = false) async {
         guard force || !isGoogleCalendarBusy else { return }
@@ -1323,6 +1453,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             googleCalendarConnection.isConnected = true
             googleCalendarConnection.accountEmail = token.accountEmail
             googleCalendarConnection.lastErrorMessage = nil
+            scheduleCalendarRecordingReminderRefresh()
         } catch {
             googleCalendarConnection.lastErrorMessage = error.localizedDescription
         }
@@ -2474,6 +2605,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
     func startRecordingFromMCP() {
         lastTranscript = ""
         mcpLastRecordingFailed = false
+        shortcutSessionController.beginManual(mode: .toggle)
+        startRecording(triggerMode: .toggle)
+    }
+
+    @MainActor
+    func startRecordingFromCalendarReminder() {
+        guard !isRecording, !isTranscribing else { return }
+        lastTranscript = ""
         shortcutSessionController.beginManual(mode: .toggle)
         startRecording(triggerMode: .toggle)
     }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -738,6 +738,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func clearGoogleCalendarConnectionState() {
+        cancelGoogleCalendarConnection()
         GoogleCalendarTokenStore.delete()
         availableGoogleCalendars = []
         googleCalendarConnection = .disconnected

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1394,13 +1394,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return
         }
         guard !isRefreshingCalendarRecordingReminders else { return }
+        let leadMinutes = calendarRecordingReminderLeadMinutes
         isRefreshingCalendarRecordingReminders = true
         calendarRecordingReminderStatusMessage = "Refreshing reminders..."
         Task { [weak self] in
             guard let self else { return }
             do {
                 let count = try await self.calendarRecordingReminderScheduler.rescheduleNow(
-                    leadMinutes: self.calendarRecordingReminderLeadMinutes
+                    leadMinutes: leadMinutes
                 )
                 await MainActor.run {
                     self.calendarRecordingReminderStatusMessage = count == 1

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -476,7 +476,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
             let trimmed = googleCalendarClientID.trimmingCharacters(in: .whitespacesAndNewlines)
             UserDefaults.standard.set(trimmed, forKey: googleCalendarClientIDStorageKey)
             guard trimmed != oldValue.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
-            clearGoogleCalendarConnectionState()
+            Task { @MainActor in
+                self.clearGoogleCalendarConnectionState()
+            }
         }
     }
 
@@ -484,7 +486,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         didSet {
             persistOptionalAPIValue(googleCalendarClientSecret, account: googleCalendarClientSecretStorageKey)
             guard googleCalendarClientSecret.trimmingCharacters(in: .whitespacesAndNewlines) != oldValue.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
-            clearGoogleCalendarConnectionState()
+            Task { @MainActor in
+                self.clearGoogleCalendarConnectionState()
+            }
         }
     }
 
@@ -732,6 +736,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         isGoogleCalendarBusy = false
     }
 
+    @MainActor
     private func clearGoogleCalendarConnectionState() {
         GoogleCalendarTokenStore.delete()
         availableGoogleCalendars = []
@@ -902,7 +907,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var contextCaptureTask: Task<AppContext?, Never>?
     private var capturedContext: AppContext?
     private var googleCalendarConnectionTask: Task<Void, Never>?
-    private lazy var calendarRecordingReminderScheduler = CalendarRecordingReminderScheduler { [weak self] timeMin, timeMax in
+    @MainActor
+    private lazy var calendarRecordingReminderScheduler = CalendarRecordingReminderScheduler(
+        notificationManager: .shared
+    ) { [weak self] timeMin, timeMax in
         guard let self else { return [] }
         return try await self.fetchCalendarRecordingReminderEvents(timeMin: timeMin, timeMax: timeMax)
     }
@@ -1445,6 +1453,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         defer { isGoogleCalendarBusy = false }
         do {
             guard let token = try await validGoogleCalendarToken() else {
+                calendarRecordingReminderScheduler.stop()
                 googleCalendarConnection = .disconnected
                 availableGoogleCalendars = []
                 return

--- a/Sources/CalendarRecordingReminderScheduler.swift
+++ b/Sources/CalendarRecordingReminderScheduler.swift
@@ -133,7 +133,8 @@ final class CalendarRecordingReminderScheduler {
             .filter(Self.isCalendarReminderIdentifier)
         let planIDs = Set((plan.scheduled + plan.immediate).map(\.identifier))
         notifiedReminderIdentifiers = notifiedReminderIdentifiers.intersection(planIDs)
-        let notifiedIDs = pendingIDs.union(deliveredIDs).union(notifiedReminderIdentifiers)
+        let immediateNotifiedIDs = pendingIDs.union(deliveredIDs).union(notifiedReminderIdentifiers)
+        let scheduledNotifiedIDs = pendingIDs.union(deliveredIDs)
         let scheduledIDs = Set(plan.scheduled.map(\.identifier))
         let pendingToRemove = pendingIDs.subtracting(scheduledIDs)
         if !pendingToRemove.isEmpty {
@@ -141,15 +142,14 @@ final class CalendarRecordingReminderScheduler {
         }
 
         var deliveredCount = 0
-        for schedule in plan.immediate where !notifiedIDs.contains(schedule.identifier) {
+        for schedule in plan.immediate where !immediateNotifiedIDs.contains(schedule.identifier) {
             await notificationManager.sendImmediateNotification(Self.notificationRequest(for: schedule, calendar: calendar))
             notifiedReminderIdentifiers.insert(schedule.identifier)
             deliveredCount += 1
         }
-        for schedule in plan.scheduled where !notifiedIDs.contains(schedule.identifier) {
+        for schedule in plan.scheduled where !scheduledNotifiedIDs.contains(schedule.identifier) {
             do {
                 try await notificationManager.add(Self.notificationRequest(for: schedule, calendar: calendar))
-                notifiedReminderIdentifiers.insert(schedule.identifier)
             } catch {
             }
         }

--- a/Sources/CalendarRecordingReminderScheduler.swift
+++ b/Sources/CalendarRecordingReminderScheduler.swift
@@ -1,0 +1,257 @@
+import Foundation
+import UserNotifications
+
+struct CalendarRecordingReminderPlan: Equatable {
+    let scheduled: [CalendarRecordingReminderSchedule]
+    let immediate: [CalendarRecordingReminderSchedule]
+}
+
+struct CalendarRecordingReminderSchedule: Equatable {
+    let identifier: String
+    let fireDate: Date
+    let event: GoogleCalendarEvent
+    let delivery: Delivery
+
+    enum Delivery: Equatable {
+        case scheduled
+        case immediate
+    }
+}
+
+final class CalendarRecordingReminderScheduler {
+    typealias EventProvider = (_ timeMin: Date, _ timeMax: Date) async throws -> [GoogleCalendarEvent]
+
+    static let notificationIdentifierPrefix = "calendar-recording-reminder"
+    static let notificationCategoryIdentifier = "calendar-recording-reminder"
+    static let defaultLeadMinutes = 10
+    static let defaultRefreshIntervalMinutes = 15
+    static let leadMinuteOptions = [1, 5, 10, 15, 30, 60]
+    static let refreshIntervalMinuteOptions = [5, 15, 30, 60]
+    static let scheduleWindow: TimeInterval = 24 * 60 * 60
+    static let startedMeetingGracePeriod: TimeInterval = 5 * 60
+
+    private let notificationManager: AppNotificationManager
+    private let eventProvider: EventProvider
+    private var refreshTimer: Timer?
+    private var refreshTask: Task<Void, Never>?
+    private var isStarted = false
+
+    init(
+        notificationManager: AppNotificationManager = .shared,
+        eventProvider: @escaping EventProvider
+    ) {
+        self.notificationManager = notificationManager
+        self.eventProvider = eventProvider
+    }
+
+    func start(leadMinutes: Int, refreshIntervalMinutes: Int) {
+        isStarted = true
+        stopTimer()
+        scheduleRefresh(leadMinutes: leadMinutes)
+        let interval = TimeInterval(Self.normalizedRefreshIntervalMinutes(refreshIntervalMinutes) * 60)
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            self?.scheduleRefresh(leadMinutes: leadMinutes)
+        }
+    }
+
+    func stop() {
+        isStarted = false
+        stopTimer()
+        refreshTask?.cancel()
+        refreshTask = nil
+        Task {
+            let identifiers = await Self.pendingCalendarReminderIdentifiers(notificationManager: notificationManager)
+            notificationManager.removePendingNotificationRequests(withIdentifiers: identifiers)
+        }
+    }
+
+    @discardableResult
+    func rescheduleNow(leadMinutes: Int) async throws -> Int {
+        try await refresh(leadMinutes: leadMinutes)
+    }
+
+    private func stopTimer() {
+        refreshTimer?.invalidate()
+        refreshTimer = nil
+    }
+
+    private func scheduleRefresh(leadMinutes: Int) {
+        refreshTask?.cancel()
+        refreshTask = Task {
+            do {
+                _ = try await refresh(leadMinutes: leadMinutes)
+            } catch is CancellationError {
+            } catch {
+            }
+        }
+    }
+
+    @discardableResult
+    private func refresh(leadMinutes: Int) async throws -> Int {
+        guard await notificationManager.canShowAlerts() else { return 0 }
+        let now = Date()
+        let events = try await eventProvider(now, now.addingTimeInterval(Self.scheduleWindow))
+        let plan = Self.reminderPlan(
+            for: events,
+            leadMinutes: leadMinutes,
+            now: now,
+            calendar: .current
+        )
+        await Self.replacePendingNotifications(
+            plan: plan,
+            notificationManager: notificationManager,
+            calendar: .current
+        )
+        return plan.scheduled.count + plan.immediate.count
+    }
+
+    private static func replacePendingNotifications(
+        plan: CalendarRecordingReminderPlan,
+        notificationManager: AppNotificationManager,
+        calendar: Calendar
+    ) async {
+        let existingIdentifiers = await pendingCalendarReminderIdentifiers(notificationManager: notificationManager)
+        notificationManager.removePendingNotificationRequests(withIdentifiers: existingIdentifiers)
+        let existingIdentifierSet = Set(existingIdentifiers)
+
+        for schedule in plan.immediate where !existingIdentifierSet.contains(schedule.identifier) {
+            await notificationManager.sendImmediateNotification(notificationRequest(for: schedule, calendar: calendar))
+        }
+        for schedule in plan.scheduled {
+            try? await notificationManager.add(notificationRequest(for: schedule, calendar: calendar))
+        }
+    }
+
+    private static func notificationRequest(
+        for schedule: CalendarRecordingReminderSchedule,
+        calendar: Calendar
+    ) -> UNNotificationRequest {
+        let content = UNMutableNotificationContent()
+        content.title = notificationTitle(for: schedule, now: Date())
+        content.body = notificationBody(for: schedule.event)
+        content.sound = .default
+        content.categoryIdentifier = notificationCategoryIdentifier
+        content.userInfo = [
+            "calendarID": schedule.event.calendarID,
+            "eventID": schedule.event.id,
+            "eventTitle": schedule.event.title,
+            "eventStart": schedule.event.start.timeIntervalSince1970,
+        ]
+        let trigger: UNNotificationTrigger?
+        switch schedule.delivery {
+        case .scheduled:
+            trigger = UNCalendarNotificationTrigger(
+                dateMatching: calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: schedule.fireDate),
+                repeats: false
+            )
+        case .immediate:
+            trigger = nil
+        }
+        return UNNotificationRequest(identifier: schedule.identifier, content: content, trigger: trigger)
+    }
+
+    private static func pendingCalendarReminderIdentifiers(notificationManager: AppNotificationManager) async -> [String] {
+        calendarReminderIdentifiers(in: await notificationManager.pendingNotificationRequestIdentifiers())
+    }
+
+    static func schedules(
+        for events: [GoogleCalendarEvent],
+        leadMinutes: Int,
+        now: Date,
+        calendar: Calendar
+    ) -> [CalendarRecordingReminderSchedule] {
+        reminderPlan(for: events, leadMinutes: leadMinutes, now: now, calendar: calendar).scheduled
+    }
+
+    static func reminderPlan(
+        for events: [GoogleCalendarEvent],
+        leadMinutes: Int,
+        now: Date,
+        calendar: Calendar
+    ) -> CalendarRecordingReminderPlan {
+        let normalizedLeadMinutes = normalizedLeadMinutes(leadMinutes)
+        let schedules = events.compactMap { event -> CalendarRecordingReminderSchedule? in
+            guard isReminderEligible(event) else { return nil }
+            let fireDate = event.start.addingTimeInterval(TimeInterval(-normalizedLeadMinutes * 60))
+            let identifier = notificationIdentifier(for: event, leadMinutes: normalizedLeadMinutes)
+            if fireDate > now {
+                return CalendarRecordingReminderSchedule(
+                    identifier: identifier,
+                    fireDate: fireDate,
+                    event: event,
+                    delivery: .scheduled
+                )
+            }
+            guard event.start > now || now.timeIntervalSince(event.start) <= startedMeetingGracePeriod else {
+                return nil
+            }
+            return CalendarRecordingReminderSchedule(
+                identifier: identifier,
+                fireDate: now,
+                event: event,
+                delivery: .immediate
+            )
+        }
+        .sorted {
+            if $0.fireDate != $1.fireDate { return $0.fireDate < $1.fireDate }
+            return $0.identifier < $1.identifier
+        }
+        return CalendarRecordingReminderPlan(
+            scheduled: schedules.filter { $0.delivery == .scheduled },
+            immediate: schedules.filter { $0.delivery == .immediate }
+        )
+    }
+
+    static func notificationTitle(for schedule: CalendarRecordingReminderSchedule, now: Date) -> String {
+        let minutesUntilStart = Int(ceil(schedule.event.start.timeIntervalSince(now) / 60))
+        if minutesUntilStart > 1 {
+            return "Meeting starts in \(minutesUntilStart) minutes"
+        }
+        if minutesUntilStart == 1 {
+            return "Meeting starts in 1 minute"
+        }
+        if schedule.event.start > now {
+            return "Meeting starts soon"
+        }
+        return "Meeting is starting now"
+    }
+
+    static func notificationBody(for event: GoogleCalendarEvent) -> String {
+        "Tap to start recording: \(event.title)"
+    }
+
+    static func isReminderEligible(_ event: GoogleCalendarEvent) -> Bool {
+        guard !event.isAllDay,
+              event.hasUsableTitle,
+              event.end > event.start else {
+            return false
+        }
+        if event.attendees.contains(where: { $0.isSelf && $0.responseStatus == "declined" }) {
+            return false
+        }
+        return true
+    }
+
+    static func notificationIdentifier(for event: GoogleCalendarEvent, leadMinutes: Int) -> String {
+        let startTimestamp = Int(event.start.timeIntervalSince1970.rounded())
+        return "\(notificationIdentifierPrefix):\(event.calendarID):\(event.id):\(startTimestamp):\(normalizedLeadMinutes(leadMinutes))"
+    }
+
+    static func isCalendarReminderIdentifier(_ identifier: String) -> Bool {
+        identifier.hasPrefix("\(notificationIdentifierPrefix):")
+    }
+
+    static func calendarReminderIdentifiers(in identifiers: [String]) -> [String] {
+        identifiers.filter(isCalendarReminderIdentifier)
+    }
+
+    static func normalizedLeadMinutes(_ value: Int) -> Int {
+        min(max(value, 1), 120)
+    }
+
+    static func normalizedRefreshIntervalMinutes(_ value: Int) -> Int {
+        refreshIntervalMinuteOptions.min { lhs, rhs in
+            abs(lhs - value) < abs(rhs - value)
+        } ?? defaultRefreshIntervalMinutes
+    }
+}

--- a/Sources/CalendarRecordingReminderScheduler.swift
+++ b/Sources/CalendarRecordingReminderScheduler.swift
@@ -18,27 +18,30 @@ struct CalendarRecordingReminderSchedule: Equatable {
     }
 }
 
+@MainActor
 final class CalendarRecordingReminderScheduler {
     typealias EventProvider = (_ timeMin: Date, _ timeMax: Date) async throws -> [GoogleCalendarEvent]
 
-    static let notificationIdentifierPrefix = "calendar-recording-reminder"
-    static let notificationCategoryIdentifier = "calendar-recording-reminder"
-    static let defaultLeadMinutes = 10
-    static let defaultRefreshIntervalMinutes = 15
-    static let leadMinuteOptions = [1, 5, 10, 15, 30, 60]
-    static let refreshIntervalMinuteOptions = [5, 15, 30, 60]
-    static let scheduleWindow: TimeInterval = 24 * 60 * 60
-    static let startedMeetingGracePeriod: TimeInterval = 5 * 60
+    nonisolated static let notificationIdentifierPrefix = "calendar-recording-reminder"
+    nonisolated static let notificationCategoryIdentifier = "calendar-recording-reminder"
+    nonisolated static let defaultLeadMinutes = 10
+    nonisolated static let defaultRefreshIntervalMinutes = 15
+    nonisolated static let leadMinuteOptions = [1, 5, 10, 15, 30, 60]
+    nonisolated static let refreshIntervalMinuteOptions = [5, 15, 30, 60]
+    nonisolated static let scheduleWindow: TimeInterval = 24 * 60 * 60
+    nonisolated static let startedMeetingGracePeriod: TimeInterval = 5 * 60
 
     private let notificationManager: AppNotificationManager
     private let eventProvider: EventProvider
     private var refreshTimer: Timer?
     private var refreshTask: Task<Void, Never>?
+    private var cleanupTask: Task<Void, Never>?
+    private var generation = 0
     private var isStarted = false
-    private var deliveredImmediateReminderIdentifiers: Set<String> = []
+    private var notifiedReminderIdentifiers: Set<String> = []
 
     init(
-        notificationManager: AppNotificationManager = .shared,
+        notificationManager: AppNotificationManager,
         eventProvider: @escaping EventProvider
     ) {
         self.notificationManager = notificationManager
@@ -46,29 +49,42 @@ final class CalendarRecordingReminderScheduler {
     }
 
     func start(leadMinutes: Int, refreshIntervalMinutes: Int) {
+        generation += 1
+        cleanupTask?.cancel()
+        cleanupTask = nil
         isStarted = true
         stopTimer()
         scheduleRefresh(leadMinutes: leadMinutes)
         let interval = TimeInterval(Self.normalizedRefreshIntervalMinutes(refreshIntervalMinutes) * 60)
         refreshTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
-            self?.scheduleRefresh(leadMinutes: leadMinutes)
+            Task { @MainActor in
+                self?.scheduleRefresh(leadMinutes: leadMinutes)
+            }
         }
     }
 
     func stop() {
+        generation += 1
+        let stopGeneration = generation
         isStarted = false
         stopTimer()
         refreshTask?.cancel()
         refreshTask = nil
-        Task {
+        cleanupTask?.cancel()
+        cleanupTask = Task { [weak self] in
+            guard let self else { return }
             let identifiers = await Self.pendingCalendarReminderIdentifiers(notificationManager: notificationManager)
+            guard !Task.isCancelled, self.generation == stopGeneration else { return }
             notificationManager.removePendingNotificationRequests(withIdentifiers: identifiers)
         }
     }
 
     @discardableResult
     func rescheduleNow(leadMinutes: Int) async throws -> Int {
-        try await refresh(leadMinutes: leadMinutes)
+        let wasStarted = isStarted
+        isStarted = true
+        defer { isStarted = wasStarted }
+        return try await refresh(leadMinutes: leadMinutes)
     }
 
     private func stopTimer() {
@@ -116,8 +132,8 @@ final class CalendarRecordingReminderScheduler {
         let deliveredIDs = Set(await notificationManager.deliveredNotificationRequestIdentifiers())
             .filter(Self.isCalendarReminderIdentifier)
         let planIDs = Set((plan.scheduled + plan.immediate).map(\.identifier))
-        deliveredImmediateReminderIdentifiers = deliveredImmediateReminderIdentifiers.intersection(planIDs)
-        let notifiedIDs = pendingIDs.union(deliveredIDs).union(deliveredImmediateReminderIdentifiers)
+        notifiedReminderIdentifiers = notifiedReminderIdentifiers.intersection(planIDs)
+        let notifiedIDs = pendingIDs.union(deliveredIDs).union(notifiedReminderIdentifiers)
         let scheduledIDs = Set(plan.scheduled.map(\.identifier))
         let pendingToRemove = pendingIDs.subtracting(scheduledIDs)
         if !pendingToRemove.isEmpty {
@@ -127,11 +143,15 @@ final class CalendarRecordingReminderScheduler {
         var deliveredCount = 0
         for schedule in plan.immediate where !notifiedIDs.contains(schedule.identifier) {
             await notificationManager.sendImmediateNotification(Self.notificationRequest(for: schedule, calendar: calendar))
-            deliveredImmediateReminderIdentifiers.insert(schedule.identifier)
+            notifiedReminderIdentifiers.insert(schedule.identifier)
             deliveredCount += 1
         }
-        for schedule in plan.scheduled where !pendingIDs.contains(schedule.identifier) {
-            try? await notificationManager.add(Self.notificationRequest(for: schedule, calendar: calendar))
+        for schedule in plan.scheduled where !notifiedIDs.contains(schedule.identifier) {
+            do {
+                try await notificationManager.add(Self.notificationRequest(for: schedule, calendar: calendar))
+                notifiedReminderIdentifiers.insert(schedule.identifier)
+            } catch {
+            }
         }
         return deliveredCount
     }
@@ -171,7 +191,7 @@ final class CalendarRecordingReminderScheduler {
         calendarReminderIdentifiers(in: await notificationManager.pendingNotificationRequestIdentifiers())
     }
 
-    static func schedules(
+    nonisolated static func schedules(
         for events: [GoogleCalendarEvent],
         leadMinutes: Int,
         now: Date,
@@ -180,7 +200,7 @@ final class CalendarRecordingReminderScheduler {
         reminderPlan(for: events, leadMinutes: leadMinutes, now: now, calendar: calendar).scheduled
     }
 
-    static func reminderPlan(
+    nonisolated static func reminderPlan(
         for events: [GoogleCalendarEvent],
         leadMinutes: Int,
         now: Date,
@@ -219,7 +239,7 @@ final class CalendarRecordingReminderScheduler {
         )
     }
 
-    static func notificationTitle(for schedule: CalendarRecordingReminderSchedule, now: Date) -> String {
+    nonisolated static func notificationTitle(for schedule: CalendarRecordingReminderSchedule, now: Date) -> String {
         let minutesUntilStart = Int(ceil(schedule.event.start.timeIntervalSince(now) / 60))
         if minutesUntilStart > 1 {
             return "Meeting starts in \(minutesUntilStart) minutes"
@@ -233,11 +253,11 @@ final class CalendarRecordingReminderScheduler {
         return "Meeting is starting now"
     }
 
-    static func notificationBody(for event: GoogleCalendarEvent) -> String {
+    nonisolated static func notificationBody(for event: GoogleCalendarEvent) -> String {
         "Tap to start recording: \(event.title)"
     }
 
-    static func isReminderEligible(_ event: GoogleCalendarEvent) -> Bool {
+    nonisolated static func isReminderEligible(_ event: GoogleCalendarEvent) -> Bool {
         guard !event.isAllDay,
               event.hasUsableTitle,
               event.end > event.start else {
@@ -249,24 +269,24 @@ final class CalendarRecordingReminderScheduler {
         return true
     }
 
-    static func notificationIdentifier(for event: GoogleCalendarEvent, leadMinutes: Int) -> String {
+    nonisolated static func notificationIdentifier(for event: GoogleCalendarEvent, leadMinutes: Int) -> String {
         let startTimestamp = Int(event.start.timeIntervalSince1970.rounded())
         return "\(notificationIdentifierPrefix):\(event.calendarID):\(event.id):\(startTimestamp):\(normalizedLeadMinutes(leadMinutes))"
     }
 
-    static func isCalendarReminderIdentifier(_ identifier: String) -> Bool {
+    nonisolated static func isCalendarReminderIdentifier(_ identifier: String) -> Bool {
         identifier.hasPrefix("\(notificationIdentifierPrefix):")
     }
 
-    static func calendarReminderIdentifiers(in identifiers: [String]) -> [String] {
+    nonisolated static func calendarReminderIdentifiers(in identifiers: [String]) -> [String] {
         identifiers.filter(isCalendarReminderIdentifier)
     }
 
-    static func normalizedLeadMinutes(_ value: Int) -> Int {
+    nonisolated static func normalizedLeadMinutes(_ value: Int) -> Int {
         min(max(value, 1), 120)
     }
 
-    static func normalizedRefreshIntervalMinutes(_ value: Int) -> Int {
+    nonisolated static func normalizedRefreshIntervalMinutes(_ value: Int) -> Int {
         refreshIntervalMinuteOptions.min { lhs, rhs in
             abs(lhs - value) < abs(rhs - value)
         } ?? defaultRefreshIntervalMinutes

--- a/Sources/CalendarRecordingReminderScheduler.swift
+++ b/Sources/CalendarRecordingReminderScheduler.swift
@@ -81,10 +81,7 @@ final class CalendarRecordingReminderScheduler {
 
     @discardableResult
     func rescheduleNow(leadMinutes: Int) async throws -> Int {
-        let wasStarted = isStarted
-        isStarted = true
-        defer { isStarted = wasStarted }
-        return try await refresh(leadMinutes: leadMinutes)
+        try await refresh(leadMinutes: leadMinutes, requiresStarted: false)
     }
 
     private func stopTimer() {
@@ -104,14 +101,14 @@ final class CalendarRecordingReminderScheduler {
     }
 
     @discardableResult
-    private func refresh(leadMinutes: Int) async throws -> Int {
+    private func refresh(leadMinutes: Int, requiresStarted: Bool = true) async throws -> Int {
         guard await notificationManager.canShowAlerts() else { return 0 }
         try Task.checkCancellation()
-        guard isStarted else { return 0 }
+        guard !requiresStarted || isStarted else { return 0 }
         let now = Date()
         let events = try await eventProvider(now, now.addingTimeInterval(Self.scheduleWindow))
         try Task.checkCancellation()
-        guard isStarted else { return 0 }
+        guard !requiresStarted || isStarted else { return 0 }
         let plan = Self.reminderPlan(
             for: events,
             leadMinutes: leadMinutes,
@@ -119,7 +116,7 @@ final class CalendarRecordingReminderScheduler {
             calendar: .current
         )
         try Task.checkCancellation()
-        guard isStarted else { return 0 }
+        guard !requiresStarted || isStarted else { return 0 }
         let deliveredCount = await replacePendingNotifications(plan: plan, calendar: .current)
         return plan.scheduled.count + deliveredCount
     }
@@ -142,9 +139,10 @@ final class CalendarRecordingReminderScheduler {
 
         var deliveredCount = 0
         for schedule in plan.immediate where !immediateNotifiedIDs.contains(schedule.identifier) {
-            await notificationManager.sendImmediateNotification(Self.notificationRequest(for: schedule, calendar: calendar))
-            notifiedReminderIdentifiers.insert(schedule.identifier)
-            deliveredCount += 1
+            if await notificationManager.sendImmediateNotification(Self.notificationRequest(for: schedule, calendar: calendar)) {
+                notifiedReminderIdentifiers.insert(schedule.identifier)
+                deliveredCount += 1
+            }
         }
         for schedule in plan.scheduled where !deliveredIDs.contains(schedule.identifier) {
             do {

--- a/Sources/CalendarRecordingReminderScheduler.swift
+++ b/Sources/CalendarRecordingReminderScheduler.swift
@@ -134,7 +134,6 @@ final class CalendarRecordingReminderScheduler {
         let planIDs = Set((plan.scheduled + plan.immediate).map(\.identifier))
         notifiedReminderIdentifiers = notifiedReminderIdentifiers.intersection(planIDs)
         let immediateNotifiedIDs = pendingIDs.union(deliveredIDs).union(notifiedReminderIdentifiers)
-        let scheduledNotifiedIDs = pendingIDs.union(deliveredIDs)
         let scheduledIDs = Set(plan.scheduled.map(\.identifier))
         let pendingToRemove = pendingIDs.subtracting(scheduledIDs)
         if !pendingToRemove.isEmpty {
@@ -147,7 +146,7 @@ final class CalendarRecordingReminderScheduler {
             notifiedReminderIdentifiers.insert(schedule.identifier)
             deliveredCount += 1
         }
-        for schedule in plan.scheduled where !scheduledNotifiedIDs.contains(schedule.identifier) {
+        for schedule in plan.scheduled where !deliveredIDs.contains(schedule.identifier) {
             do {
                 try await notificationManager.add(Self.notificationRequest(for: schedule, calendar: calendar))
             } catch {

--- a/Sources/CalendarRecordingReminderScheduler.swift
+++ b/Sources/CalendarRecordingReminderScheduler.swift
@@ -35,6 +35,7 @@ final class CalendarRecordingReminderScheduler {
     private var refreshTimer: Timer?
     private var refreshTask: Task<Void, Never>?
     private var isStarted = false
+    private var deliveredImmediateReminderIdentifiers: Set<String> = []
 
     init(
         notificationManager: AppNotificationManager = .shared,
@@ -89,37 +90,50 @@ final class CalendarRecordingReminderScheduler {
     @discardableResult
     private func refresh(leadMinutes: Int) async throws -> Int {
         guard await notificationManager.canShowAlerts() else { return 0 }
+        try Task.checkCancellation()
+        guard isStarted else { return 0 }
         let now = Date()
         let events = try await eventProvider(now, now.addingTimeInterval(Self.scheduleWindow))
+        try Task.checkCancellation()
+        guard isStarted else { return 0 }
         let plan = Self.reminderPlan(
             for: events,
             leadMinutes: leadMinutes,
             now: now,
             calendar: .current
         )
-        await Self.replacePendingNotifications(
-            plan: plan,
-            notificationManager: notificationManager,
-            calendar: .current
-        )
-        return plan.scheduled.count + plan.immediate.count
+        try Task.checkCancellation()
+        guard isStarted else { return 0 }
+        let deliveredCount = await replacePendingNotifications(plan: plan, calendar: .current)
+        return plan.scheduled.count + deliveredCount
     }
 
-    private static func replacePendingNotifications(
+    private func replacePendingNotifications(
         plan: CalendarRecordingReminderPlan,
-        notificationManager: AppNotificationManager,
         calendar: Calendar
-    ) async {
-        let existingIdentifiers = await pendingCalendarReminderIdentifiers(notificationManager: notificationManager)
-        notificationManager.removePendingNotificationRequests(withIdentifiers: existingIdentifiers)
-        let existingIdentifierSet = Set(existingIdentifiers)
+    ) async -> Int {
+        let pendingIDs = Set(await Self.pendingCalendarReminderIdentifiers(notificationManager: notificationManager))
+        let deliveredIDs = Set(await notificationManager.deliveredNotificationRequestIdentifiers())
+            .filter(Self.isCalendarReminderIdentifier)
+        let planIDs = Set((plan.scheduled + plan.immediate).map(\.identifier))
+        deliveredImmediateReminderIdentifiers = deliveredImmediateReminderIdentifiers.intersection(planIDs)
+        let notifiedIDs = pendingIDs.union(deliveredIDs).union(deliveredImmediateReminderIdentifiers)
+        let scheduledIDs = Set(plan.scheduled.map(\.identifier))
+        let pendingToRemove = pendingIDs.subtracting(scheduledIDs)
+        if !pendingToRemove.isEmpty {
+            notificationManager.removePendingNotificationRequests(withIdentifiers: Array(pendingToRemove))
+        }
 
-        for schedule in plan.immediate where !existingIdentifierSet.contains(schedule.identifier) {
-            await notificationManager.sendImmediateNotification(notificationRequest(for: schedule, calendar: calendar))
+        var deliveredCount = 0
+        for schedule in plan.immediate where !notifiedIDs.contains(schedule.identifier) {
+            await notificationManager.sendImmediateNotification(Self.notificationRequest(for: schedule, calendar: calendar))
+            deliveredImmediateReminderIdentifiers.insert(schedule.identifier)
+            deliveredCount += 1
         }
-        for schedule in plan.scheduled {
-            try? await notificationManager.add(notificationRequest(for: schedule, calendar: calendar))
+        for schedule in plan.scheduled where !pendingIDs.contains(schedule.identifier) {
+            try? await notificationManager.add(Self.notificationRequest(for: schedule, calendar: calendar))
         }
+        return deliveredCount
     }
 
     private static func notificationRequest(
@@ -127,7 +141,10 @@ final class CalendarRecordingReminderScheduler {
         calendar: Calendar
     ) -> UNNotificationRequest {
         let content = UNMutableNotificationContent()
-        content.title = notificationTitle(for: schedule, now: Date())
+        content.title = notificationTitle(
+            for: schedule,
+            now: schedule.delivery == .scheduled ? schedule.fireDate : Date()
+        )
         content.body = notificationBody(for: schedule.event)
         content.sound = .default
         content.categoryIdentifier = notificationCategoryIdentifier

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -160,10 +160,6 @@ final class ObsidianExportManager: ObservableObject {
 
     @Published private(set) var processingIDs: Set<UUID> = []
 
-    func requestNotificationPermission() {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
-    }
-
     @MainActor
     func export(
         itemID: UUID,
@@ -244,12 +240,11 @@ source: Quill
     }
 
     private func notify(title: String, body: String, success: Bool) async {
-        let content = UNMutableNotificationContent()
-        content.title = title
-        content.body = body
-        content.sound = success ? .default : nil
-        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
-        try? await UNUserNotificationCenter.current().add(request)
+        await AppNotificationManager.shared.sendImmediateNotification(
+            title: title,
+            body: body,
+            sound: success ? .default : nil
+        )
     }
 
     func runGemini(content: String, prompt: String) async throws -> String {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -621,10 +621,6 @@ struct CalendarSettingsView: View {
                     googleCalendarSection
                 }
 
-                SettingsCard("Notification Permission", icon: "bell.fill") {
-                    notificationPermissionSection
-                }
-
                 SettingsCard("Meeting Recording Reminders", icon: "bell.badge") {
                     calendarRecordingReminderSection
                 }
@@ -749,58 +745,6 @@ struct CalendarSettingsView: View {
         }
     }
 
-    private var notificationPermissionSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                Image(systemName: notificationAuthorizationGranted ? "checkmark.circle.fill" : "bell.slash")
-                    .frame(width: 20)
-                    .foregroundStyle(notificationAuthorizationGranted ? .green : .orange)
-                VStack(alignment: .leading, spacing: 3) {
-                    Text("Notifications")
-                    Text(notificationPermissionHelpText)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                if notificationAuthorizationGranted {
-                    Text("Granted")
-                        .font(.caption)
-                        .foregroundStyle(.green)
-                } else if notificationAuthorizationStatus == .denied {
-                    Button("Open Settings") {
-                        openNotificationSettings()
-                    }
-                    .font(.caption)
-                } else {
-                    Button("Grant Access") {
-                        requestNotificationPermission()
-                    }
-                    .font(.caption)
-                }
-            }
-            .padding(10)
-            .background(Color(nsColor: .controlBackgroundColor))
-            .cornerRadius(6)
-        }
-    }
-
-    private var notificationAuthorizationGranted: Bool {
-        notificationAuthorizationStatus == .authorized || notificationAuthorizationStatus == .provisional
-    }
-
-    private var notificationPermissionHelpText: String {
-        switch notificationAuthorizationStatus {
-        case .authorized, .provisional:
-            return "Quill can show meeting recording reminders."
-        case .denied:
-            return "Enable notifications in System Settings to receive meeting reminders."
-        case .notDetermined:
-            return "Allow notifications so Quill can remind you before meetings."
-        default:
-            return "Notification permission is required for meeting reminders."
-        }
-    }
-
     private var calendarRecordingReminderSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Toggle(
@@ -893,19 +837,6 @@ struct CalendarSettingsView: View {
         }
     }
 
-    private func requestNotificationPermission() {
-        Task {
-            _ = await AppNotificationManager.shared.requestAuthorization()
-            refreshNotificationAuthorizationStatus()
-        }
-    }
-
-    private func openNotificationSettings() {
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.notifications") {
-            NSWorkspace.shared.open(url)
-        }
-    }
-
     private func refreshNotificationAuthorizationStatus() {
         Task {
             let settings = await AppNotificationManager.shared.notificationSettings()
@@ -986,6 +917,7 @@ struct GeneralSettingsView: View {
     @State private var keyValidationSuccess = false
     @State private var customVocabularyInput: String = ""
     @State private var micPermissionGranted = false
+    @State private var notificationAuthorizationStatus: UNAuthorizationStatus = .notDetermined
     @State private var showMutedHint = false
     @State private var advancedProviderSettingsExpanded = false
     @State private var copiedBuildInfo = false
@@ -1211,8 +1143,12 @@ struct GeneralSettingsView: View {
             transcriptionAPIKeyInput = appState.transcriptionAPIKey
             customVocabularyInput = appState.customVocabulary
             checkMicPermission()
+            refreshNotificationAuthorizationStatus()
             appState.refreshLaunchAtLoginStatus()
             Task { await githubCache.fetchIfNeeded() }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            refreshNotificationAuthorizationStatus()
         }
         .onChange(of: appState.transcriptionAPIURL) { value in
             if transcriptionAPIURLInput != value {
@@ -1926,10 +1862,30 @@ struct GeneralSettingsView: View {
                     appState.requestScreenCapturePermission()
                 }
             )
+
+            permissionRow(
+                title: "Notifications",
+                icon: "bell.fill",
+                granted: notificationAuthorizationGranted,
+                actionTitle: notificationAuthorizationStatus == .denied ? "Open Settings" : "Grant Access",
+                action: {
+                    if notificationAuthorizationStatus == .denied {
+                        openNotificationSettings()
+                    } else {
+                        requestNotificationPermission()
+                    }
+                }
+            )
         }
     }
 
-    private func permissionRow(title: String, icon: String, granted: Bool, action: @escaping () -> Void) -> some View {
+    private func permissionRow(
+        title: String,
+        icon: String,
+        granted: Bool,
+        actionTitle: String = "Grant Access",
+        action: @escaping () -> Void
+    ) -> some View {
         HStack {
             Image(systemName: icon)
                 .frame(width: 20)
@@ -1943,7 +1899,7 @@ struct GeneralSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.green)
             } else {
-                Button("Grant Access") {
+                Button(actionTitle) {
                     action()
                 }
                 .font(.caption)
@@ -1952,6 +1908,32 @@ struct GeneralSettingsView: View {
         .padding(10)
         .background(Color(nsColor: .controlBackgroundColor))
         .cornerRadius(6)
+    }
+
+    private var notificationAuthorizationGranted: Bool {
+        notificationAuthorizationStatus == .authorized || notificationAuthorizationStatus == .provisional
+    }
+
+    private func requestNotificationPermission() {
+        Task {
+            _ = await AppNotificationManager.shared.requestAuthorization()
+            refreshNotificationAuthorizationStatus()
+        }
+    }
+
+    private func openNotificationSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.notifications") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    private func refreshNotificationAuthorizationStatus() {
+        Task {
+            let settings = await AppNotificationManager.shared.notificationSettings()
+            await MainActor.run {
+                notificationAuthorizationStatus = settings.authorizationStatus
+            }
+        }
     }
 
     private func checkMicPermission() {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import AVFoundation
 import ServiceManagement
+import UserNotifications
 
 // MARK: - Shared Helpers
 
@@ -596,6 +597,15 @@ struct AppearanceSettingsView: View {
 struct CalendarSettingsView: View {
     @EnvironmentObject var appState: AppState
     @State private var showsAdvancedGoogleCalendarSettings = false
+    @State private var notificationAuthorizationStatus: UNAuthorizationStatus = .notDetermined
+
+    private var selectedCalendarCount: Int {
+        appState.googleCalendarConnection.selectedCalendarIDs.count
+    }
+
+    private var calendarReminderSettingsDisabled: Bool {
+        !appState.googleCalendarConnection.isConnected || selectedCalendarCount == 0
+    }
 
     private var connectionControls: GoogleCalendarConnectionControls {
         appState.googleCalendarConnectionControls
@@ -610,12 +620,24 @@ struct CalendarSettingsView: View {
                 SettingsCard("Google Calendar", icon: "calendar") {
                     googleCalendarSection
                 }
+
+                SettingsCard("Notification Permission", icon: "bell.fill") {
+                    notificationPermissionSection
+                }
+
+                SettingsCard("Meeting Recording Reminders", icon: "bell.badge") {
+                    calendarRecordingReminderSection
+                }
             }
             .padding(24)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .onAppear {
             appState.loadStoredGoogleCalendarConnection()
+            refreshNotificationAuthorizationStatus()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            refreshNotificationAuthorizationStatus()
         }
     }
 
@@ -723,6 +745,172 @@ struct CalendarSettingsView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+            }
+        }
+    }
+
+    private var notificationPermissionSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Image(systemName: notificationAuthorizationGranted ? "checkmark.circle.fill" : "bell.slash")
+                    .frame(width: 20)
+                    .foregroundStyle(notificationAuthorizationGranted ? .green : .orange)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Notifications")
+                    Text(notificationPermissionHelpText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if notificationAuthorizationGranted {
+                    Text("Granted")
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                } else if notificationAuthorizationStatus == .denied {
+                    Button("Open Settings") {
+                        openNotificationSettings()
+                    }
+                    .font(.caption)
+                } else {
+                    Button("Grant Access") {
+                        requestNotificationPermission()
+                    }
+                    .font(.caption)
+                }
+            }
+            .padding(10)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .cornerRadius(6)
+        }
+    }
+
+    private var notificationAuthorizationGranted: Bool {
+        notificationAuthorizationStatus == .authorized || notificationAuthorizationStatus == .provisional
+    }
+
+    private var notificationPermissionHelpText: String {
+        switch notificationAuthorizationStatus {
+        case .authorized, .provisional:
+            return "Quill can show meeting recording reminders."
+        case .denied:
+            return "Enable notifications in System Settings to receive meeting reminders."
+        case .notDetermined:
+            return "Allow notifications so Quill can remind you before meetings."
+        default:
+            return "Notification permission is required for meeting reminders."
+        }
+    }
+
+    private var calendarRecordingReminderSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Toggle(
+                "Remind me before meetings to record",
+                isOn: $appState.calendarRecordingRemindersEnabled
+            )
+            .disabled(calendarReminderSettingsDisabled)
+
+            Text("Quill schedules macOS notifications for events in your selected calendars. Clicking a reminder starts recording without toggling an active recording off.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if !appState.googleCalendarConnection.isConnected {
+                Label("Connect Google Calendar first.", systemImage: "calendar.badge.exclamationmark")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else if selectedCalendarCount == 0 {
+                Label("Select at least one calendar above.", systemImage: "checklist")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if notificationAuthorizationStatus == .denied {
+                Label("Notifications are disabled in System Settings.", systemImage: "bell.slash")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    Button(appState.isRefreshingCalendarRecordingReminders ? "Refreshing..." : "Refresh Reminders Now") {
+                        appState.refreshCalendarRecordingRemindersNow()
+                    }
+                    .disabled(
+                        calendarReminderSettingsDisabled
+                        || !appState.calendarRecordingRemindersEnabled
+                        || appState.isRefreshingCalendarRecordingReminders
+                    )
+
+                    if appState.isRefreshingCalendarRecordingReminders {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+
+                    Text("Fetches upcoming events now and rebuilds scheduled reminders.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let message = appState.calendarRecordingReminderStatusMessage {
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(message.hasPrefix("Unable") ? .red : .secondary)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Reminder time")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Picker("Reminder time", selection: $appState.calendarRecordingReminderLeadMinutes) {
+                    ForEach(CalendarRecordingReminderScheduler.leadMinuteOptions, id: \.self) { minutes in
+                        Text("\(minutes) min before").tag(minutes)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .disabled(calendarReminderSettingsDisabled || !appState.calendarRecordingRemindersEnabled)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Calendar refresh")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Picker("Calendar refresh", selection: $appState.calendarRecordingReminderRefreshIntervalMinutes) {
+                    ForEach(CalendarRecordingReminderScheduler.refreshIntervalMinuteOptions, id: \.self) { minutes in
+                        Text("Every \(minutes) min").tag(minutes)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .disabled(calendarReminderSettingsDisabled || !appState.calendarRecordingRemindersEnabled)
+                Text("Quill refreshes upcoming events while the app is running, then lets macOS deliver the scheduled reminders.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func requestNotificationPermission() {
+        Task {
+            _ = await AppNotificationManager.shared.requestAuthorization()
+            refreshNotificationAuthorizationStatus()
+        }
+    }
+
+    private func openNotificationSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.notifications") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    private func refreshNotificationAuthorizationStatus() {
+        Task {
+            let settings = await AppNotificationManager.shared.notificationSettings()
+            await MainActor.run {
+                notificationAuthorizationStatus = settings.authorizationStatus
             }
         }
     }

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -52,7 +52,7 @@ private struct SetupProviderSettingsSheet: View {
 }
 
 struct SetupView: View {
-    var onComplete: () -> Void
+    var onComplete: @MainActor () -> Void
     @EnvironmentObject var appState: AppState
     @Environment(\.openURL) private var openURL
     private let upstreamRepoURL = URL(string: "https://github.com/zachlatta/freeflow")!

--- a/Tests/CalendarRecordingReminderSchedulerTests.swift
+++ b/Tests/CalendarRecordingReminderSchedulerTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+@main
+struct CalendarRecordingReminderSchedulerTests {
+    static func main() {
+        testLeadMinutesAffectFireDate()
+        testPastReminderTimeForUpcomingMeetingBecomesImmediate()
+        testRecentlyStartedMeetingBecomesImmediate()
+        testSkipsMeetingsStartedOutsideGracePeriod()
+        testExcludesAllDayTitlelessInvalidAndSelfDeclinedEvents()
+        testNotificationIdentifierIsStable()
+        testCalendarReminderIdentifierFilteringUsesPrefix()
+        testNotificationTitleDescribesRelativeStartTime()
+        testNormalizesLeadMinutes()
+        testNormalizesRefreshIntervalMinutesToSupportedOptions()
+        print("CalendarRecordingReminderSchedulerTests passed")
+    }
+
+    private static func testLeadMinutesAffectFireDate() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let event = calendarEvent(id: "meeting", start: 1_900, end: 2_200)
+
+        let schedules = CalendarRecordingReminderScheduler.schedules(
+            for: [event],
+            leadMinutes: 10,
+            now: now,
+            calendar: .current
+        )
+
+        assert(schedules.count == 1)
+        assert(schedules[0].fireDate == Date(timeIntervalSince1970: 1_300))
+    }
+
+    private static func testPastReminderTimeForUpcomingMeetingBecomesImmediate() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let event = calendarEvent(id: "soon", start: 1_100, end: 1_500)
+
+        let plan = CalendarRecordingReminderScheduler.reminderPlan(
+            for: [event],
+            leadMinutes: 10,
+            now: now,
+            calendar: .current
+        )
+
+        assert(plan.scheduled.isEmpty)
+        assert(plan.immediate.map { $0.event.id } == ["soon"])
+    }
+
+    private static func testRecentlyStartedMeetingBecomesImmediate() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let event = calendarEvent(id: "started", start: 900, end: 1_500)
+
+        let plan = CalendarRecordingReminderScheduler.reminderPlan(
+            for: [event],
+            leadMinutes: 10,
+            now: now,
+            calendar: .current
+        )
+
+        assert(plan.scheduled.isEmpty)
+        assert(plan.immediate.map { $0.event.id } == ["started"])
+    }
+
+    private static func testSkipsMeetingsStartedOutsideGracePeriod() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let event = calendarEvent(id: "old", start: 600, end: 1_500)
+
+        let plan = CalendarRecordingReminderScheduler.reminderPlan(
+            for: [event],
+            leadMinutes: 10,
+            now: now,
+            calendar: .current
+        )
+
+        assert(plan.scheduled.isEmpty)
+        assert(plan.immediate.isEmpty)
+    }
+
+    private static func testExcludesAllDayTitlelessInvalidAndSelfDeclinedEvents() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let valid = calendarEvent(id: "valid", start: 2_000, end: 2_500)
+        let allDay = calendarEvent(id: "all-day", start: 2_000, end: 2_500, isAllDay: true)
+        let titleless = calendarEvent(id: "titleless", title: "  ", start: 2_000, end: 2_500)
+        let invalid = calendarEvent(id: "invalid", start: 2_500, end: 2_500)
+        let declined = calendarEvent(
+            id: "declined",
+            start: 2_000,
+            end: 2_500,
+            attendees: [CalendarEventAttendee(responseStatus: "declined", isSelf: true)]
+        )
+
+        let schedules = CalendarRecordingReminderScheduler.schedules(
+            for: [allDay, titleless, invalid, declined, valid],
+            leadMinutes: 5,
+            now: now,
+            calendar: .current
+        )
+
+        assert(schedules.map { $0.event.id } == ["valid"])
+    }
+
+    private static func testNotificationIdentifierIsStable() {
+        let event = calendarEvent(calendarID: "calendar", id: "event", start: 2_000, end: 2_500)
+
+        let identifier = CalendarRecordingReminderScheduler.notificationIdentifier(for: event, leadMinutes: 10)
+
+        assert(identifier == "calendar-recording-reminder:calendar:event:2000:10")
+    }
+
+    private static func testCalendarReminderIdentifierFilteringUsesPrefix() {
+        let identifiers = CalendarRecordingReminderScheduler.calendarReminderIdentifiers(in: [
+            "calendar-recording-reminder:calendar:event:2000:10",
+            "obsidian-export:note",
+            "calendar-recording-reminder",
+        ])
+
+        assert(identifiers == ["calendar-recording-reminder:calendar:event:2000:10"])
+    }
+
+    private static func testNotificationTitleDescribesRelativeStartTime() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let future = CalendarRecordingReminderSchedule(
+            identifier: "future",
+            fireDate: now,
+            event: calendarEvent(id: "future", start: 1_600, end: 1_900),
+            delivery: .scheduled
+        )
+        let soon = CalendarRecordingReminderSchedule(
+            identifier: "soon",
+            fireDate: now,
+            event: calendarEvent(id: "soon", start: 1_030, end: 1_300),
+            delivery: .immediate
+        )
+        let started = CalendarRecordingReminderSchedule(
+            identifier: "started",
+            fireDate: now,
+            event: calendarEvent(id: "started", start: 995, end: 1_300),
+            delivery: .immediate
+        )
+
+        assert(CalendarRecordingReminderScheduler.notificationTitle(for: future, now: now) == "Meeting starts in 10 minutes")
+        assert(CalendarRecordingReminderScheduler.notificationTitle(for: soon, now: now) == "Meeting starts in 1 minute")
+        assert(CalendarRecordingReminderScheduler.notificationTitle(for: started, now: now) == "Meeting is starting now")
+    }
+
+    private static func testNormalizesLeadMinutes() {
+        assert(CalendarRecordingReminderScheduler.normalizedLeadMinutes(-1) == 1)
+        assert(CalendarRecordingReminderScheduler.normalizedLeadMinutes(10) == 10)
+        assert(CalendarRecordingReminderScheduler.normalizedLeadMinutes(500) == 120)
+    }
+
+    private static func testNormalizesRefreshIntervalMinutesToSupportedOptions() {
+        assert(CalendarRecordingReminderScheduler.normalizedRefreshIntervalMinutes(1) == 5)
+        assert(CalendarRecordingReminderScheduler.normalizedRefreshIntervalMinutes(14) == 15)
+        assert(CalendarRecordingReminderScheduler.normalizedRefreshIntervalMinutes(20) == 15)
+        assert(CalendarRecordingReminderScheduler.normalizedRefreshIntervalMinutes(50) == 60)
+    }
+
+    private static func calendarEvent(
+        calendarID: String = "calendar",
+        id: String,
+        title: String = "Meeting",
+        start: TimeInterval,
+        end: TimeInterval,
+        isAllDay: Bool = false,
+        attendees: [CalendarEventAttendee] = []
+    ) -> GoogleCalendarEvent {
+        GoogleCalendarEvent(
+            id: id,
+            calendarID: calendarID,
+            title: title,
+            start: Date(timeIntervalSince1970: start),
+            end: Date(timeIntervalSince1970: end),
+            isAllDay: isAllDay,
+            attendees: attendees
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add Calendar settings for meeting recording reminders, lead time, refresh interval, and manual refresh feedback.
- Introduce a centralized notification manager shared by Calendar reminders and Obsidian export notifications.
- Schedule rolling 24-hour calendar reminders, including immediate reminders for newly discovered imminent meetings.

## Test plan
- [x] `make test`
- [x] Build `Quill Dev` with explicit Apple Development signing identity
- [x] Verify `Quill Dev.app` code signature
- [x] Launch `/Applications/Quill Dev.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 캘린더 이벤트 기반 회의 녹음 리마인더 추가 및 앱 시작·셋업 완료 시 자동 스케줄링
  * 설정에 알림 권한 UI와 리마인더 선행 시간·새로고침 주기 제어 추가
  * 앱 전반에서 통합된 로컬 알림 관리 도입 및 즉시 알림 전송 지원

* **Tests**
  * 캘린더 리마인더 동작을 검증하는 포괄적 테스트 추가
  * CI 테스트 워크플로우에 새 리마인더 실행 경로 추가

* **Refactor**
  * 노트 뷰 등에서 알림 호출을 통합된 알림 관리자 경유로 전환
<!-- end of auto-generated comment: release notes by coderabbit.ai -->