### PR TITLE
Improve local model download lifecycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,5 +172,7 @@ test:
 	@/tmp/CalendarRecordingReminderSchedulerTests
 	@swiftc -parse-as-library Sources/TranscriptionModel.swift Sources/SetupFlow.swift Tests/SetupFlowTests.swift -o /tmp/SetupFlowTests
 	@/tmp/SetupFlowTests
+	@swiftc -parse-as-library Sources/TranscriptionModel.swift Tests/TranscriptionModelCacheTests.swift -o /tmp/TranscriptionModelCacheTests
+	@/tmp/TranscriptionModelCacheTests
 	@swiftc -parse-as-library -target $(shell uname -m)-apple-macosx13.0 $(filter-out Sources/App.swift,$(SOURCES)) Tests/AppStateTranscriptionConfigurationTests.swift -o /tmp/AppStateTranscriptionConfigurationTests
 	@/tmp/AppStateTranscriptionConfigurationTests

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1402,10 +1402,16 @@ struct GeneralSettingsView: View {
                         isSelected: appState.localTranscriptionModel == model,
                         whisperBin: appState.localWhisperPath.isEmpty
                             ? "\(FileManager.default.homeDirectoryForCurrentUser.path)/.local/bin/mlx_whisper"
-                            : appState.localWhisperPath
-                    ) {
-                        appState.localTranscriptionModel = model
-                    }
+                            : appState.localWhisperPath,
+                        onSelect: {
+                            appState.localTranscriptionModel = model
+                        },
+                        onDeleted: {
+                            if appState.localTranscriptionModel == model {
+                                appState.localTranscriptionModel = .default
+                            }
+                        }
+                    )
                 }
             }
 
