### PR TITLE
Add calendar matching diagnostics

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,9 +1,10 @@
 name: Dev Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+  # push:
+  #   branches:
+  #     - main
 
 permissions:
   contents: write

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,4 +1,4 @@
-name: Fork Release
+name: Manual Release
 
 on:
   workflow_dispatch:
@@ -20,7 +20,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: fork-release-${{ github.event.inputs.tag }}
+  group: manual-release-${{ github.event.inputs.tag }}
   cancel-in-progress: false
 
 jobs:
@@ -39,7 +39,7 @@ jobs:
         run: |
           TAG="$INPUT_TAG"
           if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$ ]]; then
-            echo "Fork release tags must look like v0.1.0 or v0.1.0-beta.1." >&2
+            echo "Release tags must look like v0.1.0 or v0.1.0-beta.1." >&2
             exit 1
           fi
 
@@ -71,7 +71,7 @@ jobs:
         run: |
           TAG="${{ steps.metadata.outputs.tag }}"
           if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "Release tag $TAG already exists on origin. Choose a new fork-owned release tag." >&2
+            echo "Release tag $TAG already exists on origin. Choose a new release tag." >&2
             exit 1
           fi
 
@@ -100,11 +100,11 @@ jobs:
             echo "body<<$DELIM"
             echo "## Installation note"
             echo
-            echo "This is a release build from the woosublee/freeflow fork."
+            echo "This is a release build from woosublee/freeflow."
             echo
             echo "- macOS may show a first-launch security warning."
             echo "- If that happens, open System Settings > Privacy & Security and choose Open Anyway."
-            echo "- Only run this build if you trust this fork release."
+            echo "- Only run this build if you trust this release."
             echo
             echo "## Download"
             echo

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -100,7 +100,7 @@ jobs:
             echo "body<<$DELIM"
             echo "## Installation note"
             echo
-            echo "This is a release build from woosublee/freeflow."
+            echo "This is a release build from ${{ github.repository }}."
             echo
             echo "- macOS may show a first-launch security warning."
             echo "- If that happens, open System Settings > Privacy & Security and choose Open Anyway."

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ all: $(APP_EXECUTABLE_TARGET)
 
 $(BUILD_SETTINGS): FORCE
 	@mkdir -p "$(BUILD_DIR)"
-	@printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n' "$(APP_NAME)" "$(BUNDLE_ID)" "$(APP_VERSION)" "$(BUILD_NUMBER)" "$(BUILD_TAG)" "$(GOOGLE_CALENDAR_OAUTH_CLIENT_ID)" "$(GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET)" > "$@.tmp"
+	@printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' "$(APP_NAME)" "$(BUNDLE_ID)" "$(APP_VERSION)" "$(BUILD_NUMBER)" "$(BUILD_TAG)" "$(GOOGLE_CALENDAR_OAUTH_CLIENT_ID)" "$(GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET)" "$(CODESIGN_IDENTITY)" > "$@.tmp"
 	@if [ ! -f "$@" ] || ! cmp -s "$@.tmp" "$@"; then mv "$@.tmp" "$@"; else rm "$@.tmp"; fi
 
 $(APP_EXECUTABLE_TARGET): $(SOURCES) Info.plist $(ICON_ICNS) $(BUILD_SETTINGS)

--- a/Makefile
+++ b/Makefile
@@ -181,8 +181,8 @@ test:
 	@/tmp/NoteTitleResolutionTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/NoteTitleResolver.swift Sources/NoteListRowDisplayData.swift Tests/NoteListRowDisplayDataTests.swift -o /tmp/NoteListRowDisplayDataTests
 	@/tmp/NoteListRowDisplayDataTests
-	@swiftc -parse-as-library Tests/ForkReleaseWorkflowTests.swift -o /tmp/ForkReleaseWorkflowTests
-	@/tmp/ForkReleaseWorkflowTests
+	@swiftc -parse-as-library Tests/ManualReleaseWorkflowTests.swift -o /tmp/ManualReleaseWorkflowTests
+	@/tmp/ManualReleaseWorkflowTests
 	@swiftc -parse-as-library Tests/BuildMetadataTests.swift -o /tmp/BuildMetadataTests
 	@/tmp/BuildMetadataTests
 	@swiftc -parse-as-library Tests/ReleaseSDKCompatibilityTests.swift -o /tmp/ReleaseSDKCompatibilityTests

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -8,6 +8,7 @@ import ScreenCaptureKit
 import Speech
 import os.log
 private let recordingLog = OSLog(subsystem: "com.woosublee.quill", category: "Recording")
