### PR TITLE
Merge upstream notch-side overlay updates

### DIFF
--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -38,7 +38,7 @@ enum RecordingOverlayLayout: String, CaseIterable, Identifiable {
         case .centered:
             return "Show the recording overlay centered below the notch."
         case .notchSides:
-            return "Show recording controls beside the notch when supported. Other states stay centered."
+            return "Show recording status beside the notch when supported. Update alerts stay centered."
         }
     }
 
@@ -163,6 +163,21 @@ struct RecordingOverlayGeometry {
             height: height
         )
     }
+
+    static func usesNotchSideLayout(
+        layout: RecordingOverlayLayout,
+        phase: OverlayPhase,
+        hasNotchGeometry: Bool
+    ) -> Bool {
+        guard layout == .notchSides, hasNotchGeometry else { return false }
+
+        switch phase {
+        case .initializing, .recording, .transcribing, .feedback:
+            return true
+        case .updateAvailable:
+            return false
+        }
+    }
 }
 
 // MARK: - Manager
@@ -214,11 +229,12 @@ final class RecordingOverlayManager {
         return screen.frame.maxY - screen.visibleFrame.maxY
     }
 
-    private var usesNotchSideRecordingLayout: Bool {
-        overlayState.recordingOverlayLayout == .notchSides
-            && overlayState.phase == .recording
-            && screenHasNotch
-            && notchSideGeometry != nil
+    private var usesNotchSideLayout: Bool {
+        RecordingOverlayGeometry.usesNotchSideLayout(
+            layout: overlayState.recordingOverlayLayout,
+            phase: overlayState.phase,
+            hasNotchGeometry: notchSideGeometry != nil
+        )
     }
 
     private var notchSideGeometry: NotchSideGeometry? {
@@ -368,11 +384,12 @@ final class RecordingOverlayManager {
     }
 
     private func setTranscribingPhase() {
+        let wasNotchSideRecordingLayout = overlayState.phase == .recording && usesNotchSideLayout
         lockedOverlayWidth = RecordingOverlayGeometry.lockedTranscribingWidth(
             existingLockedWidth: lockedOverlayWidth,
             currentPanelWidth: overlayWindow?.frame.width ?? overlayWidth,
             centeredTranscribingWidth: centeredTranscribingOverlayWidth,
-            wasNotchSideRecordingLayout: usesNotchSideRecordingLayout
+            wasNotchSideRecordingLayout: wasNotchSideRecordingLayout
         )
         overlayState.phase = .transcribing
         showOverlayPanel(animatedResize: true)
@@ -380,8 +397,8 @@ final class RecordingOverlayManager {
 
     private func makeOverlayContent(frame: NSRect) -> NSView {
         if let geometry = notchSideGeometry,
-           usesNotchSideRecordingLayout {
-            return makeNotchSideRecordingContent(frame: frame, geometry: geometry)
+           usesNotchSideLayout {
+            return makeNotchSideContent(frame: frame, geometry: geometry)
         }
 
         return makeNotchContent(
@@ -401,11 +418,11 @@ final class RecordingOverlayManager {
         )
     }
 
-    private func makeNotchSideRecordingContent(frame: NSRect, geometry: NotchSideGeometry) -> NSView {
+    private func makeNotchSideContent(frame: NSRect, geometry: NotchSideGeometry) -> NSView {
         makeTransparentContent(
             width: frame.width,
             height: frame.height,
-            rootView: NotchSideRecordingOverlayView(
+            rootView: NotchSideOverlayView(
                 state: overlayState,
                 leftContentFrame: geometry.leftContentFrame,
                 rightContentFrame: geometry.rightContentFrame,
@@ -432,8 +449,7 @@ final class RecordingOverlayManager {
     private var overlayFrame: NSRect {
         guard let screen = NSScreen.main else { return .zero }
         if let geometry = notchSideGeometry,
-           overlayState.recordingOverlayLayout == .notchSides,
-           overlayState.phase == .recording {
+           usesNotchSideLayout {
             return geometry.frame
         }
 
@@ -579,6 +595,21 @@ struct WaveformView: View {
     }
 }
 
+struct CompactWaveformView: View {
+    let audioLevel: Float
+    var showsActivityPulse = false
+
+    var body: some View {
+        WaveformView(audioLevel: audioLevel, showsActivityPulse: showsActivityPulse)
+    }
+}
+
+struct CompactProcessingIndicatorView: View {
+    var body: some View {
+        ProcessingWaveformView()
+    }
+}
+
 struct ProcessingWaveformView: View {
     private static let barCount = 5
     private static let centerIndex = CGFloat((barCount - 1) / 2)
@@ -720,35 +751,72 @@ private struct NotchExtensionBackground: View {
     }
 }
 
-private struct NotchSideRecordingOverlayView: View {
+private struct NotchSideOverlayView: View {
     @ObservedObject var state: RecordingOverlayState
     let leftContentFrame: CGRect
     let rightContentFrame: CGRect
     let onStopButtonPressed: () -> Void
 
+    private var showsLiveRecordingContent: Bool {
+        state.phase == .recording
+    }
+
     private var showsStopButton: Bool {
-        state.recordingTriggerMode == .toggle
+        showsLiveRecordingContent && state.recordingTriggerMode == .toggle
     }
 
     var body: some View {
         ZStack(alignment: .topLeading) {
             NotchExtensionBackground()
 
-            ZStack {
-                WaveformView(audioLevel: state.audioLevel, showsActivityPulse: true)
-                    .padding(.horizontal, 12)
-                if state.isCommandMode {
-                    HStack {
-                        CommandModeIndicator()
-                            .padding(.leading, 8)
-                        Spacer()
-                    }
-                }
-            }
-            .frame(width: leftContentFrame.width, height: leftContentFrame.height)
-            .position(x: leftContentFrame.midX, y: leftContentFrame.midY)
+            leftContent
+                .frame(width: leftContentFrame.width, height: leftContentFrame.height)
+                .position(x: leftContentFrame.midX, y: leftContentFrame.midY)
 
-            ZStack {
+            rightContent
+                .frame(width: rightContentFrame.width, height: rightContentFrame.height)
+                .position(x: rightContentFrame.midX, y: rightContentFrame.midY)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.phase)
+        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.audioLevel)
+        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.recordingTriggerMode)
+        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.isCommandMode)
+    }
+
+    @ViewBuilder
+    private var leftContent: some View {
+        ZStack {
+            switch state.phase {
+            case .initializing:
+                InitializingDotsView()
+                    .transition(.opacity.combined(with: .scale(scale: 0.96)))
+            case .recording:
+                VStack(spacing: 1) {
+                    if state.isCommandMode {
+                        Image(systemName: "pencil")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.92))
+                            .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                    }
+                    CompactWaveformView(audioLevel: state.audioLevel, showsActivityPulse: true)
+                }
+                .transition(.opacity.combined(with: .scale(scale: 0.96)))
+            case .transcribing:
+                CompactProcessingIndicatorView()
+                    .transition(.opacity.combined(with: .scale(scale: 0.96)))
+            case .feedback, .updateAvailable:
+                Color.clear
+            }
+        }
+        .padding(.horizontal, 12)
+    }
+
+    @ViewBuilder
+    private var rightContent: some View {
+        ZStack {
+            switch state.phase {
+            case .recording:
                 if showsStopButton {
                     Button(action: onStopButtonPressed) {
                         Image(systemName: "stop.fill")
@@ -758,15 +826,15 @@ private struct NotchSideRecordingOverlayView: View {
                             .background(Circle().fill(Color.red.opacity(0.92)))
                     }
                     .buttonStyle(.plain)
+                    .transition(.move(edge: .trailing).combined(with: .opacity))
                 }
+            case .feedback:
+                FailureIndicatorView()
+                    .transition(.opacity.combined(with: .scale(scale: 0.96)))
+            case .initializing, .transcribing, .updateAvailable:
+                Color.clear
             }
-            .frame(width: rightContentFrame.width, height: rightContentFrame.height)
-            .position(x: rightContentFrame.midX, y: rightContentFrame.midY)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.audioLevel)
-        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.recordingTriggerMode)
-        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.isCommandMode)
     }
 }
 

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -779,7 +779,6 @@ private struct NotchSideOverlayView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.phase)
-        .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.audioLevel)
         .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.recordingTriggerMode)
         .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.isCommandMode)
     }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -560,22 +560,19 @@ struct AppearanceSettingsView: View {
                 }
 
                 SettingsCard("Recording Overlay", icon: "rectangle.topthird.inset.filled") {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text("Layout")
-                            .font(.caption.weight(.semibold))
-
-                        Picker("Recording Overlay Layout", selection: $appState.recordingOverlayLayout) {
-                            ForEach(RecordingOverlayLayout.allCases) { layout in
-                                Text(layout.displayName).tag(layout)
-                            }
-                        }
-                        .pickerStyle(.segmented)
-                        .labelsHidden()
-                        .accessibilityLabel("Recording Overlay Layout")
-
-                        Text(appState.recordingOverlayLayout.helpText)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                    VStack(spacing: 10) {
+                        OverlayLayoutOptionRow(
+                            title: "Notch-side menu-bar overlay",
+                            subtitle: "Shows recording status beside the camera notch when supported, without covering app tabs or toolbars.",
+                            layout: .notchSides,
+                            selection: $appState.recordingOverlayLayout
+                        )
+                        OverlayLayoutOptionRow(
+                            title: "Centered drop-down pill",
+                            subtitle: "Shows a single centered pill below the menu bar. More visible, but it can cover a thin strip of the active app.",
+                            layout: .centered,
+                            selection: $appState.recordingOverlayLayout
+                        )
                     }
                 }
             }
@@ -589,6 +586,99 @@ struct AppearanceSettingsView: View {
         case "dark":   NSApp.appearance = NSAppearance(named: .darkAqua)
         default:       NSApp.appearance = nil
         }
+    }
+}
+
+struct OverlayLayoutOptionRow: View {
+    let title: String
+    let subtitle: String
+    let layout: RecordingOverlayLayout
+    @Binding var selection: RecordingOverlayLayout
+
+    private var isSelected: Bool {
+        selection == layout
+    }
+
+    var body: some View {
+        Button {
+            selection = layout
+        } label: {
+            HStack(alignment: .center, spacing: 14) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 20))
+                    .foregroundStyle(isSelected ? Color.blue : Color.secondary)
+
+                OverlayLayoutPreview(layout: layout)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isSelected ? Color.blue.opacity(0.12) : Color(nsColor: .controlBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(isSelected ? Color.blue.opacity(0.55) : Color.primary.opacity(0.08), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+    }
+}
+
+struct OverlayLayoutPreview: View {
+    let layout: RecordingOverlayLayout
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color(nsColor: .windowBackgroundColor))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                )
+
+            Rectangle()
+                .fill(Color.primary.opacity(0.12))
+                .frame(height: 14)
+                .frame(maxHeight: .infinity, alignment: .top)
+
+            RoundedRectangle(cornerRadius: 5)
+                .fill(Color.black)
+                .frame(width: 38, height: 13)
+                .frame(maxHeight: .infinity, alignment: .top)
+
+            if layout == .notchSides {
+                HStack(spacing: 38) {
+                    UnevenRoundedRectangle(bottomLeadingRadius: 3)
+                        .fill(Color.black)
+                        .frame(width: 18, height: 14)
+                    UnevenRoundedRectangle(bottomTrailingRadius: 3)
+                        .fill(Color.black)
+                        .frame(width: 18, height: 14)
+                }
+                .frame(maxHeight: .infinity, alignment: .top)
+            } else {
+                UnevenRoundedRectangle(bottomLeadingRadius: 5, bottomTrailingRadius: 5)
+                    .fill(Color.black)
+                    .frame(width: 50, height: 26)
+                    .frame(maxHeight: .infinity, alignment: .top)
+            }
+        }
+        .frame(width: 92, height: 54)
     }
 }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -623,7 +623,6 @@ struct OverlayLayoutOptionRow: View {
                 Spacer(minLength: 0)
             }
             .padding(14)
