### PR TITLE
Add local-only setup path and notifications step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,3 +170,7 @@ test:
 	@/tmp/GoogleCalendarServiceTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/AppNotificationManager.swift Sources/CalendarRecordingReminderScheduler.swift Tests/CalendarRecordingReminderSchedulerTests.swift -o /tmp/CalendarRecordingReminderSchedulerTests
 	@/tmp/CalendarRecordingReminderSchedulerTests
+	@swiftc -parse-as-library Sources/TranscriptionModel.swift Sources/SetupFlow.swift Tests/SetupFlowTests.swift -o /tmp/SetupFlowTests
+	@/tmp/SetupFlowTests
+	@swiftc -parse-as-library -target $(shell uname -m)-apple-macosx13.0 $(filter-out Sources/App.swift,$(SOURCES)) Tests/AppStateTranscriptionConfigurationTests.swift -o /tmp/AppStateTranscriptionConfigurationTests
+	@/tmp/AppStateTranscriptionConfigurationTests

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1474,6 +1474,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         try TranscriptionService(
             apiKey: resolvedTranscriptionAPIKey,
             baseURL: resolvedTranscriptionBaseURL,
+            useLocalTranscription: useLocalTranscription,
+            localWhisperPath: localWhisperPath.isEmpty ? nil : localWhisperPath,
+            transcriptionLanguage: transcriptionLanguage,
+            localTranscriptionModel: localTranscriptionModel,
             transcriptionModel: transcriptionModel
         )
     }