+private let calendarLog = OSLog(subsystem: "com.woosublee.quill", category: "Calendar")
 
 struct VoiceMacro: Codable, Identifiable, Equatable {
     var id: UUID = UUID()
@@ -4528,37 +4529,124 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    private static func logTimestamp(_ date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
+    }
+
     private func calendarMatchForHistoryItem(jobID: UUID) async -> CalendarEventMatch? {
-        guard let job = await MainActor.run(body: { activeTranscriptionJobs[jobID] }),
-              !job.isImportedAudio,
-              let recordingStartedAt = job.recordingStartedAt,
-              let recordingEndedAt = job.recordingEndedAt,
-              recordingEndedAt > recordingStartedAt else {
+        guard let job = await MainActor.run(body: { activeTranscriptionJobs[jobID] }) else {
+            os_log(.info, log: calendarLog, "Calendar match skipped: missing transcription job %{public}@", jobID.uuidString)
+            return nil
+        }
+        guard !job.isImportedAudio else {
+            os_log(.info, log: calendarLog, "Calendar match skipped: imported audio job %{public}@", jobID.uuidString)
+            return nil
+        }
+        guard let recordingStartedAt = job.recordingStartedAt,
+              let recordingEndedAt = job.recordingEndedAt else {
+            os_log(.info, log: calendarLog, "Calendar match skipped: missing recording interval for job %{public}@", jobID.uuidString)
+            return nil
+        }
+        guard recordingEndedAt > recordingStartedAt else {
+            os_log(
+                .info,
+                log: calendarLog,
+                "Calendar match skipped: invalid recording interval for job %{public}@ start=%{public}@ end=%{public}@",
+                jobID.uuidString,
+                Self.logTimestamp(recordingStartedAt),
+                Self.logTimestamp(recordingEndedAt)
+            )
             return nil
         }
         let selectedCalendarIDs = await MainActor.run { googleCalendarConnection.selectedCalendarIDs }
-        guard !selectedCalendarIDs.isEmpty else { return nil }
+        guard !selectedCalendarIDs.isEmpty else {
+            os_log(
+                .info,
+                log: calendarLog,
+                "Calendar match skipped: no selected calendars for job %{public}@ start=%{public}@ end=%{public}@",
+                jobID.uuidString,
+                Self.logTimestamp(recordingStartedAt),
+                Self.logTimestamp(recordingEndedAt)
+            )
+            return nil
+        }
         do {
-            guard let token = try await validGoogleCalendarToken() else { return nil }
-            let events = await GoogleCalendarService().fetchEventsSkippingFailures(
+            guard let token = try await validGoogleCalendarToken() else {
+                os_log(.info, log: calendarLog, "Calendar match skipped: no valid Google Calendar token for job %{public}@", jobID.uuidString)
+                return nil
+            }
+            os_log(
+                .info,
+                log: calendarLog,
+                "Calendar match fetch started: job=%{public}@ calendars=%d start=%{public}@ end=%{public}@",
+                jobID.uuidString,
+                selectedCalendarIDs.count,
+                Self.logTimestamp(recordingStartedAt),
+                Self.logTimestamp(recordingEndedAt)
+            )
+            let fetchResult = await GoogleCalendarService().fetchEventsWithDiagnostics(
                 accessToken: token.accessToken,
                 calendarIDs: Array(selectedCalendarIDs),
                 timeMin: recordingStartedAt,
                 timeMax: recordingEndedAt
             )
+            if !fetchResult.failedCalendarIDs.isEmpty {
+                os_log(
+                    .error,
+                    log: calendarLog,
+                    "Calendar match fetch had failures: job=%{public}@ failedCalendars=%{public}@ fetchedEvents=%d",
+                    jobID.uuidString,
+                    fetchResult.failedCalendarIDs.joined(separator: ","),
+                    fetchResult.events.count
+                )
+            } else {
+                os_log(
+                    .info,
+                    log: calendarLog,
+                    "Calendar match fetch succeeded: job=%{public}@ fetchedEvents=%d",
+                    jobID.uuidString,
+                    fetchResult.events.count
+                )
+            }
             guard let event = CalendarEventMatcher.bestMatch(
                 recordingStartedAt: recordingStartedAt,
                 recordingEndedAt: recordingEndedAt,
-                events: events
+                events: fetchResult.events
             ) else {
+                os_log(
+                    .info,
+                    log: calendarLog,
+                    "Calendar match not found: job=%{public}@ fetchedEvents=%d failedCalendars=%d",
+                    jobID.uuidString,
+                    fetchResult.events.count,
+                    fetchResult.failedCalendarIDs.count
+                )
                 return nil
             }
+            os_log(
+                .info,
+                log: calendarLog,
+                "Calendar match found: job=%{public}@ calendar=%{public}@ event=%{public}@ title=%{public}@ start=%{public}@ end=%{public}@",
+                jobID.uuidString,
+                event.calendarID,
+                event.id,
+                event.title,
+                Self.logTimestamp(event.start),
+                Self.logTimestamp(event.end)
+            )
             return event.match(
                 accountID: token.accountEmail,
                 source: .overlapSuggestion,
                 titleState: .suggested
             )
         } catch {
+            os_log(
+                .error,
+                log: calendarLog,
+                "Calendar match failed: job=%{public}@ error=%{public}@",
+                jobID.uuidString,
+                error.localizedDescription
+            )
             await MainActor.run {
                 googleCalendarConnection.lastErrorMessage = error.localizedDescription
             }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -4594,7 +4594,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 os_log(
                     .error,
                     log: calendarLog,
-                    "Calendar match fetch had failures: job=%{public}@ failedCalendars=%{public}@ fetchedEvents=%d",
+                    "Calendar match fetch had failures: job=%{public}@ failedCalendars=%{private}@ fetchedEvents=%d",
                     jobID.uuidString,
                     fetchResult.failedCalendarIDs.joined(separator: ","),
                     fetchResult.events.count
@@ -4626,7 +4626,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             os_log(
                 .info,
                 log: calendarLog,
-                "Calendar match found: job=%{public}@ calendar=%{public}@ event=%{public}@ title=%{public}@ start=%{public}@ end=%{public}@",
+                "Calendar match found: job=%{public}@ calendar=%{private}@ event=%{private}@ title=%{private}@ start=%{public}@ end=%{public}@",
                 jobID.uuidString,
                 event.calendarID,
                 event.id,

--- a/Sources/GoogleCalendarService.swift
+++ b/Sources/GoogleCalendarService.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+struct GoogleCalendarEventFetchResult: Equatable {
+    let events: [GoogleCalendarEvent]
+    let failedCalendarIDs: [String]
+}
+
 struct GoogleCalendarService {
     typealias Transport = (URLRequest) async throws -> (Data, URLResponse)
 
@@ -57,7 +62,22 @@ struct GoogleCalendarService {
         timeMin: Date,
         timeMax: Date
     ) async -> [GoogleCalendarEvent] {
+        await fetchEventsWithDiagnostics(
+            accessToken: accessToken,
+            calendarIDs: calendarIDs,
+            timeMin: timeMin,
+            timeMax: timeMax
+        ).events
+    }
+
+    func fetchEventsWithDiagnostics(
+        accessToken: String,
+        calendarIDs: [String],
+        timeMin: Date,
+        timeMax: Date
+    ) async -> GoogleCalendarEventFetchResult {
         var events: [GoogleCalendarEvent] = []
+        var failedCalendarIDs: [String] = []
         for calendarID in calendarIDs {
             do {
                 let calendarEvents = try await fetchEvents(
@@ -68,10 +88,11 @@ struct GoogleCalendarService {
                 )
                 events.append(contentsOf: calendarEvents)
             } catch {
+                failedCalendarIDs.append(calendarID)
                 continue
             }
         }
-        return events
+        return GoogleCalendarEventFetchResult(events: events, failedCalendarIDs: failedCalendarIDs)
     }
 
     private func send<Response: Decodable>(url: URL, accessToken: String) async throws -> Response {

--- a/Tests/BuildMetadataTests.swift
+++ b/Tests/BuildMetadataTests.swift
@@ -4,6 +4,7 @@ import Foundation
 struct BuildMetadataTests {
     static func main() throws {
         try testMakefileStampsLocalBuildMetadata()
+        try testBuildSettingsTrackCodesignIdentity()
         try testReleaseWorkflowsPassBuildMetadataToMake()
         print("BuildMetadataTests passed")
     }
@@ -24,6 +25,13 @@ struct BuildMetadataTests {
         assertContains(makefile, "plutil -replace CFBundleShortVersionString -string \"$(APP_VERSION)\" \"$(CONTENTS)/Info.plist\"")
         assertContains(makefile, "plutil -replace CFBundleVersion -string \"$(BUILD_NUMBER)\" \"$(CONTENTS)/Info.plist\"")
         assertContains(makefile, "plutil -replace QuillBuildTag -string \"$(BUILD_TAG)\" \"$(CONTENTS)/Info.plist\"")
+    }
+
+    private static func testBuildSettingsTrackCodesignIdentity() throws {
+        let makefile = try String(contentsOfFile: "Makefile", encoding: .utf8)
+
+        assertContains(makefile, "$(CODESIGN_IDENTITY)")
+        assertContains(makefile, "$(BUILD_TAG)\" \"$(GOOGLE_CALENDAR_OAUTH_CLIENT_ID)\" \"$(GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET)\" \"$(CODESIGN_IDENTITY)")
     }
 
     private static func testReleaseWorkflowsPassBuildMetadataToMake() throws {

--- a/Tests/BuildMetadataTests.swift
+++ b/Tests/BuildMetadataTests.swift
@@ -35,12 +35,12 @@ struct BuildMetadataTests {
     }
 
     private static func testReleaseWorkflowsPassBuildMetadataToMake() throws {
-        let forkReleaseWorkflow = try String(contentsOfFile: ".github/workflows/fork-release.yml", encoding: .utf8)
+        let manualReleaseWorkflow = try String(contentsOfFile: ".github/workflows/manual-release.yml", encoding: .utf8)
         let releaseWorkflow = try String(contentsOfFile: ".github/workflows/release.yml", encoding: .utf8)
 
-        assertContains(forkReleaseWorkflow, "APP_VERSION=\"${{ steps.metadata.outputs.version }}\"")
-        assertContains(forkReleaseWorkflow, "BUILD_NUMBER=\"${{ github.run_number }}\"")
-        assertContains(forkReleaseWorkflow, "BUILD_TAG=\"${{ steps.metadata.outputs.tag }}\"")
+        assertContains(manualReleaseWorkflow, "APP_VERSION=\"${{ steps.metadata.outputs.version }}\"")
+        assertContains(manualReleaseWorkflow, "BUILD_NUMBER=\"${{ github.run_number }}\"")
+        assertContains(manualReleaseWorkflow, "BUILD_TAG=\"${{ steps.metadata.outputs.tag }}\"")
 
         assertContains(releaseWorkflow, "APP_VERSION=\"${{ steps.version.outputs.version }}\"")
         assertContains(releaseWorkflow, "BUILD_NUMBER=\"${{ github.run_number }}\"")

--- a/Tests/GoogleCalendarServiceTests.swift
+++ b/Tests/GoogleCalendarServiceTests.swift
@@ -27,6 +27,7 @@ struct GoogleCalendarServiceTests {
         try await testFetchEventsEncodesCalendarIDAsSinglePathSegment()
         try await testEventsDecodeFractionalSecondDateTimes()
         try await testFetchEventsSkipsFailedCalendars()
+        try await testFetchEventsReportsFailedCalendars()
         print("GoogleCalendarServiceTests passed")
     }
 
@@ -393,6 +394,27 @@ struct GoogleCalendarServiceTests {
 
         assert(events.count == 2)
         assert(events.allSatisfy { $0.calendarID == "good-calendar" })
+    }
+
+    private static func testFetchEventsReportsFailedCalendars() async throws {
+        let service = GoogleCalendarService { request in
+            let url = request.url!.absoluteString
+            if url.contains("bad-calendar") {
+                return (Data("{}".utf8), HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!)
+            }
+            return (Data(eventsJSON.utf8), HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+
+        let result = await service.fetchEventsWithDiagnostics(
+            accessToken: "token",
+            calendarIDs: ["bad-calendar", "good-calendar"],
+            timeMin: Date(timeIntervalSince1970: 1_000),
+            timeMax: Date(timeIntervalSince1970: 2_000)
+        )
+
+        assert(result.events.count == 2)
+        assert(result.events.allSatisfy { $0.calendarID == "good-calendar" })
+        assert(result.failedCalendarIDs == ["bad-calendar"])
     }
 
     private static func expectedChallenge(for verifier: String) -> String {

--- a/Tests/ManualReleaseWorkflowTests.swift
+++ b/Tests/ManualReleaseWorkflowTests.swift
@@ -1,16 +1,16 @@
 import Foundation
 
 @main
-struct ForkReleaseWorkflowTests {
+struct ManualReleaseWorkflowTests {
     static func main() throws {
-        let workflowPath = ".github/workflows/fork-release.yml"
+        let workflowPath = ".github/workflows/manual-release.yml"
         guard FileManager.default.fileExists(atPath: workflowPath) else {
-            fatalError("Fork release workflow is missing at \(workflowPath)")
+            fatalError("Manual release workflow is missing at \(workflowPath)")
         }
 
         let workflow = try String(contentsOfFile: workflowPath, encoding: .utf8)
 
-        assertContains(workflow, "name: Fork Release")
+        assertContains(workflow, "name: Manual Release")
         assertContains(workflow, "workflow_dispatch:")
         assertContains(workflow, "tag:")
         assertContains(workflow, "release_name:")
@@ -49,7 +49,7 @@ struct ForkReleaseWorkflowTests {
         assertDoesNotContain(workflow, "APPLE_APP_PASSWORD")
         assertDoesNotContain(workflow, "APPLE_TEAM_ID")
 
-        print("ForkReleaseWorkflowTests passed")
+        print("ManualReleaseWorkflowTests passed")
     }
 
     private static func assertContains(_ text: String, _ expected: String) {


### PR DESCRIPTION
## Summary
- Add diagnostics for Google Calendar event fetches so per-calendar failures are retained while preserving existing matching behavior.
- Log calendar matching decision points through a Calendar-specific Unified Logging category, with calendar/event details kept private in logs.
- Include the code signing identity in Makefile build settings so changing signing mode triggers a rebuild instead of reusing stale app bundles.

## Test plan
- [x] `swiftc -parse-as-library Sources/GoogleCalendarAuthService.swift Sources/GoogleCalendarTokenStore.swift Sources/CalendarIntegrationModels.swift Sources/GoogleCalendarService.swift Tests/GoogleCalendarServiceTests.swift -o /tmp/GoogleCalendarServiceTests && /tmp/GoogleCalendarServiceTests`
- [x] `swiftc -parse-as-library Tests/BuildMetadataTests.swift -o /tmp/BuildMetadataTests && /tmp/BuildMetadataTests`
- [x] `make all` and verified the built app is signed with the configured non-ad-hoc identity
- [x] Installed via `make install-and-run` to preserve existing app permissions
- [ ] Full `make test` not completed: it repeatedly progressed through calendar-related tests and then hung in `AppStateTranscriptionConfigurationTests` during Keychain access, which appears unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 캘린더 이벤트 조회 시 실패한 캘린더를 식별해 진단 정보를 기록하고, 캘린더 매칭 로직을 단계별 검증 및 상세 로깅으로 강화했습니다.

* **새 기능 / 빌드**
  * 빌드 설정에 코드 서명 식별자를 함께 기록하도록 업데이트했습니다.

* **워크플로 / 배포**
  * 릴리스 워크플로 이름·동작을 정비하고 수동 트리거로 전환했습니다.

* **테스트**
  * 진단 반환 동작과 빌드 설정 추적을 검증하는 테스트를 추가/조정했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/freeflow/pull/93)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->