-            .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 8)
                     .fill(Color(nsColor: .controlBackgroundColor))
@@ -654,42 +653,61 @@ struct OverlayLayoutPreview: View {
                 .fill(Color(nsColor: .windowBackgroundColor))
                 .overlay(
                     RoundedRectangle(cornerRadius: 6)
-                        .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                        .stroke(Color.primary.opacity(0.15), lineWidth: 0.5)
                 )
 
-            VStack(spacing: 0) {
-                Rectangle()
-                    .fill(Color.primary.opacity(0.12))
-                    .frame(height: menuBarHeight)
+            Rectangle()
+                .fill(Color.primary.opacity(0.10))
+                .frame(height: menuBarHeight)
 
-                Rectangle()
-                    .fill(Color.primary.opacity(0.05))
-                    .frame(height: 10)
-
-                Spacer(minLength: 0)
+            HStack(spacing: 3) {
+                ForEach(0..<5, id: \.self) { _ in
+                    RoundedRectangle(cornerRadius: 1.5)
+                        .fill(Color.primary.opacity(0.18))
+                        .frame(height: 5)
+                }
             }
+            .padding(.horizontal, 6)
+            .padding(.top, menuBarHeight + 4)
 
-            RoundedRectangle(cornerRadius: 4)
-                .fill(Color.black)
-                .frame(width: notchWidth, height: notchHeight)
-                .frame(maxHeight: .infinity, alignment: .top)
+            UnevenRoundedRectangle(
+                topLeadingRadius: 0,
+                bottomLeadingRadius: 3,
+                bottomTrailingRadius: 3,
+                topTrailingRadius: 0
+            )
+            .fill(Color.black)
+            .frame(width: notchWidth, height: notchHeight)
 
             if layout == .notchSides {
-                HStack(spacing: notchWidth + 4) {
-                    RoundedRectangle(cornerRadius: 2)
-                        .fill(Color.black)
-                        .frame(width: 20, height: menuBarHeight)
-                    RoundedRectangle(cornerRadius: 2)
-                        .fill(Color.black)
-                        .frame(width: 20, height: menuBarHeight)
-                }
-                .frame(maxHeight: .infinity, alignment: .top)
-            } else {
-                UnevenRoundedRectangle(bottomLeadingRadius: 5, bottomTrailingRadius: 5)
+                HStack(spacing: notchWidth) {
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: 0,
+                        bottomLeadingRadius: 3,
+                        bottomTrailingRadius: 0,
+                        topTrailingRadius: 0
+                    )
                     .fill(Color.black)
-                    .frame(width: 46, height: 24)
-                    .offset(y: menuBarHeight)
-                    .frame(maxHeight: .infinity, alignment: .top)
+                    .frame(width: 16, height: notchHeight)
+
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: 0,
+                        bottomLeadingRadius: 0,
+                        bottomTrailingRadius: 3,
+                        topTrailingRadius: 0
+                    )
+                    .fill(Color.black)
+                    .frame(width: 16, height: notchHeight)
+                }
+            } else {
+                UnevenRoundedRectangle(
+                    topLeadingRadius: 0,
+                    bottomLeadingRadius: 5,
+                    bottomTrailingRadius: 5,
+                    topTrailingRadius: 0
+                )
+                .fill(Color.black)
+                .frame(width: notchWidth + 10, height: notchHeight + 12)
             }
         }
         .frame(width: frameWidth, height: frameHeight)

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -622,15 +622,15 @@ struct OverlayLayoutOptionRow: View {
 
                 Spacer(minLength: 0)
             }
