### PR TITLE
Keep recording overlay visible after display changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,5 +174,7 @@ test:
 	@/tmp/SetupFlowTests
 	@swiftc -parse-as-library Sources/TranscriptionModel.swift Tests/TranscriptionModelCacheTests.swift -o /tmp/TranscriptionModelCacheTests
 	@/tmp/TranscriptionModelCacheTests
+	@swiftc -parse-as-library Sources/ShortcutCore/ShortcutModels.swift Sources/RecordingOverlay.swift Tests/RecordingOverlayGeometryTests.swift -o /tmp/RecordingOverlayGeometryTests
+	@/tmp/RecordingOverlayGeometryTests
 	@swiftc -parse-as-library -target $(shell uname -m)-apple-macosx13.0 $(filter-out Sources/App.swift,$(SOURCES)) Tests/AppStateTranscriptionConfigurationTests.swift -o /tmp/AppStateTranscriptionConfigurationTests
 	@/tmp/AppStateTranscriptionConfigurationTests

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -154,6 +154,15 @@ struct RecordingOverlayGeometry {
         if let existingLockedWidth { return existingLockedWidth }
         return wasNotchSideRecordingLayout ? centeredTranscribingWidth : currentPanelWidth
     }
+
+    static func centeredFrame(screenFrame: CGRect, width: CGFloat, height: CGFloat) -> NSRect {
+        NSRect(
+            x: screenFrame.midX - width / 2,
+            y: screenFrame.maxY - height,
+            width: width,
+            height: height
+        )
+    }
 }
 
 // MARK: - Manager
@@ -162,6 +171,7 @@ final class RecordingOverlayManager {
     private var overlayWindow: NSPanel?
     private let overlayState = RecordingOverlayState()
     private var lockedOverlayWidth: CGFloat?
+    private var screenParametersObserver: NSObjectProtocol?
     private let notchSideRegionWidth: CGFloat = 92
     private let notchSidePanelHeight: CGFloat = 38
     private let notchSideHorizontalInset: CGFloat = 8
@@ -170,6 +180,22 @@ final class RecordingOverlayManager {
 
     var onStopButtonPressed: (() -> Void)?
     var onUpdateOverlayPressed: (() -> Void)?
+
+    init() {
+        screenParametersObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handleScreenParametersChanged()
+        }
+    }
+
+    deinit {
+        if let screenParametersObserver {
+            NotificationCenter.default.removeObserver(screenParametersObserver)
+        }
+    }
 
     private var screenHasNotch: Bool {
         guard let screen = NSScreen.main else { return false }
@@ -337,6 +363,10 @@ final class RecordingOverlayManager {
         resize(panel: panel, to: frame, animated: animated)
     }
 
+    private func handleScreenParametersChanged() {
+        updateOverlayLayout(animated: false)
+    }
+
     private func setTranscribingPhase() {
         lockedOverlayWidth = RecordingOverlayGeometry.lockedTranscribingWidth(
             existingLockedWidth: lockedOverlayWidth,
@@ -410,9 +440,7 @@ final class RecordingOverlayManager {
         let width = overlayWidth
         let overlap = screenHasNotch ? notchOverlap : 0
         let height: CGFloat = 38 + overlap
-        let x = screen.frame.midX - width / 2
-        let y = screen.frame.maxY - height
-        return NSRect(x: x, y: y, width: width, height: height)
+        return RecordingOverlayGeometry.centeredFrame(screenFrame: screen.frame, width: width, height: height)
     }
 
     private var centeredTranscribingOverlayWidth: CGFloat {

--- a/Tests/RecordingOverlayGeometryTests.swift
+++ b/Tests/RecordingOverlayGeometryTests.swift
@@ -7,6 +7,7 @@ struct RecordingOverlayGeometryTests {
         testNotchSideContentStartsAtTopOfVisiblePill()
         testTranscribingWidthFallsBackToCenteredWidthAfterNotchSideRecording()
         testTranscribingWidthKeepsExistingLockOnRepeatedTranscribingUpdate()
+        testCenteredFrameUsesUpdatedMainScreenGeometry()
         print("RecordingOverlayGeometryTests passed")
     }
 
@@ -51,5 +52,22 @@ struct RecordingOverlayGeometryTests {
         )
 
         assert(lockedWidth == 148)
+    }
+
+    private static func testCenteredFrameUsesUpdatedMainScreenGeometry() {
+        let oldFrame = RecordingOverlayGeometry.centeredFrame(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            width: 92,
+            height: 76
+        )
+        let updatedFrame = RecordingOverlayGeometry.centeredFrame(
+            screenFrame: CGRect(x: 0, y: 0, width: 1728, height: 1117),
+            width: 92,
+            height: 76
+        )
+
+        assert(oldFrame.origin.x == 710)
+        assert(updatedFrame.origin.x == 818)
+        assert(updatedFrame.origin.y == 1041)
     }
 }


### PR DESCRIPTION
## Summary
- Reposition the recording overlay whenever macOS screen parameters change so it stays anchored to the current main display.
- Reuse a testable centered-frame helper and include the overlay geometry test in `make test`.
- Closes #73.

## Test plan
- [x] `make test`
- [x] `make all APP_NAME='Quill Dev' BUNDLE_ID='com.woosublee.quill.dev' CODESIGN_IDENTITY='Apple Development: dntjqdlekd+kr@gmail.com (8GMU2DP9ND)'`
- [x] `open "build/Quill Dev.app" && pgrep -fl "Quill Dev" && codesign --verify --verbose=2 "build/Quill Dev.app"`
- [x] Manual external-display disconnect smoke test by reporter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 화면 파라미터 변경 시 녹화 오버레이 레이아웃이 자동으로 업데이트되도록 개선되었습니다.

* **Tests**
  * 화면 기하학 변경에 따른 프레임 계산 검증 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->