### PR TITLE
Fix release build SDK compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,8 @@ test:
 	@/tmp/NoteListRowDisplayDataTests
 	@swiftc -parse-as-library Tests/ForkReleaseWorkflowTests.swift -o /tmp/ForkReleaseWorkflowTests
 	@/tmp/ForkReleaseWorkflowTests
+	@swiftc -parse-as-library Tests/ReleaseSDKCompatibilityTests.swift -o /tmp/ReleaseSDKCompatibilityTests
+	@/tmp/ReleaseSDKCompatibilityTests
 	@swiftc -parse-as-library Sources/AppName.swift Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/TranscriptionModel.swift Sources/PipelineHistoryStore.swift Tests/PipelineHistoryCalendarMetadataTests.swift -o /tmp/PipelineHistoryCalendarMetadataTests
 	@/tmp/PipelineHistoryCalendarMetadataTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/GoogleCalendarTokenStore.swift Sources/GoogleCalendarAuthService.swift Sources/GoogleCalendarService.swift Tests/GoogleCalendarServiceTests.swift -o /tmp/GoogleCalendarServiceTests

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -84,43 +84,11 @@ private class GlassNSView: NSView {
     }
 }
 
-@available(macOS 26.0, *)
-private class LiquidGlassNSView: NSView {
-    private let glassView = NSGlassEffectView()
-    var cornerRadius: CGFloat? = nil
-
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        setup()
-    }
-
-    required init?(coder: NSCoder) { fatalError() }
-
-    private func setup() {
-        glassView.contentView = NSView()
-        glassView.wantsLayer = true
-        addSubview(glassView)
-    }
-
-    override func layout() {
-        super.layout()
-        glassView.frame = bounds
-        glassView.cornerRadius = cornerRadius ?? bounds.height / 2
-    }
-}
-
 private struct GlassView: NSViewRepresentable {
     var material: NSVisualEffectView.Material = .popover
     var cornerRadius: CGFloat? = nil
 
     func makeNSView(context: Context) -> NSView {
-        if #available(macOS 26.0, *) {
-            let view = LiquidGlassNSView()
-            if let cornerRadius {
-                view.cornerRadius = cornerRadius
-            }
-            return view
-        }
         let view = GlassNSView(material: material)
         view.cornerRadius = cornerRadius
         return view
@@ -129,9 +97,6 @@ private struct GlassView: NSViewRepresentable {
     func updateNSView(_ nsView: NSView, context: Context) {
         if let nsView = nsView as? GlassNSView {
             nsView.material = material
-            nsView.cornerRadius = cornerRadius
-        }
-        if #available(macOS 26.0, *), let nsView = nsView as? LiquidGlassNSView {
             nsView.cornerRadius = cornerRadius
         }
     }

--- a/Tests/ReleaseSDKCompatibilityTests.swift
+++ b/Tests/ReleaseSDKCompatibilityTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+@main
+struct ReleaseSDKCompatibilityTests {
+    static func main() throws {
+        let source = try String(contentsOfFile: "Sources/NoteBrowserView.swift", encoding: .utf8)
+
+        precondition(
+            !source.contains("NSGlassEffectView"),
+            "Release builds must not directly reference SDK symbols that are unavailable on GitHub's runner SDK"
+        )
+
+        print("ReleaseSDKCompatibilityTests passed")
+    }
+}


### PR DESCRIPTION
## Summary
- Remove the direct `NSGlassEffectView` reference that fails to compile on GitHub's Xcode runner SDK.
- Keep the existing `NSVisualEffectView` glass fallback for note browser glass backgrounds.
- Add a release SDK compatibility guard test so unavailable runner SDK symbols are not reintroduced.

## Test plan
- [x] `make test`
- [x] `make -B all ARCH=universal APP_NAME=Quill BUNDLE_ID=com.woosublee.quill CODESIGN_IDENTITY=-`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * SDK 호환성 검증 테스트 추가

* **리팩토**
  * 유리 효과 렌더링 구현 통합 및 단순화

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/freeflow/pull/85)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->