@@ -3350,66 +3356,74 @@ struct VoiceMacroEditorView: View {
 
 // MARK: - Model Row View
 
+struct DonutProgressView: View {
+    let fractionCompleted: Double
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.secondary.opacity(0.18), lineWidth: 3)
+            Circle()
+                .trim(from: 0, to: fractionCompleted)
+                .stroke(Color.accentColor, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+        }
+        .frame(width: 18, height: 18)
+    }
+}
+
 struct ModelRowView: View {
     let model: TranscriptionModel
     let isSelected: Bool
     let whisperBin: String
     let onSelect: () -> Void
+    let onDeleted: () -> Void
 
     @State private var isInstalled: Bool = false
     @State private var isDownloading: Bool = false
+    @State private var isDeleting: Bool = false
+    @State private var downloadTask: TranscriptionModel.DownloadTask?
+    @State private var downloadProgress = TranscriptionModel.DownloadProgress(downloadedBytes: 0, totalBytes: nil)
+    @State private var downloadWasCancelled = false
+    @State private var isHoveringDownloadProgress = false
+    @State private var errorMessage: String?
+    @State private var showDeleteConfirmation = false
+
+    private var isBusy: Bool {
+        isDownloading || isDeleting
+    }
 
     var body: some View {
-        HStack(spacing: 10) {
-            // 선택 영역 (설치된 경우만 클릭 가능)
-            Button {
-                onSelect()
-            } label: {
-                HStack(spacing: 8) {
-                    Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
-                        .foregroundStyle(isInstalled ? Color.accentColor : .secondary)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(model.displayName)
-                            .font(.caption.weight(isSelected ? .semibold : .regular))
-                        Text(model.description)
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 10) {
+                Button {
+                    onSelect()
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                            .foregroundStyle(isInstalled ? Color.accentColor : .secondary)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(model.displayName)
+                                .font(.caption.weight(isSelected ? .semibold : .regular))
+                            Text(model.description)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .disabled(!isInstalled)
+                .buttonStyle(.plain)
+                .disabled(!isInstalled || isBusy)
 
-            // 상태 / 다운로드 버튼
-            if model.isAppleSpeech {
-                Label("Built-in", systemImage: "apple.logo")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-            } else if isDownloading {
-                HStack(spacing: 4) {
-                    ProgressView()
-                        .controlSize(.mini)
-                    Text("Downloading...")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                }
-            } else if isInstalled {
-                Label("Installed", systemImage: "checkmark.circle.fill")
-                    .font(.caption2)
-                    .foregroundStyle(.green)
-            } else {
-                Button("Download") {
-                    isDownloading = true
-                    model.download(whisperBin: whisperBin) { success in
-                        isDownloading = false
-                        isInstalled = success || model.isInstalled
-                    }
-                }
-                .font(.caption)
-                .buttonStyle(.bordered)
-                .controlSize(.small)
+                modelActionView
+            }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "xmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .padding(8)
@@ -3419,8 +3433,158 @@ struct ModelRowView: View {
             RoundedRectangle(cornerRadius: 6)
                 .stroke(isSelected ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
         )
+        .confirmationDialog(
+            "Delete \(model.displayName)?",
+            isPresented: $showDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete Model", role: .destructive) {
+                deleteModelCache()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes the downloaded local model cache for \(model.displayName). You can download it again later.")
+        }
         .onAppear {
-            isInstalled = model.isInstalled
+            refreshInstallState()
+        }
+    }
+
+    @ViewBuilder
+    private var modelActionView: some View {
+        if model.isAppleSpeech {
+            Label("Built-in", systemImage: "apple.logo")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        } else if isDownloading {
+            downloadProgressView
+        } else if isDeleting {
+            busyLabel("Deleting...")
+        } else if isInstalled {
+            HStack(spacing: 8) {
+                Label("Installed", systemImage: "checkmark.circle.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.green)
+                Button {
+                    showDeleteConfirmation = true
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .font(.caption)
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(isBusy)
+            }
+        } else {
+            Button("Download") {
+                downloadModel()
+            }
+            .font(.caption)
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .disabled(isBusy)
+        }
+    }
+
+    private var downloadProgressView: some View {
+        HStack(spacing: 8) {
+            ZStack {
+                if let fractionCompleted = downloadProgress.fractionCompleted {
+                    DonutProgressView(fractionCompleted: fractionCompleted)
+                        .opacity(isHoveringDownloadProgress ? 0.25 : 1)
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                        .opacity(isHoveringDownloadProgress ? 0.25 : 1)
+                }
+                if isHoveringDownloadProgress {
+                    Button {
+                        cancelDownload()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 8, weight: .bold))
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                }
+            }
+            .frame(width: 24, height: 24)
+            .contentShape(Circle())
+            .onHover { hovering in
+                isHoveringDownloadProgress = hovering
+            }
+
+            Text(downloadProgress.displayText)
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.secondary)
+                .frame(width: 78, alignment: .leading)
+        }
+    }
+
+    private func busyLabel(_ title: String) -> some View {
+        HStack(spacing: 4) {
+            ProgressView()
+                .controlSize(.mini)
+            Text(title)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func refreshInstallState() {
+        isInstalled = model.isInstalled
+    }
+
+    private func downloadModel() {
+        errorMessage = nil
+        downloadWasCancelled = false
+        downloadProgress = model.downloadProgress()
+        isDownloading = true
+        downloadTask = model.download(
+            whisperBin: whisperBin,
+            progress: { progress in
+                downloadProgress = progress
+            },
+            completion: { result in
+                downloadTask = nil
+                isDownloading = false
+                refreshInstallState()
+                guard !downloadWasCancelled else { return }
+                if case .failure(let error) = result {
+                    errorMessage = error.localizedDescription
+                }
+            }
+        )
+    }
+
+    private func cancelDownload() {
+        downloadWasCancelled = true
+        downloadTask?.cancel()
+        downloadTask = nil
+        isDownloading = false
+        refreshInstallState()
+        errorMessage = "Download canceled."
+    }
+
+    private func deleteModelCache() {
+        errorMessage = nil
+        isDeleting = true
+        let selectedModel = model
+        Task.detached(priority: .utility) {
+            do {
+                try selectedModel.deleteCache()
+                await MainActor.run {
+                    isDeleting = false
+                    refreshInstallState()
+                    onDeleted()
+                }
+            } catch {
+                await MainActor.run {
+                    isDeleting = false
+                    refreshInstallState()
+                    errorMessage = error.localizedDescription
+                }
+            }
         }
     }
 }

--- a/Sources/TranscriptionModel.swift
+++ b/Sources/TranscriptionModel.swift
@@ -69,6 +69,10 @@ struct TranscriptionModel: Identifiable, Hashable, Codable {
             guard process.isRunning else { return }
             process.terminate()
         }
+
+        deinit {
+            cancel()
+        }
     }
 
     static let all: [TranscriptionModel] = [

--- a/Sources/TranscriptionModel.swift
+++ b/Sources/TranscriptionModel.swift
@@ -1,9 +1,75 @@
 import Foundation
 
+enum TranscriptionModelCacheError: LocalizedError {
+    case builtInModelCannotBeDownloaded
+    case builtInModelCannotBeDeleted
+    case downloaderNotFound(String)
+    case downloadFailed(exitCode: Int32, output: String)
+    case unsafeCachePath(String)
+    case deleteFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .builtInModelCannotBeDownloaded:
+            return "Apple Speech is built in and does not need downloading."
+        case .builtInModelCannotBeDeleted:
+            return "Apple Speech is built in and cannot be deleted."
+        case .downloaderNotFound(let path):
+            return "Unable to find a Python environment for mlx_whisper at \(path). Install mlx-whisper with pipx or update the mlx_whisper path."
+        case .downloadFailed(let exitCode, let output):
+            let detail = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            return detail.isEmpty
+                ? "Model download failed with exit code \(exitCode)."
+                : "Model download failed with exit code \(exitCode): \(detail)"
+        case .unsafeCachePath(let path):
+            return "Refusing to delete unexpected model cache path: \(path)"
+        case .deleteFailed(let message):
+            return "Unable to delete model cache: \(message)"
+        }
+    }
+}
+
 struct TranscriptionModel: Identifiable, Hashable, Codable {
     let id: String           // mlx-whisper에 넘기는 모델 ID (또는 "apple-speech" 센티넬)
     let displayName: String  // UI에 표시되는 이름
     let description: String  // 설명
+
+    struct PythonInvocation: Equatable {
+        let executableURL: URL
+        let arguments: [String]
+    }
+
+    struct DownloadProgress: Equatable {
+        let downloadedBytes: Int64
+        let totalBytes: Int64?
+
+        var fractionCompleted: Double? {
+            guard let totalBytes, totalBytes > 0 else { return nil }
+            return min(Double(downloadedBytes) / Double(totalBytes), 1)
+        }
+
+        var displayText: String {
+            guard downloadedBytes > 0 else { return "Starting..." }
+            let sizeText = ByteCountFormatter.string(fromByteCount: downloadedBytes, countStyle: .file)
+            if let fractionCompleted {
+                return "\(Int((fractionCompleted * 100).rounded()))% · \(sizeText)"
+            }
+            return sizeText
+        }
+    }
+
+    final class DownloadTask {
+        private let process: Process
+
+        init(process: Process) {
+            self.process = process
+        }
+
+        func cancel() {
+            guard process.isRunning else { return }
+            process.terminate()
+        }
+    }
 
     static let all: [TranscriptionModel] = [
         TranscriptionModel(
@@ -35,39 +101,72 @@ struct TranscriptionModel: Identifiable, Hashable, Codable {
 
     var isAppleSpeech: Bool { id == "apple-speech" }
 
+    var estimatedDownloadBytes: Int64? {
+        switch id {
+        case "mlx-community/whisper-large-v3-turbo":
+            return 810_000_000
+        case "mlx-community/whisper-large-v3-mlx":
+            return 3_100_000_000
+        case "mlx-community/whisper-medium-mlx":
+            return 1_600_000_000
+        case "mlx-community/whisper-small-mlx":
+            return 520_000_000
+        default:
+            return nil
+        }
+    }
+
     static let `default` = all[0]
 
     static func find(id: String) -> TranscriptionModel {
         all.first { $0.id == id } ?? .default
     }
 
-    // huggingface hub 캐시 경로에서 모델 ID를 폴더명으로 변환
-    // e.g. "mlx-community/whisper-large-v3-turbo" → "models--mlx-community--whisper-large-v3-turbo"
     var cacheDirectoryName: String {
         "models--" + id.replacingOccurrences(of: "/", with: "--")
     }
 
-    // 모델 가중치 파일이 존재하는지 확인 (snapshots 또는 blobs)
-    var isInstalled: Bool {
+    static func huggingFaceHubCacheRoot(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        if let hubCache = nonEmptyEnvironmentValue("HUGGINGFACE_HUB_CACHE", in: environment) {
+            return expandedPathURL(hubCache, homeDirectory: homeDirectory)
+        }
+        if let hubCache = nonEmptyEnvironmentValue("HF_HUB_CACHE", in: environment) {
+            return expandedPathURL(hubCache, homeDirectory: homeDirectory)
+        }
+        if let hfHome = nonEmptyEnvironmentValue("HF_HOME", in: environment) {
+            return expandedPathURL(hfHome, homeDirectory: homeDirectory).appendingPathComponent("hub")
+        }
+        return homeDirectory.appendingPathComponent(".cache/huggingface/hub")
+    }
+
+    func cacheDirectory(in hubRoot: URL = TranscriptionModel.huggingFaceHubCacheRoot()) -> URL {
+        hubRoot.appendingPathComponent(cacheDirectoryName)
+    }
+
+    func isInstalled(
+        in hubRoot: URL = TranscriptionModel.huggingFaceHubCacheRoot(),
+        fileManager: FileManager = .default
+    ) -> Bool {
         if isAppleSpeech { return true }
 
-        let cacheDir = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".cache/huggingface/hub")
-            .appendingPathComponent(cacheDirectoryName)
-
-        // snapshots 폴더에서 weights.npz 확인
+        let cacheDir = cacheDirectory(in: hubRoot)
         let snapshotsDir = cacheDir.appendingPathComponent("snapshots")
-        if let snapshots = try? FileManager.default.contentsOfDirectory(at: snapshotsDir, includingPropertiesForKeys: nil) {
+        if let snapshots = try? fileManager.contentsOfDirectory(at: snapshotsDir, includingPropertiesForKeys: nil) {
             for snapshot in snapshots {
-                if FileManager.default.fileExists(atPath: snapshot.appendingPathComponent("weights.npz").path) {
+                if fileManager.fileExists(atPath: snapshot.appendingPathComponent("weights.npz").path) {
+                    return true
+                }
+                if fileManager.fileExists(atPath: snapshot.appendingPathComponent("weights.safetensors").path) {
                     return true
                 }
             }
         }
 
-        // blobs 폴더에서 100MB 이상 파일 확인 (모델 가중치)
         let blobsDir = cacheDir.appendingPathComponent("blobs")
-        if let blobs = try? FileManager.default.contentsOfDirectory(at: blobsDir, includingPropertiesForKeys: [.fileSizeKey]) {
+        if let blobs = try? fileManager.contentsOfDirectory(at: blobsDir, includingPropertiesForKeys: [.fileSizeKey]) {
             for blob in blobs {
                 let size = (try? blob.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
                 if size > 100_000_000 {
@@ -79,40 +178,216 @@ struct TranscriptionModel: Identifiable, Hashable, Codable {
         return false
     }
 
-    // mlx_whisper를 통해 모델 다운로드 (백그라운드)
-    func download(whisperBin: String, completion: @escaping (Bool) -> Void) {
-        DispatchQueue.global(qos: .utility).async {
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: whisperBin)
-            let home = FileManager.default.homeDirectoryForCurrentUser.path
-            process.environment = [
-                "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:\(home)/.local/bin",
-                "HOME": home
-            ]
-            // 빈 오디오 없이 모델만 다운로드하는 트릭: 존재하지 않는 파일로 실행하면 모델 다운로드 후 오류
-            // 대신 python으로 snapshot_download 직접 호출
-            let script = """
-import sys
-sys.path.insert(0, '\(home)/.local/pipx/venvs/mlx-whisper/lib/python3.14/site-packages')
-from huggingface_hub import snapshot_download
-snapshot_download('\(id)')
-print('DONE')
-"""
-            let pythonBin = "\(home)/.local/pipx/venvs/mlx-whisper/bin/python"
-            process.executableURL = URL(fileURLWithPath: pythonBin)
-            process.arguments = ["-c", script]
+    var isInstalled: Bool {
+        isInstalled()
+    }
 
-            let stdout = Pipe()
-            process.standardOutput = stdout
-            process.standardError = Pipe()
+    func downloadProgress(
+        in hubRoot: URL = TranscriptionModel.huggingFaceHubCacheRoot(),
+        fileManager: FileManager = .default
+    ) -> DownloadProgress {
+        let blobsDir = cacheDirectory(in: hubRoot).appendingPathComponent("blobs")
+        let blobs = (try? fileManager.contentsOfDirectory(at: blobsDir, includingPropertiesForKeys: [.fileSizeKey])) ?? []
+        let downloadedBytes = blobs.reduce(Int64(0)) { total, blob in
+            let size = Int64((try? blob.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+            return total + size
+        }
+        return DownloadProgress(downloadedBytes: downloadedBytes, totalBytes: estimatedDownloadBytes)
+    }
 
-            try? process.run()
-            process.waitUntilExit()
+    func deleteCache(
+        in hubRoot: URL = TranscriptionModel.huggingFaceHubCacheRoot(),
+        fileManager: FileManager = .default
+    ) throws {
+        guard !isAppleSpeech else { throw TranscriptionModelCacheError.builtInModelCannotBeDeleted }
 
-            let output = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let standardizedHubRoot = hubRoot.standardizedFileURL
+        let target = cacheDirectory(in: standardizedHubRoot).standardizedFileURL
+        guard target.deletingLastPathComponent().path == standardizedHubRoot.path,
+              target.lastPathComponent == cacheDirectoryName else {
+            throw TranscriptionModelCacheError.unsafeCachePath(target.path)
+        }
+
+        do {
+            try fileManager.removeItem(at: target)
+        } catch {
+            let nsError = error as NSError
+            if nsError.domain == NSCocoaErrorDomain, nsError.code == NSFileNoSuchFileError {
+                return
+            }
+            throw TranscriptionModelCacheError.deleteFailed(error.localizedDescription)
+        }
+    }
+
+    @discardableResult
+    func download(
+        whisperBin: String,
+        progress: @escaping (DownloadProgress) -> Void = { _ in },
+        completion: @escaping (Result<Void, TranscriptionModelCacheError>) -> Void
+    ) -> DownloadTask? {
+        guard !isAppleSpeech else {
             DispatchQueue.main.async {
-                completion(output.contains("DONE"))
+                completion(.failure(.builtInModelCannotBeDownloaded))
+            }
+            return nil
+        }
+
+        let process = Process()
+        let task = DownloadTask(process: process)
+        DispatchQueue.global(qos: .utility).async {
+            let fileManager = FileManager.default
+            let home = fileManager.homeDirectoryForCurrentUser
+            let hubRoot = Self.huggingFaceHubCacheRoot(homeDirectory: home)
+            guard let pythonInvocation = Self.pythonInvocation(for: whisperBin, homeDirectory: home, fileManager: fileManager) else {
+                DispatchQueue.main.async {
+                    completion(.failure(.downloaderNotFound(whisperBin)))
+                }
+                return
+            }
+
+            process.executableURL = pythonInvocation.executableURL
+            process.arguments = pythonInvocation.arguments + [
+                "-c",
+                """
+                import sys
+                from huggingface_hub import snapshot_download
+                snapshot_download(sys.argv[1])
+                """,
+                id
+            ]
+            var environment = ProcessInfo.processInfo.environment
+            environment["HOME"] = home.path
+            environment["HUGGINGFACE_HUB_CACHE"] = hubRoot.path
+            let existingPath = environment["PATH"] ?? "/usr/bin:/bin"
+            environment["PATH"] = "/opt/homebrew/bin:/usr/local/bin:\(home.path)/.local/bin:\(existingPath)"
+            process.environment = environment
+
+            let outputDirectory = fileManager.temporaryDirectory
+            let outputID = UUID().uuidString
+            let stdoutURL = outputDirectory.appendingPathComponent("quill-model-download-\(outputID).stdout")
+            let stderrURL = outputDirectory.appendingPathComponent("quill-model-download-\(outputID).stderr")
+            _ = fileManager.createFile(atPath: stdoutURL.path, contents: nil)
+            _ = fileManager.createFile(atPath: stderrURL.path, contents: nil)
+            defer {
+                try? fileManager.removeItem(at: stdoutURL)
+                try? fileManager.removeItem(at: stderrURL)
+            }
+
+            let stdoutHandle: FileHandle
+            let stderrHandle: FileHandle
+            do {
+                stdoutHandle = try FileHandle(forWritingTo: stdoutURL)
+                stderrHandle = try FileHandle(forWritingTo: stderrURL)
+            } catch {
+                DispatchQueue.main.async {
+                    completion(.failure(.downloadFailed(exitCode: -1, output: error.localizedDescription)))
+                }
+                return
+            }
+            process.standardOutput = stdoutHandle
+            process.standardError = stderrHandle
+
+            do {
+                try process.run()
+            } catch {
+                try? stdoutHandle.close()
+                try? stderrHandle.close()
+                DispatchQueue.main.async {
+                    completion(.failure(.downloaderNotFound(pythonInvocation.executableURL.path)))
+                }
+                return
+            }
+
+            while process.isRunning {
+                let currentProgress = self.downloadProgress(in: hubRoot)
+                DispatchQueue.main.async {
+                    progress(currentProgress)
+                }
+                Thread.sleep(forTimeInterval: 0.5)
+            }
+            process.waitUntilExit()
+            try? stdoutHandle.close()
+            try? stderrHandle.close()
+            let stdoutText = (try? String(contentsOf: stdoutURL, encoding: .utf8)) ?? ""
+            let stderrText = (try? String(contentsOf: stderrURL, encoding: .utf8)) ?? ""
+            let output = Self.summarizedOutput(stderrText.isEmpty ? stdoutText : stderrText)
+            let installed = self.isInstalled(in: hubRoot)
+
+            DispatchQueue.main.async {
+                progress(self.downloadProgress(in: hubRoot))
+                if process.terminationStatus == 0, installed {
+                    completion(.success(()))
+                } else {
+                    completion(.failure(.downloadFailed(exitCode: process.terminationStatus, output: output)))
+                }
             }
         }
+        return task
+    }
+
+    private static func nonEmptyEnvironmentValue(_ key: String, in environment: [String: String]) -> String? {
+        let value = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return value.isEmpty ? nil : value
+    }
+
+    private static func expandedPathURL(_ path: String, homeDirectory: URL) -> URL {
+        if path == "~" {
+            return homeDirectory
+        }
+        if path.hasPrefix("~/") {
+            return homeDirectory.appendingPathComponent(String(path.dropFirst(2)))
+        }
+        return URL(fileURLWithPath: path)
+    }
+
+    static func pythonInvocation(
+        for whisperBin: String,
+        homeDirectory: URL,
+        fileManager: FileManager
+    ) -> PythonInvocation? {
+        let expandedWhisperBin = expandedPathURL(whisperBin, homeDirectory: homeDirectory)
+        let resolvedWhisperBin = expandedWhisperBin.resolvingSymlinksInPath()
+        let candidates = [
+            PythonInvocation(
+                executableURL: expandedWhisperBin.deletingLastPathComponent().appendingPathComponent("python"),
+                arguments: []
+            ),
+            PythonInvocation(
+                executableURL: resolvedWhisperBin.deletingLastPathComponent().appendingPathComponent("python"),
+                arguments: []
+            ),
+            shebangInvocation(for: expandedWhisperBin),
+            PythonInvocation(
+                executableURL: homeDirectory.appendingPathComponent(".local/pipx/venvs/mlx-whisper/bin/python"),
+                arguments: []
+            )
+        ].compactMap { $0 }
+
+        return candidates.first { fileManager.isExecutableFile(atPath: $0.executableURL.path) }
+    }
+
+    private static func shebangInvocation(for executable: URL) -> PythonInvocation? {
+        guard let text = try? String(contentsOf: executable, encoding: .utf8),
+              let firstLine = text.split(separator: "\n", maxSplits: 1).first,
+              firstLine.hasPrefix("#!") else {
+            return nil
+        }
+        let parts = firstLine.dropFirst(2).split(separator: " ").map(String.init)
+        guard let command = parts.first,
+              parts.contains(where: { $0.contains("python") }) || command.contains("python") else {
+            return nil
+        }
+        return PythonInvocation(executableURL: URL(fileURLWithPath: command), arguments: Array(parts.dropFirst()))
+    }
+
+    private static func summarizedOutput(_ text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        let lines = trimmed.split(separator: "\n").map(String.init)
+        let head = lines.prefix(8).joined(separator: "\n")
+        if lines.count > 8 {
+            return head + "\n... (\(lines.count - 8) more lines)"
+        }
+        return head
     }
 }

--- a/Sources/TranscriptionModel.swift
+++ b/Sources/TranscriptionModel.swift
@@ -60,12 +60,23 @@ struct TranscriptionModel: Identifiable, Hashable, Codable {
 
     final class DownloadTask {
         private let process: Process
+        private let lock = NSLock()
+        private var cancelled = false
 
         init(process: Process) {
             self.process = process
         }
 
+        var isCancelled: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return cancelled
+        }
+
         func cancel() {
+            lock.lock()
+            cancelled = true
+            lock.unlock()
             guard process.isRunning else { return }
             process.terminate()
         }
@@ -290,6 +301,15 @@ struct TranscriptionModel: Identifiable, Hashable, Codable {
             }
             process.standardOutput = stdoutHandle
             process.standardError = stderrHandle
+
+            guard !task.isCancelled else {
+                try? stdoutHandle.close()
+                try? stderrHandle.close()
+                DispatchQueue.main.async {
+                    completion(.failure(.downloadFailed(exitCode: -1, output: "Cancelled")))
+                }
+                return
+            }
 
             do {
                 try process.run()

--- a/Tests/TranscriptionModelCacheTests.swift
+++ b/Tests/TranscriptionModelCacheTests.swift
@@ -1,0 +1,192 @@
+import Foundation
+
+@main
+struct TranscriptionModelCacheTests {
+    static func main() throws {
+        try testAppleSpeechIsAlwaysInstalled()
+        try testCacheDirectoryNameUsesHuggingFaceConvention()
+        try testSnapshotWeightsNPZMarksModelInstalled()
+        try testSnapshotWeightsSafetensorsMarksModelInstalled()
+        try testLargeBlobMarksModelInstalled()
+        try testDeleteRemovesOnlySelectedModelCache()
+        try testDeleteRejectsAppleSpeech()
+        try testDeleteMissingCacheSucceeds()
+        try testPythonDownloaderUsesSiblingPythonForSymlinkedWhisperBinary()
+        try testPythonDownloaderPreservesEnvShebangArguments()
+        try testDownloadProgressCountsCachedBytes()
+        try testZeroByteDownloadProgressUsesStartingLabel()
+        try testDownloadTaskCancelTerminatesAttachedProcess()
+        print("TranscriptionModelCacheTests passed")
+    }
+
+    private static func testAppleSpeechIsAlwaysInstalled() throws {
+        assert(TranscriptionModel.find(id: "apple-speech").isInstalled(in: temporaryHubRoot()))
+    }
+
+    private static func testCacheDirectoryNameUsesHuggingFaceConvention() throws {
+        let model = TranscriptionModel.find(id: "mlx-community/whisper-large-v3-turbo")
+
+        assert(model.cacheDirectoryName == "models--mlx-community--whisper-large-v3-turbo")
+        assert(model.cacheDirectory(in: URL(fileURLWithPath: "/tmp/hub")).path == "/tmp/hub/models--mlx-community--whisper-large-v3-turbo")
+    }
+
+    private static func testSnapshotWeightsNPZMarksModelInstalled() throws {
+        let hubRoot = temporaryHubRoot()
+        defer { try? FileManager.default.removeItem(at: hubRoot) }
+        let model = TranscriptionModel.find(id: "mlx-community/whisper-large-v3-mlx")
+        let snapshot = model.cacheDirectory(in: hubRoot)
+            .appendingPathComponent("snapshots")
+            .appendingPathComponent("revision")
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: snapshot.appendingPathComponent("weights.npz").path, contents: Data())
+
+        assert(model.isInstalled(in: hubRoot))
+    }
+
+    private static func testSnapshotWeightsSafetensorsMarksModelInstalled() throws {
+        let hubRoot = temporaryHubRoot()
+        defer { try? FileManager.default.removeItem(at: hubRoot) }
+        let model = TranscriptionModel.find(id: "mlx-community/whisper-large-v3-turbo")
+        let snapshot = model.cacheDirectory(in: hubRoot)
+            .appendingPathComponent("snapshots")
+            .appendingPathComponent("revision")
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: snapshot.appendingPathComponent("weights.safetensors").path, contents: Data())
+
+        assert(model.isInstalled(in: hubRoot))
+    }
+
+    private static func testLargeBlobMarksModelInstalled() throws {
+        let hubRoot = temporaryHubRoot()
+        defer { try? FileManager.default.removeItem(at: hubRoot) }
+        let model = TranscriptionModel.find(id: "mlx-community/whisper-small-mlx")
+        let blobs = model.cacheDirectory(in: hubRoot).appendingPathComponent("blobs")
+        try FileManager.default.createDirectory(at: blobs, withIntermediateDirectories: true)
+        let blob = blobs.appendingPathComponent("large-blob")
+        FileManager.default.createFile(atPath: blob.path, contents: Data())
+        let handle = try FileHandle(forWritingTo: blob)
+        try handle.truncate(atOffset: 100_000_001)
+        try handle.close()
+
+        assert(model.isInstalled(in: hubRoot))
+    }
+
+    private static func testDeleteRemovesOnlySelectedModelCache() throws {
+        let hubRoot = temporaryHubRoot()
+        defer { try? FileManager.default.removeItem(at: hubRoot) }
+        let selected = TranscriptionModel.find(id: "mlx-community/whisper-large-v3-turbo")
+        let unrelated = TranscriptionModel.find(id: "mlx-community/whisper-large-v3-mlx")
+        try FileManager.default.createDirectory(at: selected.cacheDirectory(in: hubRoot), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: unrelated.cacheDirectory(in: hubRoot), withIntermediateDirectories: true)
+
+        try selected.deleteCache(in: hubRoot)
+
+        assert(!FileManager.default.fileExists(atPath: selected.cacheDirectory(in: hubRoot).path))
+        assert(FileManager.default.fileExists(atPath: unrelated.cacheDirectory(in: hubRoot).path))
+    }
+
+    private static func testDeleteRejectsAppleSpeech() throws {
+        let model = TranscriptionModel.find(id: "apple-speech")
+
+        do {
+            try model.deleteCache(in: temporaryHubRoot())
+            assertionFailure("Apple Speech cache deletion should fail")
+        } catch TranscriptionModelCacheError.builtInModelCannotBeDeleted {
+        } catch {
+            assertionFailure("Unexpected error: \(error)")
+        }
+    }
+
+    private static func testDeleteMissingCacheSucceeds() throws {
+        let hubRoot = temporaryHubRoot()
+        defer { try? FileManager.default.removeItem(at: hubRoot) }
+        let model = TranscriptionModel.find(id: "mlx-community/whisper-medium-mlx")
+
+        try model.deleteCache(in: hubRoot)
+
+        assert(!FileManager.default.fileExists(atPath: model.cacheDirectory(in: hubRoot).path))
+    }
+
+    private static func testPythonDownloaderUsesSiblingPythonForSymlinkedWhisperBinary() throws {
+        let root = temporaryHubRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let home = root.appendingPathComponent("home")
+        let venvBin = root.appendingPathComponent("venv/bin")
+        let shimBin = root.appendingPathComponent("shim/bin")
+        try FileManager.default.createDirectory(at: venvBin, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: shimBin, withIntermediateDirectories: true)
+        let python = venvBin.appendingPathComponent("python")
+        let whisper = venvBin.appendingPathComponent("mlx_whisper")
+        let shim = shimBin.appendingPathComponent("mlx_whisper")
+        FileManager.default.createFile(atPath: python.path, contents: Data())
+        FileManager.default.createFile(atPath: whisper.path, contents: Data())
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: python.path)
+        try FileManager.default.createSymbolicLink(at: shim, withDestinationURL: whisper)
+
+        let invocation = TranscriptionModel.pythonInvocation(for: shim.path, homeDirectory: home, fileManager: .default)
+
+        assert(invocation?.executableURL == python)
+        assert(invocation?.arguments.isEmpty == true)
+    }
+
+    private static func testPythonDownloaderPreservesEnvShebangArguments() throws {
+        let root = temporaryHubRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let home = root.appendingPathComponent("home")
+        let bin = root.appendingPathComponent("bin")
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        let whisper = bin.appendingPathComponent("mlx_whisper")
+        try "#!/usr/bin/env -S python3 -I\n".write(to: whisper, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: whisper.path)
+
+        let invocation = TranscriptionModel.pythonInvocation(for: whisper.path, homeDirectory: home, fileManager: .default)
+
+        assert(invocation?.executableURL.path == "/usr/bin/env")
+        assert(invocation?.arguments == ["-S", "python3", "-I"])
+    }
+
+    private static func testDownloadProgressCountsCachedBytes() throws {
+        let hubRoot = temporaryHubRoot()
+        defer { try? FileManager.default.removeItem(at: hubRoot) }
+        let model = TranscriptionModel.find(id: "mlx-community/whisper-large-v3-turbo")
+        let blobs = model.cacheDirectory(in: hubRoot).appendingPathComponent("blobs")
+        try FileManager.default.createDirectory(at: blobs, withIntermediateDirectories: true)
+        let completeBlob = blobs.appendingPathComponent("complete")
+        let incompleteBlob = blobs.appendingPathComponent("partial.incomplete")
+        FileManager.default.createFile(atPath: completeBlob.path, contents: Data())
+        FileManager.default.createFile(atPath: incompleteBlob.path, contents: Data())
+        try FileHandle(forWritingTo: completeBlob).truncate(atOffset: 2_000)
+        try FileHandle(forWritingTo: incompleteBlob).truncate(atOffset: 3_000)
+
+        let progress = model.downloadProgress(in: hubRoot)
+
+        assert(progress.downloadedBytes == 5_000)
+        assert((progress.fractionCompleted ?? 0) > 0)
+        assert((progress.fractionCompleted ?? 1) < 1)
+    }
+
+    private static func testZeroByteDownloadProgressUsesStartingLabel() throws {
+        let progress = TranscriptionModel.DownloadProgress(downloadedBytes: 0, totalBytes: 100)
+
+        assert(progress.displayText == "Starting...")
+    }
+
+    private static func testDownloadTaskCancelTerminatesAttachedProcess() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["30"]
+        try process.run()
+        let task = TranscriptionModel.DownloadTask(process: process)
+
+        task.cancel()
+        process.waitUntilExit()
+
+        assert(process.terminationReason == .uncaughtSignal)
+    }
+
+    private static func temporaryHubRoot() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-transcription-model-cache-tests")
+            .appendingPathComponent(UUID().uuidString)
+    }
+}

--- a/Tests/TranscriptionModelCacheTests.swift
+++ b/Tests/TranscriptionModelCacheTests.swift
@@ -16,6 +16,7 @@ struct TranscriptionModelCacheTests {
         try testDownloadProgressCountsCachedBytes()
         try testZeroByteDownloadProgressUsesStartingLabel()
         try testDownloadTaskCancelTerminatesAttachedProcess()
+        try testDownloadTaskDeinitTerminatesAttachedProcess()
         print("TranscriptionModelCacheTests passed")
     }
 
@@ -179,6 +180,21 @@ struct TranscriptionModelCacheTests {
         let task = TranscriptionModel.DownloadTask(process: process)
 
         task.cancel()
+        process.waitUntilExit()
+
+        assert(process.terminationReason == .uncaughtSignal)
+    }
+
+    private static func testDownloadTaskDeinitTerminatesAttachedProcess() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["30"]
+        try process.run()
+
+        do {
+            let task = TranscriptionModel.DownloadTask(process: process)
+            _ = task
+        }
         process.waitUntilExit()
 
         assert(process.terminationReason == .uncaughtSignal)

--- a/Tests/TranscriptionModelCacheTests.swift
+++ b/Tests/TranscriptionModelCacheTests.swift
@@ -16,6 +16,7 @@ struct TranscriptionModelCacheTests {
         try testDownloadProgressCountsCachedBytes()
         try testZeroByteDownloadProgressUsesStartingLabel()
         try testDownloadTaskCancelTerminatesAttachedProcess()
+        try testDownloadTaskRemembersCancellationBeforeProcessStarts()
         try testDownloadTaskDeinitTerminatesAttachedProcess()
         print("TranscriptionModelCacheTests passed")
     }
@@ -183,6 +184,17 @@ struct TranscriptionModelCacheTests {
         process.waitUntilExit()
 
         assert(process.terminationReason == .uncaughtSignal)
+    }
+
+    private static func testDownloadTaskRemembersCancellationBeforeProcessStarts() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["30"]
+        let task = TranscriptionModel.DownloadTask(process: process)
+
+        task.cancel()
+
+        assert(task.isCancelled)
     }
 
     private static func testDownloadTaskDeinitTerminatesAttachedProcess() throws {

--- a/Tests/TranscriptionModelCacheTests.swift
+++ b/Tests/TranscriptionModelCacheTests.swift
@@ -181,8 +181,8 @@ struct TranscriptionModelCacheTests {
         let task = TranscriptionModel.DownloadTask(process: process)
 
         task.cancel()
-        process.waitUntilExit()
 
+        assert(waitForExit(process, timeout: 5))
         assert(process.terminationReason == .uncaughtSignal)
     }
 
@@ -207,9 +207,20 @@ struct TranscriptionModelCacheTests {
             let task = TranscriptionModel.DownloadTask(process: process)
             _ = task
         }
-        process.waitUntilExit()
 
+        assert(waitForExit(process, timeout: 5))
         assert(process.terminationReason == .uncaughtSignal)
+    }
+
+    private static func waitForExit(_ process: Process, timeout seconds: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(seconds)
+        while process.isRunning, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        if process.isRunning {
+            process.terminate()
+        }
+        return !process.isRunning
     }
 
     private static func temporaryHubRoot() -> URL {


### PR DESCRIPTION
## Summary
- Add local Whisper model cache helpers for Hugging Face install detection, deletion, progress, and cancellation.
- Update Settings model rows with download failure messages, delete confirmation, determinate donut progress, and hover-to-cancel control.
- Add focused cache/download lifecycle tests and include them in `make test`.

## Test plan
- [x] `make test`
- [x] `make APP_NAME="Quill Dev" BUNDLE_ID="com.woosublee.quill.dev" CODESIGN_IDENTITY="Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)"`
- [x] `codesign --verify --deep --strict "build/Quill Dev.app"`
- [x] Manual Quill Dev Settings check for download progress, hover cancel, delete, and error states

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로컬 모델 다운로드 도넛 진행률 시각화, 다운로드 중 호버로 취소 가능한 인터랙션 및 상세 상태 표시 추가
* **버그 수정 / 품질 개선**
  * 설치 감지 로직 및 캐시 삭제 안전성 강화, 실패 시 요약된 오류 메시지 제공 개선
* **테스트**
  * 모델 캐시·다운로드·삭제·취소 동작을 검증하는 독립 실행형 테스트 스위트 추가
* **잡일**
  * 테스트 실행 레시피에 새 테스트 대상 추가 (빌드/실행 업데이트)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->