### PR TITLE
Improve note browser scroll performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,8 @@ test:
 	@/tmp/CalendarEventMatcherTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/NoteTitleResolver.swift Tests/NoteTitleResolutionTests.swift -o /tmp/NoteTitleResolutionTests
 	@/tmp/NoteTitleResolutionTests
+	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/NoteTitleResolver.swift Sources/NoteListRowDisplayData.swift Tests/NoteListRowDisplayDataTests.swift -o /tmp/NoteListRowDisplayDataTests
+	@/tmp/NoteListRowDisplayDataTests
 	@swiftc -parse-as-library Sources/AppName.swift Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/TranscriptionModel.swift Sources/PipelineHistoryStore.swift Tests/PipelineHistoryCalendarMetadataTests.swift -o /tmp/PipelineHistoryCalendarMetadataTests
 	@/tmp/PipelineHistoryCalendarMetadataTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/GoogleCalendarTokenStore.swift Sources/GoogleCalendarAuthService.swift Sources/GoogleCalendarService.swift Tests/GoogleCalendarServiceTests.swift -o /tmp/GoogleCalendarServiceTests

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2195,14 +2195,28 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    func updatePermissionStatus(accessibility: Bool, screenRecording: Bool) {
+        if hasAccessibility != accessibility {
+            hasAccessibility = accessibility
+        }
+        if hasScreenRecordingPermission != screenRecording {
+            hasScreenRecordingPermission = screenRecording
+        }
+    }
+
     func startAccessibilityPolling() {
         accessibilityTimer?.invalidate()
-        hasAccessibility = AXIsProcessTrusted()
-        hasScreenRecordingPermission = hasScreenCapturePermission()
+        updatePermissionStatus(
+            accessibility: AXIsProcessTrusted(),
+            screenRecording: hasScreenCapturePermission()
+        )
         accessibilityTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
             DispatchQueue.main.async {
-                self?.hasAccessibility = AXIsProcessTrusted()
-                self?.hasScreenRecordingPermission = self?.hasScreenCapturePermission() ?? false
+                guard let self else { return }
+                self.updatePermissionStatus(
+                    accessibility: AXIsProcessTrusted(),
+                    screenRecording: self.hasScreenCapturePermission()
+                )
             }
         }
     }

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -137,21 +137,6 @@ private struct GlassView: NSViewRepresentable {
     }
 }
 
