### PR TITLE
Refactor stopped transcription completion flow

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -146,6 +146,16 @@ struct StoppedTranscriptionCompletionSummary {
     }
 }
 
+struct StoppedTranscriptionSettingsSnapshot {
+    let customVocabulary: String
+    let customSystemPrompt: String
+    let useLocalTranscription: Bool
+    let localTranscriptionModel: TranscriptionModel
+    let transcriptionLanguage: TranscriptionLanguage
+    let usedContextCapture: Bool
+    let usedPostProcessing: Bool
+}
+
 private enum CommandInvocation: String {
     case automatic
     case manual
@@ -4017,24 +4027,35 @@ final class AppState: ObservableObject, @unchecked Sendable {
         completion: StoppedTranscriptionCompletionSummary,
         context: AppContext,
         intent: SessionIntent,
-        audioFileName: String?
-    ) async {
+        audioFileName: String?,
+        settings: StoppedTranscriptionSettingsSnapshot
+    ) async throws {
+        try Task.checkCancellation()
         let calendarMatch = await calendarMatchForHistoryItem(jobID: jobID)
-        await MainActor.run {
+        try Task.checkCancellation()
+        try await MainActor.run {
+            try Task.checkCancellation()
             recordPipelineHistoryEntry(
                 jobID: jobID,
                 rawTranscript: completion.rawTranscript,
                 postProcessedTranscript: completion.finalTranscript,
                 postProcessingPrompt: completion.prompt,
-                systemPrompt: Self.resolvedSystemPrompt(customSystemPrompt),
+                systemPrompt: Self.resolvedSystemPrompt(settings.customSystemPrompt),
                 context: context,
                 processingStatus: completion.processingStatus,
                 intent: intent,
                 audioFileName: audioFileName,
+                useLocalTranscriptionOverride: settings.useLocalTranscription,
+                localTranscriptionModelIDOverride: settings.localTranscriptionModel.id,
+                usedContextCaptureOverride: settings.usedContextCapture,
+                usedPostProcessingOverride: settings.usedPostProcessing,
+                transcriptionLanguageCodeOverride: settings.transcriptionLanguage.code,
+                customVocabularyOverride: settings.customVocabulary,
+                customSystemPromptOverride: settings.customSystemPrompt,
                 calendarMatch: calendarMatch
             )
             cleanupRecorderIfIdle()
-            let completionStatusText = preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
+            let completionStatusText = disableAutoPaste || !preserveClipboard ? "Copied to clipboard!" : "Pasted at cursor!"
             updateForegroundUIForStoppedTranscriptionCompletion(
                 overlayID: overlayID,
                 completion: completion,
@@ -4084,8 +4105,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             } else {
                 dismissTranscribingOverlay()
             }
+            let pendingClipboardRestore = writeTranscriptToPasteboard(completion.finalTranscript)
             if !disableAutoPaste {
-                let pendingClipboardRestore = writeTranscriptToPasteboard(completion.finalTranscript)
                 pasteAtCursorWhenShortcutReleased {
                     if completion.shouldPressEnterAfterPaste {
                         self.pressEnterAfterPaste {
@@ -4176,6 +4197,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let capturedCustomVocabulary = customVocabulary
         let capturedCustomSystemPrompt = customSystemPrompt
         let capturedOutputLanguage = outputLanguage
+        let capturedSettings = StoppedTranscriptionSettingsSnapshot(
+            customVocabulary: capturedCustomVocabulary,
+            customSystemPrompt: capturedCustomSystemPrompt,
+            useLocalTranscription: capturedUseLocalTranscription,
+            localTranscriptionModel: capturedLocalTranscriptionModel,
+            transcriptionLanguage: capturedTranscriptionLanguage,
+            usedContextCapture: !disableContextCapture,
+            usedPostProcessing: !disablePostProcessing
+        )
         let capturedLiveTranscriber = liveTranscriber
         let capturedPressEnterCommandEnabled = isPressEnterVoiceCommandEnabled
         liveTranscriber = nil
@@ -4212,13 +4242,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         outputLanguage: capturedOutputLanguage,
                         pressEnterCommandEnabled: capturedPressEnterCommandEnabled
                     )
-                    await self.runSuccessfulStoppedTranscriptionCompletionPipeline(
+                    try await self.runSuccessfulStoppedTranscriptionCompletionPipeline(
                         jobID: jobID,
                         overlayID: myOverlayID,
                         completion: completion,
                         context: appContext,
                         intent: sessionIntent,
-                        audioFileName: savedAudioFile?.fileName
+                        audioFileName: savedAudioFile?.fileName,
+                        settings: capturedSettings
                     )
                 } catch is CancellationError {
                     await MainActor.run {
@@ -4242,11 +4273,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             rawTranscript: "",
                             postProcessedTranscript: "",
                             postProcessingPrompt: "",
-                            systemPrompt: Self.resolvedSystemPrompt(self.customSystemPrompt),
+                            systemPrompt: Self.resolvedSystemPrompt(capturedSettings.customSystemPrompt),
                             context: resolvedContext,
                             processingStatus: "Error: \(error.localizedDescription)",
                             intent: sessionIntent,
                             audioFileName: errorAudioFile?.fileName,
+                            useLocalTranscriptionOverride: capturedSettings.useLocalTranscription,
+                            localTranscriptionModelIDOverride: capturedSettings.localTranscriptionModel.id,
+                            usedContextCaptureOverride: capturedSettings.usedContextCapture,
+                            usedPostProcessingOverride: capturedSettings.usedPostProcessing,
+                            transcriptionLanguageCodeOverride: capturedSettings.transcriptionLanguage.code,
+                            customVocabularyOverride: capturedSettings.customVocabulary,
+                            customSystemPromptOverride: capturedSettings.customSystemPrompt,
                             calendarMatch: calendarMatch
                         )
                         self.cleanupRecorderIfIdle()
@@ -4357,13 +4395,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         outputLanguage: capturedOutputLanguage,
                         pressEnterCommandEnabled: capturedPressEnterCommandEnabled
                     )
-                    await self.runSuccessfulStoppedTranscriptionCompletionPipeline(
+                    try await self.runSuccessfulStoppedTranscriptionCompletionPipeline(
                         jobID: jobID,
                         overlayID: myOverlayID,
                         completion: completion,
                         context: appContext,
                         intent: sessionIntent,
-                        audioFileName: savedAudioFile?.fileName
+                        audioFileName: savedAudioFile?.fileName,
+                        settings: capturedSettings
                     )
                 } catch is CancellationError {
                     await MainActor.run {
@@ -4381,11 +4420,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             rawTranscript: "",
                             postProcessedTranscript: "",
                             postProcessingPrompt: "",
-                            systemPrompt: Self.resolvedSystemPrompt(self.customSystemPrompt),
+                            systemPrompt: Self.resolvedSystemPrompt(capturedSettings.customSystemPrompt),
                             context: resolvedContext,
                             processingStatus: "Error: \(error.localizedDescription)",
                             intent: sessionIntent,
                             audioFileName: savedAudioFile?.fileName,
+                            useLocalTranscriptionOverride: capturedSettings.useLocalTranscription,
+                            localTranscriptionModelIDOverride: capturedSettings.localTranscriptionModel.id,
+                            usedContextCaptureOverride: capturedSettings.usedContextCapture,
+                            usedPostProcessingOverride: capturedSettings.usedPostProcessing,
+                            transcriptionLanguageCodeOverride: capturedSettings.transcriptionLanguage.code,
+                            customVocabularyOverride: capturedSettings.customVocabulary,
+                            customSystemPromptOverride: capturedSettings.customSystemPrompt,
                             calendarMatch: calendarMatch
                         )
                         self.cleanupRecorderIfIdle()

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -121,6 +121,31 @@ private struct TranscriptCommandParsingResult {
     let shouldPressEnterAfterPaste: Bool
 }
 
+struct StoppedTranscriptionCompletionSummary {
+    let rawTranscript: String
+    let finalTranscript: String
+    let prompt: String
+    let processingStatus: String
+    let shouldPressEnterAfterPaste: Bool
+    let shouldPersistRawDictationFallback: Bool
+
+    init(
+        rawTranscript: String,
+        finalTranscript: String,
+        prompt: String,
+        processingStatus: String,
+        shouldPressEnterAfterPaste: Bool,
+        outcomeWasPostProcessingFailedFallback: Bool
+    ) {
+        self.rawTranscript = rawTranscript
+        self.finalTranscript = finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.prompt = prompt
+        self.processingStatus = processingStatus
+        self.shouldPressEnterAfterPaste = shouldPressEnterAfterPaste
+        self.shouldPersistRawDictationFallback = outcomeWasPostProcessingFailedFallback && !self.finalTranscript.isEmpty
+    }
+}
+
 private enum CommandInvocation: String {
     case automatic
     case manual
@@ -3924,6 +3949,165 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return try await fileService.transcribe(fileURL: fileURL)
     }
 
+    private func resolveStoppedRecordingContext(
+        sessionContext: AppContext?,
+        inFlightContextTask: Task<AppContext?, Never>?
+    ) async -> AppContext {
+        if let sessionContext {
+            return sessionContext
+        }
+        if let inFlightContext = await inFlightContextTask?.value {
+            return inFlightContext
+        }
+        return fallbackContextAtStop()
+    }
+
+    private func makeStoppedTranscriptionCompletionSummary(
+        rawTranscript: String,
+        intent: SessionIntent,
+        context: AppContext,
+        postProcessingService: PostProcessingService,
+        customVocabulary: String,
+        customSystemPrompt: String,
+        outputLanguage: String,
+        pressEnterCommandEnabled: Bool
+    ) async throws -> StoppedTranscriptionCompletionSummary {
+        let parsedTranscript = Self.parseTranscriptCommands(
+            from: rawTranscript,
+            pressEnterCommandEnabled: pressEnterCommandEnabled
+        )
+        try Task.checkCancellation()
+        await MainActor.run { [weak self] in
+            self?.debugStatusMessage = "Running post-processing"
+        }
+        let result = await processTranscript(
+            parsedTranscript.transcript,
+            intent: intent,
+            context: context,
+            postProcessingService: postProcessingService,
+            customVocabulary: customVocabulary,
+            customSystemPrompt: customSystemPrompt,
+            outputLanguage: outputLanguage
+        )
+        try Task.checkCancellation()
+        let processingStatus = Self.statusMessage(
+            for: result.outcome,
+            parsedTranscript: parsedTranscript
+        )
+        let outcomeWasPostProcessingFailedFallback: Bool
+        switch result.outcome {
+        case .postProcessingFailedFallback:
+            outcomeWasPostProcessingFailedFallback = true
+        default:
+            outcomeWasPostProcessingFailedFallback = false
+        }
+        return StoppedTranscriptionCompletionSummary(
+            rawTranscript: parsedTranscript.transcript,
+            finalTranscript: result.finalTranscript,
+            prompt: result.prompt,
+            processingStatus: processingStatus,
+            shouldPressEnterAfterPaste: parsedTranscript.shouldPressEnterAfterPaste,
+            outcomeWasPostProcessingFailedFallback: outcomeWasPostProcessingFailedFallback
+        )
+    }
+
+    private func runSuccessfulStoppedTranscriptionCompletionPipeline(
+        jobID: UUID,
+        overlayID: UUID,
+        completion: StoppedTranscriptionCompletionSummary,
+        context: AppContext,
+        intent: SessionIntent,
+        audioFileName: String?
+    ) async {
+        let calendarMatch = await calendarMatchForHistoryItem(jobID: jobID)
+        await MainActor.run {
+            recordPipelineHistoryEntry(
+                jobID: jobID,
+                rawTranscript: completion.rawTranscript,
+                postProcessedTranscript: completion.finalTranscript,
+                postProcessingPrompt: completion.prompt,
+                systemPrompt: Self.resolvedSystemPrompt(customSystemPrompt),
+                context: context,
+                processingStatus: completion.processingStatus,
+                intent: intent,
+                audioFileName: audioFileName,
+                calendarMatch: calendarMatch
+            )
+            cleanupRecorderIfIdle()
+            let completionStatusText = preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
+            updateForegroundUIForStoppedTranscriptionCompletion(
+                overlayID: overlayID,
+                completion: completion,
+                context: context,
+                completionStatusText: completionStatusText,
+                enterOnlyStatusText: "Pressed Enter"
+            )
+            finishTranscriptionJob(jobID, overlayID: overlayID)
+        }
+    }
+
+    @MainActor
+    private func updateForegroundUIForStoppedTranscriptionCompletion(
+        overlayID: UUID,
+        completion: StoppedTranscriptionCompletionSummary,
+        context: AppContext,
+        completionStatusText: String,
+        enterOnlyStatusText: String
+    ) {
+        guard overlayTranscriptionID == overlayID else { return }
+        lastContextSummary = context.contextSummary
+        lastContextScreenshotDataURL = context.screenshotDataURL
+        lastContextScreenshotStatus = context.screenshotError
+            ?? "available (\(context.screenshotMimeType ?? "image"))"
+        lastContextAppName = context.appName ?? ""
+        lastContextBundleIdentifier = context.bundleIdentifier ?? ""
+        lastContextWindowTitle = context.windowTitle ?? ""
+        lastContextSelectedText = context.selectedText ?? ""
+        lastContextLLMPrompt = context.contextPrompt ?? ""
+        lastPostProcessingPrompt = completion.prompt
+        lastRawTranscript = completion.rawTranscript
+        lastPostProcessedTranscript = completion.finalTranscript
+        lastPostProcessingStatus = completion.processingStatus
+        lastTranscript = completion.finalTranscript
+        debugStatusMessage = "Done"
+        statusText = completionStatusText
+        if completion.finalTranscript.isEmpty {
+            mcpLastRecordingFailed = true
+            statusText = completion.shouldPressEnterAfterPaste ? enterOnlyStatusText : "Nothing to transcribe"
+            dismissTranscribingOverlay()
+            if completion.shouldPressEnterAfterPaste {
+                pressEnterWhenShortcutReleased()
+            }
+        } else {
+            if completion.shouldPersistRawDictationFallback {
+                scheduleOverlayDismissAfterFailureIndicator(after: 2.5)
+            } else {
+                dismissTranscribingOverlay()
+            }
+            if !disableAutoPaste {
+                let pendingClipboardRestore = writeTranscriptToPasteboard(completion.finalTranscript)
+                pasteAtCursorWhenShortcutReleased {
+                    if completion.shouldPressEnterAfterPaste {
+                        self.pressEnterAfterPaste {
+                            self.restoreClipboardIfNeeded(pendingClipboardRestore)
+                        }
+                    } else {
+                        self.restoreClipboardIfNeeded(pendingClipboardRestore)
+                    }
+                }
+            }
+        }
+        scheduleReadyStatusReset(after: 3, matching: [completionStatusText, "Nothing to transcribe", enterOnlyStatusText])
+    }
+
+    @MainActor
+    private func finishTranscriptionJob(_ id: UUID, overlayID: UUID) {
+        finishTranscriptionJob(id)
+        if overlayTranscriptionID == overlayID {
+            cancelTranscribingIndicatorTask()
+        }
+    }
+
     @MainActor
     private func stopAndTranscribe() {
         cancelPendingShortcutStart()
@@ -3997,64 +4181,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         liveTranscriber = nil
         audioRecorder.onPCM16Samples = nil
 
-        let updateForegroundUI: @MainActor @Sendable (
-            String, String, String, String, AppContext, String, String, Bool, Bool
-        ) -> Void = { [weak self] rawTranscript, finalTranscript, prompt, processingStatus, context, completionStatusText, enterOnlyStatusText, shouldPressEnterAfterPaste, shouldPersistRawDictationFallback in
-            guard let self else { return }
-            guard self.overlayTranscriptionID == myOverlayID else { return }
-            self.lastContextSummary = context.contextSummary
-            self.lastContextScreenshotDataURL = context.screenshotDataURL
-            self.lastContextScreenshotStatus = context.screenshotError
-                ?? "available (\(context.screenshotMimeType ?? "image"))"
-            self.lastContextAppName = context.appName ?? ""
-            self.lastContextBundleIdentifier = context.bundleIdentifier ?? ""
-            self.lastContextWindowTitle = context.windowTitle ?? ""
-            self.lastContextSelectedText = context.selectedText ?? ""
-            self.lastContextLLMPrompt = context.contextPrompt ?? ""
-            self.lastPostProcessingPrompt = prompt
-            self.lastRawTranscript = rawTranscript
-            self.lastPostProcessedTranscript = finalTranscript
-            self.lastPostProcessingStatus = processingStatus
-            self.lastTranscript = finalTranscript
-            self.debugStatusMessage = "Done"
-            self.statusText = completionStatusText
-            if finalTranscript.isEmpty {
-                self.mcpLastRecordingFailed = true
-                self.statusText = shouldPressEnterAfterPaste ? enterOnlyStatusText : "Nothing to transcribe"
-                self.dismissTranscribingOverlay()
-                if shouldPressEnterAfterPaste {
-                    self.pressEnterWhenShortcutReleased()
-                }
-            } else {
-                if shouldPersistRawDictationFallback {
-                    self.scheduleOverlayDismissAfterFailureIndicator(after: 2.5)
-                } else {
-                    self.dismissTranscribingOverlay()
-                }
-                if !self.disableAutoPaste {
-                    let pendingClipboardRestore = self.writeTranscriptToPasteboard(finalTranscript)
-                    self.pasteAtCursorWhenShortcutReleased {
-                        if shouldPressEnterAfterPaste {
-                            self.pressEnterAfterPaste {
-                                self.restoreClipboardIfNeeded(pendingClipboardRestore)
-                            }
-                        } else {
-                            self.restoreClipboardIfNeeded(pendingClipboardRestore)
-                        }
-                    }
-                }
-            }
-            self.scheduleReadyStatusReset(after: 3, matching: [completionStatusText, "Nothing to transcribe", enterOnlyStatusText])
-        }
-
-        let completeJob: @MainActor @Sendable (UUID, UUID) -> Void = { [weak self] id, overlayID in
-            guard let self else { return }
-            self.finishTranscriptionJob(id)
-            if self.overlayTranscriptionID == overlayID {
-                self.cancelTranscribingIndicatorTask()
-            }
-        }
-
         if let transcriber = capturedLiveTranscriber, transcriber.handlesRecording {
             if overlayTranscriptionID == myOverlayID {
                 prepareTranscribingOverlay(for: myOverlayID, statusText: "Transcribing...", debugStatus: "Transcribing audio")
@@ -4071,89 +4197,38 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     await MainActor.run {
                         self.updateTranscriptionJob(jobID) { $0.audioFileName = savedAudioFile?.fileName }
                     }
-                    let parsedTranscript = Self.parseTranscriptCommands(
-                        from: rawTranscript,
-                        pressEnterCommandEnabled: capturedPressEnterCommandEnabled
+                    try Task.checkCancellation()
+                    let appContext = await self.resolveStoppedRecordingContext(
+                        sessionContext: sessionContext,
+                        inFlightContextTask: inFlightContextTask
                     )
-                    try Task.checkCancellation()
-                    let appContext: AppContext
-                    if let sessionContext {
-                        appContext = sessionContext
-                    } else if let inFlightContext = await inFlightContextTask?.value {
-                        appContext = inFlightContext
-                    } else {
-                        appContext = self.fallbackContextAtStop()
-                    }
-                    try Task.checkCancellation()
-                    await MainActor.run { [weak self] in
-                        self?.debugStatusMessage = "Running post-processing"
-                    }
-                    let result = await self.processTranscript(
-                        parsedTranscript.transcript,
+                    let completion = try await self.makeStoppedTranscriptionCompletionSummary(
+                        rawTranscript: rawTranscript,
                         intent: sessionIntent,
                         context: appContext,
                         postProcessingService: postProcessingService,
                         customVocabulary: capturedCustomVocabulary,
                         customSystemPrompt: capturedCustomSystemPrompt,
-                        outputLanguage: capturedOutputLanguage
+                        outputLanguage: capturedOutputLanguage,
+                        pressEnterCommandEnabled: capturedPressEnterCommandEnabled
                     )
-                    try Task.checkCancellation()
-                    let trimmedRawTranscript = parsedTranscript.transcript
-                    let trimmedFinalTranscript = result.finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let processingStatus = Self.statusMessage(
-                        for: result.outcome,
-                        parsedTranscript: parsedTranscript
+                    await self.runSuccessfulStoppedTranscriptionCompletionPipeline(
+                        jobID: jobID,
+                        overlayID: myOverlayID,
+                        completion: completion,
+                        context: appContext,
+                        intent: sessionIntent,
+                        audioFileName: savedAudioFile?.fileName
                     )
-                    let shouldPersistRawDictationFallback: Bool
-                    switch result.outcome {
-                    case .postProcessingFailedFallback:
-                        shouldPersistRawDictationFallback = !trimmedFinalTranscript.isEmpty
-                    default:
-                        shouldPersistRawDictationFallback = false
-                    }
-                    let calendarMatch = await self.calendarMatchForHistoryItem(jobID: jobID)
-                    await MainActor.run {
-                        self.recordPipelineHistoryEntry(
-                            jobID: jobID,
-                            rawTranscript: trimmedRawTranscript,
-                            postProcessedTranscript: trimmedFinalTranscript,
-                            postProcessingPrompt: result.prompt,
-                            systemPrompt: Self.resolvedSystemPrompt(self.customSystemPrompt),
-                            context: appContext,
-                            processingStatus: processingStatus,
-                            intent: sessionIntent,
-                            audioFileName: savedAudioFile?.fileName,
-                            calendarMatch: calendarMatch
-                        )
-                        self.cleanupRecorderIfIdle()
-                        let completionStatusText = self.preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
-                        let enterOnlyStatusText = "Pressed Enter"
-                        updateForegroundUI(
-                            trimmedRawTranscript,
-                            trimmedFinalTranscript,
-                            result.prompt,
-                            processingStatus,
-                            appContext,
-                            completionStatusText,
-                            enterOnlyStatusText,
-                            parsedTranscript.shouldPressEnterAfterPaste,
-                            shouldPersistRawDictationFallback
-                        )
-                        completeJob(jobID, myOverlayID)
-                    }
                 } catch is CancellationError {
                     await MainActor.run {
-                        completeJob(jobID, myOverlayID)
+                        self.finishTranscriptionJob(jobID, overlayID: myOverlayID)
                     }
                 } catch {
-                    let resolvedContext: AppContext
-                    if let sessionContext {
-                        resolvedContext = sessionContext
-                    } else if let inFlightContext = await inFlightContextTask?.value {
-                        resolvedContext = inFlightContext
-                    } else {
-                        resolvedContext = self.fallbackContextAtStop()
-                    }
+                    let resolvedContext = await self.resolveStoppedRecordingContext(
+                        sessionContext: sessionContext,
+                        inFlightContextTask: inFlightContextTask
+                    )
                     let errorAudioFile = transcriber.recordedAudioURL.flatMap { url -> SavedAudioFile? in
                         let saved = Self.saveAudioFile(from: url)
                         try? FileManager.default.removeItem(at: url)
@@ -4176,7 +4251,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         )
                         self.cleanupRecorderIfIdle()
                         guard self.overlayTranscriptionID == myOverlayID else {
-                            completeJob(jobID, myOverlayID)
+                            self.finishTranscriptionJob(jobID, overlayID: myOverlayID)
                             return
                         }
                         self.errorMessage = error.localizedDescription
@@ -4190,7 +4265,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.lastContextScreenshotDataURL = resolvedContext.screenshotDataURL
                         self.lastContextScreenshotStatus = resolvedContext.screenshotError
                             ?? "available (\(resolvedContext.screenshotMimeType ?? "image"))"
-                        completeJob(jobID, myOverlayID)
+                        self.finishTranscriptionJob(jobID, overlayID: myOverlayID)
                     }
                 }
             }
@@ -4267,91 +4342,38 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             fileURL: transcriptionFileURL
                         )
                     }
-                    let parsedTranscript = Self.parseTranscriptCommands(
-                        from: rawTranscript,
-                        pressEnterCommandEnabled: capturedPressEnterCommandEnabled
+                    try Task.checkCancellation()
+                    let appContext = await self.resolveStoppedRecordingContext(
+                        sessionContext: sessionContext,
+                        inFlightContextTask: inFlightContextTask
                     )
-                    try Task.checkCancellation()
-                    let appContext: AppContext
-                    if let sessionContext {
-                        appContext = sessionContext
-                    } else if let inFlightContext = await inFlightContextTask?.value {
-                        appContext = inFlightContext
-                    } else {
-                        appContext = self.fallbackContextAtStop()
-                    }
-                    try Task.checkCancellation()
-                    await MainActor.run { [weak self] in
-                        self?.debugStatusMessage = "Running post-processing"
-                    }
-                    let result = await self.processTranscript(
-                        parsedTranscript.transcript,
+                    let completion = try await self.makeStoppedTranscriptionCompletionSummary(
+                        rawTranscript: rawTranscript,
                         intent: sessionIntent,
                         context: appContext,
                         postProcessingService: postProcessingService,
                         customVocabulary: capturedCustomVocabulary,
                         customSystemPrompt: capturedCustomSystemPrompt,
-                        outputLanguage: capturedOutputLanguage
+                        outputLanguage: capturedOutputLanguage,
+                        pressEnterCommandEnabled: capturedPressEnterCommandEnabled
                     )
-                    try Task.checkCancellation()
-
-                    let trimmedRawTranscript = parsedTranscript.transcript
-                    let trimmedFinalTranscript = result.finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let processingStatus = Self.statusMessage(
-                        for: result.outcome,
-                        parsedTranscript: parsedTranscript
+                    await self.runSuccessfulStoppedTranscriptionCompletionPipeline(
+                        jobID: jobID,
+                        overlayID: myOverlayID,
+                        completion: completion,
+                        context: appContext,
+                        intent: sessionIntent,
+                        audioFileName: savedAudioFile?.fileName
                     )
-                    let shouldPersistRawDictationFallback: Bool
-                    switch result.outcome {
-                    case .postProcessingFailedFallback:
-                        shouldPersistRawDictationFallback = !trimmedFinalTranscript.isEmpty
-                    default:
-                        shouldPersistRawDictationFallback = false
-                    }
-                    let calendarMatch = await self.calendarMatchForHistoryItem(jobID: jobID)
-
-                    await MainActor.run {
-                        self.recordPipelineHistoryEntry(
-                            jobID: jobID,
-                            rawTranscript: trimmedRawTranscript,
-                            postProcessedTranscript: trimmedFinalTranscript,
-                            postProcessingPrompt: result.prompt,
-                            systemPrompt: Self.resolvedSystemPrompt(self.customSystemPrompt),
-                            context: appContext,
-                            processingStatus: processingStatus,
-                            intent: sessionIntent,
-                            audioFileName: savedAudioFile?.fileName,
-                            calendarMatch: calendarMatch
-                        )
-                        self.cleanupRecorderIfIdle()
-                        let completionStatusText = self.preserveClipboard ? "Pasted at cursor!" : "Copied to clipboard!"
-                        let enterOnlyStatusText = "Pressed Enter"
-                        updateForegroundUI(
-                            trimmedRawTranscript,
-                            trimmedFinalTranscript,
-                            result.prompt,
-                            processingStatus,
-                            appContext,
-                            completionStatusText,
-                            enterOnlyStatusText,
-                            parsedTranscript.shouldPressEnterAfterPaste,
-                            shouldPersistRawDictationFallback
-                        )
-                        completeJob(jobID, myOverlayID)
-                    }
                 } catch is CancellationError {
                     await MainActor.run {
-                        completeJob(jobID, myOverlayID)
+                        self.finishTranscriptionJob(jobID, overlayID: myOverlayID)
                     }
                 } catch {
-                    let resolvedContext: AppContext
-                    if let sessionContext {
-                        resolvedContext = sessionContext
-                    } else if let inFlightContext = await inFlightContextTask?.value {
-                        resolvedContext = inFlightContext
-                    } else {
-                        resolvedContext = self.fallbackContextAtStop()
-                    }
+                    let resolvedContext = await self.resolveStoppedRecordingContext(
+                        sessionContext: sessionContext,
+                        inFlightContextTask: inFlightContextTask
+                    )
                     let calendarMatch = await self.calendarMatchForHistoryItem(jobID: jobID)
                     await MainActor.run {
                         self.recordPipelineHistoryEntry(
@@ -4368,7 +4390,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         )
                         self.cleanupRecorderIfIdle()
                         guard self.overlayTranscriptionID == myOverlayID else {
-                            completeJob(jobID, myOverlayID)
+                            self.finishTranscriptionJob(jobID, overlayID: myOverlayID)
                             return
                         }
                         self.errorMessage = error.localizedDescription
@@ -4382,7 +4404,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.lastContextScreenshotDataURL = resolvedContext.screenshotDataURL
                         self.lastContextScreenshotStatus = resolvedContext.screenshotError
                             ?? "available (\(resolvedContext.screenshotMimeType ?? "image"))"
-                        completeJob(jobID, myOverlayID)
+                        self.finishTranscriptionJob(jobID, overlayID: myOverlayID)
                     }
                 }
             }

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -19,6 +19,9 @@ struct AppStateTranscriptionConfigurationTests {
         testRecordingCancelShortcutRejectsMoreSpecificHoldOverlap()
         testRecordingCancelShortcutRejectsManualModifierRuntimeOverlap()
         testCommandModeManualModifierReportsCancelOverlap()
+        testStoppedTranscriptionCompletionSummaryTrimsFinalTranscript()
+        testStoppedTranscriptionCompletionSummaryShowsFallbackIndicatorForNonEmptyRawFallback()
+        testStoppedTranscriptionCompletionSummaryHidesFallbackIndicatorForEmptyRawFallback()
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
@@ -286,6 +289,52 @@ struct AppStateTranscriptionConfigurationTests {
 
         assert(validation == "Cancel shortcut must be distinct from dictation shortcuts.")
         assert(appState.commandModeManualModifierValidationMessage == "Cancel shortcut must be distinct from dictation shortcuts.")
+    }
+
+    private static func testStoppedTranscriptionCompletionSummaryTrimsFinalTranscript() {
+        let summary = StoppedTranscriptionCompletionSummary(
+            rawTranscript: "raw transcript",
+            finalTranscript: "  final transcript\n",
+            prompt: "prompt",
+            processingStatus: "Post-processing succeeded",
+            shouldPressEnterAfterPaste: false,
+            outcomeWasPostProcessingFailedFallback: false
+        )
+
+        assert(summary.rawTranscript == "raw transcript")
+        assert(summary.finalTranscript == "final transcript")
+        assert(summary.prompt == "prompt")
+        assert(summary.processingStatus == "Post-processing succeeded")
+        assert(!summary.shouldPressEnterAfterPaste)
+        assert(!summary.shouldPersistRawDictationFallback)
+    }
+
+    private static func testStoppedTranscriptionCompletionSummaryShowsFallbackIndicatorForNonEmptyRawFallback() {
+        let summary = StoppedTranscriptionCompletionSummary(
+            rawTranscript: "raw transcript",
+            finalTranscript: "raw transcript",
+            prompt: "",
+            processingStatus: "Post-processing failed, using raw transcript",
+            shouldPressEnterAfterPaste: false,
+            outcomeWasPostProcessingFailedFallback: true
+        )
+
+        assert(summary.shouldPersistRawDictationFallback)
+    }
+
+    private static func testStoppedTranscriptionCompletionSummaryHidesFallbackIndicatorForEmptyRawFallback() {
+        let summary = StoppedTranscriptionCompletionSummary(
+            rawTranscript: "",
+            finalTranscript: "  \n",
+            prompt: "",
+            processingStatus: "Skipped macros and post-processing for empty raw transcript",
+            shouldPressEnterAfterPaste: true,
+            outcomeWasPostProcessingFailedFallback: true
+        )
+
+        assert(summary.finalTranscript.isEmpty)
+        assert(summary.shouldPressEnterAfterPaste)
+        assert(!summary.shouldPersistRawDictationFallback)
     }
 
     private static func resetDefaults() {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -22,6 +22,7 @@ struct AppStateTranscriptionConfigurationTests {
         testStoppedTranscriptionCompletionSummaryTrimsFinalTranscript()
         testStoppedTranscriptionCompletionSummaryShowsFallbackIndicatorForNonEmptyRawFallback()
         testStoppedTranscriptionCompletionSummaryHidesFallbackIndicatorForEmptyRawFallback()
+        testStoppedTranscriptionSettingsSnapshotCapturesHistoryMetadata()
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
@@ -301,12 +302,12 @@ struct AppStateTranscriptionConfigurationTests {
             outcomeWasPostProcessingFailedFallback: false
         )
 
-        assert(summary.rawTranscript == "raw transcript")
-        assert(summary.finalTranscript == "final transcript")
-        assert(summary.prompt == "prompt")
-        assert(summary.processingStatus == "Post-processing succeeded")
-        assert(!summary.shouldPressEnterAfterPaste)
-        assert(!summary.shouldPersistRawDictationFallback)
+        precondition(summary.rawTranscript == "raw transcript")
+        precondition(summary.finalTranscript == "final transcript")
+        precondition(summary.prompt == "prompt")
+        precondition(summary.processingStatus == "Post-processing succeeded")
+        precondition(!summary.shouldPressEnterAfterPaste)
+        precondition(!summary.shouldPersistRawDictationFallback)
     }
 
     private static func testStoppedTranscriptionCompletionSummaryShowsFallbackIndicatorForNonEmptyRawFallback() {
@@ -319,7 +320,7 @@ struct AppStateTranscriptionConfigurationTests {
             outcomeWasPostProcessingFailedFallback: true
         )
 
-        assert(summary.shouldPersistRawDictationFallback)
+        precondition(summary.shouldPersistRawDictationFallback)
     }
 
     private static func testStoppedTranscriptionCompletionSummaryHidesFallbackIndicatorForEmptyRawFallback() {
@@ -332,9 +333,29 @@ struct AppStateTranscriptionConfigurationTests {
             outcomeWasPostProcessingFailedFallback: true
         )
 
-        assert(summary.finalTranscript.isEmpty)
-        assert(summary.shouldPressEnterAfterPaste)
-        assert(!summary.shouldPersistRawDictationFallback)
+        precondition(summary.finalTranscript.isEmpty)
+        precondition(summary.shouldPressEnterAfterPaste)
+        precondition(!summary.shouldPersistRawDictationFallback)
+    }
+
+    private static func testStoppedTranscriptionSettingsSnapshotCapturesHistoryMetadata() {
+        let snapshot = StoppedTranscriptionSettingsSnapshot(
+            customVocabulary: "team terms",
+            customSystemPrompt: "custom prompt",
+            useLocalTranscription: true,
+            localTranscriptionModel: .find(id: "apple-speech"),
+            transcriptionLanguage: .find(code: "en"),
+            usedContextCapture: true,
+            usedPostProcessing: false
+        )
+
+        precondition(snapshot.customVocabulary == "team terms")
+        precondition(snapshot.customSystemPrompt == "custom prompt")
+        precondition(snapshot.useLocalTranscription)
+        precondition(snapshot.localTranscriptionModel.id == "apple-speech")
+        precondition(snapshot.transcriptionLanguage.code == "en")
+        precondition(snapshot.usedContextCapture)
+        precondition(!snapshot.usedPostProcessing)
     }
 
     private static func resetDefaults() {


### PR DESCRIPTION
## Summary
- Share the stopped-recording completion pipeline used by live and file-backed transcription paths.
- Preserve source-specific raw transcript acquisition while centralizing history recording, foreground UI updates, and job finalization.
- Add regression coverage for completion summary trimming and fallback indicator behavior.

## Test plan
- [x] `make test`
- [x] `make all`
- [x] Opened `build/Quill.app` and smoke-tested live and non-live recording completion flows

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 음성 인식 중지 후 최종 전사 처리 흐름 안정성 향상 — 중지/취소 시 UI 상태, 오버레이 및 작업 종료가 일관되게 정리됩니다.
  * 전사 공백 처리와 최종/원본 폴백 보존 로직 개선으로 잘못된 덮어쓰기 방지.

* **Refactor**
  * 중지 완료 파이프라인 통일로 캘린더 매치·기록·UI 업데이트 흐름이 일관화됨.

* **Tests**
  * 최종 전사 결과 및 폴백 보존 동작을 검증하는 테스트 추가.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/freeflow/pull/97)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->