### PR TITLE
Refine canceled model download state

### DIFF
--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -3458,6 +3458,8 @@ struct ModelRowView: View {
                 .foregroundStyle(.secondary)
         } else if isDownloading {
             downloadProgressView
+        } else if downloadProgress.isCancelled {
+            canceledDownloadView
         } else if isDeleting {
             busyLabel("Deleting...")
         } else if isInstalled {
@@ -3488,24 +3490,33 @@ struct ModelRowView: View {
 
     private var downloadProgressView: some View {
         HStack(spacing: 8) {
+            Text(downloadProgress.displayText)
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(minWidth: 104, alignment: .trailing)
+
             ZStack {
-                if let fractionCompleted = downloadProgress.fractionCompleted {
-                    DonutProgressView(fractionCompleted: fractionCompleted)
-                        .opacity(isHoveringDownloadProgress ? 0.25 : 1)
-                } else {
-                    ProgressView()
-                        .controlSize(.small)
-                        .opacity(isHoveringDownloadProgress ? 0.25 : 1)
-                }
-                if isHoveringDownloadProgress {
-                    Button {
-                        cancelDownload()
-                    } label: {
-                        Image(systemName: "xmark")
-                            .font(.system(size: 8, weight: .bold))
+                if !downloadProgress.isCancelled {
+                    if let fractionCompleted = downloadProgress.fractionCompleted {
+                        DonutProgressView(fractionCompleted: fractionCompleted)
+                            .opacity(isHoveringDownloadProgress ? 0.25 : 1)
+                    } else {
+                        ProgressView()
+                            .controlSize(.small)
+                            .opacity(isHoveringDownloadProgress ? 0.25 : 1)
                     }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
+                    if isHoveringDownloadProgress {
+                        Button {
+                            cancelDownload()
+                        } label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 8, weight: .bold))
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.secondary)
+                    }
                 }
             }
             .frame(width: 24, height: 24)
@@ -3513,13 +3524,22 @@ struct ModelRowView: View {
             .onHover { hovering in
                 isHoveringDownloadProgress = hovering
             }
+        }
+    }
 
+    private var canceledDownloadView: some View {
+        HStack(spacing: 8) {
             Text(downloadProgress.displayText)
                 .font(.caption2.monospacedDigit())
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
-                .frame(minWidth: 104, alignment: .leading)
+                .frame(minWidth: 72, alignment: .trailing)
+            Button("Download") {
+                downloadModel()
+            }
+            .font(.caption)
+            .buttonStyle(.bordered)
+            .controlSize(.small)
         }
     }
 
@@ -3564,8 +3584,13 @@ struct ModelRowView: View {
         downloadTask?.cancel()
         downloadTask = nil
         isDownloading = false
+        try? model.deleteIncompleteDownloadFiles()
+        downloadProgress = TranscriptionModel.DownloadProgress(
+            downloadedBytes: model.downloadProgress().downloadedBytes,
+            totalBytes: downloadProgress.totalBytes,
+            isCancelled: true
+        )
         refreshInstallState()
-        errorMessage = "Download canceled."
     }
 
     private func deleteModelCache() {

--- a/Sources/TranscriptionModel.swift
+++ b/Sources/TranscriptionModel.swift
@@ -42,6 +42,13 @@ struct TranscriptionModel: Identifiable, Hashable, Codable {
     struct DownloadProgress: Equatable {
         let downloadedBytes: Int64
         let totalBytes: Int64?
+        let isCancelled: Bool
+
+        init(downloadedBytes: Int64, totalBytes: Int64?, isCancelled: Bool = false) {
+            self.downloadedBytes = downloadedBytes
+            self.totalBytes = totalBytes
+            self.isCancelled = isCancelled
+        }
 
         var fractionCompleted: Double? {
             guard let totalBytes, totalBytes > 0 else { return nil }
@@ -49,6 +56,7 @@ struct TranscriptionModel: Identifiable, Hashable, Codable {
         }
 
         var displayText: String {
+            if isCancelled { return "Canceled" }
             guard downloadedBytes > 0 else { return "Starting..." }
             let sizeText = ByteCountFormatter.string(fromByteCount: downloadedBytes, countStyle: .file)
             if let fractionCompleted {
@@ -183,6 +191,7 @@ struct TranscriptionModel: Identifiable, Hashable, Codable {
         let blobsDir = cacheDir.appendingPathComponent("blobs")
         if let blobs = try? fileManager.contentsOfDirectory(at: blobsDir, includingPropertiesForKeys: [.fileSizeKey]) {
             for blob in blobs {
+                guard !blob.lastPathComponent.hasSuffix(".incomplete") else { continue }
                 let size = (try? blob.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
                 if size > 100_000_000 {
                     return true
@@ -208,6 +217,27 @@ struct TranscriptionModel: Identifiable, Hashable, Codable {
             return total + size
         }
         return DownloadProgress(downloadedBytes: downloadedBytes, totalBytes: estimatedDownloadBytes)
+    }
+
+    func deleteIncompleteDownloadFiles(
+        in hubRoot: URL = TranscriptionModel.huggingFaceHubCacheRoot(),
+        fileManager: FileManager = .default
+    ) throws {
+        guard !isAppleSpeech else { return }
+
+        let blobsDir = cacheDirectory(in: hubRoot).appendingPathComponent("blobs")
+        let blobs = (try? fileManager.contentsOfDirectory(at: blobsDir, includingPropertiesForKeys: nil)) ?? []
+        for blob in blobs where blob.lastPathComponent.hasSuffix(".incomplete") {
+            do {
+                try fileManager.removeItem(at: blob)
+            } catch {
+                let nsError = error as NSError
+                if nsError.domain == NSCocoaErrorDomain, nsError.code == NSFileNoSuchFileError {
+                    continue
+                }
+                throw TranscriptionModelCacheError.deleteFailed(error.localizedDescription)
+            }
+        }
     }
 
     func deleteCache(

--- a/Tests/TranscriptionModelCacheTests.swift
+++ b/Tests/TranscriptionModelCacheTests.swift
@@ -8,6 +8,8 @@ struct TranscriptionModelCacheTests {
         try testSnapshotWeightsNPZMarksModelInstalled()
         try testSnapshotWeightsSafetensorsMarksModelInstalled()
         try testLargeBlobMarksModelInstalled()
+        try testIncompleteLargeBlobDoesNotMarkModelInstalled()
+        try testDeleteIncompleteDownloadFilesRemovesOnlyIncompleteBlobs()
         try testDeleteRemovesOnlySelectedModelCache()
         try testDeleteRejectsAppleSpeech()
         try testDeleteMissingCacheSucceeds()
@@ -15,6 +17,7 @@ struct TranscriptionModelCacheTests {
         try testPythonDownloaderPreservesEnvShebangArguments()
         try testDownloadProgressCountsCachedBytes()
         try testZeroByteDownloadProgressUsesStartingLabel()
+        try testCanceledDownloadProgressUsesCanceledLabel()
         try testDownloadTaskCancelTerminatesAttachedProcess()
         try testDownloadTaskRemembersCancellationBeforeProcessStarts()
         try testDownloadTaskDeinitTerminatesAttachedProcess()
@@ -71,6 +74,38 @@ struct TranscriptionModelCacheTests {
         try handle.close()
 
         assert(model.isInstalled(in: hubRoot))
+    }
+
+    private static func testIncompleteLargeBlobDoesNotMarkModelInstalled() throws {
+        let hubRoot = temporaryHubRoot()
+        defer { try? FileManager.default.removeItem(at: hubRoot) }
+        let model = TranscriptionModel.find(id: "mlx-community/whisper-small-mlx")
+        let blobs = model.cacheDirectory(in: hubRoot).appendingPathComponent("blobs")
+        try FileManager.default.createDirectory(at: blobs, withIntermediateDirectories: true)
+        let blob = blobs.appendingPathComponent("large-blob.incomplete")
+        FileManager.default.createFile(atPath: blob.path, contents: Data())
+        let handle = try FileHandle(forWritingTo: blob)
+        try handle.truncate(atOffset: 100_000_001)
+        try handle.close()
+
+        assert(!model.isInstalled(in: hubRoot))
+    }
+
+    private static func testDeleteIncompleteDownloadFilesRemovesOnlyIncompleteBlobs() throws {
+        let hubRoot = temporaryHubRoot()
+        defer { try? FileManager.default.removeItem(at: hubRoot) }
+        let model = TranscriptionModel.find(id: "mlx-community/whisper-large-v3-turbo")
+        let blobs = model.cacheDirectory(in: hubRoot).appendingPathComponent("blobs")
+        try FileManager.default.createDirectory(at: blobs, withIntermediateDirectories: true)
+        let completeBlob = blobs.appendingPathComponent("complete")
+        let incompleteBlob = blobs.appendingPathComponent("partial.incomplete")
+        FileManager.default.createFile(atPath: completeBlob.path, contents: Data())
+        FileManager.default.createFile(atPath: incompleteBlob.path, contents: Data())
+
+        try model.deleteIncompleteDownloadFiles(in: hubRoot)
+
+        assert(FileManager.default.fileExists(atPath: completeBlob.path))
+        assert(!FileManager.default.fileExists(atPath: incompleteBlob.path))
     }
 
     private static func testDeleteRemovesOnlySelectedModelCache() throws {
@@ -171,6 +206,12 @@ struct TranscriptionModelCacheTests {
         let progress = TranscriptionModel.DownloadProgress(downloadedBytes: 0, totalBytes: 100)
 
         assert(progress.displayText == "Starting...")
+    }
+
+    private static func testCanceledDownloadProgressUsesCanceledLabel() throws {
+        let progress = TranscriptionModel.DownloadProgress(downloadedBytes: 1_000, totalBytes: 100_000, isCancelled: true)
+
+        assert(progress.displayText == "Canceled")
     }
 
     private static func testDownloadTaskCancelTerminatesAttachedProcess() throws {


### PR DESCRIPTION
## Summary
- Move local model download progress text to the left and keep the donut progress on the right.
- Show canceled downloads inline without growing the row height.
- Remove `.incomplete` Hugging Face blob files on cancel and exclude them from installed-state detection.

## Test plan
- [x] `swiftc -parse-as-library Sources/TranscriptionModel.swift Tests/TranscriptionModelCacheTests.swift -o /tmp/TranscriptionModelCacheTests && /tmp/TranscriptionModelCacheTests`
- [x] `make test`
- [x] `make APP_NAME="Quill Dev" BUNDLE_ID="com.woosublee.quill.dev" CODESIGN_IDENTITY="Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)"`
- [x] Manual Quill Dev check for cancel state and retry layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 모델 다운로드 취소 시 불완전한 파일이 자동으로 정리됩니다.
  * 다운로드 취소 상태가 더 명확하게 표시됩니다.

* **개선 사항**
  * 다운로드 진행률 표시 및 레이아웃이 일관성 있게 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->