-// MARK: - Status helpers
-
-private enum TranscriptStatus: Equatable {
-    case done, recording, transcribing, fail
-}
-
-private func transcriptStatus(for item: PipelineHistoryItem, retrying: Set<UUID>) -> TranscriptStatus {
-    if retrying.contains(item.id) { return .transcribing }
-    if item.postProcessingStatus == "live-recording" { return .recording }
-    if item.postProcessingStatus == "importing" { return .transcribing }
-    if item.postProcessingStatus == PipelineHistoryItem.transcriptionRecoveryPlaceholderStatus { return .transcribing }
-    if item.postProcessingStatus.hasPrefix("Error:") { return .fail }
-    return .done
-}
-
 // MARK: - Obsidian Export Manager
 
 final class ObsidianExportManager: ObservableObject {
@@ -664,10 +649,12 @@ struct NoteBrowserView: View {
                     LazyVStack(spacing: 2) {
                         ForEach(filteredHistory) { item in
                             NoteListRow(
-                                item: item,
-                                isSelected: selectedItemID == item.id,
-                                customTitle: titleStore.title(for: item.id),
-                                retryingIDs: appState.retryingItemIDs
+                                displayData: NoteListRowDisplayData(
+                                    item: item,
+                                    customTitle: titleStore.title(for: item.id),
+                                    retryingIDs: appState.retryingItemIDs
+                                ),
+                                isSelected: selectedItemID == item.id
                             )
                             .onTapGesture { selectedItemID = item.id }
                         }
@@ -801,25 +788,21 @@ struct NoteBrowserView: View {
 // MARK: - Note List Row
 
 private struct NoteListRow: View {
-    let item: PipelineHistoryItem
+    let displayData: NoteListRowDisplayData
     let isSelected: Bool
-    var customTitle: String? = nil
-    let retryingIDs: Set<UUID>
 
     @EnvironmentObject private var exportManager: ObsidianExportManager
     @Environment(\.colorScheme) private var colorScheme
     @State private var isHovered = false
 
-    private var status: TranscriptStatus { transcriptStatus(for: item, retrying: retryingIDs) }
-
-    private var isExporting: Bool { exportManager.processingIDs.contains(item.id) }
+    private var isExporting: Bool { exportManager.processingIDs.contains(displayData.id) }
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
             // Content
             VStack(alignment: .leading, spacing: 3) {
                 HStack(spacing: 4) {
-                    Text(rowDate)
+                    Text(displayData.rowDate)
                         .font(.system(size: 9, weight: .semibold))
                         .foregroundStyle(selectedMetaColor)
                         .textCase(.uppercase)
@@ -836,17 +819,17 @@ private struct NoteListRow: View {
                     statusIndicator
                 }
 
-                Text(displayTitle)
+                Text(displayData.displayTitle)
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(selectedTitleColor)
                     .lineLimit(1)
 
-                Text(notePreview.isEmpty ? " " : notePreview)
+                Text(displayData.preview.isEmpty ? " " : displayData.preview)
                     .font(.system(size: 11.5))
                     .foregroundStyle(selectedPreviewColor)
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)
-                    .opacity(notePreview.isEmpty ? 0 : 1)
+                    .opacity(displayData.preview.isEmpty ? 0 : 1)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
@@ -903,7 +886,7 @@ private struct NoteListRow: View {
 
     @ViewBuilder
     private var statusIndicator: some View {
-        switch status {
+        switch displayData.status {
         case .done:
             Circle()
                 .fill(Color.green)
@@ -917,34 +900,6 @@ private struct NoteListRow: View {
         }
     }
 
-    private var rowDate: String {
-        let f = DateFormatter()
-        f.dateFormat = "M월 d일 · HH:mm"
-        return f.string(from: item.timestamp)
-    }
-
-    private var normalizedContent: String {
-        item.postProcessedTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var displayTitle: String {
-        NoteTitleResolver.displayTitle(for: item, customTitle: customTitle, isTranscribing: status == .transcribing)
-    }
-
-    private var autoTitle: String {
-        NoteTitleResolver.automaticTitle(for: item, isTranscribing: status == .transcribing)
-    }
-
-    private var notePreview: String {
-        if status == .fail { return item.postProcessingStatus.replacingOccurrences(of: "Error: ", with: "") }
-        let content = normalizedContent
-        if customTitle != nil || item.calendarMatch?.appliedTitle != nil {
-            return String(content.prefix(100))
-        }
-        guard content.count > autoTitle.count else { return "" }
-        let rest = content.dropFirst(autoTitle.count).trimmingCharacters(in: .whitespacesAndNewlines)
-        return String(rest.prefix(100))
-    }
 }
 
 // MARK: - Note Detail View
@@ -1838,6 +1793,20 @@ private struct NoteTextView: NSViewRepresentable {
 
     func makeCoordinator() -> Coordinator { Coordinator(onCommit: onCommit) }
 
+    private func configureForTranscriptDisplay(_ textView: NSTextView) {
+        textView.isRichText = false
+        textView.importsGraphics = false
+        textView.enabledTextCheckingTypes = 0
+        textView.isContinuousSpellCheckingEnabled = false
+        textView.isGrammarCheckingEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.allowsUndo = true
+        textView.layoutManager?.allowsNonContiguousLayout = true
+    }
+
     func makeNSView(context: Context) -> NSScrollView {
         let scrollView = NSScrollView()
         scrollView.hasVerticalScroller = true
@@ -1847,6 +1816,7 @@ private struct NoteTextView: NSViewRepresentable {
         scrollView.borderType = .noBorder
 
         let textView = NSTextView()
+        configureForTranscriptDisplay(textView)
         textView.isEditable = true
         textView.isSelectable = true
         textView.drawsBackground = false

--- a/Sources/NoteListRowDisplayData.swift
+++ b/Sources/NoteListRowDisplayData.swift
@@ -67,8 +67,10 @@ struct NoteListRowDisplayData: Equatable {
         if customTitle != nil || item.calendarMatch?.appliedTitle != nil {
             return String(content.prefix(100))
         }
-        guard content.count > displayTitle.count else { return "" }
-        let rest = content.dropFirst(displayTitle.count).trimmingCharacters(in: .whitespacesAndNewlines)
-        return String(rest.prefix(100))
+        if content.hasPrefix(displayTitle) {
+            let rest = content.dropFirst(displayTitle.count).trimmingCharacters(in: .whitespacesAndNewlines)
+            return String(rest.prefix(100))
+        }
+        return String(content.prefix(100))
     }
 }

--- a/Sources/NoteListRowDisplayData.swift
+++ b/Sources/NoteListRowDisplayData.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+enum TranscriptStatus: Equatable {
+    case done, recording, transcribing, fail
+}
+
+func transcriptStatus(for item: PipelineHistoryItem, retrying: Set<UUID>) -> TranscriptStatus {
+    if retrying.contains(item.id) { return .transcribing }
+    if item.postProcessingStatus == "live-recording" { return .recording }
+    if item.postProcessingStatus == "importing" { return .transcribing }
+    if item.postProcessingStatus == PipelineHistoryItem.transcriptionRecoveryPlaceholderStatus { return .transcribing }
+    if item.postProcessingStatus.hasPrefix("Error:") { return .fail }
+    return .done
+}
+
+struct NoteListRowDisplayData: Equatable {
+    let id: UUID
+    let status: TranscriptStatus
+    let rowDate: String
+    let displayTitle: String
+    let preview: String
+
+    init(item: PipelineHistoryItem, customTitle: String?, retryingIDs: Set<UUID>) {
+        let status = transcriptStatus(for: item, retrying: retryingIDs)
+        let content = item.postProcessedTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayTitle = NoteTitleResolver.displayTitle(
+            for: item,
+            customTitle: customTitle,
+            isTranscribing: status == .transcribing
+        )
+
+        self.id = item.id
+        self.status = status
+        self.rowDate = Self.rowDateFormatter.string(from: item.timestamp)
+        self.displayTitle = displayTitle
+        self.preview = Self.preview(
+            for: item,
+            status: status,
+            content: content,
+            customTitle: customTitle,
+            displayTitle: displayTitle
+        )
+    }
+
+    private static let rowDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "M월 d일 · HH:mm"
+        return formatter
+    }()
+
+    private static func preview(
+        for item: PipelineHistoryItem,
+        status: TranscriptStatus,
+        content: String,
+        customTitle: String?,
+        displayTitle: String
+    ) -> String {
+        if status == .fail {
+            return item.postProcessingStatus.replacingOccurrences(of: "Error: ", with: "")
+        }
+        if customTitle != nil || item.calendarMatch?.appliedTitle != nil {
+            return String(content.prefix(100))
+        }
+        guard content.count > displayTitle.count else { return "" }
+        let rest = content.dropFirst(displayTitle.count).trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(rest.prefix(100))
+    }
+}

--- a/Sources/NoteListRowDisplayData.swift
+++ b/Sources/NoteListRowDisplayData.swift
@@ -58,7 +58,11 @@ struct NoteListRowDisplayData: Equatable {
         displayTitle: String
     ) -> String {
         if status == .fail {
-            return item.postProcessingStatus.replacingOccurrences(of: "Error: ", with: "")
+            return String(item.postProcessingStatus.dropFirst("Error:".count))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if status == .transcribing {
+            return ""
         }
         if customTitle != nil || item.calendarMatch?.appliedTitle != nil {
             return String(content.prefix(100))

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 
 @main
@@ -5,6 +6,7 @@ struct AppStateTranscriptionConfigurationTests {
     static func main() throws {
         try testMakeTranscriptionServiceUsesLocalConfiguration()
         try testMakeTranscriptionServiceMapsEmptyLocalWhisperPathToNil()
+        testPermissionStatusUpdateSkipsUnchangedValues()
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
@@ -35,6 +37,22 @@ struct AppStateTranscriptionConfigurationTests {
         let configuration = mirroredTranscriptionConfiguration(service)
 
         assert(configuration.localWhisperPath == nil)
+    }
+
+    private static func testPermissionStatusUpdateSkipsUnchangedValues() {
+        resetDefaults()
+        let appState = AppState()
+        appState.updatePermissionStatus(accessibility: true, screenRecording: true)
+
+        var changeCount = 0
+        let cancellable = appState.objectWillChange.sink { _ in
+            changeCount += 1
+        }
+
+        appState.updatePermissionStatus(accessibility: true, screenRecording: true)
+        cancellable.cancel()
+
+        assert(changeCount == 0, "Expected unchanged permission status to skip publishing, got \(changeCount) updates")
     }
 
     private static func resetDefaults() {

--- a/Tests/NoteListRowDisplayDataTests.swift
+++ b/Tests/NoteListRowDisplayDataTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+@main
+struct NoteListRowDisplayDataTests {
+    static func main() {
+        testFormatsRowDate()
+        testUsesCustomTitleAndContentPreview()
+        testDropsAutomaticTitleFromPreview()
+        testFailurePreviewUsesErrorMessage()
+        testTranscribingTitleAndEmptyPreview()
+        print("NoteListRowDisplayDataTests passed")
+    }
+
+    private static func testFormatsRowDate() {
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = .current
+        components.year = 2025
+        components.month = 5
+        components.day = 5
+        components.hour = 9
+        components.minute = 0
+        let item = historyItem(
+            timestamp: components.date!,
+            transcript: "Team sync notes"
+        )
+
+        let data = NoteListRowDisplayData(item: item, customTitle: nil, retryingIDs: [])
+
+        assert(data.rowDate == "5월 5일 · 09:00", "Unexpected row date: \(data.rowDate)")
+    }
+
+    private static func testUsesCustomTitleAndContentPreview() {
+        let item = historyItem(transcript: "Automatic transcript title\nDetails continue here")
+
+        let data = NoteListRowDisplayData(item: item, customTitle: "Manual title", retryingIDs: [])
+
+        assert(data.displayTitle == "Manual title")
+        assert(data.preview == "Automatic transcript title\nDetails continue here")
+    }
+
+    private static func testDropsAutomaticTitleFromPreview() {
+        let item = historyItem(transcript: "Automatic transcript title\nDetails continue here")
+
+        let data = NoteListRowDisplayData(item: item, customTitle: nil, retryingIDs: [])
+
+        assert(data.displayTitle == "Automatic transcript title")
+        assert(data.preview == "Details continue here", "Unexpected preview: \(data.preview)")
+    }
+
+    private static func testFailurePreviewUsesErrorMessage() {
+        let item = historyItem(
+            transcript: "Ignored transcript",
+            postProcessingStatus: "Error: Network unavailable"
+        )
+
+        let data = NoteListRowDisplayData(item: item, customTitle: nil, retryingIDs: [])
+
+        assert(data.status == .fail)
+        assert(data.preview == "Network unavailable")
+    }
+
+    private static func testTranscribingTitleAndEmptyPreview() {
+        let id = UUID()
+        let item = historyItem(id: id, transcript: "", postProcessingStatus: "importing")
+
+        let data = NoteListRowDisplayData(item: item, customTitle: nil, retryingIDs: [id])
+
+        assert(data.status == .transcribing)
+        assert(data.displayTitle == "Transcribing...")
+        assert(data.preview.isEmpty)
+    }
+
+    private static func historyItem(
+        id: UUID = UUID(),
+        timestamp: Date = Date(timeIntervalSince1970: 1),
+        transcript: String,
+        postProcessingStatus: String = "Post-processing succeeded"
+    ) -> PipelineHistoryItem {
+        PipelineHistoryItem(
+            id: id,
+            timestamp: timestamp,
+            rawTranscript: transcript,
+            postProcessedTranscript: transcript,
+            postProcessingPrompt: nil,
+            contextSummary: "",
+            contextPrompt: nil,
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "No screenshot",
+            postProcessingStatus: postProcessingStatus,
+            debugStatus: "Done",
+            customVocabulary: ""
+        )
+    }
+}

--- a/Tests/NoteListRowDisplayDataTests.swift
+++ b/Tests/NoteListRowDisplayDataTests.swift
@@ -7,7 +7,9 @@ struct NoteListRowDisplayDataTests {
         testUsesCustomTitleAndContentPreview()
         testDropsAutomaticTitleFromPreview()
         testFailurePreviewUsesErrorMessage()
+        testFailurePreviewHandlesMissingSpaceAfterPrefix()
         testTranscribingTitleAndEmptyPreview()
+        testRetryingItemHidesExistingPreview()
         print("NoteListRowDisplayDataTests passed")
     }
 
@@ -60,6 +62,18 @@ struct NoteListRowDisplayDataTests {
         assert(data.preview == "Network unavailable")
     }
 
+    private static func testFailurePreviewHandlesMissingSpaceAfterPrefix() {
+        let item = historyItem(
+            transcript: "Ignored transcript",
+            postProcessingStatus: "Error:Network unavailable"
+        )
+
+        let data = NoteListRowDisplayData(item: item, customTitle: nil, retryingIDs: [])
+
+        assert(data.status == .fail)
+        assert(data.preview == "Network unavailable", "Unexpected failure preview: \(data.preview)")
+    }
+
     private static func testTranscribingTitleAndEmptyPreview() {
         let id = UUID()
         let item = historyItem(id: id, transcript: "", postProcessingStatus: "importing")
@@ -69,6 +83,16 @@ struct NoteListRowDisplayDataTests {
         assert(data.status == .transcribing)
         assert(data.displayTitle == "Transcribing...")
         assert(data.preview.isEmpty)
+    }
+
+    private static func testRetryingItemHidesExistingPreview() {
+        let id = UUID()
+        let item = historyItem(id: id, transcript: "Previous title\nPrevious content")
+
+        let data = NoteListRowDisplayData(item: item, customTitle: nil, retryingIDs: [id])
+
+        assert(data.status == .transcribing)
+        assert(data.preview.isEmpty, "Expected retrying item to hide stale preview, got: \(data.preview)")
     }
 
     private static func historyItem(


### PR DESCRIPTION
## Summary
- Precompute note list row display data so row rendering no longer recreates date, title, status, and preview strings on each body evaluation.
- Reduce transcript text rendering overhead by disabling unnecessary rich-text and text-checking features while preserving editing/autosave.
- Avoid 2-second permission polling invalidating SwiftUI views when permission values are unchanged.

## Test plan
- [x] `make test`
- [x] `make -B all APP_NAME="Quill" BUNDLE_ID="com.woosublee.quill" CODESIGN_IDENTITY="<local Apple Development identity>"`
- [x] `codesign --verify --deep --strict build/Quill.app`
- [x] Installed with Makefile `install` path and verified note browser list/transcript scrolling manually.
- [x] Animation Hitches: list-scroll periodic interaction delays went from 15 rows before the polling fix to 0 rows after rerun.

Fixes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 노트 목록의 상태 표시 및 미리보기 생성 로직 도입으로 표시 정확성 향상
  * 편집기 텍스트 설정 최적화로 일관된 트랜스크립트 편집 경험 제공
  * 권한 폴링 로직 개선으로 불필요한 상태 업데이트 감소

* **테스트**
  * 노트 목록 표시 데이터 및 권한 업데이트 동작을 검증하는 테스트 확장 및 추가

* **잡일**
  * 빌드/테스트 스크립트 관련 업데이트 적용

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/freeflow/pull/81)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->