### PR TITLE
Persist custom note titles in history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,8 @@ test:
 	@/tmp/NoteTitleResolutionTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/NoteTitleResolver.swift Sources/NoteListRowDisplayData.swift Tests/NoteListRowDisplayDataTests.swift -o /tmp/NoteListRowDisplayDataTests
 	@/tmp/NoteListRowDisplayDataTests
+	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/LegacyNoteTitleMigration.swift Tests/LegacyNoteTitleMigrationTests.swift -o /tmp/LegacyNoteTitleMigrationTests
+	@/tmp/LegacyNoteTitleMigrationTests
 	@swiftc -parse-as-library Tests/ManualReleaseWorkflowTests.swift -o /tmp/ManualReleaseWorkflowTests
 	@/tmp/ManualReleaseWorkflowTests
 	@swiftc -parse-as-library Tests/BuildMetadataTests.swift -o /tmp/BuildMetadataTests

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1081,10 +1081,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
         for removedAssets in removedStoredFiles {
             Self.deleteStoredFiles(removedAssets)
         }
-        let savedHistory = Self.markInterruptedRecoveryPlaceholders(
+        var savedHistory = Self.markInterruptedRecoveryPlaceholders(
             in: pipelineHistoryStore.loadAllHistory(),
             store: pipelineHistoryStore
         )
+        let historyStore = pipelineHistoryStore
+        do {
+            savedHistory = try LegacyNoteTitleMigration.migrate(history: savedHistory) { item in
+                try historyStore.update(item)
+            }
+        } catch {
+            print("Failed to migrate legacy note titles: \(error)")
+        }
         let referencedAudioFileNames = Set(savedHistory.compactMap(\.audioFileName))
         let referencedTranscriptFileNames = Set(savedHistory.compactMap(\.transcriptFileName))
         Task.detached(priority: .background) {
@@ -1776,6 +1784,22 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    func updateHistoryItemTitle(id: UUID, title: String) {
+        guard let item = pipelineHistory.first(where: { $0.id == id }) else { return }
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedTitle = trimmed.isEmpty ? nil : trimmed
+        guard item.customTitle != normalizedTitle else { return }
+        let updated = item.withCustomTitle(normalizedTitle)
+        do {
+            try pipelineHistoryStore.update(updated)
+            if let index = pipelineHistory.firstIndex(where: { $0.id == id }) {
+                pipelineHistory[index] = updated
+            }
+        } catch {
+            errorMessage = "Failed to save note title: \(error.localizedDescription)"
+        }
+    }
+
     func updateTranscript(id: UUID, text: String) {
         guard let item = pipelineHistory.first(where: { $0.id == id }) else { return }
         // 파일에도 동기화해서 앱 재시작 후 폴백 로딩 시에도 일관성 유지
@@ -1808,7 +1832,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
             usedPostProcessing: item.usedPostProcessing,
             transcriptionLanguageCode: item.transcriptionLanguageCode,
             localTranscriptionModelID: item.localTranscriptionModelID,
-            transcriptFileName: item.transcriptFileName
+            transcriptFileName: item.transcriptFileName,
+            contextAppName: item.contextAppName,
+            contextBundleIdentifier: item.contextBundleIdentifier,
+            contextWindowTitle: item.contextWindowTitle,
+            customTitle: item.customTitle
         )
         do {
             try pipelineHistoryStore.update(updated)
@@ -4436,7 +4464,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             transcriptFileName: existing.transcriptFileName,
             contextAppName: existing.contextAppName,
             contextBundleIdentifier: existing.contextBundleIdentifier,
-            contextWindowTitle: existing.contextWindowTitle
+            contextWindowTitle: existing.contextWindowTitle,
+            customTitle: existing.customTitle
         )
         // DB write 없이 메모리만 업데이트 — partial 결과는 최종 저장 시 반영됨
         pipelineHistory[index] = updated
@@ -4719,7 +4748,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             transcriptFileName: transcriptFileName,
             contextAppName: context.appName,
             contextBundleIdentifier: context.bundleIdentifier,
-            contextWindowTitle: context.windowTitle
+            contextWindowTitle: context.windowTitle,
+            customTitle: existingEntry?.customTitle
         )
         do {
             if existingID != nil {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1784,17 +1784,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
     func updateHistoryItemTitle(id: UUID, title: String) {
-        guard let item = pipelineHistory.first(where: { $0.id == id }) else { return }
+        guard let index = pipelineHistory.firstIndex(where: { $0.id == id }) else { return }
+        let item = pipelineHistory[index]
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedTitle = trimmed.isEmpty ? nil : trimmed
         guard item.customTitle != normalizedTitle else { return }
         let updated = item.withCustomTitle(normalizedTitle)
         do {
             try pipelineHistoryStore.update(updated)
-            if let index = pipelineHistory.firstIndex(where: { $0.id == id }) {
-                pipelineHistory[index] = updated
-            }
+            pipelineHistory[index] = updated
         } catch {
             errorMessage = "Failed to save note title: \(error.localizedDescription)"
         }

--- a/Sources/LegacyNoteTitleMigration.swift
+++ b/Sources/LegacyNoteTitleMigration.swift
@@ -28,9 +28,7 @@ enum LegacyNoteTitleMigration {
         for item in updatedItems {
             try update(item)
         }
-        if !updatedItems.isEmpty {
-            defaults.removeObject(forKey: storageKey)
-        }
+        defaults.removeObject(forKey: storageKey)
         return migratedHistory
     }
 

--- a/Sources/LegacyNoteTitleMigration.swift
+++ b/Sources/LegacyNoteTitleMigration.swift
@@ -37,9 +37,16 @@ enum LegacyNoteTitleMigration {
               let raw = try? JSONDecoder().decode([String: String].self, from: data) else {
             return nil
         }
-        return Dictionary(uniqueKeysWithValues: raw.compactMap { key, value in
-            guard let id = UUID(uuidString: key) else { return nil }
-            return (id, value)
+        var titlesByID: [UUID: [(key: String, value: String)]] = [:]
+        for (key, value) in raw {
+            guard let id = UUID(uuidString: key) else { continue }
+            titlesByID[id, default: []].append((key, value))
+        }
+
+        return Dictionary(uniqueKeysWithValues: titlesByID.map { id, titles in
+            let selected = titles.first(where: { $0.key == id.uuidString })
+                ?? titles.min { $0.key < $1.key }!
+            return (id, selected.value)
         })
     }
 }

--- a/Sources/LegacyNoteTitleMigration.swift
+++ b/Sources/LegacyNoteTitleMigration.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+enum LegacyNoteTitleMigration {
+    static let storageKey = "note_custom_titles"
+
+    static func migrate(
+        history: [PipelineHistoryItem],
+        defaults: UserDefaults = .standard,
+        update: (PipelineHistoryItem) throws -> Void
+    ) throws -> [PipelineHistoryItem] {
+        guard let legacyTitles = loadLegacyTitles(from: defaults), !legacyTitles.isEmpty else {
+            return history
+        }
+
+        var migratedHistory = history
+        var updatedItems: [PipelineHistoryItem] = []
+        for index in migratedHistory.indices {
+            let item = migratedHistory[index]
+            guard item.customTitle == nil,
+                  let legacyTitle = legacyTitles[item.id] else { continue }
+            let trimmedTitle = legacyTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedTitle.isEmpty else { continue }
+            let updated = item.withCustomTitle(trimmedTitle)
+            migratedHistory[index] = updated
+            updatedItems.append(updated)
+        }
+
+        for item in updatedItems {
+            try update(item)
+        }
+        if !updatedItems.isEmpty {
+            defaults.removeObject(forKey: storageKey)
+        }
+        return migratedHistory
+    }
+
+    private static func loadLegacyTitles(from defaults: UserDefaults) -> [UUID: String]? {
+        guard let data = defaults.data(forKey: storageKey),
+              let raw = try? JSONDecoder().decode([String: String].self, from: data) else {
+            return nil
+        }
+        return Dictionary(uniqueKeysWithValues: raw.compactMap { key, value in
+            guard let id = UUID(uuidString: key) else { return nil }
+            return (id, value)
+        })
+    }
+}

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -947,7 +947,9 @@ private struct NoteDetailView: View {
             .onChange(of: titleDraft) { newValue in
                 titleDebounceTimer?.invalidate()
                 let timer = Timer(timeInterval: 0.5, repeats: false) { _ in
-                    appState.updateHistoryItemTitle(id: item.id, title: newValue)
+                    Task { @MainActor in
+                        appState.updateHistoryItemTitle(id: item.id, title: newValue)
+                    }
                 }
                 RunLoop.main.add(timer, forMode: .common)
                 titleDebounceTimer = timer

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -254,42 +254,6 @@ source: Quill
     }
 }
 
-// MARK: - Note Title Store
-
-final class NoteTitleStore: ObservableObject {
-    static let shared = NoteTitleStore()
-    @Published private(set) var titles: [UUID: String] = [:]
-    private let key = "note_custom_titles"
-
-    private init() {
-        if let data = UserDefaults.standard.data(forKey: key),
-           let raw = try? JSONDecoder().decode([String: String].self, from: data) {
-            titles = Dictionary(uniqueKeysWithValues: raw.compactMap {
-                guard let uuid = UUID(uuidString: $0.key) else { return nil }
-                return (uuid, $0.value)
-            })
-        }
-    }
-
-    func setTitle(_ title: String, for id: UUID) {
-        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            guard titles.removeValue(forKey: id) != nil else { return }
-        } else {
-            guard titles[id] != trimmed else { return }
-            titles[id] = trimmed
-        }
-        save()
-    }
-
-    func title(for id: UUID) -> String? { titles[id] }
-
-    private func save() {
-        let raw = Dictionary(uniqueKeysWithValues: titles.map { ($0.key.uuidString, $0.value) })
-        if let data = try? JSONEncoder().encode(raw) { UserDefaults.standard.set(data, forKey: key) }
-    }
-}
-
 // MARK: - Audio Import
 
 private struct PendingAudioImport: Identifiable {
@@ -418,7 +382,6 @@ private struct AudioImportSheet: View {
 struct NoteBrowserView: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var exportManager: ObsidianExportManager
-    @StateObject private var titleStore = NoteTitleStore.shared
     @State private var selectedItemID: UUID?
     @State private var searchText = ""
     @State private var knownHistoryIDs: Set<UUID> = []
@@ -430,7 +393,7 @@ struct NoteBrowserView: View {
         return appState.pipelineHistory.filter {
             $0.postProcessedTranscript.lowercased().contains(q) ||
             $0.contextSummary.lowercased().contains(q) ||
-            (titleStore.title(for: $0.id) ?? "").lowercased().contains(q) ||
+            ($0.customTitle ?? "").lowercased().contains(q) ||
             ($0.calendarMatch?.title ?? "").lowercased().contains(q)
         }
     }
@@ -616,7 +579,6 @@ struct NoteBrowserView: View {
                             NoteListRow(
                                 displayData: NoteListRowDisplayData(
                                     item: item,
-                                    customTitle: titleStore.title(for: item.id),
                                     retryingIDs: appState.retryingItemIDs
                                 ),
                                 isSelected: selectedItemID == item.id
@@ -688,7 +650,7 @@ struct NoteBrowserView: View {
     private var detailPanel: some View {
         if let id = selectedItemID,
            let item = appState.pipelineHistory.first(where: { $0.id == id }) {
-            NoteDetailView(item: item, titleStore: titleStore) {
+            NoteDetailView(item: item) {
                 appState.deleteHistoryEntry(id: id)
             }
             .id(id)
@@ -871,7 +833,6 @@ private struct NoteListRow: View {
 
 private struct NoteDetailView: View {
     let item: PipelineHistoryItem
-    let titleStore: NoteTitleStore
     let onDelete: () -> Void
 
     @Environment(\.colorScheme) private var colorScheme
@@ -890,7 +851,7 @@ private struct NoteDetailView: View {
     private var displayContent: String { loadedContent ?? item.postProcessedTranscript }
 
     private var suggestedCalendarTitle: String? {
-        guard titleStore.title(for: item.id) == nil,
+        guard item.customTitle == nil,
               item.calendarMatch?.titleState == .suggested else {
             return nil
         }
@@ -925,7 +886,7 @@ private struct NoteDetailView: View {
             ObsidianExportSheet(
                 item: item,
                 content: displayContent,
-                customTitle: titleStore.title(for: item.id),
+                customTitle: item.customTitle,
                 onDismiss: { showExportSheet = false }
             )
         }
@@ -985,14 +946,14 @@ private struct NoteDetailView: View {
             .frame(minHeight: 38, alignment: .leading)
             .onChange(of: titleDraft) { newValue in
                 titleDebounceTimer?.invalidate()
-                let timer = Timer(timeInterval: 0.5, repeats: false) { [weak titleStore] _ in
-                    titleStore?.setTitle(newValue, for: item.id)
+                let timer = Timer(timeInterval: 0.5, repeats: false) { _ in
+                    appState.updateHistoryItemTitle(id: item.id, title: newValue)
                 }
                 RunLoop.main.add(timer, forMode: .common)
                 titleDebounceTimer = timer
             }
             .onAppear {
-                titleDraft = titleStore.title(for: item.id) ?? ""
+                titleDraft = item.customTitle ?? ""
             }
             .overrideCursor(.iBeam)
 
@@ -1018,7 +979,7 @@ private struct NoteDetailView: View {
 
                     Button("Apply") {
                         titleDraft = suggestedCalendarAppliedTitle
-                        titleStore.setTitle(suggestedCalendarAppliedTitle, for: item.id)
+                        appState.updateHistoryItemTitle(id: item.id, title: suggestedCalendarAppliedTitle)
                     }
                     .font(.caption.weight(.semibold))
                     .buttonStyle(.bordered)

--- a/Sources/NoteListRowDisplayData.swift
+++ b/Sources/NoteListRowDisplayData.swift
@@ -20,12 +20,12 @@ struct NoteListRowDisplayData: Equatable {
     let displayTitle: String
     let preview: String
 
-    init(item: PipelineHistoryItem, customTitle: String?, retryingIDs: Set<UUID>) {
+    init(item: PipelineHistoryItem, retryingIDs: Set<UUID>) {
         let status = transcriptStatus(for: item, retrying: retryingIDs)
+        let customTitle = item.customTitle
         let content = item.postProcessedTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
         let displayTitle = NoteTitleResolver.displayTitle(
             for: item,
-            customTitle: customTitle,
             isTranscribing: status == .transcribing
         )
 

--- a/Sources/NoteListRowDisplayData.swift
+++ b/Sources/NoteListRowDisplayData.swift
@@ -22,7 +22,8 @@ struct NoteListRowDisplayData: Equatable {
 
     init(item: PipelineHistoryItem, retryingIDs: Set<UUID>) {
         let status = transcriptStatus(for: item, retrying: retryingIDs)
-        let customTitle = item.customTitle
+        let trimmedCustomTitle = item.customTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let customTitle = trimmedCustomTitle?.isEmpty == true ? nil : trimmedCustomTitle
         let content = item.postProcessedTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
         let displayTitle = NoteTitleResolver.displayTitle(
             for: item,

--- a/Sources/NoteTitleResolver.swift
+++ b/Sources/NoteTitleResolver.swift
@@ -13,8 +13,8 @@ enum NoteTitleResolver {
         "\(calendarTitleDateFormatter.string(from: recordingStartedAt)) \(suggestedTitle)"
     }
 
-    static func displayTitle(for item: PipelineHistoryItem, customTitle: String?, isTranscribing: Bool = false) -> String {
-        if let customTitle {
+    static func displayTitle(for item: PipelineHistoryItem, isTranscribing: Bool = false) -> String {
+        if let customTitle = item.customTitle {
             let trimmed = customTitle.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmed.isEmpty { return trimmed }
         }

--- a/Sources/PipelineHistoryItem.swift
+++ b/Sources/PipelineHistoryItem.swift
@@ -46,6 +46,7 @@ struct PipelineHistoryItem: Identifiable, Codable {
     let contextAppName: String?
     let contextBundleIdentifier: String?
     let contextWindowTitle: String?
+    let customTitle: String?
 
     init(
         intent: PipelineHistoryItemIntent = .dictation,
@@ -78,7 +79,8 @@ struct PipelineHistoryItem: Identifiable, Codable {
         transcriptFileName: String? = nil,
         contextAppName: String? = nil,
         contextBundleIdentifier: String? = nil,
-        contextWindowTitle: String? = nil
+        contextWindowTitle: String? = nil,
+        customTitle: String? = nil
     ) {
         self.intent = intent
         self.selectedText = selectedText
@@ -111,6 +113,7 @@ struct PipelineHistoryItem: Identifiable, Codable {
         self.contextAppName = contextAppName
         self.contextBundleIdentifier = contextBundleIdentifier
         self.contextWindowTitle = contextWindowTitle
+        self.customTitle = customTitle
     }
 
     static func transcriptionRecoveryPlaceholder(
@@ -171,7 +174,45 @@ struct PipelineHistoryItem: Identifiable, Codable {
             transcriptFileName: nil,
             contextAppName: contextAppName,
             contextBundleIdentifier: contextBundleIdentifier,
-            contextWindowTitle: contextWindowTitle
+            contextWindowTitle: contextWindowTitle,
+            customTitle: nil
+        )
+    }
+
+    func withCustomTitle(_ customTitle: String?) -> PipelineHistoryItem {
+        PipelineHistoryItem(
+            intent: intent,
+            selectedText: selectedText,
+            capturedSelection: capturedSelection,
+            id: id,
+            timestamp: timestamp,
+            recordingStartedAt: recordingStartedAt,
+            recordingEndedAt: recordingEndedAt,
+            calendarMatch: calendarMatch,
+            rawTranscript: rawTranscript,
+            postProcessedTranscript: postProcessedTranscript,
+            postProcessingPrompt: postProcessingPrompt,
+            systemPrompt: systemPrompt,
+            contextSummary: contextSummary,
+            contextSystemPrompt: contextSystemPrompt,
+            contextPrompt: contextPrompt,
+            contextScreenshotDataURL: contextScreenshotDataURL,
+            contextScreenshotStatus: contextScreenshotStatus,
+            postProcessingStatus: postProcessingStatus,
+            debugStatus: debugStatus,
+            customVocabulary: customVocabulary,
+            customSystemPrompt: customSystemPrompt,
+            audioFileName: audioFileName,
+            usedLocalTranscription: usedLocalTranscription,
+            usedContextCapture: usedContextCapture,
+            usedPostProcessing: usedPostProcessing,
+            transcriptionLanguageCode: transcriptionLanguageCode,
+            localTranscriptionModelID: localTranscriptionModelID,
+            transcriptFileName: transcriptFileName,
+            contextAppName: contextAppName,
+            contextBundleIdentifier: contextBundleIdentifier,
+            contextWindowTitle: contextWindowTitle,
+            customTitle: customTitle
         )
     }
 
@@ -207,7 +248,8 @@ struct PipelineHistoryItem: Identifiable, Codable {
             transcriptFileName: transcriptFileName,
             contextAppName: contextAppName,
             contextBundleIdentifier: contextBundleIdentifier,
-            contextWindowTitle: contextWindowTitle
+            contextWindowTitle: contextWindowTitle,
+            customTitle: customTitle
         )
     }
 }

--- a/Sources/PipelineHistoryStore.swift
+++ b/Sources/PipelineHistoryStore.swift
@@ -134,6 +134,7 @@ final class PipelineHistoryStore {
                 entity.contextAppName = item.contextAppName
                 entity.contextBundleIdentifier = item.contextBundleIdentifier
                 entity.contextWindowTitle = item.contextWindowTitle
+                entity.customTitle = item.customTitle
                 try saveContext()
             } catch {
                 thrownError = error
@@ -253,6 +254,7 @@ final class PipelineHistoryStore {
                 entity.contextAppName = item.contextAppName
                 entity.contextBundleIdentifier = item.contextBundleIdentifier
                 entity.contextWindowTitle = item.contextWindowTitle
+                entity.customTitle = item.customTitle
                 try saveContext()
             } catch {
                 thrownError = error
@@ -357,7 +359,8 @@ final class PipelineHistoryStore {
             transcriptFileName: entity.transcriptFileName,
             contextAppName: entity.contextAppName,
             contextBundleIdentifier: entity.contextBundleIdentifier,
-            contextWindowTitle: entity.contextWindowTitle
+            contextWindowTitle: entity.contextWindowTitle,
+            customTitle: entity.customTitle
         )
     }
 
@@ -399,7 +402,8 @@ final class PipelineHistoryStore {
             makeAttribute(name: "transcriptFileName", type: .stringAttributeType, isOptional: true),
             makeAttribute(name: "contextAppName", type: .stringAttributeType, isOptional: true),
             makeAttribute(name: "contextBundleIdentifier", type: .stringAttributeType, isOptional: true),
-            makeAttribute(name: "contextWindowTitle", type: .stringAttributeType, isOptional: true)
+            makeAttribute(name: "contextWindowTitle", type: .stringAttributeType, isOptional: true),
+            makeAttribute(name: "customTitle", type: .stringAttributeType, isOptional: true)
         ]
 
         model.entities = [entity]
@@ -454,4 +458,5 @@ final class PipelineHistoryEntry: NSManagedObject {
     @NSManaged var contextAppName: String?
     @NSManaged var contextBundleIdentifier: String?
     @NSManaged var contextWindowTitle: String?
+    @NSManaged var customTitle: String?
 }

--- a/Tests/LegacyNoteTitleMigrationTests.swift
+++ b/Tests/LegacyNoteTitleMigrationTests.swift
@@ -5,6 +5,8 @@ struct LegacyNoteTitleMigrationTests {
     static func main() throws {
         try testMigratesMatchingLegacyTitlesAndRemovesLegacyKeyAfterSuccessfulUpdates()
         try testRemovesLegacyKeyWhenOnlyStaleTitlesRemain()
+        try testDuplicateLegacyUUIDKeysPreferCanonicalValue()
+        try testDuplicateLegacyUUIDKeysUseSortedFallbackWhenCanonicalMissing()
         try testKeepsLegacyKeyWhenAnyUpdateFails()
         print("LegacyNoteTitleMigrationTests passed")
     }
@@ -51,6 +53,48 @@ struct LegacyNoteTitleMigrationTests {
         assert(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) == nil)
     }
 
+    private static func testDuplicateLegacyUUIDKeysPreferCanonicalValue() throws {
+        let defaults = makeDefaults()
+        let id = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!
+        storeRawLegacyTitles([
+            id.uuidString: "Canonical title",
+            id.uuidString.lowercased(): "Lowercase title"
+        ], defaults: defaults)
+        let history = [historyItem(id: id, transcript: "Transcript title")]
+        var updatedItems: [PipelineHistoryItem] = []
+
+        let migrated = try LegacyNoteTitleMigration.migrate(
+            history: history,
+            defaults: defaults,
+            update: { updatedItems.append($0) }
+        )
+
+        assert(migrated[0].customTitle == "Canonical title")
+        assert(updatedItems.map(\.customTitle) == ["Canonical title"])
+        assert(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) == nil)
+    }
+
+    private static func testDuplicateLegacyUUIDKeysUseSortedFallbackWhenCanonicalMissing() throws {
+        let defaults = makeDefaults()
+        let id = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440001")!
+        storeRawLegacyTitles([
+            id.uuidString.lowercased(): "Lowercase title",
+            "550E8400-e29b-41d4-a716-446655440001": "Mixedcase title"
+        ], defaults: defaults)
+        let history = [historyItem(id: id, transcript: "Transcript title")]
+        var updatedItems: [PipelineHistoryItem] = []
+
+        let migrated = try LegacyNoteTitleMigration.migrate(
+            history: history,
+            defaults: defaults,
+            update: { updatedItems.append($0) }
+        )
+
+        assert(migrated[0].customTitle == "Mixedcase title")
+        assert(updatedItems.map(\.customTitle) == ["Mixedcase title"])
+        assert(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) == nil)
+    }
+
     private static func testKeepsLegacyKeyWhenAnyUpdateFails() throws {
         let defaults = makeDefaults()
         let id = UUID(uuidString: "00000000-0000-0000-0000-000000000085")!
@@ -78,7 +122,11 @@ struct LegacyNoteTitleMigrationTests {
 
     private static func storeLegacyTitles(_ titles: [UUID: String], defaults: UserDefaults) {
         let raw = Dictionary(uniqueKeysWithValues: titles.map { ($0.key.uuidString, $0.value) })
-        let data = try! JSONEncoder().encode(raw)
+        storeRawLegacyTitles(raw, defaults: defaults)
+    }
+
+    private static func storeRawLegacyTitles(_ titles: [String: String], defaults: UserDefaults) {
+        let data = try! JSONEncoder().encode(titles)
         defaults.set(data, forKey: LegacyNoteTitleMigration.storageKey)
     }
 

--- a/Tests/LegacyNoteTitleMigrationTests.swift
+++ b/Tests/LegacyNoteTitleMigrationTests.swift
@@ -4,6 +4,7 @@ import Foundation
 struct LegacyNoteTitleMigrationTests {
     static func main() throws {
         try testMigratesMatchingLegacyTitlesAndRemovesLegacyKeyAfterSuccessfulUpdates()
+        try testRemovesLegacyKeyWhenOnlyStaleTitlesRemain()
         try testKeepsLegacyKeyWhenAnyUpdateFails()
         print("LegacyNoteTitleMigrationTests passed")
     }
@@ -29,6 +30,24 @@ struct LegacyNoteTitleMigrationTests {
         assert(migrated[0].customTitle == "Migrated title")
         assert(updatedItems.map(\.id) == [migratedID])
         assert(updatedItems[0].customTitle == "Migrated title")
+        assert(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) == nil)
+    }
+
+    private static func testRemovesLegacyKeyWhenOnlyStaleTitlesRemain() throws {
+        let defaults = makeDefaults()
+        let staleID = UUID(uuidString: "00000000-0000-0000-0000-000000000086")!
+        storeLegacyTitles([staleID: "Deleted note title"], defaults: defaults)
+        let history = [historyItem(id: UUID(uuidString: "00000000-0000-0000-0000-000000000087")!, transcript: "Transcript title")]
+        var updatedItems: [PipelineHistoryItem] = []
+
+        let migrated = try LegacyNoteTitleMigration.migrate(
+            history: history,
+            defaults: defaults,
+            update: { updatedItems.append($0) }
+        )
+
+        assert(migrated.count == 1)
+        assert(updatedItems.isEmpty)
         assert(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) == nil)
     }
 

--- a/Tests/LegacyNoteTitleMigrationTests.swift
+++ b/Tests/LegacyNoteTitleMigrationTests.swift
@@ -2,6 +2,10 @@ import Foundation
 
 @main
 struct LegacyNoteTitleMigrationTests {
+    enum TestError: Error {
+        case failed(String)
+    }
+
     static func main() throws {
         try testMigratesMatchingLegacyTitlesAndRemovesLegacyKeyAfterSuccessfulUpdates()
         try testRemovesLegacyKeyWhenOnlyStaleTitlesRemain()
@@ -9,6 +13,12 @@ struct LegacyNoteTitleMigrationTests {
         try testDuplicateLegacyUUIDKeysUseSortedFallbackWhenCanonicalMissing()
         try testKeepsLegacyKeyWhenAnyUpdateFails()
         print("LegacyNoteTitleMigrationTests passed")
+    }
+
+    private static func require(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+        if !condition() {
+            throw TestError.failed(message)
+        }
     }
 
     private static func testMigratesMatchingLegacyTitlesAndRemovesLegacyKeyAfterSuccessfulUpdates() throws {
@@ -28,11 +38,11 @@ struct LegacyNoteTitleMigrationTests {
             update: { updatedItems.append($0) }
         )
 
-        assert(migrated.count == 1)
-        assert(migrated[0].customTitle == "Migrated title")
-        assert(updatedItems.map(\.id) == [migratedID])
-        assert(updatedItems[0].customTitle == "Migrated title")
-        assert(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) == nil)
+        try require(migrated.count == 1, "Expected one migrated history item")
+        try require(migrated[0].customTitle == "Migrated title", "Expected trimmed migrated title")
+        try require(updatedItems.map(\.id) == [migratedID], "Expected only the matching item to persist")
+        try require(updatedItems[0].customTitle == "Migrated title", "Expected persisted title to be trimmed")
+        try require(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) == nil, "Expected successful migration to remove legacy key")
     }
 
     private static func testRemovesLegacyKeyWhenOnlyStaleTitlesRemain() throws {
@@ -48,9 +58,9 @@ struct LegacyNoteTitleMigrationTests {
             update: { updatedItems.append($0) }
         )
 
-        assert(migrated.count == 1)
-        assert(updatedItems.isEmpty)
-        assert(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) == nil)
+        try require(migrated.count == 1, "Expected stale-only migration to preserve history")
+        try require(updatedItems.isEmpty, "Expected no persisted updates for stale legacy titles")
+        try require(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) == nil, "Expected stale-only migration to remove legacy key")
     }
 
     private static func testDuplicateLegacyUUIDKeysPreferCanonicalValue() throws {
@@ -69,9 +79,9 @@ struct LegacyNoteTitleMigrationTests {
             update: { updatedItems.append($0) }
         )
 
-        assert(migrated[0].customTitle == "Canonical title")
-        assert(updatedItems.map(\.customTitle) == ["Canonical title"])
-        assert(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) == nil)
+        try require(migrated[0].customTitle == "Canonical title", "Expected canonical UUID key to win")
+        try require(updatedItems.map(\.customTitle) == ["Canonical title"], "Expected canonical title to persist")
+        try require(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) == nil, "Expected duplicate-key migration to remove legacy key")
     }
 
     private static func testDuplicateLegacyUUIDKeysUseSortedFallbackWhenCanonicalMissing() throws {
@@ -90,9 +100,9 @@ struct LegacyNoteTitleMigrationTests {
             update: { updatedItems.append($0) }
         )
 
-        assert(migrated[0].customTitle == "Mixedcase title")
-        assert(updatedItems.map(\.customTitle) == ["Mixedcase title"])
-        assert(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) == nil)
+        try require(migrated[0].customTitle == "Mixedcase title", "Expected sorted duplicate-key fallback title")
+        try require(updatedItems.map(\.customTitle) == ["Mixedcase title"], "Expected fallback title to persist")
+        try require(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) == nil, "Expected fallback duplicate-key migration to remove legacy key")
     }
 
     private static func testKeepsLegacyKeyWhenAnyUpdateFails() throws {
@@ -107,9 +117,11 @@ struct LegacyNoteTitleMigrationTests {
                 defaults: defaults,
                 update: { _ in throw NSError(domain: "LegacyNoteTitleMigrationTests", code: 1) }
             )
-            assertionFailure("Expected migration to throw when persistence fails")
+            throw TestError.failed("Expected migration to throw when persistence fails")
+        } catch let error as TestError {
+            throw error
         } catch {
-            assert(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) != nil)
+            try require(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) != nil, "Expected failed migration to keep legacy key")
         }
     }
 

--- a/Tests/LegacyNoteTitleMigrationTests.swift
+++ b/Tests/LegacyNoteTitleMigrationTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+@main
+struct LegacyNoteTitleMigrationTests {
+    static func main() throws {
+        try testMigratesMatchingLegacyTitlesAndRemovesLegacyKeyAfterSuccessfulUpdates()
+        try testKeepsLegacyKeyWhenAnyUpdateFails()
+        print("LegacyNoteTitleMigrationTests passed")
+    }
+
+    private static func testMigratesMatchingLegacyTitlesAndRemovesLegacyKeyAfterSuccessfulUpdates() throws {
+        let defaults = makeDefaults()
+        let migratedID = UUID(uuidString: "00000000-0000-0000-0000-000000000083")!
+        let staleID = UUID(uuidString: "00000000-0000-0000-0000-000000000084")!
+        storeLegacyTitles([
+            migratedID: "  Migrated title  ",
+            staleID: "Deleted note title"
+        ], defaults: defaults)
+        let history = [historyItem(id: migratedID, transcript: "Transcript title")]
+        var updatedItems: [PipelineHistoryItem] = []
+
+        let migrated = try LegacyNoteTitleMigration.migrate(
+            history: history,
+            defaults: defaults,
+            update: { updatedItems.append($0) }
+        )
+
+        assert(migrated.count == 1)
+        assert(migrated[0].customTitle == "Migrated title")
+        assert(updatedItems.map(\.id) == [migratedID])
+        assert(updatedItems[0].customTitle == "Migrated title")
+        assert(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) == nil)
+    }
+
+    private static func testKeepsLegacyKeyWhenAnyUpdateFails() throws {
+        let defaults = makeDefaults()
+        let id = UUID(uuidString: "00000000-0000-0000-0000-000000000085")!
+        storeLegacyTitles([id: "Migrated title"], defaults: defaults)
+        let history = [historyItem(id: id, transcript: "Transcript title")]
+
+        do {
+            _ = try LegacyNoteTitleMigration.migrate(
+                history: history,
+                defaults: defaults,
+                update: { _ in throw NSError(domain: "LegacyNoteTitleMigrationTests", code: 1) }
+            )
+            assertionFailure("Expected migration to throw when persistence fails")
+        } catch {
+            assert(defaults.data(forKey: LegacyNoteTitleMigration.storageKey) != nil)
+        }
+    }
+
+    private static func makeDefaults() -> UserDefaults {
+        let suiteName = "LegacyNoteTitleMigrationTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private static func storeLegacyTitles(_ titles: [UUID: String], defaults: UserDefaults) {
+        let raw = Dictionary(uniqueKeysWithValues: titles.map { ($0.key.uuidString, $0.value) })
+        let data = try! JSONEncoder().encode(raw)
+        defaults.set(data, forKey: LegacyNoteTitleMigration.storageKey)
+    }
+
+    private static func historyItem(id: UUID, transcript: String, customTitle: String? = nil) -> PipelineHistoryItem {
+        PipelineHistoryItem(
+            id: id,
+            timestamp: Date(timeIntervalSince1970: 1),
+            rawTranscript: transcript,
+            postProcessedTranscript: transcript,
+            postProcessingPrompt: nil,
+            contextSummary: "",
+            contextPrompt: nil,
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "No screenshot",
+            postProcessingStatus: "Post-processing succeeded",
+            debugStatus: "Done",
+            customVocabulary: "",
+            customTitle: customTitle
+        )
+    }
+}

--- a/Tests/NoteListRowDisplayDataTests.swift
+++ b/Tests/NoteListRowDisplayDataTests.swift
@@ -4,7 +4,7 @@ import Foundation
 struct NoteListRowDisplayDataTests {
     static func main() {
         testFormatsRowDate()
-        testUsesCustomTitleAndContentPreview()
+        testUsesItemCustomTitleAndContentPreview()
         testDropsAutomaticTitleFromPreview()
         testFailurePreviewUsesErrorMessage()
         testFailurePreviewHandlesMissingSpaceAfterPrefix()
@@ -27,15 +27,18 @@ struct NoteListRowDisplayDataTests {
             transcript: "Team sync notes"
         )
 
-        let data = NoteListRowDisplayData(item: item, customTitle: nil, retryingIDs: [])
+        let data = NoteListRowDisplayData(item: item, retryingIDs: [])
 
         assert(data.rowDate == "5월 5일 · 09:00", "Unexpected row date: \(data.rowDate)")
     }
 
-    private static func testUsesCustomTitleAndContentPreview() {
-        let item = historyItem(transcript: "Automatic transcript title\nDetails continue here")
+    private static func testUsesItemCustomTitleAndContentPreview() {
+        let item = historyItem(
+            transcript: "Automatic transcript title\nDetails continue here",
+            customTitle: "Manual title"
+        )
 
-        let data = NoteListRowDisplayData(item: item, customTitle: "Manual title", retryingIDs: [])
+        let data = NoteListRowDisplayData(item: item, retryingIDs: [])
 
         assert(data.displayTitle == "Manual title")
         assert(data.preview == "Automatic transcript title\nDetails continue here")
@@ -44,7 +47,7 @@ struct NoteListRowDisplayDataTests {
     private static func testDropsAutomaticTitleFromPreview() {
         let item = historyItem(transcript: "Automatic transcript title\nDetails continue here")
 
-        let data = NoteListRowDisplayData(item: item, customTitle: nil, retryingIDs: [])
+        let data = NoteListRowDisplayData(item: item, retryingIDs: [])
 
         assert(data.displayTitle == "Automatic transcript title")
         assert(data.preview == "Details continue here", "Unexpected preview: \(data.preview)")
@@ -56,7 +59,7 @@ struct NoteListRowDisplayDataTests {
             postProcessingStatus: "Error: Network unavailable"
         )
 
-        let data = NoteListRowDisplayData(item: item, customTitle: nil, retryingIDs: [])
+        let data = NoteListRowDisplayData(item: item, retryingIDs: [])
 
         assert(data.status == .fail)
         assert(data.preview == "Network unavailable")
@@ -68,7 +71,7 @@ struct NoteListRowDisplayDataTests {
             postProcessingStatus: "Error:Network unavailable"
         )
 
-        let data = NoteListRowDisplayData(item: item, customTitle: nil, retryingIDs: [])
+        let data = NoteListRowDisplayData(item: item, retryingIDs: [])
 
         assert(data.status == .fail)
         assert(data.preview == "Network unavailable", "Unexpected failure preview: \(data.preview)")
@@ -78,7 +81,7 @@ struct NoteListRowDisplayDataTests {
         let id = UUID()
         let item = historyItem(id: id, transcript: "", postProcessingStatus: "importing")
 
-        let data = NoteListRowDisplayData(item: item, customTitle: nil, retryingIDs: [id])
+        let data = NoteListRowDisplayData(item: item, retryingIDs: [id])
 
         assert(data.status == .transcribing)
         assert(data.displayTitle == "Transcribing...")
@@ -89,7 +92,7 @@ struct NoteListRowDisplayDataTests {
         let id = UUID()
         let item = historyItem(id: id, transcript: "Previous title\nPrevious content")
 
-        let data = NoteListRowDisplayData(item: item, customTitle: nil, retryingIDs: [id])
+        let data = NoteListRowDisplayData(item: item, retryingIDs: [id])
 
         assert(data.status == .transcribing)
         assert(data.preview.isEmpty, "Expected retrying item to hide stale preview, got: \(data.preview)")
@@ -99,7 +102,8 @@ struct NoteListRowDisplayDataTests {
         id: UUID = UUID(),
         timestamp: Date = Date(timeIntervalSince1970: 1),
         transcript: String,
-        postProcessingStatus: String = "Post-processing succeeded"
+        postProcessingStatus: String = "Post-processing succeeded",
+        customTitle: String? = nil
     ) -> PipelineHistoryItem {
         PipelineHistoryItem(
             id: id,
@@ -113,7 +117,8 @@ struct NoteListRowDisplayDataTests {
             contextScreenshotStatus: "No screenshot",
             postProcessingStatus: postProcessingStatus,
             debugStatus: "Done",
-            customVocabulary: ""
+            customVocabulary: "",
+            customTitle: customTitle
         )
     }
 }

--- a/Tests/NoteListRowDisplayDataTests.swift
+++ b/Tests/NoteListRowDisplayDataTests.swift
@@ -6,6 +6,7 @@ struct NoteListRowDisplayDataTests {
         testFormatsRowDate()
         testUsesItemCustomTitleAndContentPreview()
         testDropsAutomaticTitleFromPreview()
+        testWhitespaceOnlyCustomTitleDoesNotForceContentPreview()
         testFailurePreviewUsesErrorMessage()
         testFailurePreviewHandlesMissingSpaceAfterPrefix()
         testTranscribingTitleAndEmptyPreview()
@@ -46,6 +47,18 @@ struct NoteListRowDisplayDataTests {
 
     private static func testDropsAutomaticTitleFromPreview() {
         let item = historyItem(transcript: "Automatic transcript title\nDetails continue here")
+
+        let data = NoteListRowDisplayData(item: item, retryingIDs: [])
+
+        assert(data.displayTitle == "Automatic transcript title")
+        assert(data.preview == "Details continue here", "Unexpected preview: \(data.preview)")
+    }
+
+    private static func testWhitespaceOnlyCustomTitleDoesNotForceContentPreview() {
+        let item = historyItem(
+            transcript: "Automatic transcript title\nDetails continue here",
+            customTitle: "  \n  "
+        )
 
         let data = NoteListRowDisplayData(item: item, retryingIDs: [])
 

--- a/Tests/NoteTitleResolutionTests.swift
+++ b/Tests/NoteTitleResolutionTests.swift
@@ -3,7 +3,7 @@ import Foundation
 @main
 struct NoteTitleResolutionTests {
     static func main() {
-        testCustomTitleWins()
+        testItemCustomTitleWins()
         testAppliedCalendarTitleWinsOverTranscriptTitle()
         testSuggestedCalendarTitleDoesNotOverrideTranscriptTitle()
         testFallbackUsedWhenNoContentOrAppliedCalendarTitle()
@@ -13,39 +13,43 @@ struct NoteTitleResolutionTests {
         print("NoteTitleResolutionTests passed")
     }
 
-    private static func testCustomTitleWins() {
-        let item = item(transcript: "Transcript title", calendarMatch: match(title: "Calendar title", titleState: .applied))
-        let title = NoteTitleResolver.displayTitle(for: item, customTitle: "Manual title")
+    private static func testItemCustomTitleWins() {
+        let item = item(
+            transcript: "Transcript title",
+            calendarMatch: match(title: "Calendar title", titleState: .applied),
+            customTitle: "Manual title"
+        )
+        let title = NoteTitleResolver.displayTitle(for: item)
         assert(title == "Manual title")
     }
 
     private static func testAppliedCalendarTitleWinsOverTranscriptTitle() {
         let item = item(transcript: "Transcript title", calendarMatch: match(title: "Calendar title", titleState: .applied))
-        let title = NoteTitleResolver.displayTitle(for: item, customTitle: nil)
+        let title = NoteTitleResolver.displayTitle(for: item)
         assert(title == "Calendar title")
     }
 
     private static func testSuggestedCalendarTitleDoesNotOverrideTranscriptTitle() {
         let item = item(transcript: "Transcript title", calendarMatch: match(title: "Calendar title", titleState: .suggested))
-        let title = NoteTitleResolver.displayTitle(for: item, customTitle: nil)
+        let title = NoteTitleResolver.displayTitle(for: item)
         assert(title == "Transcript title")
     }
 
     private static func testFallbackUsedWhenNoContentOrAppliedCalendarTitle() {
         let item = item(transcript: "", calendarMatch: nil)
-        let title = NoteTitleResolver.displayTitle(for: item, customTitle: nil)
+        let title = NoteTitleResolver.displayTitle(for: item)
         assert(title == "(No content)")
     }
 
     private static func testTranscribingFallbackWinsOverFailedEmptyContent() {
         let item = item(transcript: "", calendarMatch: nil, postProcessingStatus: "Error: Previous failure")
-        let title = NoteTitleResolver.displayTitle(for: item, customTitle: nil, isTranscribing: true)
+        let title = NoteTitleResolver.displayTitle(for: item, isTranscribing: true)
         assert(title == "Transcribing...")
     }
 
     private static func testAppliedCalendarTitleKeepsWinningWhileTranscribing() {
         let item = item(transcript: "", calendarMatch: match(title: "Calendar title", titleState: .applied), postProcessingStatus: "Error: Previous failure")
-        let title = NoteTitleResolver.displayTitle(for: item, customTitle: nil, isTranscribing: true)
+        let title = NoteTitleResolver.displayTitle(for: item, isTranscribing: true)
         assert(title == "Calendar title")
     }
 
@@ -58,7 +62,12 @@ struct NoteTitleResolutionTests {
         assert(title == "2025-05-05 Team Standup")
     }
 
-    private static func item(transcript: String, calendarMatch: CalendarEventMatch?, postProcessingStatus: String = "Post-processing succeeded") -> PipelineHistoryItem {
+    private static func item(
+        transcript: String,
+        calendarMatch: CalendarEventMatch?,
+        postProcessingStatus: String = "Post-processing succeeded",
+        customTitle: String? = nil
+    ) -> PipelineHistoryItem {
         PipelineHistoryItem(
             timestamp: Date(timeIntervalSince1970: 1),
             calendarMatch: calendarMatch,
@@ -71,7 +80,8 @@ struct NoteTitleResolutionTests {
             contextScreenshotStatus: "No screenshot",
             postProcessingStatus: postProcessingStatus,
             debugStatus: "Done",
-            customVocabulary: ""
+            customVocabulary: "",
+            customTitle: customTitle
         )
     }
 

--- a/Tests/PipelineHistoryCalendarMetadataTests.swift
+++ b/Tests/PipelineHistoryCalendarMetadataTests.swift
@@ -3,11 +3,34 @@ import Foundation
 @main
 struct PipelineHistoryCalendarMetadataTests {
     static func main() throws {
+        try testCustomTitleRoundTripsThroughPipelineHistoryItemCodable()
         try testCalendarMetadataRoundTripsThroughPipelineHistoryItemCodable()
         testCalendarMetadataCopyHelpersPreserveFields()
         try testLegacyEncodedHistoryItemDecodesMissingCalendarMetadataAsNil()
+        try testCustomTitlePersistsThroughPipelineHistoryStore()
         try testCalendarMetadataPersistsThroughPipelineHistoryStore()
         print("PipelineHistoryCalendarMetadataTests passed")
+    }
+
+    private static func testCustomTitleRoundTripsThroughPipelineHistoryItemCodable() throws {
+        let item = PipelineHistoryItem(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000086")!,
+            timestamp: Date(timeIntervalSince1970: 1_600),
+            rawTranscript: "raw",
+            postProcessedTranscript: "processed",
+            postProcessingPrompt: nil,
+            contextSummary: "",
+            contextPrompt: nil,
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "No screenshot",
+            postProcessingStatus: "Post-processing succeeded",
+            debugStatus: "Done",
+            customVocabulary: "",
+            customTitle: "Manual title"
+        )
+        let data = try JSONEncoder().encode(item)
+        let decoded = try JSONDecoder().decode(PipelineHistoryItem.self, from: data)
+        assert(decoded.customTitle == "Manual title")
     }
 
     private static func testCalendarMetadataRoundTripsThroughPipelineHistoryItemCodable() throws {
@@ -109,6 +132,32 @@ struct PipelineHistoryCalendarMetadataTests {
         assert(decoded.recordingStartedAt == nil)
         assert(decoded.recordingEndedAt == nil)
         assert(decoded.calendarMatch == nil)
+        assert(decoded.customTitle == nil)
+    }
+
+    private static func testCustomTitlePersistsThroughPipelineHistoryStore() throws {
+        let store = PipelineHistoryStore(inMemory: true)
+        let id = UUID(uuidString: "00000000-0000-0000-0000-000000000087")!
+        let item = PipelineHistoryItem(
+            id: id,
+            timestamp: Date(timeIntervalSince1970: 4_500),
+            rawTranscript: "raw",
+            postProcessedTranscript: "processed",
+            postProcessingPrompt: nil,
+            contextSummary: "",
+            contextPrompt: nil,
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "No screenshot",
+            postProcessingStatus: "Post-processing succeeded",
+            debugStatus: "Done",
+            customVocabulary: "",
+            customTitle: "Stored manual title"
+        )
+        _ = try store.append(item, maxCount: 10)
+        let loaded = store.loadAllHistory()
+        assert(loaded.count == 1)
+        assert(loaded[0].id == id)
+        assert(loaded[0].customTitle == "Stored manual title")
     }
 
     private static func testCalendarMetadataPersistsThroughPipelineHistoryStore() throws {


### PR DESCRIPTION
## Summary
- Store custom note titles on `PipelineHistoryItem` and persist them through pipeline history storage.
- Replace the note browser's separate UserDefaults title store with the `AppState` / `PipelineHistoryStore` update path.
- Safely migrate legacy `note_custom_titles` values and preserve the legacy key if persistence fails.

## Test plan
- [x] `make test`
- [x] Quill Dev migration smoke test verified the legacy key removal and SQLite `customTitle` persistence
- [x] Installed and launched Quill, then verified migrated custom title rows in `PipelineHistory.sqlite`

## Follow-up
- #94 tracks removing the legacy migration code after the migration window is complete.

Closes #83

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 노트별 커스텀 제목을 항목에 직접 저장·편집하도록 UI와 저장소 통합
  * 기존(레거시) 커스텀 제목의 자동 마이그레이션 지원 추가

* **Bug Fixes**
  * 제목 편집·전송 중 커스텀 제목 보존 및 데이터 손실 방지
  * 달력 제안 제목 적용과 리스트/세부화면 표시의 일관성·안정성 개선

* **Tests**
  * 마이그레이션과 제목 관련 시나리오 테스트 추가 및 테스트 실행에 포함

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/freeflow/pull/95)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->