### PR TITLE
Allow configuring recording cancel shortcut

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,8 +172,10 @@ test:
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/CalendarEventMatcher.swift Tests/CalendarEventMatcherTests.swift -o /tmp/CalendarEventMatcherTests
 	@swiftc -parse-as-library Sources/AppName.swift Sources/ModifierKeyEventState.swift Sources/ShortcutCore/ShortcutModels.swift Sources/ShortcutCore/ShortcutMatcher.swift Sources/GlobalShortcutBackend.swift Sources/HotkeyManager.swift Tests/ShortcutMatcherTests.swift -o /tmp/ShortcutMatcherTests
 	@swiftc -parse-as-library Sources/ShortcutCore/ShortcutModels.swift Sources/ShortcutBinding.swift Sources/ShortcutCaptureKeyHandling.swift Tests/ShortcutCaptureKeyHandlingTests.swift -o /tmp/ShortcutCaptureKeyHandlingTests
+	@swiftc -parse-as-library Sources/ShortcutValidationMessages.swift Tests/ShortcutValidationMessagesTests.swift -o /tmp/ShortcutValidationMessagesTests
 	@/tmp/ShortcutMatcherTests
 	@/tmp/ShortcutCaptureKeyHandlingTests
+	@/tmp/ShortcutValidationMessagesTests
 	@/tmp/CalendarEventMatcherTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/NoteTitleResolver.swift Tests/NoteTitleResolutionTests.swift -o /tmp/NoteTitleResolutionTests
 	@/tmp/NoteTitleResolutionTests

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,9 @@ FORCE:
 test:
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/CalendarEventMatcher.swift Tests/CalendarEventMatcherTests.swift -o /tmp/CalendarEventMatcherTests
 	@swiftc -parse-as-library Sources/AppName.swift Sources/ModifierKeyEventState.swift Sources/ShortcutCore/ShortcutModels.swift Sources/ShortcutCore/ShortcutMatcher.swift Sources/GlobalShortcutBackend.swift Sources/HotkeyManager.swift Tests/ShortcutMatcherTests.swift -o /tmp/ShortcutMatcherTests
+	@swiftc -parse-as-library Sources/ShortcutCore/ShortcutModels.swift Sources/ShortcutBinding.swift Sources/ShortcutCaptureKeyHandling.swift Tests/ShortcutCaptureKeyHandlingTests.swift -o /tmp/ShortcutCaptureKeyHandlingTests
 	@/tmp/ShortcutMatcherTests
+	@/tmp/ShortcutCaptureKeyHandlingTests
 	@/tmp/CalendarEventMatcherTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/NoteTitleResolver.swift Tests/NoteTitleResolutionTests.swift -o /tmp/NoteTitleResolutionTests
 	@/tmp/NoteTitleResolutionTests

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,8 @@ FORCE:
 
 test:
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/CalendarEventMatcher.swift Tests/CalendarEventMatcherTests.swift -o /tmp/CalendarEventMatcherTests
+	@swiftc -parse-as-library Sources/AppName.swift Sources/ModifierKeyEventState.swift Sources/ShortcutCore/ShortcutModels.swift Sources/ShortcutCore/ShortcutMatcher.swift Sources/GlobalShortcutBackend.swift Sources/HotkeyManager.swift Tests/ShortcutMatcherTests.swift -o /tmp/ShortcutMatcherTests
+	@/tmp/ShortcutMatcherTests
 	@/tmp/CalendarEventMatcherTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/NoteTitleResolver.swift Tests/NoteTitleResolutionTests.swift -o /tmp/NoteTitleResolutionTests
 	@/tmp/NoteTitleResolutionTests

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -985,7 +985,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
             fallback: shortcuts.toggle.isCustom ? shortcuts.toggle : nil
         )
         let storedRecordingCancelShortcut = Self.loadShortcut(forKey: recordingCancelShortcutStorageKey)
