### PR TITLE
Prevent download progress text wrapping

### DIFF
--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -3517,7 +3517,9 @@ struct ModelRowView: View {
             Text(downloadProgress.displayText)
                 .font(.caption2.monospacedDigit())
                 .foregroundStyle(.secondary)
-                .frame(width: 78, alignment: .leading)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(minWidth: 104, alignment: .leading)
         }
     }
 


### PR DESCRIPTION
## Summary
- Keep local model download progress text on one line.
- Give the progress label enough minimum width to avoid wrapping as byte counts grow.

## Test plan
- [x] `make test`
- [x] `make APP_NAME="Quill Dev" BUNDLE_ID="com.woosublee.quill.dev" CODESIGN_IDENTITY="Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)"`
- [x] `codesign --verify --deep --strict "build/Quill Dev.app"`
- [x] Manual Quill Dev check for download progress label wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* **다운로드 진행률 표시 개선**: 좁은 화면에서 다운로드 진행률 레이블이 잘리는 현상을 개선했습니다. 진행률 텍스트가 이제 더 나은 너비 조절로 표시되어 더 나은 가독성을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->