-            .padding(12)
+            .padding(14)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(isSelected ? Color.blue.opacity(0.12) : Color(nsColor: .controlBackgroundColor))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(isSelected ? Color.blue.opacity(0.55) : Color.primary.opacity(0.08), lineWidth: 1)
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(isSelected ? Color.blue : Color.clear, lineWidth: 2)
+                    )
             )
         }
         .buttonStyle(.plain)
@@ -642,6 +642,12 @@ struct OverlayLayoutOptionRow: View {
 struct OverlayLayoutPreview: View {
     let layout: RecordingOverlayLayout
 
+    private let frameWidth: CGFloat = 110
+    private let frameHeight: CGFloat = 56
+    private let menuBarHeight: CGFloat = 8
+    private let notchWidth: CGFloat = 26
+    private let notchHeight: CGFloat = 8
+
     var body: some View {
         ZStack(alignment: .top) {
             RoundedRectangle(cornerRadius: 6)
@@ -651,34 +657,43 @@ struct OverlayLayoutPreview: View {
                         .stroke(Color.primary.opacity(0.08), lineWidth: 1)
                 )
 
-            Rectangle()
-                .fill(Color.primary.opacity(0.12))
-                .frame(height: 14)
-                .frame(maxHeight: .infinity, alignment: .top)
+            VStack(spacing: 0) {
+                Rectangle()
+                    .fill(Color.primary.opacity(0.12))
+                    .frame(height: menuBarHeight)
 
-            RoundedRectangle(cornerRadius: 5)
+                Rectangle()
+                    .fill(Color.primary.opacity(0.05))
+                    .frame(height: 10)
+
+                Spacer(minLength: 0)
+            }
+
+            RoundedRectangle(cornerRadius: 4)
                 .fill(Color.black)
-                .frame(width: 38, height: 13)
+                .frame(width: notchWidth, height: notchHeight)
                 .frame(maxHeight: .infinity, alignment: .top)
 
             if layout == .notchSides {
-                HStack(spacing: 38) {
-                    UnevenRoundedRectangle(bottomLeadingRadius: 3)
+                HStack(spacing: notchWidth + 4) {
+                    RoundedRectangle(cornerRadius: 2)
                         .fill(Color.black)
-                        .frame(width: 18, height: 14)
-                    UnevenRoundedRectangle(bottomTrailingRadius: 3)
+                        .frame(width: 20, height: menuBarHeight)
+                    RoundedRectangle(cornerRadius: 2)
                         .fill(Color.black)
-                        .frame(width: 18, height: 14)
+                        .frame(width: 20, height: menuBarHeight)
                 }
                 .frame(maxHeight: .infinity, alignment: .top)
             } else {
                 UnevenRoundedRectangle(bottomLeadingRadius: 5, bottomTrailingRadius: 5)
                     .fill(Color.black)
-                    .frame(width: 50, height: 26)
+                    .frame(width: 46, height: 24)
+                    .offset(y: menuBarHeight)
                     .frame(maxHeight: .infinity, alignment: .top)
             }
         }
-        .frame(width: 92, height: 54)
+        .frame(width: frameWidth, height: frameHeight)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
     }
 }
 

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -68,6 +68,7 @@ struct SetupView: View {
         case holdShortcut
         case toggleShortcut
         case commandMode
+        case overlayStyle
         case vocabulary
         case launchAtLogin
         case testTranscription
@@ -264,6 +265,8 @@ struct SetupView: View {
             toggleShortcutStep
         case .commandMode:
             commandModeStep
+        case .overlayStyle:
+            overlayStyleStep
         case .vocabulary:
             vocabularyStep
         case .launchAtLogin:
@@ -906,6 +909,39 @@ struct SetupView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color(nsColor: .controlBackgroundColor))
             .cornerRadius(10)
+        }
+    }
+
+    var overlayStyleStep: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "rectangle.topthird.inset.filled")
+                .font(.system(size: 60))
+                .foregroundStyle(.blue)
+
+            Text("Recording overlay style")
+                .font(.title)
+                .fontWeight(.bold)
+
+            Text("Choose how Quill shows recording status while you dictate. You can change this later in Settings.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(spacing: 10) {
+                OverlayLayoutOptionRow(
+                    title: "Notch-side menu-bar overlay",
+                    subtitle: "Shows recording status beside the camera notch when supported, without covering app tabs or toolbars.",
+                    layout: .notchSides,
+                    selection: $appState.recordingOverlayLayout
+                )
+                OverlayLayoutOptionRow(
+                    title: "Centered drop-down pill",
+                    subtitle: "Shows a single centered pill below the menu bar. More visible, but it can cover a thin strip of the active app.",
+                    layout: .centered,
+                    selection: $appState.recordingOverlayLayout
+                )
+            }
+            .padding(.top, 6)
         }
     }
 

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -7,6 +7,7 @@ struct AppStateTranscriptionConfigurationTests {
         try testMakeTranscriptionServiceUsesLocalConfiguration()
         try testMakeTranscriptionServiceMapsEmptyLocalWhisperPathToNil()
         testPermissionStatusUpdateSkipsUnchangedValues()
+        testRecordingOverlayLayoutPersistsWithoutCompactOverlayBoolean()
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
@@ -53,6 +54,19 @@ struct AppStateTranscriptionConfigurationTests {
         cancellable.cancel()
 
         assert(changeCount == 0, "Expected unchanged permission status to skip publishing, got \(changeCount) updates")
+    }
+
+    private static func testRecordingOverlayLayoutPersistsWithoutCompactOverlayBoolean() {
+        resetDefaults()
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: "recording_overlay_layout")
+        defaults.removeObject(forKey: "use_compact_overlay")
+
+        let appState = AppState()
+        appState.recordingOverlayLayout = .notchSides
+
+        assert(defaults.string(forKey: "recording_overlay_layout") == "notchSides")
+        assert(defaults.object(forKey: "use_compact_overlay") == nil)
     }
 
     private static func resetDefaults() {

--- a/Tests/RecordingOverlayGeometryTests.swift
+++ b/Tests/RecordingOverlayGeometryTests.swift
@@ -8,6 +8,7 @@ struct RecordingOverlayGeometryTests {
         testTranscribingWidthFallsBackToCenteredWidthAfterNotchSideRecording()
         testTranscribingWidthKeepsExistingLockOnRepeatedTranscribingUpdate()
         testCenteredFrameUsesUpdatedMainScreenGeometry()
+        testNotchSideLayoutPhaseEligibility()
         print("RecordingOverlayGeometryTests passed")
     }
 
@@ -69,5 +70,43 @@ struct RecordingOverlayGeometryTests {
         assert(oldFrame.origin.x == 710)
         assert(updatedFrame.origin.x == 818)
         assert(updatedFrame.origin.y == 1041)
+    }
+
+    private static func testNotchSideLayoutPhaseEligibility() {
+        assert(RecordingOverlayGeometry.usesNotchSideLayout(
+            layout: .notchSides,
+            phase: .initializing,
+            hasNotchGeometry: true
+        ))
+        assert(RecordingOverlayGeometry.usesNotchSideLayout(
+            layout: .notchSides,
+            phase: .recording,
+            hasNotchGeometry: true
+        ))
+        assert(RecordingOverlayGeometry.usesNotchSideLayout(
+            layout: .notchSides,
+            phase: .transcribing,
+            hasNotchGeometry: true
+        ))
+        assert(RecordingOverlayGeometry.usesNotchSideLayout(
+            layout: .notchSides,
+            phase: .feedback,
+            hasNotchGeometry: true
+        ))
+        assert(!RecordingOverlayGeometry.usesNotchSideLayout(
+            layout: .notchSides,
+            phase: .updateAvailable,
+            hasNotchGeometry: true
+        ))
+        assert(!RecordingOverlayGeometry.usesNotchSideLayout(
+            layout: .centered,
+            phase: .recording,
+            hasNotchGeometry: true
+        ))
+        assert(!RecordingOverlayGeometry.usesNotchSideLayout(
+            layout: .notchSides,
+            phase: .recording,
+            hasNotchGeometry: false
+        ))
     }
 }