-        let recordingCancelShortcut = storedRecordingCancelShortcut.binding ?? .defaultRecordingCancel
+        let recordingCancelShortcut = Self.initialRecordingCancelShortcut(
+            stored: storedRecordingCancelShortcut.binding,
+            hold: shortcuts.hold,
+            toggle: shortcuts.toggle
+        )
         let savedRecordingCancelCustomShortcut = Self.loadSavedCustomShortcut(
             forKey: savedRecordingCancelCustomShortcutStorageKey,
             fallback: recordingCancelShortcut.isCustom && recordingCancelShortcut != .defaultRecordingCancel
@@ -1280,6 +1284,26 @@ final class AppState: ObservableObject, @unchecked Sendable {
             hadStoredValue: true,
             didNormalize: normalized != decoded
         )
+    }
+
+    private static func initialRecordingCancelShortcut(
+        stored: ShortcutBinding?,
+        hold: ShortcutBinding,
+        toggle: ShortcutBinding
+    ) -> ShortcutBinding {
+        if let stored {
+            return stored
+        }
+        if defaultRecordingCancelOverlaps(hold) || defaultRecordingCancelOverlaps(toggle) {
+            return .disabled
+        }
+        return .defaultRecordingCancel
+    }
+
+    private static func defaultRecordingCancelOverlaps(_ binding: ShortcutBinding) -> Bool {
+        guard !binding.isDisabled else { return false }
+        guard binding.kind == .key else { return false }
+        return binding.keyCode == ShortcutBinding.defaultRecordingCancel.keyCode
     }
 
     private static func loadSavedCustomShortcut(
@@ -5091,16 +5115,28 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
 private extension ShortcutBinding {
     func primaryInputOverlapsForCancellation(with other: ShortcutBinding) -> Bool {
-        guard kind == other.kind else { return false }
-
-        switch kind {
-        case .disabled:
-            return false
-        case .key:
-            return keyCode == other.keyCode
-        case .modifierKey:
-            return keyCode == other.keyCode
+        if kind == other.kind {
+            switch kind {
+            case .disabled:
+                return false
+            case .key, .modifierKey:
+                return keyCode == other.keyCode
+            }
         }
+
+        if kind == .modifierKey,
+           other.kind == .key,
+           let modifier = Self.logicalModifier(forKeyCode: keyCode) {
+            return other.modifiers.contains(modifier)
+        }
+
+        if kind == .key,
+           other.kind == .modifierKey,
+           let modifier = Self.logicalModifier(forKeyCode: other.keyCode) {
+            return modifiers.contains(modifier)
+        }
+
+        return false
     }
 
     func isActiveForCancellationConflict(

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2481,7 +2481,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @discardableResult
     func setRecordingCancelShortcut(_ binding: ShortcutBinding) -> String? {
         let binding = binding.normalizedForStorageMigration()
-        guard !binding.conflicts(with: holdShortcut), !binding.conflicts(with: toggleShortcut) else {
+        guard !cancelShortcutOverlapsDictationShortcut(binding, holdShortcut),
+              !cancelShortcutOverlapsDictationShortcut(binding, toggleShortcut) else {
             return "Cancel shortcut must be distinct from dictation shortcuts."
         }
 
@@ -2499,7 +2500,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         guard !binding.conflicts(with: otherBinding) else {
             return "Hold and tap shortcuts must be distinct."
         }
-        guard !binding.conflicts(with: recordingCancelShortcut) else {
+        guard !cancelShortcutOverlapsDictationShortcut(recordingCancelShortcut, binding) else {
             return "Dictation shortcuts must be distinct from the cancel shortcut."
         }
 
@@ -2529,6 +2530,28 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         return nil
+    }
+
+    private func cancelShortcutOverlapsDictationShortcut(_ cancel: ShortcutBinding, _ dictation: ShortcutBinding) -> Bool {
+        guard !cancel.isDisabled, !dictation.isDisabled else { return false }
+        guard cancel.primaryInputOverlapsForCancellation(with: dictation) else { return false }
+
+        let orderedModifierKeyCodes = Array(ShortcutBinding.modifierKeyCodes).sorted()
+        let combinations = 1 << orderedModifierKeyCodes.count
+
+        for mask in 0..<combinations {
+            var pressedModifierKeyCodes: Set<UInt16> = []
+            for (index, keyCode) in orderedModifierKeyCodes.enumerated() where (mask & (1 << index)) != 0 {
+                pressedModifierKeyCodes.insert(keyCode)
+            }
+
+            if cancel.isActiveForCancellationConflict(pressedModifierKeyCodes: pressedModifierKeyCodes)
+                && dictation.isActiveForCancellationConflict(pressedModifierKeyCodes: pressedModifierKeyCodes) {
+                return true
+            }
+        }
+
+        return false
     }
 
     private func commandModeManualModifierCollisionMessage(
@@ -5026,6 +5049,45 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 return
             }
             self.statusText = "Ready"
+        }
+    }
+}
+
+private extension ShortcutBinding {
+    func primaryInputOverlapsForCancellation(with other: ShortcutBinding) -> Bool {
+        guard kind == other.kind else { return false }
+
+        switch kind {
+        case .disabled:
+            return false
+        case .key:
+            return keyCode == other.keyCode
+        case .modifierKey:
+            return keyCode == other.keyCode
+        }
+    }
+
+    func isActiveForCancellationConflict(pressedModifierKeyCodes: Set<UInt16>) -> Bool {
+        let currentModifiers = Self.modifiers(for: pressedModifierKeyCodes)
+        guard currentModifiers.isSuperset(of: modifiers) else {
+            return false
+        }
+
+        if let exactModifierKeyCodes,
+           !Self.exactModifierKeyCodesMatch(
+            pressedModifierKeyCodes,
+            exactModifierKeyCodes: exactModifierKeyCodes
+           ) {
+            return false
+        }
+
+        switch kind {
+        case .disabled:
+            return false
+        case .key:
+            return true
+        case .modifierKey:
+            return pressedModifierKeyCodes.contains(keyCode)
         }
     }
 }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2518,7 +2518,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 self?.handleShortcutEvent(event)
             }
         }
-        hotkeyManager.onEscapeKeyPressed = { [weak self] in
+        hotkeyManager.onRecordingCancelShortcut = { [weak self] in
             guard let self else { return false }
             let shouldHandle = Thread.isMainThread
                 ? self.shouldConfirmEscapeCancellation
@@ -2538,7 +2538,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         shouldMonitorHotkeys = false
         hotkeyMonitoringErrorMessage = nil
         hotkeyManager.onShortcutEvent = nil
-        hotkeyManager.onEscapeKeyPressed = nil
+        hotkeyManager.onRecordingCancelShortcut = nil
         hotkeyManager.stop()
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2536,6 +2536,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         guard !cancel.isDisabled, !dictation.isDisabled else { return false }
         guard cancel.primaryInputOverlapsForCancellation(with: dictation) else { return false }
 
+        let permittedAdditionalExactMatchModifiers = permittedAdditionalExactMatchModifiersForShortcutMatching
         let orderedModifierKeyCodes = Array(ShortcutBinding.modifierKeyCodes).sorted()
         let combinations = 1 << orderedModifierKeyCodes.count
 
@@ -2545,8 +2546,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 pressedModifierKeyCodes.insert(keyCode)
             }
 
-            if cancel.isActiveForCancellationConflict(pressedModifierKeyCodes: pressedModifierKeyCodes)
-                && dictation.isActiveForCancellationConflict(pressedModifierKeyCodes: pressedModifierKeyCodes) {
+            if cancel.isActiveForCancellationConflict(
+                pressedModifierKeyCodes: pressedModifierKeyCodes,
+                permittedAdditionalExactMatchModifiers: permittedAdditionalExactMatchModifiers
+            ) && dictation.isActiveForCancellationConflict(
+                pressedModifierKeyCodes: pressedModifierKeyCodes,
+                permittedAdditionalExactMatchModifiers: permittedAdditionalExactMatchModifiers
+            ) {
                 return true
             }
         }
@@ -2627,19 +2633,19 @@ final class AppState: ObservableObject, @unchecked Sendable {
         restartHotkeyMonitoring()
     }
 
-    private var activeShortcutConfiguration: ShortcutConfiguration {
-        let permittedAdditionalExactMatchModifiers: ShortcutModifiers
+    private var permittedAdditionalExactMatchModifiersForShortcutMatching: ShortcutModifiers {
         if isCommandModeEnabled, commandModeStyle == .manual {
-            permittedAdditionalExactMatchModifiers = commandModeManualModifier.shortcutModifier
-        } else {
-            permittedAdditionalExactMatchModifiers = []
+            return commandModeManualModifier.shortcutModifier
         }
+        return []
+    }
 
-        return ShortcutConfiguration(
+    private var activeShortcutConfiguration: ShortcutConfiguration {
+        ShortcutConfiguration(
             hold: holdShortcut,
             toggle: toggleShortcut,
             recordingCancel: recordingCancelShortcut,
-            permittedAdditionalExactMatchModifiers: permittedAdditionalExactMatchModifiers
+            permittedAdditionalExactMatchModifiers: permittedAdditionalExactMatchModifiersForShortcutMatching
         )
     }
 
@@ -5067,7 +5073,10 @@ private extension ShortcutBinding {
         }
     }
 
-    func isActiveForCancellationConflict(pressedModifierKeyCodes: Set<UInt16>) -> Bool {
+    func isActiveForCancellationConflict(
+        pressedModifierKeyCodes: Set<UInt16>,
+        permittedAdditionalExactMatchModifiers: ShortcutModifiers
+    ) -> Bool {
         let currentModifiers = Self.modifiers(for: pressedModifierKeyCodes)
         guard currentModifiers.isSuperset(of: modifiers) else {
             return false
@@ -5076,7 +5085,8 @@ private extension ShortcutBinding {
         if let exactModifierKeyCodes,
            !Self.exactModifierKeyCodesMatch(
             pressedModifierKeyCodes,
-            exactModifierKeyCodes: exactModifierKeyCodes
+            exactModifierKeyCodes: exactModifierKeyCodes,
+            permittedAdditionalExactMatchModifiers: permittedAdditionalExactMatchModifiers
            ) {
             return false
         }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2448,6 +2448,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     var commandModeManualModifierValidationMessage: String? {
         guard isCommandModeEnabled, commandModeStyle == .manual else { return nil }
         return commandModeManualModifierCollisionMessage(for: commandModeManualModifier)
+            ?? recordingCancelShortcutCollisionMessage()
     }
 
     @discardableResult
@@ -2455,6 +2456,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         isCommandModeEnabled = enabled
         if enabled, commandModeStyle == .manual {
             return commandModeManualModifierCollisionMessage(for: commandModeManualModifier)
+                ?? recordingCancelShortcutCollisionMessage()
         }
         return nil
     }
@@ -2464,6 +2466,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         commandModeStyle = style
         if isCommandModeEnabled, style == .manual {
             return commandModeManualModifierCollisionMessage(for: commandModeManualModifier)
+                ?? recordingCancelShortcutCollisionMessage()
         }
         return nil
     }
@@ -2474,6 +2477,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         commandModeManualModifier = modifier
         if isCommandModeEnabled, commandModeStyle == .manual {
             return commandModeManualModifierCollisionMessage(for: modifier)
+                ?? recordingCancelShortcutCollisionMessage(
+                    permittedAdditionalExactMatchModifiers: modifier.shortcutModifier
+                )
         }
         return nil
     }
@@ -2532,11 +2538,35 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return nil
     }
 
-    private func cancelShortcutOverlapsDictationShortcut(_ cancel: ShortcutBinding, _ dictation: ShortcutBinding) -> Bool {
+    private func recordingCancelShortcutCollisionMessage(
+        permittedAdditionalExactMatchModifiers: ShortcutModifiers? = nil
+    ) -> String? {
+        let permittedAdditionalExactMatchModifiers = permittedAdditionalExactMatchModifiers
+            ?? permittedAdditionalExactMatchModifiersForShortcutMatching
+        if cancelShortcutOverlapsDictationShortcut(
+            recordingCancelShortcut,
+            holdShortcut,
+            permittedAdditionalExactMatchModifiers: permittedAdditionalExactMatchModifiers
+        ) || cancelShortcutOverlapsDictationShortcut(
+            recordingCancelShortcut,
+            toggleShortcut,
+            permittedAdditionalExactMatchModifiers: permittedAdditionalExactMatchModifiers
+        ) {
+            return "Cancel shortcut must be distinct from dictation shortcuts."
+        }
+        return nil
+    }
+
+    private func cancelShortcutOverlapsDictationShortcut(
+        _ cancel: ShortcutBinding,
+        _ dictation: ShortcutBinding,
+        permittedAdditionalExactMatchModifiers: ShortcutModifiers? = nil
+    ) -> Bool {
         guard !cancel.isDisabled, !dictation.isDisabled else { return false }
         guard cancel.primaryInputOverlapsForCancellation(with: dictation) else { return false }
 
-        let permittedAdditionalExactMatchModifiers = permittedAdditionalExactMatchModifiersForShortcutMatching
+        let permittedAdditionalExactMatchModifiers = permittedAdditionalExactMatchModifiers
+            ?? permittedAdditionalExactMatchModifiersForShortcutMatching
         let orderedModifierKeyCodes = Array(ShortcutBinding.modifierKeyCodes).sorted()
         let combinations = 1 << orderedModifierKeyCodes.count
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -210,8 +210,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let contextModelStorageKey = "context_model"
     private let holdShortcutStorageKey = "hold_shortcut"
     private let toggleShortcutStorageKey = "toggle_shortcut"
+    private let recordingCancelShortcutStorageKey = "recording_cancel_shortcut"
     private let savedHoldCustomShortcutStorageKey = "saved_hold_custom_shortcut"
     private let savedToggleCustomShortcutStorageKey = "saved_toggle_custom_shortcut"
+    private let savedRecordingCancelCustomShortcutStorageKey = "saved_recording_cancel_custom_shortcut"
     private let customVocabularyStorageKey = "custom_vocabulary"
     private let selectedMicrophoneStorageKey = "selected_microphone_id"
     private let customSystemPromptStorageKey = "custom_system_prompt"
@@ -356,6 +358,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @Published var recordingCancelShortcut: ShortcutBinding {
+        didSet {
+            persistShortcut(recordingCancelShortcut, key: recordingCancelShortcutStorageKey)
+            restartHotkeyMonitoring()
+        }
+    }
+
     @Published private(set) var savedHoldCustomShortcut: ShortcutBinding? {
         didSet {
             persistOptionalShortcut(savedHoldCustomShortcut, key: savedHoldCustomShortcutStorageKey)
@@ -365,6 +374,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published private(set) var savedToggleCustomShortcut: ShortcutBinding? {
         didSet {
             persistOptionalShortcut(savedToggleCustomShortcut, key: savedToggleCustomShortcutStorageKey)
+        }
+    }
+
+    @Published private(set) var savedRecordingCancelCustomShortcut: ShortcutBinding? {
+        didSet {
+            persistOptionalShortcut(savedRecordingCancelCustomShortcut, key: savedRecordingCancelCustomShortcutStorageKey)
         }
     }
 
@@ -969,6 +984,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
             forKey: savedToggleCustomShortcutStorageKey,
             fallback: shortcuts.toggle.isCustom ? shortcuts.toggle : nil
         )
+        let storedRecordingCancelShortcut = Self.loadShortcut(forKey: recordingCancelShortcutStorageKey)
+        let recordingCancelShortcut = storedRecordingCancelShortcut.binding ?? .defaultRecordingCancel
+        let savedRecordingCancelCustomShortcut = Self.loadSavedCustomShortcut(
+            forKey: savedRecordingCancelCustomShortcutStorageKey,
+            fallback: recordingCancelShortcut.isCustom && recordingCancelShortcut != .defaultRecordingCancel
+                ? recordingCancelShortcut
+                : nil
+        )
         let customVocabulary = UserDefaults.standard.string(forKey: customVocabularyStorageKey) ?? ""
         let customSystemPrompt = UserDefaults.standard.string(forKey: customSystemPromptStorageKey) ?? ""
         let customContextPrompt = UserDefaults.standard.string(forKey: customContextPromptStorageKey) ?? ""
@@ -1087,8 +1110,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.contextModel = contextModel
         self.holdShortcut = shortcuts.hold
         self.toggleShortcut = shortcuts.toggle
+        self.recordingCancelShortcut = recordingCancelShortcut
         self.savedHoldCustomShortcut = savedHoldCustomShortcut.binding
         self.savedToggleCustomShortcut = savedToggleCustomShortcut.binding
+        self.savedRecordingCancelCustomShortcut = savedRecordingCancelCustomShortcut.binding
         self.isCommandModeEnabled = isCommandModeEnabled
         self.commandModeStyle = commandModeStyle
         self.commandModeManualModifier = commandModeManualModifier
@@ -1151,6 +1176,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
         if savedToggleCustomShortcut.didUpdateStoredValue {
             persistOptionalShortcut(savedToggleCustomShortcut.binding, key: savedToggleCustomShortcutStorageKey)
+        }
+        if storedRecordingCancelShortcut.binding == nil || storedRecordingCancelShortcut.didNormalize {
+            persistShortcut(recordingCancelShortcut, key: recordingCancelShortcutStorageKey)
+        }
+        if savedRecordingCancelCustomShortcut.didUpdateStoredValue {
+            persistOptionalShortcut(savedRecordingCancelCustomShortcut.binding, key: savedRecordingCancelCustomShortcutStorageKey)
         }
 
         if shouldRestoreMutedAudio {
@@ -2410,6 +2441,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    var savedRecordingCancelShortcut: ShortcutBinding? {
+        savedRecordingCancelCustomShortcut
+    }
+
     var commandModeManualModifierValidationMessage: String? {
         guard isCommandModeEnabled, commandModeStyle == .manual else { return nil }
         return commandModeManualModifierCollisionMessage(for: commandModeManualModifier)
@@ -2444,11 +2479,28 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @discardableResult
+    func setRecordingCancelShortcut(_ binding: ShortcutBinding) -> String? {
+        let binding = binding.normalizedForStorageMigration()
+        guard !binding.conflicts(with: holdShortcut), !binding.conflicts(with: toggleShortcut) else {
+            return "Cancel shortcut must be distinct from dictation shortcuts."
+        }
+
+        if binding.isCustom && binding != .defaultRecordingCancel {
+            savedRecordingCancelCustomShortcut = binding
+        }
+        recordingCancelShortcut = binding
+        return nil
+    }
+
+    @discardableResult
     func setShortcut(_ binding: ShortcutBinding, for role: ShortcutRole) -> String? {
         let binding = binding.normalizedForStorageMigration()
         let otherBinding = role == .hold ? toggleShortcut : holdShortcut
         guard !binding.conflicts(with: otherBinding) else {
             return "Hold and tap shortcuts must be distinct."
+        }
+        guard !binding.conflicts(with: recordingCancelShortcut) else {
+            return "Dictation shortcuts must be distinct from the cancel shortcut."
         }
 
         let nextHoldShortcut = role == .hold ? binding : holdShortcut
@@ -2563,6 +2615,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return ShortcutConfiguration(
             hold: holdShortcut,
             toggle: toggleShortcut,
+            recordingCancel: recordingCancelShortcut,
             permittedAdditionalExactMatchModifiers: permittedAdditionalExactMatchModifiers
         )
     }

--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -23,7 +23,6 @@ final class GlobalShortcutBackend {
     private var fnKeyIsDown = false
 
     var onInputEvent: ((ShortcutInputEvent) -> ShortcutConsumeDecision)?
-    var onEscapeKeyPressed: (() -> Bool)?
 
     func start() throws {
         stop()
@@ -147,11 +146,6 @@ final class GlobalShortcutBackend {
     }
 
     private func handleKeyDown(_ event: NSEvent) -> Bool {
-        if event.keyCode == 53 {
-            guard !event.isARepeat else { return false }
-            return onEscapeKeyPressed?() ?? false
-        }
-
         guard !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) else { return false }
         let snapshotDecision = onInputEvent?(
             .modifierSnapshot(ModifierKeyEventState.pressedModifierKeyCodes(

--- a/Sources/HotkeyManager.swift
+++ b/Sources/HotkeyManager.swift
@@ -10,6 +10,7 @@ final class HotkeyManager {
 
     var onShortcutEvent: ((ShortcutEvent) -> Void)?
     var onEscapeKeyPressed: (() -> Bool)?
+    var onRecordingCancelShortcut: (() -> Bool)?
 
     var currentPressedModifiers: ShortcutModifiers {
         inputState.currentModifiers
@@ -25,14 +26,10 @@ final class HotkeyManager {
         backend.onInputEvent = { [weak self] event in
             self?.handleInputEvent(event) ?? .passthrough
         }
-        backend.onEscapeKeyPressed = { [weak self] in
-            self?.onEscapeKeyPressed?() ?? false
-        }
         do {
             try backend.start()
         } catch {
             backend.onInputEvent = nil
-            backend.onEscapeKeyPressed = nil
             inputState = ShortcutInputState()
             throw error
         }
@@ -41,7 +38,6 @@ final class HotkeyManager {
     func stop() {
         backend.stop()
         backend.onInputEvent = nil
-        backend.onEscapeKeyPressed = nil
         inputState = ShortcutInputState()
     }
 
@@ -56,9 +52,29 @@ final class HotkeyManager {
             configuration: configuration
         )
         inputState = result.state
+        return Self.dispatchShortcutMatchResult(
+            result,
+            onShortcutEvent: { [weak self] event in self?.onShortcutEvent?(event) },
+            onRecordingCancelShortcut: { [weak self] in self?.onRecordingCancelShortcut?() ?? false }
+        )
+    }
+
+    static func dispatchShortcutMatchResult(
+        _ result: ShortcutMatchResult,
+        onShortcutEvent: (ShortcutEvent) -> Void,
+        onRecordingCancelShortcut: () -> Bool
+    ) -> ShortcutConsumeDecision {
+        var consumeDecision = result.consumeDecision
+
         for event in result.emittedEvents {
-            onShortcutEvent?(event)
+            switch event {
+            case .recordingCancelRequested:
+                consumeDecision = onRecordingCancelShortcut() ? .consume : .passthrough
+            case .holdActivated, .holdDeactivated, .toggleActivated, .toggleDeactivated:
+                onShortcutEvent(event)
+            }
         }
-        return result.consumeDecision
+
+        return consumeDecision
     }
 }

--- a/Sources/HotkeyManager.swift
+++ b/Sources/HotkeyManager.swift
@@ -9,7 +9,6 @@ final class HotkeyManager {
     private var inputState = ShortcutInputState()
 
     var onShortcutEvent: ((ShortcutEvent) -> Void)?
-    var onEscapeKeyPressed: (() -> Bool)?
     var onRecordingCancelShortcut: (() -> Bool)?
 
     var currentPressedModifiers: ShortcutModifiers {
@@ -64,17 +63,27 @@ final class HotkeyManager {
         onShortcutEvent: (ShortcutEvent) -> Void,
         onRecordingCancelShortcut: () -> Bool
     ) -> ShortcutConsumeDecision {
-        var consumeDecision = result.consumeDecision
+        var consumedByForwardedShortcut = false
+        var consumedByRecordingCancel = false
+        var sawRecordingCancelEvent = false
 
         for event in result.emittedEvents {
             switch event {
             case .recordingCancelRequested:
-                consumeDecision = onRecordingCancelShortcut() ? .consume : .passthrough
+                sawRecordingCancelEvent = true
+                consumedByRecordingCancel = onRecordingCancelShortcut() || consumedByRecordingCancel
             case .holdActivated, .holdDeactivated, .toggleActivated, .toggleDeactivated:
+                consumedByForwardedShortcut = true
                 onShortcutEvent(event)
             }
         }
 
-        return consumeDecision
+        if consumedByForwardedShortcut || consumedByRecordingCancel {
+            return .consume
+        }
+        if result.consumeDecision == .consume && !sawRecordingCancelEvent {
+            return .consume
+        }
+        return .passthrough
     }
 }

--- a/Sources/ShortcutCaptureKeyHandling.swift
+++ b/Sources/ShortcutCaptureKeyHandling.swift
@@ -1,0 +1,35 @@
+import AppKit
+
+enum ShortcutCaptureKeyAction: Equatable {
+    case finishCapture
+    case updateCapture(ShortcutBinding)
+    case ignore
+}
+
+enum ShortcutCaptureKeyHandling {
+    static func action(
+        for event: NSEvent,
+        pressedModifierKeyCodes: Set<UInt16>,
+        hasPendingCapture: Bool
+    ) -> ShortcutCaptureKeyAction {
+        if hasPendingCapture,
+           pressedModifierKeyCodes.isEmpty,
+           isFinishCaptureKey(event.keyCode) {
+            return .finishCapture
+        }
+
+        guard !ShortcutBinding.modifierKeyCodes.contains(event.keyCode),
+              let binding = ShortcutBinding.from(
+                event: event,
+                pressedModifierKeyCodes: pressedModifierKeyCodes
+              ) else {
+            return .ignore
+        }
+
+        return .updateCapture(binding)
+    }
+
+    private static func isFinishCaptureKey(_ keyCode: UInt16) -> Bool {
+        keyCode == 36 || keyCode == 53 || keyCode == 76
+    }
+}

--- a/Sources/ShortcutComponents.swift
+++ b/Sources/ShortcutComponents.swift
@@ -46,7 +46,11 @@ struct DictationShortcutEditor: View {
                     set: { activeCaptureTarget = $0 ? .hold : nil }
                 ),
                 onSelect: { binding in
-                    holdValidationMessage = appState.setShortcut(binding, for: .hold)
+                    let message = appState.setShortcut(binding, for: .hold)
+                    holdValidationMessage = message
+                    if message == nil {
+                        cancelValidationMessage = nil
+                    }
                 }
             )
 
@@ -59,7 +63,11 @@ struct DictationShortcutEditor: View {
                     set: { activeCaptureTarget = $0 ? .toggle : nil }
                 ),
                 onSelect: { binding in
-                    toggleValidationMessage = appState.setShortcut(binding, for: .toggle)
+                    let message = appState.setShortcut(binding, for: .toggle)
+                    toggleValidationMessage = message
+                    if message == nil {
+                        cancelValidationMessage = nil
+                    }
                 }
             )
 
@@ -72,7 +80,12 @@ struct DictationShortcutEditor: View {
                     set: { activeCaptureTarget = $0 ? .recordingCancel : nil }
                 ),
                 onSelect: { binding in
-                    cancelValidationMessage = appState.setRecordingCancelShortcut(binding)
+                    let message = appState.setRecordingCancelShortcut(binding)
+                    cancelValidationMessage = message
+                    if message == nil {
+                        holdValidationMessage = nil
+                        toggleValidationMessage = nil
+                    }
                 }
             )
 
@@ -287,6 +300,11 @@ private struct ShortcutCaptureRow: View {
                 )
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.blue)
+            }
+        }
+        .onChange(of: isCapturing) { isCapturing in
+            if !isCapturing {
+                stopCapture(clearCaptureState: false)
             }
         }
         .onDisappear {

--- a/Sources/ShortcutComponents.swift
+++ b/Sources/ShortcutComponents.swift
@@ -337,30 +337,18 @@ private struct ShortcutCaptureRow: View {
             }
         }
         backend.onKeyDownEvent = { event in
-            let isReturnKey = event.keyCode == 36 || event.keyCode == 76
-            let hasPendingCapture = currentBinding != nil
-
-            if isReturnKey && hasPendingCapture {
+            switch ShortcutCaptureKeyHandling.action(
+                for: event,
+                pressedModifierKeyCodes: captureInputState.pressedModifierKeyCodes,
+                hasPendingCapture: currentBinding != nil
+            ) {
+            case .finishCapture:
                 finishCapture()
+            case .updateCapture(let binding):
+                currentBinding = binding
+            case .ignore:
                 return
             }
-            if event.keyCode == 53 && hasPendingCapture {
-                finishCapture()
-                return
-            }
-
-            guard !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) else {
-                return
-            }
-
-            guard let binding = ShortcutBinding.from(
-                event: event,
-                pressedModifierKeyCodes: captureInputState.pressedModifierKeyCodes
-            ) else {
-                return
-            }
-
-            currentBinding = binding
         }
         backend.start()
         captureBackend = backend

--- a/Sources/ShortcutComponents.swift
+++ b/Sources/ShortcutComponents.swift
@@ -46,11 +46,15 @@ struct DictationShortcutEditor: View {
                     set: { activeCaptureTarget = $0 ? .hold : nil }
                 ),
                 onSelect: { binding in
-                    let message = appState.setShortcut(binding, for: .hold)
-                    holdValidationMessage = message
-                    if message == nil {
-                        cancelValidationMessage = nil
-                    }
+                    var messages = ShortcutValidationMessages(
+                        hold: holdValidationMessage,
+                        toggle: toggleValidationMessage,
+                        recordingCancel: cancelValidationMessage
+                    )
+                    messages.applySelectionResult(appState.setShortcut(binding, for: .hold), target: .hold)
+                    holdValidationMessage = messages.hold
+                    toggleValidationMessage = messages.toggle
+                    cancelValidationMessage = messages.recordingCancel
                 }
             )
 
@@ -63,11 +67,15 @@ struct DictationShortcutEditor: View {
                     set: { activeCaptureTarget = $0 ? .toggle : nil }
                 ),
                 onSelect: { binding in
-                    let message = appState.setShortcut(binding, for: .toggle)
-                    toggleValidationMessage = message
-                    if message == nil {
-                        cancelValidationMessage = nil
-                    }
+                    var messages = ShortcutValidationMessages(
+                        hold: holdValidationMessage,
+                        toggle: toggleValidationMessage,
+                        recordingCancel: cancelValidationMessage
+                    )
+                    messages.applySelectionResult(appState.setShortcut(binding, for: .toggle), target: .toggle)
+                    holdValidationMessage = messages.hold
+                    toggleValidationMessage = messages.toggle
+                    cancelValidationMessage = messages.recordingCancel
                 }
             )
 
@@ -80,12 +88,15 @@ struct DictationShortcutEditor: View {
                     set: { activeCaptureTarget = $0 ? .recordingCancel : nil }
                 ),
                 onSelect: { binding in
-                    let message = appState.setRecordingCancelShortcut(binding)
-                    cancelValidationMessage = message
-                    if message == nil {
-                        holdValidationMessage = nil
-                        toggleValidationMessage = nil
-                    }
+                    var messages = ShortcutValidationMessages(
+                        hold: holdValidationMessage,
+                        toggle: toggleValidationMessage,
+                        recordingCancel: cancelValidationMessage
+                    )
+                    messages.applySelectionResult(appState.setRecordingCancelShortcut(binding), target: .recordingCancel)
+                    holdValidationMessage = messages.hold
+                    toggleValidationMessage = messages.toggle
+                    cancelValidationMessage = messages.recordingCancel
                 }
             )
 

--- a/Sources/ShortcutComponents.swift
+++ b/Sources/ShortcutComponents.swift
@@ -1,15 +1,22 @@
 import SwiftUI
 import AppKit
 
+private enum DictationShortcutCaptureTarget {
+    case hold
+    case toggle
+    case recordingCancel
+}
+
 struct DictationShortcutEditor: View {
     @EnvironmentObject var appState: AppState
 
     let showsIntroText: Bool
     let onCaptureStateChange: ((Bool) -> Void)?
 
-    @State private var activeCaptureRole: ShortcutRole?
+    @State private var activeCaptureTarget: DictationShortcutCaptureTarget?
     @State private var holdValidationMessage: String?
     @State private var toggleValidationMessage: String?
+    @State private var cancelValidationMessage: String?
 
     init(showsIntroText: Bool = true, onCaptureStateChange: ((Bool) -> Void)? = nil) {
         self.showsIntroText = showsIntroText
@@ -35,8 +42,8 @@ struct DictationShortcutEditor: View {
                 selection: appState.holdShortcut,
                 validationMessage: holdValidationMessage,
                 isCapturing: Binding(
-                    get: { activeCaptureRole == .hold },
-                    set: { activeCaptureRole = $0 ? .hold : nil }
+                    get: { activeCaptureTarget == .hold },
+                    set: { activeCaptureTarget = $0 ? .hold : nil }
                 ),
                 onSelect: { binding in
                     holdValidationMessage = appState.setShortcut(binding, for: .hold)
@@ -48,11 +55,24 @@ struct DictationShortcutEditor: View {
                 selection: appState.toggleShortcut,
                 validationMessage: toggleValidationMessage,
                 isCapturing: Binding(
-                    get: { activeCaptureRole == .toggle },
-                    set: { activeCaptureRole = $0 ? .toggle : nil }
+                    get: { activeCaptureTarget == .toggle },
+                    set: { activeCaptureTarget = $0 ? .toggle : nil }
                 ),
                 onSelect: { binding in
                     toggleValidationMessage = appState.setShortcut(binding, for: .toggle)
+                }
+            )
+
+            RecordingCancelShortcutSection(
+                selection: appState.recordingCancelShortcut,
+                savedBinding: appState.savedRecordingCancelShortcut,
+                validationMessage: cancelValidationMessage,
+                isCapturing: Binding(
+                    get: { activeCaptureTarget == .recordingCancel },
+                    set: { activeCaptureTarget = $0 ? .recordingCancel : nil }
+                ),
+                onSelect: { binding in
+                    cancelValidationMessage = appState.setRecordingCancelShortcut(binding)
                 }
             )
 
@@ -66,8 +86,8 @@ struct DictationShortcutEditor: View {
                     .foregroundStyle(.orange)
             }
         }
-        .onChange(of: activeCaptureRole) { role in
-            onCaptureStateChange?(role != nil)
+        .onChange(of: activeCaptureTarget) { target in
+            onCaptureStateChange?(target != nil)
         }
         .onDisappear {
             onCaptureStateChange?(false)
@@ -106,6 +126,53 @@ struct ShortcutRoleSection: View {
                 ShortcutCaptureRow(
                     savedBinding: appState.savedCustomShortcut(for: role),
                     isSelected: selection.isCustom,
+                    isCapturing: $isCapturing,
+                    onSelectSaved: onSelect,
+                    onCapture: onSelect
+                )
+            }
+
+            if let validationMessage, !validationMessage.isEmpty {
+                Label(validationMessage, systemImage: "xmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+}
+
+struct RecordingCancelShortcutSection: View {
+    let selection: ShortcutBinding
+    let savedBinding: ShortcutBinding?
+    let validationMessage: String?
+    @Binding var isCapturing: Bool
+    let onSelect: (ShortcutBinding) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Recording Cancel Shortcut")
+                .font(.subheadline.weight(.semibold))
+
+            Text("While recording or transcribing, this shortcut opens the cancel confirmation dialog. Disable it if you want Esc to keep working in other apps.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            VStack(spacing: 6) {
+                ShortcutPresetRow(
+                    title: "Disabled",
+                    isSelected: selection.isDisabled,
+                    action: { onSelect(.disabled) }
+                )
+
+                ShortcutPresetRow(
+                    title: ShortcutBinding.defaultRecordingCancel.displayName,
+                    isSelected: selection == .defaultRecordingCancel,
+                    action: { onSelect(.defaultRecordingCancel) }
+                )
+
+                ShortcutCaptureRow(
+                    savedBinding: savedBinding,
+                    isSelected: selection.isCustom && selection != .defaultRecordingCancel,
                     isCapturing: $isCapturing,
                     onSelectSaved: onSelect,
                     onCapture: onSelect

--- a/Sources/ShortcutCore/DictationShortcutSessionController.swift
+++ b/Sources/ShortcutCore/DictationShortcutSessionController.swift
@@ -22,7 +22,7 @@ final class DictationShortcutSessionController {
                 activeMode = .hold
                 toggleStopArmed = false
                 return .start(.hold)
-            case .holdDeactivated, .toggleDeactivated:
+            case .holdDeactivated, .toggleDeactivated, .recordingCancelRequested:
                 return nil
             }
         }
@@ -39,7 +39,7 @@ final class DictationShortcutSessionController {
             case .holdDeactivated:
                 reset()
                 return .stop
-            case .holdActivated, .toggleDeactivated:
+            case .holdActivated, .toggleDeactivated, .recordingCancelRequested:
                 return nil
             }
 
@@ -52,7 +52,7 @@ final class DictationShortcutSessionController {
                 guard toggleStopArmed else { return nil }
                 reset()
                 return .stop
-            case .holdActivated, .holdDeactivated:
+            case .holdActivated, .holdDeactivated, .recordingCancelRequested:
                 return nil
             }
         }

--- a/Sources/ShortcutCore/ShortcutMatcher.swift
+++ b/Sources/ShortcutCore/ShortcutMatcher.swift
@@ -107,11 +107,20 @@ enum ShortcutMatcher {
                 state: nextState,
                 configuration: configuration
             )
-            let emittedEvents = updateActiveBindings(in: &nextState, configuration: configuration)
+            var emittedEvents = updateActiveBindings(in: &nextState, configuration: configuration)
+            if recordingCancelWasActivated(
+                by: keyCode,
+                isDown: isDown,
+                previousState: state,
+                currentState: nextState,
+                configuration: configuration
+            ) {
+                emittedEvents.append(.recordingCancelRequested)
+            }
             return ShortcutMatchResult(
                 state: nextState,
                 emittedEvents: emittedEvents,
-                consumeDecision: (shouldConsumeBefore || shouldConsumeAfter) ? .consume : .passthrough
+                consumeDecision: (shouldConsumeBefore || shouldConsumeAfter || emittedEvents.contains(.recordingCancelRequested)) ? .consume : .passthrough
             )
 
         case .keyChanged(let keyCode, let isDown, let isRepeat):
@@ -259,6 +268,22 @@ enum ShortcutMatcher {
             return false
         }
         return bindingIsActive(configuration.recordingCancel, state: state, configuration: configuration)
+    }
+
+    private static func recordingCancelWasActivated(
+        by keyCode: UInt16,
+        isDown: Bool,
+        previousState: ShortcutInputState,
+        currentState: ShortcutInputState,
+        configuration: ShortcutConfiguration
+    ) -> Bool {
+        guard isDown else { return false }
+        guard configuration.recordingCancel.kind == .modifierKey,
+              configuration.recordingCancel.keyCode == keyCode else {
+            return false
+        }
+        return !bindingIsActive(configuration.recordingCancel, state: previousState, configuration: configuration)
+            && bindingIsActive(configuration.recordingCancel, state: currentState, configuration: configuration)
     }
 
     private static func shouldConsumeKeyEvent(

--- a/Sources/ShortcutCore/ShortcutMatcher.swift
+++ b/Sources/ShortcutCore/ShortcutMatcher.swift
@@ -278,8 +278,7 @@ enum ShortcutMatcher {
         configuration: ShortcutConfiguration
     ) -> Bool {
         guard isDown else { return false }
-        guard configuration.recordingCancel.kind == .modifierKey,
-              configuration.recordingCancel.keyCode == keyCode else {
+        guard configuration.recordingCancel.kind == .modifierKey else {
             return false
         }
         return !bindingIsActive(configuration.recordingCancel, state: previousState, configuration: configuration)

--- a/Sources/ShortcutCore/ShortcutMatcher.swift
+++ b/Sources/ShortcutCore/ShortcutMatcher.swift
@@ -27,6 +27,7 @@ struct ShortcutInputState: Equatable {
         let keyReferenceHeld = pressedKeyCodes.contains { keyCode in
             configuration.hold.kind == .key && configuration.hold.keyCode == keyCode
                 || configuration.toggle.kind == .key && configuration.toggle.keyCode == keyCode
+                || configuration.recordingCancel.kind == .key && configuration.recordingCancel.keyCode == keyCode
         }
         if keyReferenceHeld {
             return true
@@ -41,6 +42,14 @@ struct ShortcutInputState: Equatable {
         }
 
         if configuration.toggle.referencesPressedModifiers(
+            pressedModifierKeyCodes: pressedModifierKeyCodes,
+            currentModifiers: currentModifiers,
+            permittedAdditionalExactMatchModifiers: configuration.permittedAdditionalExactMatchModifiers
+        ) {
+            return true
+        }
+
+        if configuration.recordingCancel.referencesPressedModifiers(
             pressedModifierKeyCodes: pressedModifierKeyCodes,
             currentModifiers: currentModifiers,
             permittedAdditionalExactMatchModifiers: configuration.permittedAdditionalExactMatchModifiers
@@ -132,11 +141,20 @@ enum ShortcutMatcher {
                 state: nextState,
                 configuration: configuration
             )
-            let emittedEvents = updateActiveBindings(in: &nextState, configuration: configuration)
+            var emittedEvents = updateActiveBindings(in: &nextState, configuration: configuration)
+            if recordingCancelWasActivated(
+                by: keyCode,
+                isDown: isDown,
+                isRepeat: isRepeat,
+                state: nextState,
+                configuration: configuration
+            ) {
+                emittedEvents.append(.recordingCancelRequested)
+            }
             return ShortcutMatchResult(
                 state: nextState,
                 emittedEvents: emittedEvents,
-                consumeDecision: (shouldConsumeBefore || shouldConsumeAfter) ? .consume : .passthrough
+                consumeDecision: (shouldConsumeBefore || shouldConsumeAfter || emittedEvents.contains(.recordingCancelRequested)) ? .consume : .passthrough
             )
         }
     }
@@ -226,6 +244,21 @@ enum ShortcutMatcher {
         case .modifierKey:
             return state.pressedModifierKeyCodes.contains(binding.keyCode)
         }
+    }
+
+    private static func recordingCancelWasActivated(
+        by keyCode: UInt16,
+        isDown: Bool,
+        isRepeat: Bool,
+        state: ShortcutInputState,
+        configuration: ShortcutConfiguration
+    ) -> Bool {
+        guard isDown, !isRepeat else { return false }
+        guard configuration.recordingCancel.kind == .key,
+              configuration.recordingCancel.keyCode == keyCode else {
+            return false
+        }
+        return bindingIsActive(configuration.recordingCancel, state: state, configuration: configuration)
     }
 
     private static func shouldConsumeKeyEvent(

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -69,24 +69,28 @@ enum ShortcutEvent: Equatable {
     case holdDeactivated
     case toggleActivated
     case toggleDeactivated
+    case recordingCancelRequested
 }
 
 struct ShortcutConfiguration: Equatable {
     let hold: ShortcutBinding
     let toggle: ShortcutBinding
+    let recordingCancel: ShortcutBinding
     let permittedAdditionalExactMatchModifiers: ShortcutModifiers
 
     init(
         hold: ShortcutBinding,
         toggle: ShortcutBinding,
+        recordingCancel: ShortcutBinding = .defaultRecordingCancel,
         permittedAdditionalExactMatchModifiers: ShortcutModifiers = []
     ) {
         self.hold = hold
         self.toggle = toggle
+        self.recordingCancel = recordingCancel
         self.permittedAdditionalExactMatchModifiers = permittedAdditionalExactMatchModifiers
     }
 
-    static let disabled = ShortcutConfiguration(hold: .disabled, toggle: .disabled)
+    static let disabled = ShortcutConfiguration(hold: .disabled, toggle: .disabled, recordingCancel: .disabled)
 }
 
 enum ShortcutPreset: String, CaseIterable, Identifiable, Codable {
@@ -337,6 +341,13 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
     )
     static let defaultHold = ShortcutPreset.fnKey.binding
     static let defaultToggle = ShortcutPreset.fnKey.binding.withAddedModifiers(.command)
+    static let defaultRecordingCancel = ShortcutBinding(
+        keyCode: 53,
+        keyDisplay: "Esc",
+        modifiers: [],
+        kind: .key,
+        preset: nil
+    )
 
     static let modifierKeyCodes: Set<UInt16> = [54, 55, 56, 58, 59, 60, 61, 62, 63]
 

--- a/Sources/ShortcutValidationMessages.swift
+++ b/Sources/ShortcutValidationMessages.swift
@@ -1,0 +1,27 @@
+enum ShortcutValidationTarget {
+    case hold
+    case toggle
+    case recordingCancel
+}
+
+struct ShortcutValidationMessages: Equatable {
+    var hold: String?
+    var toggle: String?
+    var recordingCancel: String?
+
+    mutating func applySelectionResult(_ message: String?, target: ShortcutValidationTarget) {
+        switch target {
+        case .hold:
+            hold = message
+        case .toggle:
+            toggle = message
+        case .recordingCancel:
+            recordingCancel = message
+        }
+
+        guard message == nil else { return }
+        hold = nil
+        toggle = nil
+        recordingCancel = nil
+    }
+}

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -11,9 +11,11 @@ struct AppStateTranscriptionConfigurationTests {
         testRecordingCancelShortcutDefaultsToEscape()
         testRecordingCancelShortcutPersistsDisabled()
         testRecordingCancelShortcutPersistsCustomShortcut()
+        testRecordingCancelShortcutDisablesDefaultWhenStoredHoldUsesEscape()
         testRecordingCancelShortcutRejectsHoldConflict()
         testHoldShortcutRejectsCancelConflict()
         testHoldShortcutRejectsMoreSpecificCancelOverlap()
+        testRecordingCancelShortcutRejectsModifierOnlyOverlapWithKeyCombo()
         testRecordingCancelShortcutRejectsMoreSpecificHoldOverlap()
         testRecordingCancelShortcutRejectsManualModifierRuntimeOverlap()
         testCommandModeManualModifierReportsCancelOverlap()
@@ -118,6 +120,24 @@ struct AppStateTranscriptionConfigurationTests {
         assert(appState.savedRecordingCancelCustomShortcut == custom)
     }
 
+    private static func testRecordingCancelShortcutDisablesDefaultWhenStoredHoldUsesEscape() {
+        resetDefaults()
+        let defaults = UserDefaults.standard
+        let escHold = ShortcutBinding.defaultRecordingCancel
+        defaults.set(try! JSONEncoder().encode(escHold), forKey: "hold_shortcut")
+        defaults.removeObject(forKey: "recording_cancel_shortcut")
+
+        let appState = AppState()
+        let storedCancel = try! JSONDecoder().decode(
+            ShortcutBinding.self,
+            from: defaults.data(forKey: "recording_cancel_shortcut")!
+        )
+
+        assert(appState.holdShortcut == escHold)
+        assert(appState.recordingCancelShortcut == .disabled)
+        assert(storedCancel == .disabled)
+    }
+
     private static func testRecordingCancelShortcutRejectsHoldConflict() {
         resetDefaults()
         let appState = AppState()
@@ -154,6 +174,35 @@ struct AppStateTranscriptionConfigurationTests {
 
         assert(validation == "Dictation shortcuts must be distinct from the cancel shortcut.")
         assert(appState.holdShortcut == .defaultHold)
+    }
+
+    private static func testRecordingCancelShortcutRejectsModifierOnlyOverlapWithKeyCombo() {
+        resetDefaults()
+        let appState = AppState()
+        let commandOnly = ShortcutBinding(
+            keyCode: 55,
+            keyDisplay: "Command",
+            modifiers: [],
+            kind: .modifierKey,
+            preset: nil,
+            exactModifierKeyCodes: [55]
+        )
+        let commandA = ShortcutBinding(
+            keyCode: 0,
+            keyDisplay: "A",
+            modifiers: .command,
+            kind: .key,
+            preset: nil,
+            exactModifierKeyCodes: [55]
+        )
+
+        assert(appState.setRecordingCancelShortcut(.disabled) == nil)
+        assert(appState.setShortcut(commandA, for: .hold) == nil)
+
+        let validation = appState.setRecordingCancelShortcut(commandOnly)
+
+        assert(validation == "Cancel shortcut must be distinct from dictation shortcuts.")
+        assert(appState.recordingCancelShortcut == .disabled)
     }
 
     private static func testRecordingCancelShortcutRejectsMoreSpecificHoldOverlap() {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -8,6 +8,7 @@ struct AppStateTranscriptionConfigurationTests {
         try testMakeTranscriptionServiceMapsEmptyLocalWhisperPathToNil()
         testPermissionStatusUpdateSkipsUnchangedValues()
         testRecordingOverlayLayoutPersistsWithoutCompactOverlayBoolean()
+        testHotkeyMonitoringUsesRecordingCancelCallback()
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
@@ -67,6 +68,16 @@ struct AppStateTranscriptionConfigurationTests {
 
         assert(defaults.string(forKey: "recording_overlay_layout") == "notchSides")
         assert(defaults.object(forKey: "use_compact_overlay") == nil)
+    }
+
+    private static func testHotkeyMonitoringUsesRecordingCancelCallback() {
+        resetDefaults()
+        let appState = AppState()
+
+        appState.startHotkeyMonitoring()
+        defer { appState.stopHotkeyMonitoring() }
+
+        assert(appState.hotkeyManager.onRecordingCancelShortcut != nil)
     }
 
     private static func resetDefaults() {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -13,6 +13,8 @@ struct AppStateTranscriptionConfigurationTests {
         testRecordingCancelShortcutPersistsCustomShortcut()
         testRecordingCancelShortcutRejectsHoldConflict()
         testHoldShortcutRejectsCancelConflict()
+        testHoldShortcutRejectsMoreSpecificCancelOverlap()
+        testRecordingCancelShortcutRejectsMoreSpecificHoldOverlap()
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
@@ -134,6 +136,44 @@ struct AppStateTranscriptionConfigurationTests {
         assert(appState.holdShortcut == .defaultHold)
     }
 
+    private static func testHoldShortcutRejectsMoreSpecificCancelOverlap() {
+        resetDefaults()
+        let appState = AppState()
+        let commandEsc = ShortcutBinding(
+            keyCode: 53,
+            keyDisplay: "Esc",
+            modifiers: .command,
+            kind: .key,
+            preset: nil,
+            exactModifierKeyCodes: [55]
+        )
+
+        let validation = appState.setShortcut(commandEsc, for: .hold)
+
+        assert(validation == "Dictation shortcuts must be distinct from the cancel shortcut.")
+        assert(appState.holdShortcut == .defaultHold)
+    }
+
+    private static func testRecordingCancelShortcutRejectsMoreSpecificHoldOverlap() {
+        resetDefaults()
+        let appState = AppState()
+        let commandEsc = ShortcutBinding(
+            keyCode: 53,
+            keyDisplay: "Esc",
+            modifiers: .command,
+            kind: .key,
+            preset: nil,
+            exactModifierKeyCodes: [55]
+        )
+        assert(appState.setRecordingCancelShortcut(.disabled) == nil)
+        assert(appState.setShortcut(commandEsc, for: .hold) == nil)
+
+        let validation = appState.setRecordingCancelShortcut(.defaultRecordingCancel)
+
+        assert(validation == "Cancel shortcut must be distinct from dictation shortcuts.")
+        assert(appState.recordingCancelShortcut != .defaultRecordingCancel)
+    }
+
     private static func resetDefaults() {
         let defaults = UserDefaults.standard
         for key in defaults.dictionaryRepresentation().keys where key.hasPrefix("app_state_transcription_test_") {
@@ -142,7 +182,11 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.removeObject(forKey: "use_local_transcription")
         defaults.removeObject(forKey: "local_transcription_model")
         defaults.removeObject(forKey: "transcription_language")
+        defaults.removeObject(forKey: "hold_shortcut")
+        defaults.removeObject(forKey: "toggle_shortcut")
         defaults.removeObject(forKey: "recording_cancel_shortcut")
+        defaults.removeObject(forKey: "saved_hold_custom_shortcut")
+        defaults.removeObject(forKey: "saved_toggle_custom_shortcut")
         defaults.removeObject(forKey: "saved_recording_cancel_custom_shortcut")
     }
 

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -8,6 +8,11 @@ struct AppStateTranscriptionConfigurationTests {
         try testMakeTranscriptionServiceMapsEmptyLocalWhisperPathToNil()
         testPermissionStatusUpdateSkipsUnchangedValues()
         testRecordingOverlayLayoutPersistsWithoutCompactOverlayBoolean()
+        testRecordingCancelShortcutDefaultsToEscape()
+        testRecordingCancelShortcutPersistsDisabled()
+        testRecordingCancelShortcutPersistsCustomShortcut()
+        testRecordingCancelShortcutRejectsHoldConflict()
+        testHoldShortcutRejectsCancelConflict()
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
@@ -69,6 +74,66 @@ struct AppStateTranscriptionConfigurationTests {
         assert(defaults.object(forKey: "use_compact_overlay") == nil)
     }
 
+    private static func testRecordingCancelShortcutDefaultsToEscape() {
+        resetDefaults()
+        UserDefaults.standard.removeObject(forKey: "recording_cancel_shortcut")
+
+        let appState = AppState()
+
+        assert(appState.recordingCancelShortcut == .defaultRecordingCancel)
+    }
+
+    private static func testRecordingCancelShortcutPersistsDisabled() {
+        resetDefaults()
+        var appState = AppState()
+        let validation = appState.setRecordingCancelShortcut(.disabled)
+        assert(validation == nil)
+
+        appState = AppState()
+
+        assert(appState.recordingCancelShortcut == .disabled)
+    }
+
+    private static func testRecordingCancelShortcutPersistsCustomShortcut() {
+        resetDefaults()
+        let custom = ShortcutBinding(
+            keyCode: 47,
+            keyDisplay: ".",
+            modifiers: .command,
+            kind: .key,
+            preset: nil,
+            exactModifierKeyCodes: [55]
+        )
+        var appState = AppState()
+        let validation = appState.setRecordingCancelShortcut(custom)
+        assert(validation == nil)
+
+        appState = AppState()
+
+        assert(appState.recordingCancelShortcut == custom)
+        assert(appState.savedRecordingCancelCustomShortcut == custom)
+    }
+
+    private static func testRecordingCancelShortcutRejectsHoldConflict() {
+        resetDefaults()
+        let appState = AppState()
+
+        let validation = appState.setRecordingCancelShortcut(appState.holdShortcut)
+
+        assert(validation == "Cancel shortcut must be distinct from dictation shortcuts.")
+        assert(appState.recordingCancelShortcut == .defaultRecordingCancel)
+    }
+
+    private static func testHoldShortcutRejectsCancelConflict() {
+        resetDefaults()
+        let appState = AppState()
+
+        let validation = appState.setShortcut(.defaultRecordingCancel, for: .hold)
+
+        assert(validation == "Dictation shortcuts must be distinct from the cancel shortcut.")
+        assert(appState.holdShortcut == .defaultHold)
+    }
+
     private static func resetDefaults() {
         let defaults = UserDefaults.standard
         for key in defaults.dictionaryRepresentation().keys where key.hasPrefix("app_state_transcription_test_") {
@@ -77,6 +142,8 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.removeObject(forKey: "use_local_transcription")
         defaults.removeObject(forKey: "local_transcription_model")
         defaults.removeObject(forKey: "transcription_language")
+        defaults.removeObject(forKey: "recording_cancel_shortcut")
+        defaults.removeObject(forKey: "saved_recording_cancel_custom_shortcut")
     }
 
     private static func mirroredTranscriptionConfiguration(_ service: TranscriptionService) -> (

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -16,6 +16,7 @@ struct AppStateTranscriptionConfigurationTests {
         testHoldShortcutRejectsMoreSpecificCancelOverlap()
         testRecordingCancelShortcutRejectsMoreSpecificHoldOverlap()
         testRecordingCancelShortcutRejectsManualModifierRuntimeOverlap()
+        testCommandModeManualModifierReportsCancelOverlap()
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
@@ -207,6 +208,37 @@ struct AppStateTranscriptionConfigurationTests {
         assert(appState.recordingCancelShortcut == .disabled)
     }
 
+    private static func testCommandModeManualModifierReportsCancelOverlap() {
+        resetDefaults()
+        let appState = AppState()
+        let commandEsc = ShortcutBinding(
+            keyCode: 53,
+            keyDisplay: "Esc",
+            modifiers: .command,
+            kind: .key,
+            preset: nil,
+            exactModifierKeyCodes: [55]
+        )
+        let commandOptionEsc = ShortcutBinding(
+            keyCode: 53,
+            keyDisplay: "Esc",
+            modifiers: [.command, .option],
+            kind: .key,
+            preset: nil,
+            exactModifierKeyCodes: [55, 58]
+        )
+
+        assert(appState.setRecordingCancelShortcut(.disabled) == nil)
+        assert(appState.setShortcut(commandEsc, for: .hold) == nil)
+        assert(appState.setRecordingCancelShortcut(commandOptionEsc) == nil)
+        _ = appState.setCommandModeEnabled(true)
+
+        let validation = appState.setCommandModeStyle(.manual)
+
+        assert(validation == "Cancel shortcut must be distinct from dictation shortcuts.")
+        assert(appState.commandModeManualModifierValidationMessage == "Cancel shortcut must be distinct from dictation shortcuts.")
+    }
+
     private static func resetDefaults() {
         let defaults = UserDefaults.standard
         for key in defaults.dictionaryRepresentation().keys where key.hasPrefix("app_state_transcription_test_") {
@@ -221,6 +253,9 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.removeObject(forKey: "saved_hold_custom_shortcut")
         defaults.removeObject(forKey: "saved_toggle_custom_shortcut")
         defaults.removeObject(forKey: "saved_recording_cancel_custom_shortcut")
+        defaults.removeObject(forKey: "command_mode_enabled")
+        defaults.removeObject(forKey: "command_mode_style")
+        defaults.removeObject(forKey: "command_mode_manual_modifier")
     }
 
     private static func mirroredTranscriptionConfiguration(_ service: TranscriptionService) -> (

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -15,6 +15,7 @@ struct AppStateTranscriptionConfigurationTests {
         testHoldShortcutRejectsCancelConflict()
         testHoldShortcutRejectsMoreSpecificCancelOverlap()
         testRecordingCancelShortcutRejectsMoreSpecificHoldOverlap()
+        testRecordingCancelShortcutRejectsManualModifierRuntimeOverlap()
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
@@ -172,6 +173,38 @@ struct AppStateTranscriptionConfigurationTests {
 
         assert(validation == "Cancel shortcut must be distinct from dictation shortcuts.")
         assert(appState.recordingCancelShortcut != .defaultRecordingCancel)
+    }
+
+    private static func testRecordingCancelShortcutRejectsManualModifierRuntimeOverlap() {
+        resetDefaults()
+        let appState = AppState()
+        _ = appState.setCommandModeEnabled(true)
+        _ = appState.setCommandModeStyle(.manual)
+        _ = appState.setCommandModeManualModifier(.option)
+        let commandEsc = ShortcutBinding(
+            keyCode: 53,
+            keyDisplay: "Esc",
+            modifiers: .command,
+            kind: .key,
+            preset: nil,
+            exactModifierKeyCodes: [55]
+        )
+        let commandOptionEsc = ShortcutBinding(
+            keyCode: 53,
+            keyDisplay: "Esc",
+            modifiers: [.command, .option],
+            kind: .key,
+            preset: nil,
+            exactModifierKeyCodes: [55, 58]
+        )
+
+        assert(appState.setRecordingCancelShortcut(.disabled) == nil)
+        assert(appState.setShortcut(commandEsc, for: .hold) == nil)
+
+        let validation = appState.setRecordingCancelShortcut(commandOptionEsc)
+
+        assert(validation == "Cancel shortcut must be distinct from dictation shortcuts.")
+        assert(appState.recordingCancelShortcut == .disabled)
     }
 
     private static func resetDefaults() {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -8,7 +8,6 @@ struct AppStateTranscriptionConfigurationTests {
         try testMakeTranscriptionServiceMapsEmptyLocalWhisperPathToNil()
         testPermissionStatusUpdateSkipsUnchangedValues()
         testRecordingOverlayLayoutPersistsWithoutCompactOverlayBoolean()
-        testHotkeyMonitoringUsesRecordingCancelCallback()
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
@@ -68,16 +67,6 @@ struct AppStateTranscriptionConfigurationTests {
 
         assert(defaults.string(forKey: "recording_overlay_layout") == "notchSides")
         assert(defaults.object(forKey: "use_compact_overlay") == nil)
-    }
-
-    private static func testHotkeyMonitoringUsesRecordingCancelCallback() {
-        resetDefaults()
-        let appState = AppState()
-
-        appState.startHotkeyMonitoring()
-        defer { appState.stopHotkeyMonitoring() }
-
-        assert(appState.hotkeyManager.onRecordingCancelShortcut != nil)
     }
 
     private static func resetDefaults() {

--- a/Tests/ShortcutCaptureKeyHandlingTests.swift
+++ b/Tests/ShortcutCaptureKeyHandlingTests.swift
@@ -1,0 +1,94 @@
+import AppKit
+
+@main
+struct ShortcutCaptureKeyHandlingTests {
+    static func main() {
+        testBareEscWithPendingBindingFinishesCapture()
+        testCommandEscWithPendingBindingUpdatesCapture()
+        testCommandReturnWithPendingBindingUpdatesCapture()
+        print("ShortcutCaptureKeyHandlingTests passed")
+    }
+
+    private static func testBareEscWithPendingBindingFinishesCapture() {
+        let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\u{1b}",
+            charactersIgnoringModifiers: "\u{1b}",
+            isARepeat: false,
+            keyCode: 53
+        )!
+
+        let action = ShortcutCaptureKeyHandling.action(
+            for: event,
+            pressedModifierKeyCodes: [],
+            hasPendingCapture: true
+        )
+
+        assert(action == .finishCapture)
+    }
+
+    private static func testCommandEscWithPendingBindingUpdatesCapture() {
+        let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: .command,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\u{1b}",
+            charactersIgnoringModifiers: "\u{1b}",
+            isARepeat: false,
+            keyCode: 53
+        )!
+
+        let action = ShortcutCaptureKeyHandling.action(
+            for: event,
+            pressedModifierKeyCodes: [55],
+            hasPendingCapture: true
+        )
+
+        assert(action == .updateCapture(ShortcutBinding(
+            keyCode: 53,
+            keyDisplay: "Esc",
+            modifiers: .command,
+            kind: .key,
+            preset: nil,
+            exactModifierKeyCodes: [55]
+        )))
+    }
+
+    private static func testCommandReturnWithPendingBindingUpdatesCapture() {
+        let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: .command,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\r",
+            charactersIgnoringModifiers: "\r",
+            isARepeat: false,
+            keyCode: 36
+        )!
+
+        let action = ShortcutCaptureKeyHandling.action(
+            for: event,
+            pressedModifierKeyCodes: [55],
+            hasPendingCapture: true
+        )
+
+        assert(action == .updateCapture(ShortcutBinding(
+            keyCode: 36,
+            keyDisplay: "↩",
+            modifiers: .command,
+            kind: .key,
+            preset: nil,
+            exactModifierKeyCodes: [55]
+        )))
+    }
+}

--- a/Tests/ShortcutMatcherTests.swift
+++ b/Tests/ShortcutMatcherTests.swift
@@ -6,6 +6,7 @@ struct ShortcutMatcherTests {
         testDisabledCancelShortcutPassesThrough()
         testEscCancelShortcutEmitsCancelEvent()
         testModifierOnlyCancelShortcutEmitsCancelEvent()
+        testModifierCombinationCancelShortcutEmitsRegardlessOfPressOrder()
         testRepeatedEscDoesNotEmitCancelEvent()
         testCustomCancelShortcutRequiresConfiguredModifiers()
         testCancelDeclinePassesThrough()
@@ -63,6 +64,48 @@ struct ShortcutMatcherTests {
 
         assert(result.emittedEvents == [.recordingCancelRequested])
         assert(result.consumeDecision == .consume)
+    }
+
+    private static func testModifierCombinationCancelShortcutEmitsRegardlessOfPressOrder() {
+        let rightOptionWithCommand = ShortcutBinding(
+            keyCode: 61,
+            keyDisplay: "Right Option",
+            modifiers: .command,
+            kind: .modifierKey,
+            preset: nil,
+            exactModifierKeyCodes: [55, 61]
+        )
+        let configuration = ShortcutConfiguration(
+            hold: .disabled,
+            toggle: .disabled,
+            recordingCancel: rightOptionWithCommand
+        )
+
+        let commandFirst = ShortcutMatcher.reduce(
+            state: ShortcutInputState(),
+            event: .modifierChanged(keyCode: 55, isDown: true),
+            configuration: configuration
+        )
+        let commandThenRightOption = ShortcutMatcher.reduce(
+            state: commandFirst.state,
+            event: .modifierChanged(keyCode: 61, isDown: true),
+            configuration: configuration
+        )
+        assert(commandThenRightOption.emittedEvents == [.recordingCancelRequested])
+        assert(commandThenRightOption.consumeDecision == .consume)
+
+        let rightOptionFirst = ShortcutMatcher.reduce(
+            state: ShortcutInputState(),
+            event: .modifierChanged(keyCode: 61, isDown: true),
+            configuration: configuration
+        )
+        let rightOptionThenCommand = ShortcutMatcher.reduce(
+            state: rightOptionFirst.state,
+            event: .modifierChanged(keyCode: 55, isDown: true),
+            configuration: configuration
+        )
+        assert(rightOptionThenCommand.emittedEvents == [.recordingCancelRequested])
+        assert(rightOptionThenCommand.consumeDecision == .consume)
     }
 
     private static func testRepeatedEscDoesNotEmitCancelEvent() {

--- a/Tests/ShortcutMatcherTests.swift
+++ b/Tests/ShortcutMatcherTests.swift
@@ -5,6 +5,7 @@ struct ShortcutMatcherTests {
     static func main() {
         testDisabledCancelShortcutPassesThrough()
         testEscCancelShortcutEmitsCancelEvent()
+        testModifierOnlyCancelShortcutEmitsCancelEvent()
         testRepeatedEscDoesNotEmitCancelEvent()
         testCustomCancelShortcutRequiresConfiguredModifiers()
         testCancelDeclinePassesThrough()
@@ -40,6 +41,23 @@ struct ShortcutMatcherTests {
         let result = ShortcutMatcher.reduce(
             state: ShortcutInputState(),
             event: .keyChanged(keyCode: 53, isDown: true, isRepeat: false),
+            configuration: configuration
+        )
+
+        assert(result.emittedEvents == [.recordingCancelRequested])
+        assert(result.consumeDecision == .consume)
+    }
+
+    private static func testModifierOnlyCancelShortcutEmitsCancelEvent() {
+        let configuration = ShortcutConfiguration(
+            hold: .disabled,
+            toggle: .disabled,
+            recordingCancel: ShortcutPreset.rightOption.binding
+        )
+
+        let result = ShortcutMatcher.reduce(
+            state: ShortcutInputState(),
+            event: .modifierChanged(keyCode: 61, isDown: true),
             configuration: configuration
         )
 

--- a/Tests/ShortcutMatcherTests.swift
+++ b/Tests/ShortcutMatcherTests.swift
@@ -9,6 +9,7 @@ struct ShortcutMatcherTests {
         testCustomCancelShortcutRequiresConfiguredModifiers()
         testCancelDeclinePassesThrough()
         testCancelAcceptConsumes()
+        testCancelDeclinePreservesForwardedShortcutConsumption()
         print("ShortcutMatcherTests passed")
     }
 
@@ -139,6 +140,24 @@ struct ShortcutMatcherTests {
         )
 
         assert(forwardedEvents.isEmpty)
+        assert(decision == .consume)
+    }
+
+    private static func testCancelDeclinePreservesForwardedShortcutConsumption() {
+        let result = ShortcutMatchResult(
+            state: ShortcutInputState(),
+            emittedEvents: [.holdActivated, .recordingCancelRequested],
+            consumeDecision: .consume
+        )
+        var forwardedEvents: [ShortcutEvent] = []
+
+        let decision = HotkeyManager.dispatchShortcutMatchResult(
+            result,
+            onShortcutEvent: { forwardedEvents.append($0) },
+            onRecordingCancelShortcut: { false }
+        )
+
+        assert(forwardedEvents == [.holdActivated])
         assert(decision == .consume)
     }
 }

--- a/Tests/ShortcutMatcherTests.swift
+++ b/Tests/ShortcutMatcherTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+@main
+struct ShortcutMatcherTests {
+    static func main() {
+        testDisabledCancelShortcutPassesThrough()
+        testEscCancelShortcutEmitsCancelEvent()
+        testRepeatedEscDoesNotEmitCancelEvent()
+        testCustomCancelShortcutRequiresConfiguredModifiers()
+        testCancelDeclinePassesThrough()
+        testCancelAcceptConsumes()
+        print("ShortcutMatcherTests passed")
+    }
+
+    private static func testDisabledCancelShortcutPassesThrough() {
+        let configuration = ShortcutConfiguration(
+            hold: .disabled,
+            toggle: .disabled,
+            recordingCancel: .disabled
+        )
+
+        let result = ShortcutMatcher.reduce(
+            state: ShortcutInputState(),
+            event: .keyChanged(keyCode: 53, isDown: true, isRepeat: false),
+            configuration: configuration
+        )
+
+        assert(result.emittedEvents.isEmpty)
+        assert(result.consumeDecision == .passthrough)
+    }
+
+    private static func testEscCancelShortcutEmitsCancelEvent() {
+        let configuration = ShortcutConfiguration(
+            hold: .disabled,
+            toggle: .disabled,
+            recordingCancel: .defaultRecordingCancel
+        )
+
+        let result = ShortcutMatcher.reduce(
+            state: ShortcutInputState(),
+            event: .keyChanged(keyCode: 53, isDown: true, isRepeat: false),
+            configuration: configuration
+        )
+
+        assert(result.emittedEvents == [.recordingCancelRequested])
+        assert(result.consumeDecision == .consume)
+    }
+
+    private static func testRepeatedEscDoesNotEmitCancelEvent() {
+        let configuration = ShortcutConfiguration(
+            hold: .disabled,
+            toggle: .disabled,
+            recordingCancel: .defaultRecordingCancel
+        )
+
+        let initial = ShortcutMatcher.reduce(
+            state: ShortcutInputState(),
+            event: .keyChanged(keyCode: 53, isDown: true, isRepeat: false),
+            configuration: configuration
+        )
+        let repeated = ShortcutMatcher.reduce(
+            state: initial.state,
+            event: .keyChanged(keyCode: 53, isDown: true, isRepeat: true),
+            configuration: configuration
+        )
+
+        assert(repeated.emittedEvents.isEmpty)
+        assert(repeated.consumeDecision == .passthrough)
+    }
+
+    private static func testCustomCancelShortcutRequiresConfiguredModifiers() {
+        let commandPeriod = ShortcutBinding(
+            keyCode: 47,
+            keyDisplay: ".",
+            modifiers: .command,
+            kind: .key,
+            preset: nil,
+            exactModifierKeyCodes: [55]
+        )
+        let configuration = ShortcutConfiguration(
+            hold: .disabled,
+            toggle: .disabled,
+            recordingCancel: commandPeriod
+        )
+
+        let barePeriod = ShortcutMatcher.reduce(
+            state: ShortcutInputState(),
+            event: .keyChanged(keyCode: 47, isDown: true, isRepeat: false),
+            configuration: configuration
+        )
+        assert(barePeriod.emittedEvents.isEmpty)
+        assert(barePeriod.consumeDecision == .passthrough)
+
+        let snapshot = ShortcutMatcher.reduce(
+            state: ShortcutInputState(),
+            event: .modifierSnapshot([55]),
+            configuration: configuration
+        )
+        let commandPeriodResult = ShortcutMatcher.reduce(
+            state: snapshot.state,
+            event: .keyChanged(keyCode: 47, isDown: true, isRepeat: false),
+            configuration: configuration
+        )
+
+        assert(commandPeriodResult.emittedEvents == [.recordingCancelRequested])
+        assert(commandPeriodResult.consumeDecision == .consume)
+    }
+
+    private static func testCancelDeclinePassesThrough() {
+        let result = ShortcutMatchResult(
+            state: ShortcutInputState(),
+            emittedEvents: [.recordingCancelRequested],
+            consumeDecision: .consume
+        )
+        var forwardedEvents: [ShortcutEvent] = []
+
+        let decision = HotkeyManager.dispatchShortcutMatchResult(
+            result,
+            onShortcutEvent: { forwardedEvents.append($0) },
+            onRecordingCancelShortcut: { false }
+        )
+
+        assert(forwardedEvents.isEmpty)
+        assert(decision == .passthrough)
+    }
+
+    private static func testCancelAcceptConsumes() {
+        let result = ShortcutMatchResult(
+            state: ShortcutInputState(),
+            emittedEvents: [.recordingCancelRequested],
+            consumeDecision: .consume
+        )
+        var forwardedEvents: [ShortcutEvent] = []
+
+        let decision = HotkeyManager.dispatchShortcutMatchResult(
+            result,
+            onShortcutEvent: { forwardedEvents.append($0) },
+            onRecordingCancelShortcut: { true }
+        )
+
+        assert(forwardedEvents.isEmpty)
+        assert(decision == .consume)
+    }
+}

--- a/Tests/ShortcutValidationMessagesTests.swift
+++ b/Tests/ShortcutValidationMessagesTests.swift
@@ -1,0 +1,21 @@
+@main
+struct ShortcutValidationMessagesTests {
+    static func main() {
+        testSuccessfulSelectionClearsAllValidationMessages()
+        print("ShortcutValidationMessagesTests passed")
+    }
+
+    private static func testSuccessfulSelectionClearsAllValidationMessages() {
+        var messages = ShortcutValidationMessages(
+            hold: "Hold and tap shortcuts must be distinct.",
+            toggle: "Hold and tap shortcuts must be distinct.",
+            recordingCancel: "Cancel shortcut must be distinct from dictation shortcuts."
+        )
+
+        messages.applySelectionResult(nil, target: .toggle)
+
+        assert(messages.hold == nil)
+        assert(messages.toggle == nil)
+        assert(messages.recordingCancel == nil)
+    }
+}

--- a/docs/superpowers/specs/2026-05-13-recording-cancel-shortcut-design.md
+++ b/docs/superpowers/specs/2026-05-13-recording-cancel-shortcut-design.md
@@ -1,0 +1,149 @@
+# Recording Cancel Shortcut Design
+
+**Goal:** Let users disable or change the shortcut that opens the recording cancellation confirmation, while keeping the current `Esc` behavior as the default.
+
+**Context:** Today `GlobalShortcutBackend` special-cases key code `53` (`Esc`) and routes it through `onEscapeKeyPressed`. `AppState` consumes that key while recording, transcribing, or waiting on a toggle recording start, then shows the existing cancellation confirmation. This prevents `Esc` from reaching other apps during active recording sessions. Issue #89 asks for this cancel shortcut to be configurable or changeable separately from `Esc`.
+
+## Approach
+
+Add a dedicated recording cancel shortcut that uses the existing `ShortcutBinding` model.
+
+- Add `recordingCancelShortcut` to `AppState`, with default value `Esc`.
+- Allow the shortcut to be `Disabled`, `Esc`, or a custom `ShortcutBinding`.
+- Persist both the selected cancel shortcut and the last custom cancel shortcut in `UserDefaults`.
+- Generalize the hotkey path so cancel is matched by shortcut configuration instead of a hard-coded `Esc` callback.
+- Keep the existing cancellation confirmation behavior and dialog copy.
+- Add the setting inside the existing `Settings → Dictation Shortcuts` card.
+
+## Behavior
+
+The default behavior remains unchanged: pressing `Esc` during recording, transcription, or a pending toggle recording start opens the cancellation confirmation dialog and consumes the key event.
+
+When the cancel shortcut is disabled, Quill does not consume `Esc` or any other cancel shortcut during recording. `Esc` remains available to the foreground app.
+
+When the cancel shortcut is custom, Quill consumes only that configured shortcut while cancellation is applicable. Other keys, including `Esc`, pass through unless they are also part of the dictation hold/tap shortcut system.
+
+The cancel shortcut has no effect and should not consume events when cancellation is not applicable. Cancellation is applicable only when `AppState.shouldConfirmEscapeCancellation` would currently return true: recording, transcribing, pending toggle start, or active toggle recording session.
+
+## Architecture
+
+### AppState
+
+`AppState` owns the persisted setting and validation.
+
+- `@Published var recordingCancelShortcut: ShortcutBinding`
+- `@Published private(set) var savedRecordingCancelCustomShortcut: ShortcutBinding?`
+- storage keys:
+  - `recording_cancel_shortcut`
+  - `saved_recording_cancel_custom_shortcut`
+- default:
+  - `ShortcutBinding.defaultRecordingCancel`, representing `Esc`
+
+Add a setter such as `setRecordingCancelShortcut(_:) -> String?` that mirrors `setShortcut(_:for:)`.
+
+Validation should reject cancel shortcuts that conflict with the hold or tap dictation shortcuts. A disabled cancel shortcut is always valid. Command-mode manual modifier collisions are not rejected because the cancel shortcut is a separate one-shot action and should only conflict when it shares the same full shortcut identity with hold or tap.
+
+### Shortcut model
+
+Extend the shortcut configuration and matcher rather than preserving a separate escape-only path.
+
+- Add `recordingCancel: ShortcutBinding` to `ShortcutConfiguration`.
+- Add a cancel event to the emitted shortcut event model, for example `ShortcutEvent.recordingCancelRequested`.
+- Update matching so the cancel shortcut can emit a cancel event on key down or modifier activation, while still respecting `ShortcutBinding.disabled`.
+- Do not emit cancel events for repeated keyDown events.
+- Ensure unrelated key events remain passthrough.
+
+This keeps shortcut matching in one place and removes the brittle assumption that recording cancellation is always `Esc`.
+
+### HotkeyManager and GlobalShortcutBackend
+
+`GlobalShortcutBackend` should stop treating `Esc` as a special global callback. Key code `53` should flow through the normal key event path so `ShortcutMatcher` can decide whether it belongs to the configured cancel shortcut.
+
+`HotkeyManager` should expose a dedicated cancel callback, such as `onRecordingCancelShortcut: (() -> Bool)?`, where the returned Boolean decides whether the triggering event is consumed. Hold/tap shortcut events continue to use `onShortcutEvent`.
+
+When `ShortcutMatcher` emits a cancel event, `HotkeyManager` asks the cancel callback before finalizing the consume decision. If `AppState` returns `true`, the triggering event is consumed and the existing cancellation alert is presented. If `AppState` returns `false`, the cancel event is dropped and the key event passes through unless a hold/tap shortcut also requires consumption. This makes the app-state-dependent passthrough behavior explicit while still matching cancel through the shared shortcut model.
+
+## Settings UI
+
+Add a `Recording Cancel Shortcut` section under `Dictation Shortcuts`, below the hold/tap editor and above `Shortcut Start Delay`.
+
+The section contains:
+
+1. `Disabled`
+2. `Esc`
+3. `Custom Shortcut`
+
+The section description should explain the trade-off:
+
+> While recording or transcribing, this shortcut opens the cancel confirmation dialog. Disable it if you want Esc to keep working in other apps.
+
+The UI should show validation errors below the section, using the same visual style as existing shortcut validation. The likely validation message is:
+
+> Cancel shortcut must be distinct from dictation shortcuts.
+
+Prefer a focused `RecordingCancelShortcutSection` that reuses the existing row style and capture behavior where practical. Do not refactor the entire hold/tap shortcut editor unless the implementation requires a small extraction to avoid duplicated capture code.
+
+## Data flow
+
+1. App launches.
+2. `AppState` loads hold, tap, and cancel shortcuts from `UserDefaults`.
+3. Missing or invalid cancel shortcut data falls back to `Esc`.
+4. `AppState.activeShortcutConfiguration` includes hold, tap, and recording cancel shortcuts.
+5. Hotkey monitoring starts with the full shortcut configuration.
+6. User presses a key while recording.
+7. `GlobalShortcutBackend` forwards the key through normal shortcut input events.
+8. `ShortcutMatcher` determines whether hold, tap, or cancel matched.
+9. For hold/tap events, `AppState` receives the emitted shortcut event through `onShortcutEvent`.
+10. For cancel events, `HotkeyManager` calls the dedicated cancel callback.
+11. `AppState` checks whether cancellation is applicable.
+12. If applicable, Quill shows the existing confirmation dialog and returns `true` so the event is consumed.
+13. If not applicable, Quill returns `false` so the event passes through unless another shortcut matched.
+
+## Error handling
+
+- Missing stored cancel shortcut: default to `Esc`.
+- Undecodable stored cancel shortcut: default to `Esc`.
+- Disabled cancel shortcut: never consume events for cancellation.
+- Conflict with hold/tap shortcut: do not commit the new cancel shortcut and show validation text.
+- Event tap unavailable: preserve existing hotkey monitoring error behavior.
+- Existing cancellation dialog already visible: do not open another dialog and do not consume unrelated events.
+
+## Testing
+
+Add or update tests in the existing `swiftc`-driven test suite.
+
+### Shortcut matcher tests
+
+Cover:
+
+- Disabled cancel shortcut does not emit cancel or consume.
+- Default `Esc` cancel shortcut emits cancel on `Esc` keyDown.
+- Default `Esc` cancel shortcut ignores repeated keyDown.
+- Custom cancel shortcut emits cancel only for the configured key/modifier combination.
+- Unrelated keys pass through.
+- Matched cancel shortcut passes through when the cancel callback declines consumption.
+- Hold/tap behavior still works with cancel configured.
+
+### AppState settings tests
+
+Cover:
+
+- Missing stored cancel shortcut loads as `Esc`.
+- Disabled cancel shortcut persists and reloads.
+- Custom cancel shortcut persists and reloads.
+- A cancel shortcut conflicting with hold or tap is rejected.
+- Changing cancel shortcut restarts hotkey monitoring through the existing published setting path.
+
+### Manual verification
+
+- Default settings: start recording, press `Esc`, confirm the cancellation dialog appears.
+- Disabled setting: start recording, press `Esc`, confirm Quill does not show its cancellation dialog.
+- Custom setting: set a custom cancel shortcut, start recording, press that shortcut, confirm the cancellation dialog appears.
+- Run `make test`.
+
+## Non-goals
+
+- Do not change the confirmation dialog behavior beyond removing the hard-coded `Esc` assumption.
+- Do not change hold/tap dictation shortcut semantics.
+- Do not add a separate setup wizard step for the cancel shortcut.
+- Do not migrate existing users away from `Esc`; the default remains `Esc` for both new and existing installs.


### PR DESCRIPTION
## Summary
- Add a configurable recording cancel shortcut while keeping Esc as the default
- Route cancel handling through ShortcutBinding/ShortcutMatcher instead of hard-coded Esc handling
- Add Settings UI for Disabled, Esc, and custom cancel shortcuts with persistence and conflict validation

## Test plan
- [x] `HOME="$(mktemp -d /tmp/freeflow-draft-pr-test-home.XXXXXX)" make test`
- [ ] Manual app check for default Esc, Disabled, key custom, modifier-only custom, and modifier-combo custom cancel shortcuts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 녹음 취소 단축키를 별도 설정할 수 있는 UI 섹션이 추가되었습니다 (기본값: Esc).
  * 단축키 캡처 흐름이 개선되어 취소/업데이트/무시 동작을 더 정확히 처리합니다.

* **테스트**
  * 녹음 취소 관련 검증 및 매처 동작을 포함한 단축키 테스트가 다수 추가되었습니다.

* **개선사항**
  * 입력 이벤트 처리 경로가 통합되어 단축키 매칭과 소비 결정이 일관되게 동작합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/freeflow/pull/92)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->