@@ -4507,7 +4511,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private func startRealtimeStreamingIfEnabled() {
-        guard realtimeStreamingEnabled else { return }
+        guard realtimeStreamingEnabled, !useLocalTranscription else { return }
         let trimmedBase = resolvedTranscriptionBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedBase.isEmpty else {
             os_log(.info, log: recordingLog, "realtime streaming requested but base URL is empty — skipping")

--- a/Sources/SetupFlow.swift
+++ b/Sources/SetupFlow.swift
@@ -1,0 +1,33 @@
+import UserNotifications
+
+enum SetupFlow {
+    static let localOnlySkipButtonTitle = "Skip"
+
+    struct LocalOnlySkipState: Equatable {
+        let useLocalTranscription: Bool
+        let localTranscriptionModelID: String
+        let disablePostProcessing: Bool
+        let disableContextCapture: Bool
+        let realtimeStreamingEnabled: Bool
+        let isCommandModeEnabled: Bool
+    }
+
+    static func localOnlySkipState() -> LocalOnlySkipState {
+        LocalOnlySkipState(
+            useLocalTranscription: true,
+            localTranscriptionModelID: TranscriptionModel.default.id,
+            disablePostProcessing: true,
+            disableContextCapture: true,
+            realtimeStreamingEnabled: false,
+            isCommandModeEnabled: false
+        )
+    }
+
+    static func isNotificationAuthorizationGranted(_ status: UNAuthorizationStatus) -> Bool {
+        status == .authorized || status == .provisional
+    }
+
+    static func notificationPermissionActionTitle(for status: UNAuthorizationStatus) -> String {
+        status == .denied ? "Open Settings" : "Grant Access"
+    }
+}

--- a/Sources/SetupFlow.swift
+++ b/Sources/SetupFlow.swift
@@ -6,6 +6,9 @@ enum SetupFlow {
     struct LocalOnlySkipState: Equatable {
         let useLocalTranscription: Bool
         let localTranscriptionModelID: String
+        let apiKey: String
+        let transcriptionAPIKey: String
+        let transcriptionAPIURL: String
         let disablePostProcessing: Bool
         let disableContextCapture: Bool
         let realtimeStreamingEnabled: Bool
@@ -15,7 +18,10 @@ enum SetupFlow {
     static func localOnlySkipState() -> LocalOnlySkipState {
         LocalOnlySkipState(
             useLocalTranscription: true,
-            localTranscriptionModelID: TranscriptionModel.default.id,
+            localTranscriptionModelID: "apple-speech",
+            apiKey: "",
+            transcriptionAPIKey: "",
+            transcriptionAPIURL: "",
             disablePostProcessing: true,
             disableContextCapture: true,
             realtimeStreamingEnabled: false,

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -1204,6 +1204,12 @@ struct SetupView: View {
 
     func skipAPIKeyForLocalOnly() {
         let skipState = SetupFlow.localOnlySkipState()
+        appState.apiKey = skipState.apiKey
+        appState.transcriptionAPIKey = skipState.transcriptionAPIKey
+        appState.transcriptionAPIURL = skipState.transcriptionAPIURL
+        apiKeyInput = skipState.apiKey
+        transcriptionAPIKeyInput = skipState.transcriptionAPIKey
+        transcriptionAPIURLInput = skipState.transcriptionAPIURL
         appState.useLocalTranscription = skipState.useLocalTranscription
         appState.localTranscriptionModel = .find(id: skipState.localTranscriptionModelID)
         appState.disablePostProcessing = skipState.disablePostProcessing

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -3,6 +3,7 @@ import AVFoundation
 import Combine
 import Foundation
 import ServiceManagement
+import UserNotifications
 
 private struct SetupProviderSettingsSheet: View {
     @Environment(\.dismiss) private var dismiss
@@ -63,6 +64,7 @@ struct SetupView: View {
         case speechRecognition
         case accessibility
         case screenRecording
+        case notifications
         case holdShortcut
         case toggleShortcut
         case commandMode
@@ -75,6 +77,7 @@ struct SetupView: View {
     @State private var currentStep = SetupStep.welcome
     @State private var micPermissionGranted = false
     @State private var accessibilityGranted = false
+    @State private var notificationAuthorizationStatus: UNAuthorizationStatus = .notDetermined
     @State private var apiKeyInput: String = ""
     @State private var apiBaseURLInput: String = ""
     @State private var transcriptionAPIURLInput: String = ""
@@ -139,11 +142,20 @@ struct SetupView: View {
                     Group {
                         if currentStep != .ready {
                             if currentStep == .apiKey {
-                                Button(isValidatingKey ? "Validating..." : "Continue") {
-                                    validateAndContinue()
+                                HStack {
+                                    Button(SetupFlow.localOnlySkipButtonTitle) {
+                                        skipAPIKeyForLocalOnly()
+                                    }
+                                    .buttonStyle(.plain)
+                                    .foregroundStyle(.secondary)
+                                    .disabled(isValidatingKey)
+
+                                    Button(isValidatingKey ? "Validating..." : "Continue") {
+                                        validateAndContinue()
+                                    }
+                                    .keyboardShortcut(.defaultAction)
+                                    .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isValidatingKey)
                                 }
-                                .keyboardShortcut(.defaultAction)
-                                .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isValidatingKey)
                             } else if currentStep == .vocabulary {
                                 Button("Continue") {
                                     saveCustomVocabularyAndContinue()
@@ -199,6 +211,7 @@ struct SetupView: View {
             customVocabularyInput = appState.customVocabulary
             checkMicPermission()
             checkAccessibility()
+            refreshNotificationAuthorizationStatus()
             Task {
                 await githubCache.fetchIfNeeded()
             }
@@ -223,6 +236,9 @@ struct SetupView: View {
                 appState.resumeHotkeyMonitoringAfterShortcutCapture()
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            refreshNotificationAuthorizationStatus()
+        }
     }
 
     @ViewBuilder
@@ -240,6 +256,8 @@ struct SetupView: View {
             accessibilityStep
         case .screenRecording:
             screenRecordingStep
+        case .notifications:
+            notificationsStep
         case .holdShortcut:
             holdShortcutStep
         case .toggleShortcut:
@@ -392,7 +410,7 @@ struct SetupView: View {
                     .font(.title)
                     .fontWeight(.bold)
 
-                Text("Enter an API key for your OpenAI-compatible provider. If you are not using Groq, expand the advanced provider settings and enter that provider's base URL and model IDs before continuing.")
+                Text("Add an API key for cloud transcription, AI cleanup, context-aware output, and Edit Mode. If you only want local transcription right now, skip this step and configure an API provider later in Settings.")
                     .multilineTextAlignment(.center)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -417,7 +435,7 @@ struct SetupView: View {
                     VStack(alignment: .leading, spacing: 6) {
                         Text("API Key")
                             .font(.headline)
-                        SecureField("Paste your API key", text: $apiKeyInput)
+                        SecureField("Paste your API key (optional for local-only)", text: $apiKeyInput)
                             .textFieldStyle(.roundedBorder)
                             .font(.system(.body, design: .monospaced))
                             .disabled(isValidatingKey)
@@ -651,6 +669,57 @@ struct SetupView: View {
         }
         .onDisappear {
             screenRecordingTimer?.invalidate()
+        }
+    }
+
+    var notificationsStep: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "bell.badge.fill")
+                .font(.system(size: 60))
+                .foregroundStyle(.blue)
+
+            Text("Notifications")
+                .font(.title)
+                .fontWeight(.bold)
+
+            Text("Quill can show calendar recording reminders before meetings so you can start recording from the notification.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text("This permission is optional. You can skip it now and enable notifications later in Settings.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.orange)
+                .font(.callout)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack {
+                Image(systemName: "bell.fill")
+                    .frame(width: 24)
+                    .foregroundStyle(.blue)
+                Text("Notifications")
+                Spacer()
+                if notificationAuthorizationGranted {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Text("Granted")
+                        .foregroundStyle(.green)
+                } else {
+                    Button(SetupFlow.notificationPermissionActionTitle(for: notificationAuthorizationStatus)) {
+                        if notificationAuthorizationStatus == .denied {
+                            openNotificationSettings()
+                        } else {
+                            requestNotificationPermission()
+                        }
+                    }
+                }
+            }
+            .padding(12)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .cornerRadius(8)
+        }
+        .onAppear {
+            refreshNotificationAuthorizationStatus()
         }
     }
 
@@ -1067,7 +1136,7 @@ struct SetupView: View {
             return appState.hasSpeechRecognitionPermission
         case .accessibility:
             return accessibilityGranted
-        case .screenRecording:
+        case .screenRecording, .notifications:
             return true
         case .testTranscription:
             return testPhase == .done && !testTranscript.isEmpty && testError == nil
@@ -1133,6 +1202,20 @@ struct SetupView: View {
         }
     }
 
+    func skipAPIKeyForLocalOnly() {
+        let skipState = SetupFlow.localOnlySkipState()
+        appState.useLocalTranscription = skipState.useLocalTranscription
+        appState.localTranscriptionModel = .find(id: skipState.localTranscriptionModelID)
+        appState.disablePostProcessing = skipState.disablePostProcessing
+        appState.disableContextCapture = skipState.disableContextCapture
+        appState.realtimeStreamingEnabled = skipState.realtimeStreamingEnabled
+        _ = appState.setCommandModeEnabled(skipState.isCommandModeEnabled)
+        keyValidationError = nil
+        withAnimation {
+            currentStep = nextStep(currentStep)
+        }
+    }
+
     func saveCustomVocabularyAndContinue() {
         appState.customVocabulary = customVocabularyInput.trimmingCharacters(in: .whitespacesAndNewlines)
         withAnimation {
@@ -1180,6 +1263,32 @@ struct SetupView: View {
 
     func requestAccessibility() {
         appState.openAccessibilitySettings()
+    }
+
+    private var notificationAuthorizationGranted: Bool {
+        SetupFlow.isNotificationAuthorizationGranted(notificationAuthorizationStatus)
+    }
+
+    private func requestNotificationPermission() {
+        Task {
+            _ = await AppNotificationManager.shared.requestAuthorization()
+            refreshNotificationAuthorizationStatus()
+        }
+    }
+
+    private func openNotificationSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.notifications") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    private func refreshNotificationAuthorizationStatus() {
+        Task {
+            let settings = await AppNotificationManager.shared.notificationSettings()
+            await MainActor.run {
+                notificationAuthorizationStatus = settings.authorizationStatus
+            }
+        }
     }
 
     func startScreenRecordingPolling() {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+@main
+struct AppStateTranscriptionConfigurationTests {
+    static func main() throws {
+        try testMakeTranscriptionServiceUsesLocalConfiguration()
+        print("AppStateTranscriptionConfigurationTests passed")
+    }
+
+    private static func testMakeTranscriptionServiceUsesLocalConfiguration() throws {
+        resetDefaults()
+        let appState = AppState()
+        appState.useLocalTranscription = true
+        appState.localTranscriptionModel = .find(id: "apple-speech")
+        appState.transcriptionLanguage = .find(code: "en")
+        appState.localWhisperPath = "/tmp/quill-test-mlx-whisper"
+
+        let service = try appState.makeTranscriptionService()
+        let configuration = mirroredTranscriptionConfiguration(service)
+
+        assert(configuration.useLocalTranscription)
+        assert(configuration.localTranscriptionModelID == "apple-speech")
+        assert(configuration.transcriptionLanguageCode == "en")
+        assert(configuration.localWhisperPath == "/tmp/quill-test-mlx-whisper")
+    }
+
+    private static func resetDefaults() {
+        let defaults = UserDefaults.standard
+        for key in defaults.dictionaryRepresentation().keys where key.hasPrefix("app_state_transcription_test_") {
+            defaults.removeObject(forKey: key)
+        }
+        defaults.removeObject(forKey: "use_local_transcription")
+        defaults.removeObject(forKey: "local_transcription_model")
+        defaults.removeObject(forKey: "transcription_language")
+    }
+
+    private static func mirroredTranscriptionConfiguration(_ service: TranscriptionService) -> (
+        useLocalTranscription: Bool,
+        localTranscriptionModelID: String,
+        transcriptionLanguageCode: String,
+        localWhisperPath: String?
+    ) {
+        let mirror = Mirror(reflecting: service)
+        let useLocalTranscription = mirror.descendant("useLocalTranscription") as? Bool ?? false
+        let localTranscriptionModel = mirror.descendant("localTranscriptionModel") as? TranscriptionModel ?? .default
+        let transcriptionLanguage = mirror.descendant("transcriptionLanguage") as? TranscriptionLanguage ?? .auto
+        let localWhisperPath = mirror.descendant("localWhisperPath") as? String
+        return (useLocalTranscription, localTranscriptionModel.id, transcriptionLanguage.code, localWhisperPath)
+    }
+}

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -4,6 +4,7 @@ import Foundation
 struct AppStateTranscriptionConfigurationTests {
     static func main() throws {
         try testMakeTranscriptionServiceUsesLocalConfiguration()
+        try testMakeTranscriptionServiceMapsEmptyLocalWhisperPathToNil()
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
@@ -22,6 +23,18 @@ struct AppStateTranscriptionConfigurationTests {
         assert(configuration.localTranscriptionModelID == "apple-speech")
         assert(configuration.transcriptionLanguageCode == "en")
         assert(configuration.localWhisperPath == "/tmp/quill-test-mlx-whisper")
+    }
+
+    private static func testMakeTranscriptionServiceMapsEmptyLocalWhisperPathToNil() throws {
+        resetDefaults()
+        let appState = AppState()
+        appState.useLocalTranscription = true
+        appState.localWhisperPath = ""
+
+        let service = try appState.makeTranscriptionService()
+        let configuration = mirroredTranscriptionConfiguration(service)
+
+        assert(configuration.localWhisperPath == nil)
     }
 
     private static func resetDefaults() {

--- a/Tests/SetupFlowTests.swift
+++ b/Tests/SetupFlowTests.swift
@@ -45,6 +45,5 @@ struct SetupFlowTests {
     private static func testNotificationActionTitles() {
         assert(SetupFlow.notificationPermissionActionTitle(for: .notDetermined) == "Grant Access")
         assert(SetupFlow.notificationPermissionActionTitle(for: .denied) == "Open Settings")
-        assert(SetupFlow.notificationPermissionActionTitle(for: .authorized) == "Grant Access")
     }
 }

--- a/Tests/SetupFlowTests.swift
+++ b/Tests/SetupFlowTests.swift
@@ -6,6 +6,7 @@ struct SetupFlowTests {
     static func main() {
         testLocalOnlySkipButtonTitleIsShort()
         testLocalOnlySkipStateUsesAppleSpeech()
+        testLocalOnlySkipStateClearsCloudCredentials()
         testNotificationAuthorizationGrantedStates()
         testNotificationActionTitles()
         print("SetupFlowTests passed")
@@ -24,6 +25,14 @@ struct SetupFlowTests {
         assert(state.disableContextCapture)
         assert(!state.realtimeStreamingEnabled)
         assert(!state.isCommandModeEnabled)
+    }
+
+    private static func testLocalOnlySkipStateClearsCloudCredentials() {
+        let state = SetupFlow.localOnlySkipState()
+
+        assert(state.apiKey.isEmpty)
+        assert(state.transcriptionAPIKey.isEmpty)
+        assert(state.transcriptionAPIURL.isEmpty)
     }
 
     private static func testNotificationAuthorizationGrantedStates() {

--- a/Tests/SetupFlowTests.swift
+++ b/Tests/SetupFlowTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import UserNotifications
+
+@main
+struct SetupFlowTests {
+    static func main() {
+        testLocalOnlySkipButtonTitleIsShort()
+        testLocalOnlySkipStateUsesAppleSpeech()
+        testNotificationAuthorizationGrantedStates()
+        testNotificationActionTitles()
+        print("SetupFlowTests passed")
+    }
+
+    private static func testLocalOnlySkipButtonTitleIsShort() {
+        assert(SetupFlow.localOnlySkipButtonTitle == "Skip")
+    }
+
+    private static func testLocalOnlySkipStateUsesAppleSpeech() {
+        let state = SetupFlow.localOnlySkipState()
+
+        assert(state.useLocalTranscription)
+        assert(state.localTranscriptionModelID == "apple-speech")
+        assert(state.disablePostProcessing)
+        assert(state.disableContextCapture)
+        assert(!state.realtimeStreamingEnabled)
+        assert(!state.isCommandModeEnabled)
+    }
+
+    private static func testNotificationAuthorizationGrantedStates() {
+        assert(SetupFlow.isNotificationAuthorizationGranted(.authorized))
+        assert(SetupFlow.isNotificationAuthorizationGranted(.provisional))
+        assert(!SetupFlow.isNotificationAuthorizationGranted(.notDetermined))
+        assert(!SetupFlow.isNotificationAuthorizationGranted(.denied))
+    }
+
+    private static func testNotificationActionTitles() {
+        assert(SetupFlow.notificationPermissionActionTitle(for: .notDetermined) == "Grant Access")
+        assert(SetupFlow.notificationPermissionActionTitle(for: .denied) == "Open Settings")
+        assert(SetupFlow.notificationPermissionActionTitle(for: .authorized) == "Grant Access")
+    }
+}

--- a/docs/superpowers/specs/2026-05-07-local-only-setup-notifications-design.md
+++ b/docs/superpowers/specs/2026-05-07-local-only-setup-notifications-design.md
@@ -1,0 +1,80 @@
+# Local-only setup and notification permission design
+
+## Goal
+
+First-time setup should let users finish Quill setup without a Groq or other API key when they plan to use local transcription. Setup should also introduce notification permission for calendar recording reminders without making that permission mandatory.
+
+## Current behavior
+
+`SetupView` places the API Key step near the start of onboarding. The Continue button is disabled while the API key field is empty, and the only forward path validates the entered key before advancing. Notification permission can be granted later from Settings, but setup does not mention it.
+
+## Proposed setup flow
+
+Keep the existing onboarding sequence and add two focused changes:
+
+1. The API Key step keeps the existing provider validation path and adds a secondary `Skip for local-only` action.
+2. A new Notifications step appears with the other permission-oriented setup steps.
+
+This avoids a larger mode-selection redesign while making the local-only path explicit.
+
+## API Key step behavior
+
+The primary Continue button remains the API validation path:
+
+- Trim the entered API key and provider base URL.
+- Persist the resolved base URL.
+- Validate the key with the current `TranscriptionService.validateAPIKey` behavior.
+- Persist the key only when validation succeeds.
+
+The new `Skip for local-only` action:
+
+- Does not call API validation.
+- Sets `appState.useLocalTranscription = true`.
+- Sets `appState.localTranscriptionModel` to the Apple Speech model.
+- Disables post-processing, context capture, realtime streaming, and Edit Mode until the user enables/configures API-backed features later.
+- Leaves API key storage empty.
+- Advances to the next setup step.
+
+The API step copy should state that an API provider is needed for cloud transcription, AI post-processing/context features, and Edit Mode, but can be configured later in Settings.
+
+## Notifications step behavior
+
+Add a setup step that uses `AppNotificationManager.shared.notificationSettings()` and `requestAuthorization()`.
+
+The step shows:
+
+- Granted state when authorization is `.authorized` or `.provisional`.
+- `Grant Access` when authorization has not been requested.
+- `Open Settings` when authorization is `.denied`.
+- A clear note that notification access is optional and can be enabled later in Settings.
+
+Continue is always enabled on this step. Denying or skipping notification access must not block setup completion.
+
+## Data flow
+
+- Setup loads existing API/provider settings from `AppState` on appear.
+- API validation continues to update API provider values through existing `AppState` properties.
+- Local-only skip updates the transcription mode and local model properties needed for immediate API-free transcription, and turns off API-backed post-processing/context/realtime/Edit Mode defaults.
+- `AppState.makeTranscriptionService()` uses the current local transcription configuration so setup test transcription and shared transcription paths honor local-only mode.
+- Notification status is local view state refreshed on appear and when the app becomes active.
+- Calendar reminder scheduling already checks notification authorization before adding requests, so setup does not need to special-case scheduler behavior.
+
+## Error handling
+
+- Existing API validation errors remain inline on the API step.
+- Local-only skip has no network or validation error path.
+- Notification authorization failures are reflected by refreshed authorization status. If denied, the action changes to opening System Settings.
+
+## Testing and verification
+
+Add or update lightweight tests only where practical for pure logic. The main verification is app-level because the changes are SwiftUI setup flow and macOS permission UI:
+
+- Build through the Makefile using the development app name, development bundle ID, and explicit code signing identity.
+- Run the built development app.
+- Reset setup state for the development bundle if needed.
+- Verify API key entry still validates and advances.
+- Verify empty API key no longer blocks when using `Skip for local-only`.
+- Verify skip selects local transcription with Apple Speech, disables API-backed post-processing/context/realtime/Edit Mode defaults, and allows the test transcription step to proceed without an API key.
+- Verify shared transcription service creation preserves local mode, local model, local whisper path, and transcription language settings.
+- Verify the Notifications step shows Grant Access/Open Settings/Granted states and Continue remains available in every state.
+- Verify Settings still exposes API provider and notification permission controls after setup.


### PR DESCRIPTION
## Summary
- Adds a local-only Skip path on the API key setup step that selects Apple Speech and disables API-backed features by default.
- Adds an optional Notifications setup step for calendar recording reminders.
- Ensures transcription service creation preserves local transcription configuration.

## Test plan
- [x] `make test`
- [x] Built and launched the Quill Dev app
- [x] Reset Quill Dev setup state and TCC permissions
- [x] Verified the installed Quill Dev app contains the updated local-only setup copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 설정에 "로컬 전용 건너뛰기" 추가 — API 키 없이 로컬 음성 인식으로 진행 가능
  * 설정 흐름에 알림 권한 단계 추가 — 상태에 따른 안내 및 설정 열기 제공

* **동작 개선**
  * 로컬 전용 모드에서 실시간 스트리밍 자동 비활성화로 불필요한 시작 방지
  * 빈 로컬 모델 경로는 무시되어 안정성 향상
  * 일부 설정 단계에서 계속하기 제약 완화

* **테스트**
  * 로컬 전용 구성 및 알림/설정 흐름 검증용 자동화 테스트 추가

* **문서**
  * 로컬 전용 설정 및 알림 흐름 설계 명세 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->