--- a/Tests/RecordingOverlayGeometryTests.swift
+++ b/Tests/RecordingOverlayGeometryTests.swift
@@ -3,12 +3,13 @@ import CoreGraphics
 
 @main
 struct RecordingOverlayGeometryTests {
-    static func main() {
+    static func main() throws {
         testNotchSideContentStartsAtTopOfVisiblePill()
         testTranscribingWidthFallsBackToCenteredWidthAfterNotchSideRecording()
         testTranscribingWidthKeepsExistingLockOnRepeatedTranscribingUpdate()
         testCenteredFrameUsesUpdatedMainScreenGeometry()
         testNotchSideLayoutPhaseEligibility()
+        try testNotchSideOverlayAvoidsContainerAudioLevelAnimation()
         print("RecordingOverlayGeometryTests passed")
     }
 
@@ -108,5 +109,20 @@ struct RecordingOverlayGeometryTests {
             phase: .recording,
             hasNotchGeometry: false
         ))
+    }
+
+    private static func testNotchSideOverlayAvoidsContainerAudioLevelAnimation() throws {
+        let source = try String(contentsOfFile: "Sources/RecordingOverlay.swift", encoding: .utf8)
+        guard let viewStart = source.range(of: "private struct NotchSideOverlayView")?.lowerBound,
+              let nextView = source.range(of: "struct RecordingOverlayView", range: viewStart..<source.endIndex)?.lowerBound else {
+            assertionFailure("Expected to find NotchSideOverlayView source block")
+            return
+        }
+
+        let viewSource = source[viewStart..<nextView]
+        assert(
+            !viewSource.contains("value: state.audioLevel"),
+            "NotchSideOverlayView must not animate the whole container for high-frequency audioLevel updates"
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Merge upstream PR #158's multi-phase notch-side overlay behavior into Quill's existing `RecordingOverlayLayout` model.
- Add card-style overlay selection in Settings and Setup without introducing upstream's `use_compact_overlay` setting.
- Preserve Quill's auxiliary-area notch geometry while adding initializing, transcribing, feedback, and command-mode wing indicators.

## Test plan
- [x] `HOME=$(mktemp -d /tmp/quill-test-home.XXXXXX) make test`
- [x] `make -B APP_NAME="Quill Dev" BUNDLE_ID="com.woosublee.quill.dev" CODESIGN_IDENTITY="$IDENTITY"`
- [x] Launch `build/Quill Dev.app`
- [x] Manually verify Settings overlay picker cards
- [x] Reset `com.woosublee.quill.dev` setup completion and manually verify Setup overlay picker cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 녹음 오버레이에 "노치 측면 메뉴 바" 레이아웃 옵션 추가
  * 설정에 오버레이 레이아웃 시각적 미리보기 및 선택 가능한 카드형 옵션 추가
  * 초기 설정 흐름에 오버레이 스타일 선택 단계 추가

* **개선 사항**
  * 녹음 상태 관련 도움말 문구 개선 및 업데이트 알림 중앙 정렬 유지
  * 노치 측면 레이아웃용 간결한 컴팩트 UI와 전환 동작 개선, 피드백 상태 표시 향상

* **테스트**
  * 오버레이 레이아웃 지속성 및 노치 측면 위상 적격성 검증 테스트 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/freeflow/pull/86)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->