### PR TITLE
Refine note browser recording time display

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -791,6 +791,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func clearGoogleCalendarConnectionState() {
         cancelGoogleCalendarConnection()
         GoogleCalendarTokenStore.delete()
+        Self.clearGoogleCalendarConnectionMetadata()
         availableGoogleCalendars = []
         googleCalendarConnection = .disconnected
         UserDefaults.standard.removeObject(forKey: googleCalendarSelectedIDsStorageKey)
@@ -851,6 +852,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     redirectURI: callbackURL.absoluteString
                 )
                 try GoogleCalendarTokenStore.save(token)
+                Self.saveGoogleCalendarConnectionMetadata(accountEmail: token.accountEmail)
                 await MainActor.run {
                     self.googleCalendarConnection = GoogleCalendarConnectionState(
                         isConnected: true,
@@ -1065,10 +1067,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let googleCalendarClientID = UserDefaults.standard.string(forKey: googleCalendarClientIDStorageKey) ?? ""
         let googleCalendarClientSecret = Self.loadOptionalStoredAPIValue(account: googleCalendarClientSecretStorageKey)
         let selectedGoogleCalendarIDs = Self.loadStringSet(forKey: googleCalendarSelectedIDsStorageKey)
+        let storedGoogleCalendarConnectionMetadata = Self.loadGoogleCalendarConnectionMetadata()
         let calendarRecordingRemindersEnabled = UserDefaults.standard.bool(forKey: calendarRecordingRemindersEnabledStorageKey)
-        let storedCalendarToken = GoogleCalendarTokenStore.load(
-            allowsAuthenticationUI: GoogleCalendarStartupTokenLoadPolicy.allowsAuthenticationUI
-        )
         let storedCalendarRecordingReminderLeadMinutes = UserDefaults.standard.object(forKey: calendarRecordingReminderLeadMinutesStorageKey) != nil
             ? UserDefaults.standard.integer(forKey: calendarRecordingReminderLeadMinutesStorageKey)
             : CalendarRecordingReminderScheduler.defaultLeadMinutes
@@ -1181,12 +1181,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.recordingOverlayLayout = recordingOverlayLayout
         self.googleCalendarClientID = googleCalendarClientID
         self.googleCalendarClientSecret = googleCalendarClientSecret
-        self.googleCalendarConnection = GoogleCalendarConnectionState(
-            isConnected: storedCalendarToken != nil,
-            accountEmail: storedCalendarToken?.accountEmail,
-            selectedCalendarIDs: selectedGoogleCalendarIDs,
-            lastErrorMessage: nil
-        )
+        self.googleCalendarConnection = storedGoogleCalendarConnectionMetadata?.connectionState(
+            selectedCalendarIDs: selectedGoogleCalendarIDs
+        ) ?? .disconnected
         self.calendarRecordingRemindersEnabled = calendarRecordingRemindersEnabled
         self.calendarRecordingReminderLeadMinutes = calendarRecordingReminderLeadMinutes
         self.calendarRecordingReminderRefreshIntervalMinutes = calendarRecordingReminderRefreshIntervalMinutes
@@ -1299,6 +1296,20 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return stored
         }
         return defaultAPIBaseURL
+    }
+
+    private static func loadGoogleCalendarConnectionMetadata() -> GoogleCalendarConnectionMetadata? {
+        guard let data = UserDefaults.standard.data(forKey: GoogleCalendarConnectionMetadata.storageKey) else { return nil }
+        return try? JSONDecoder().decode(GoogleCalendarConnectionMetadata.self, from: data)
+    }
+
+    private static func saveGoogleCalendarConnectionMetadata(accountEmail: String?) {
+        guard let data = try? JSONEncoder().encode(GoogleCalendarConnectionMetadata(accountEmail: accountEmail)) else { return }
+        UserDefaults.standard.set(data, forKey: GoogleCalendarConnectionMetadata.storageKey)
+    }
+
+    private static func clearGoogleCalendarConnectionMetadata() {
+        UserDefaults.standard.removeObject(forKey: GoogleCalendarConnectionMetadata.storageKey)
     }
 
     private static func loadShortcutConfiguration(holdKey: String, toggleKey: String) -> StoredShortcutConfiguration {
@@ -1556,11 +1567,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         do {
             guard let token = try await validGoogleCalendarToken() else {
                 calendarRecordingReminderScheduler.stop()
+                Self.clearGoogleCalendarConnectionMetadata()
                 googleCalendarConnection = .disconnected
                 availableGoogleCalendars = []
                 return
             }
             let calendars = try await GoogleCalendarService().fetchCalendars(accessToken: token.accessToken)
+            Self.saveGoogleCalendarConnectionMetadata(accountEmail: token.accountEmail)
             availableGoogleCalendars = calendars
             googleCalendarConnection.isConnected = true
             googleCalendarConnection.accountEmail = token.accountEmail

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1066,12 +1066,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let googleCalendarClientSecret = Self.loadOptionalStoredAPIValue(account: googleCalendarClientSecretStorageKey)
         let selectedGoogleCalendarIDs = Self.loadStringSet(forKey: googleCalendarSelectedIDsStorageKey)
         let calendarRecordingRemindersEnabled = UserDefaults.standard.bool(forKey: calendarRecordingRemindersEnabledStorageKey)
-        let storedCalendarToken = GoogleCalendarStartupTokenLoadPolicy.shouldLoadToken(
-            remindersEnabled: calendarRecordingRemindersEnabled,
-            selectedCalendarIDs: selectedGoogleCalendarIDs
-        ) ? GoogleCalendarTokenStore.load(
+        let storedCalendarToken = GoogleCalendarTokenStore.load(
             allowsAuthenticationUI: GoogleCalendarStartupTokenLoadPolicy.allowsAuthenticationUI
-        ) : nil
+        )
         let storedCalendarRecordingReminderLeadMinutes = UserDefaults.standard.object(forKey: calendarRecordingReminderLeadMinutesStorageKey) != nil
             ? UserDefaults.standard.integer(forKey: calendarRecordingReminderLeadMinutesStorageKey)
             : CalendarRecordingReminderScheduler.defaultLeadMinutes

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1069,7 +1069,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let storedCalendarToken = GoogleCalendarStartupTokenLoadPolicy.shouldLoadToken(
             remindersEnabled: calendarRecordingRemindersEnabled,
             selectedCalendarIDs: selectedGoogleCalendarIDs
-        ) ? GoogleCalendarTokenStore.load() : nil
+        ) ? GoogleCalendarTokenStore.load(
+            allowsAuthenticationUI: GoogleCalendarStartupTokenLoadPolicy.allowsAuthenticationUI
+        ) : nil
         let storedCalendarRecordingReminderLeadMinutes = UserDefaults.standard.object(forKey: calendarRecordingReminderLeadMinutesStorageKey) != nil
             ? UserDefaults.standard.integer(forKey: calendarRecordingReminderLeadMinutesStorageKey)
             : CalendarRecordingReminderScheduler.defaultLeadMinutes

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1300,7 +1300,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private static func loadGoogleCalendarConnectionMetadata() -> GoogleCalendarConnectionMetadata? {
         guard let data = UserDefaults.standard.data(forKey: GoogleCalendarConnectionMetadata.storageKey) else { return nil }
-        return try? JSONDecoder().decode(GoogleCalendarConnectionMetadata.self, from: data)
+        do {
+            return try JSONDecoder().decode(GoogleCalendarConnectionMetadata.self, from: data)
+        } catch {
+            UserDefaults.standard.removeObject(forKey: GoogleCalendarConnectionMetadata.storageKey)
+            return nil
+        }
     }
 
     private static func saveGoogleCalendarConnectionMetadata(accountEmail: String?) {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1065,8 +1065,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let googleCalendarClientID = UserDefaults.standard.string(forKey: googleCalendarClientIDStorageKey) ?? ""
         let googleCalendarClientSecret = Self.loadOptionalStoredAPIValue(account: googleCalendarClientSecretStorageKey)
         let selectedGoogleCalendarIDs = Self.loadStringSet(forKey: googleCalendarSelectedIDsStorageKey)
-        let storedCalendarToken = GoogleCalendarTokenStore.load()
         let calendarRecordingRemindersEnabled = UserDefaults.standard.bool(forKey: calendarRecordingRemindersEnabledStorageKey)
+        let storedCalendarToken = GoogleCalendarStartupTokenLoadPolicy.shouldLoadToken(
+            remindersEnabled: calendarRecordingRemindersEnabled,
+            selectedCalendarIDs: selectedGoogleCalendarIDs
+        ) ? GoogleCalendarTokenStore.load() : nil
         let storedCalendarRecordingReminderLeadMinutes = UserDefaults.standard.object(forKey: calendarRecordingReminderLeadMinutesStorageKey) != nil
             ? UserDefaults.standard.integer(forKey: calendarRecordingReminderLeadMinutesStorageKey)
             : CalendarRecordingReminderScheduler.defaultLeadMinutes

--- a/Sources/CalendarIntegrationModels.swift
+++ b/Sources/CalendarIntegrationModels.swift
@@ -40,10 +40,6 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     }
 }
 
-enum GoogleCalendarStartupTokenLoadPolicy {
-    static let allowsAuthenticationUI = false
-}
-
 enum CalendarMatchSource: String, Codable, Equatable {
     case overlapSuggestion = "overlap_suggestion"
     case calendarNotification = "calendar_notification"
@@ -186,6 +182,21 @@ struct GoogleCalendarConnectionState: Codable, Equatable {
     var lastErrorMessage: String?
 
     static let disconnected = GoogleCalendarConnectionState(isConnected: false, accountEmail: nil, selectedCalendarIDs: [], lastErrorMessage: nil)
+}
+
+struct GoogleCalendarConnectionMetadata: Codable, Equatable {
+    static let storageKey = "google_calendar_connection_metadata"
+
+    let accountEmail: String?
+
+    func connectionState(selectedCalendarIDs: Set<String>) -> GoogleCalendarConnectionState {
+        GoogleCalendarConnectionState(
+            isConnected: true,
+            accountEmail: accountEmail,
+            selectedCalendarIDs: selectedCalendarIDs,
+            lastErrorMessage: nil
+        )
+    }
 }
 
 struct GoogleCalendarConnectionControls: Equatable {

--- a/Sources/CalendarIntegrationModels.swift
+++ b/Sources/CalendarIntegrationModels.swift
@@ -41,8 +41,10 @@ enum SettingsTab: String, CaseIterable, Identifiable {
 }
 
 enum GoogleCalendarStartupTokenLoadPolicy {
+    static let allowsAuthenticationUI = false
+
     static func shouldLoadToken(remindersEnabled: Bool, selectedCalendarIDs: Set<String>) -> Bool {
-        remindersEnabled && !selectedCalendarIDs.isEmpty
+        true
     }
 }
 

--- a/Sources/CalendarIntegrationModels.swift
+++ b/Sources/CalendarIntegrationModels.swift
@@ -42,10 +42,6 @@ enum SettingsTab: String, CaseIterable, Identifiable {
 
 enum GoogleCalendarStartupTokenLoadPolicy {
     static let allowsAuthenticationUI = false
-
-    static func shouldLoadToken(remindersEnabled: Bool, selectedCalendarIDs: Set<String>) -> Bool {
-        true
-    }
 }
 
 enum CalendarMatchSource: String, Codable, Equatable {

--- a/Sources/CalendarIntegrationModels.swift
+++ b/Sources/CalendarIntegrationModels.swift
@@ -40,6 +40,12 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     }
 }
 
+enum GoogleCalendarStartupTokenLoadPolicy {
+    static func shouldLoadToken(remindersEnabled: Bool, selectedCalendarIDs: Set<String>) -> Bool {
+        remindersEnabled && !selectedCalendarIDs.isEmpty
+    }
+}
+
 enum CalendarMatchSource: String, Codable, Equatable {
     case overlapSuggestion = "overlap_suggestion"
     case calendarNotification = "calendar_notification"

--- a/Sources/GoogleCalendarTokenStore.swift
+++ b/Sources/GoogleCalendarTokenStore.swift
@@ -1,5 +1,4 @@
 import Foundation
-import LocalAuthentication
 import Security
 
 struct GoogleCalendarOAuthToken: Codable, Equatable {
@@ -17,19 +16,14 @@ enum GoogleCalendarTokenStore {
     private static let service = (Bundle.main.bundleIdentifier ?? "com.woosublee.quill") + ".google-calendar"
     private static let account = "oauth-token"
 
-    static func load(allowsAuthenticationUI: Bool = true) -> GoogleCalendarOAuthToken? {
-        var query: [String: Any] = [
+    static func load() -> GoogleCalendarOAuthToken? {
+        let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
-        if !allowsAuthenticationUI {
-            let context = LAContext()
-            context.interactionNotAllowed = true
-            query[kSecUseAuthenticationContext as String] = context
-        }
         var result: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         guard status == errSecSuccess,

--- a/Sources/GoogleCalendarTokenStore.swift
+++ b/Sources/GoogleCalendarTokenStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import LocalAuthentication
 import Security
 
 struct GoogleCalendarOAuthToken: Codable, Equatable {
@@ -16,14 +17,19 @@ enum GoogleCalendarTokenStore {
     private static let service = (Bundle.main.bundleIdentifier ?? "com.woosublee.quill") + ".google-calendar"
     private static let account = "oauth-token"
 
-    static func load() -> GoogleCalendarOAuthToken? {
-        let query: [String: Any] = [
+    static func load(allowsAuthenticationUI: Bool = true) -> GoogleCalendarOAuthToken? {
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
+        if !allowsAuthenticationUI {
+            let context = LAContext()
+            context.interactionNotAllowed = true
+            query[kSecUseAuthenticationContext as String] = context
+        }
         var result: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         guard status == errSecSuccess,

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -905,35 +905,7 @@ private struct NoteDetailView: View {
 
     private var noteHeader: some View {
         VStack(alignment: .leading, spacing: 6) {
-            // Meta line — monospace, small caps
-            HStack(spacing: 8) {
-                Text(item.timestamp.formatted(date: .abbreviated, time: .shortened))
-                    .font(.system(size: 10, design: .monospaced))
-                    .foregroundStyle(.tertiary)
-                    .textCase(.uppercase)
-                    .kerning(0.5)
-                statusBadges
-                if isLiveRecording {
-                    LiveRecordingBadge()
-                } else if isError {
-                    Image(systemName: "exclamationmark.triangle")
-                        .font(.system(size: 10, weight: .light))
-                        .foregroundStyle(.red.opacity(0.6))
-                        .help("Transcription failed")
-                }
-                if !item.contextSummary.isEmpty
-                    && !item.contextSummary.hasPrefix("Could not")
-                    && item.contextSummary != "Context capture disabled" {
-                    Text("·")
-                        .foregroundStyle(.quaternary)
-                        .font(.system(size: 10))
-                    Text(item.contextSummary)
-                        .font(.system(size: 10, design: .monospaced))
-                        .foregroundStyle(.tertiary)
-                        .lineLimit(1)
-                }
-                Spacer()
-            }
+            metadataLine
 
             // Title — auto-save on change
             TextField(
@@ -1015,6 +987,66 @@ private struct NoteDetailView: View {
         }
     }
 
+    private var metadataLine: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 8) {
+                detailTimestampLabel
+                statusBadges
+                noteStateIndicator
+                contextSummaryLabel
+                Spacer(minLength: 0)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    detailTimestampLabel
+                    noteStateIndicator
+                    Spacer(minLength: 0)
+                }
+                HStack(spacing: 8) {
+                    statusBadges
+                    contextSummaryLabel
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+    }
+
+    private var detailTimestampLabel: some View {
+        Text(NoteTimestampFormatter.detailTimestamp(for: item))
+            .font(.system(size: 10, design: .monospaced))
+            .foregroundStyle(.tertiary)
+            .textCase(.uppercase)
+            .kerning(0.5)
+            .lineLimit(1)
+    }
+
+    @ViewBuilder
+    private var noteStateIndicator: some View {
+        if isLiveRecording {
+            LiveRecordingBadge()
+        } else if isError {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 10, weight: .light))
+                .foregroundStyle(.red.opacity(0.6))
+                .help("Transcription failed")
+        }
+    }
+
+    @ViewBuilder
+    private var contextSummaryLabel: some View {
+        if !item.contextSummary.isEmpty
+            && !item.contextSummary.hasPrefix("Could not")
+            && item.contextSummary != "Context capture disabled" {
+            Text("·")
+                .foregroundStyle(.quaternary)
+                .font(.system(size: 10))
+            Text(item.contextSummary)
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+        }
+    }
+
     @ViewBuilder
     private var statusBadges: some View {
         HStack(spacing: 5) {
@@ -1044,6 +1076,7 @@ private struct NoteDetailView: View {
                 )
             }
         }
+        .fixedSize(horizontal: true, vertical: false)
     }
 
     private var metaDot: some View {

--- a/Sources/NoteListRowDisplayData.swift
+++ b/Sources/NoteListRowDisplayData.swift
@@ -13,6 +13,68 @@ func transcriptStatus(for item: PipelineHistoryItem, retrying: Set<UUID>) -> Tra
     return .done
 }
 
+enum NoteTimestampFormatter {
+    static func detailTimestamp(for item: PipelineHistoryItem) -> String {
+        intervalTimestamp(
+            for: item,
+            fallbackFormatter: fullDateTimeFormatter,
+            startFormatter: fullDateTimeFormatter,
+            crossDateEndFormatter: fullDateTimeFormatter
+        )
+    }
+
+    static func rowTimestamp(for item: PipelineHistoryItem) -> String {
+        guard let startedAt = item.recordingStartedAt else {
+            return rowSingleTimestampFormatter.string(from: item.timestamp)
+        }
+        return rowStartTimestampFormatter.string(from: startedAt)
+    }
+
+    private static func intervalTimestamp(
+        for item: PipelineHistoryItem,
+        fallbackFormatter: DateFormatter,
+        startFormatter: DateFormatter,
+        crossDateEndFormatter: DateFormatter
+    ) -> String {
+        guard let startedAt = item.recordingStartedAt,
+              let endedAt = item.recordingEndedAt,
+              endedAt >= startedAt else {
+            return fallbackFormatter.string(from: item.timestamp)
+        }
+
+        let startText = startFormatter.string(from: startedAt)
+        guard calendar.isDate(startedAt, inSameDayAs: endedAt) else {
+            return "\(startText) - \(crossDateEndFormatter.string(from: endedAt))"
+        }
+
+        if periodFormatter.string(from: startedAt) == periodFormatter.string(from: endedAt) {
+            return "\(startText) - \(timeFormatter.string(from: endedAt))"
+        }
+        return "\(startText) - \(periodTimeFormatter.string(from: endedAt))"
+    }
+
+    private static let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "ko_KR")
+        return calendar
+    }()
+
+    private static let fullDateTimeFormatter = makeFormatter("yyyy년 M월 d일 a h:mm")
+    private static let rowSingleTimestampFormatter = makeFormatter("M월 d일 · HH:mm")
+    private static let rowStartTimestampFormatter = makeFormatter("M월 d일 a h:mm")
+    private static let periodTimeFormatter = makeFormatter("a h:mm")
+    private static let timeFormatter = makeFormatter("h:mm")
+    private static let periodFormatter = makeFormatter("a")
+
+    private static func makeFormatter(_ dateFormat: String) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = dateFormat
+        return formatter
+    }
+}
+
 struct NoteListRowDisplayData: Equatable {
     let id: UUID
     let status: TranscriptStatus
@@ -32,7 +94,7 @@ struct NoteListRowDisplayData: Equatable {
 
         self.id = item.id
         self.status = status
-        self.rowDate = Self.rowDateFormatter.string(from: item.timestamp)
+        self.rowDate = NoteTimestampFormatter.rowTimestamp(for: item)
         self.displayTitle = displayTitle
         self.preview = Self.preview(
             for: item,
@@ -42,14 +104,6 @@ struct NoteListRowDisplayData: Equatable {
             displayTitle: displayTitle
         )
     }
-
-    private static let rowDateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "M월 d일 · HH:mm"
-        return formatter
-    }()
 
     private static func preview(
         for item: PipelineHistoryItem,

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -23,6 +23,7 @@ struct AppStateTranscriptionConfigurationTests {
         testStoppedTranscriptionCompletionSummaryShowsFallbackIndicatorForNonEmptyRawFallback()
         testStoppedTranscriptionCompletionSummaryHidesFallbackIndicatorForEmptyRawFallback()
         testStoppedTranscriptionSettingsSnapshotCapturesHistoryMetadata()
+        try testGoogleCalendarConnectionMetadataRestoresStartupState()
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
@@ -338,6 +339,20 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(!summary.shouldPersistRawDictationFallback)
     }
 
+    private static func testGoogleCalendarConnectionMetadataRestoresStartupState() throws {
+        resetDefaults()
+        let selectedCalendarIDs: Set<String> = ["primary"]
+        UserDefaults.standard.set(try JSONEncoder().encode(Array(selectedCalendarIDs).sorted()), forKey: "google_calendar_selected_ids")
+        let metadata = GoogleCalendarConnectionMetadata(accountEmail: "user@example.com")
+        UserDefaults.standard.set(try JSONEncoder().encode(metadata), forKey: GoogleCalendarConnectionMetadata.storageKey)
+
+        let appState = AppState()
+
+        assert(appState.googleCalendarConnection.isConnected)
+        assert(appState.googleCalendarConnection.accountEmail == "user@example.com")
+        assert(appState.googleCalendarConnection.selectedCalendarIDs == selectedCalendarIDs)
+    }
+
     private static func testStoppedTranscriptionSettingsSnapshotCapturesHistoryMetadata() {
         let snapshot = StoppedTranscriptionSettingsSnapshot(
             customVocabulary: "team terms",
@@ -375,6 +390,8 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.removeObject(forKey: "command_mode_enabled")
         defaults.removeObject(forKey: "command_mode_style")
         defaults.removeObject(forKey: "command_mode_manual_modifier")
+        defaults.removeObject(forKey: "google_calendar_selected_ids")
+        defaults.removeObject(forKey: GoogleCalendarConnectionMetadata.storageKey)
     }
 
     private static func mirroredTranscriptionConfiguration(_ service: TranscriptionService) -> (

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -24,6 +24,7 @@ struct AppStateTranscriptionConfigurationTests {
         testStoppedTranscriptionCompletionSummaryHidesFallbackIndicatorForEmptyRawFallback()
         testStoppedTranscriptionSettingsSnapshotCapturesHistoryMetadata()
         try testGoogleCalendarConnectionMetadataRestoresStartupState()
+        testGoogleCalendarConnectionMetadataClearsCorruptValue()
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
@@ -351,6 +352,16 @@ struct AppStateTranscriptionConfigurationTests {
         assert(appState.googleCalendarConnection.isConnected)
         assert(appState.googleCalendarConnection.accountEmail == "user@example.com")
         assert(appState.googleCalendarConnection.selectedCalendarIDs == selectedCalendarIDs)
+    }
+
+    private static func testGoogleCalendarConnectionMetadataClearsCorruptValue() {
+        resetDefaults()
+        UserDefaults.standard.set(Data("not-json".utf8), forKey: GoogleCalendarConnectionMetadata.storageKey)
+
+        let appState = AppState()
+
+        assert(!appState.googleCalendarConnection.isConnected)
+        assert(UserDefaults.standard.data(forKey: GoogleCalendarConnectionMetadata.storageKey) == nil)
     }
 
     private static func testStoppedTranscriptionSettingsSnapshotCapturesHistoryMetadata() {

--- a/Tests/NoteListRowDisplayDataTests.swift
+++ b/Tests/NoteListRowDisplayDataTests.swift
@@ -4,6 +4,14 @@ import Foundation
 struct NoteListRowDisplayDataTests {
     static func main() {
         testFormatsRowDate()
+        testFormatsSameMorningRowDateStartTime()
+        testFormatsMorningToAfternoonRowDateStartTime()
+        testFormatsCrossDateRowDateStartTime()
+        testFormatsSameMorningRecordingInterval()
+        testFormatsMorningToAfternoonRecordingInterval()
+        testFormatsSameAfternoonRecordingInterval()
+        testFormatsCrossDateRecordingInterval()
+        testUsesSingleTimestampWhenRecordingIntervalIsMissing()
         testUsesItemCustomTitleAndContentPreview()
         testDropsAutomaticTitleFromPreview()
         testWhitespaceOnlyCustomTitleDoesNotForceContentPreview()
@@ -15,22 +23,116 @@ struct NoteListRowDisplayDataTests {
     }
 
     private static func testFormatsRowDate() {
-        var components = DateComponents()
-        components.calendar = Calendar(identifier: .gregorian)
-        components.timeZone = .current
-        components.year = 2025
-        components.month = 5
-        components.day = 5
-        components.hour = 9
-        components.minute = 0
         let item = historyItem(
-            timestamp: components.date!,
+            timestamp: date(year: 2025, month: 5, day: 5, hour: 9, minute: 0),
             transcript: "Team sync notes"
         )
 
         let data = NoteListRowDisplayData(item: item, retryingIDs: [])
 
         assert(data.rowDate == "5월 5일 · 09:00", "Unexpected row date: \(data.rowDate)")
+    }
+
+    private static func testFormatsSameMorningRowDateStartTime() {
+        let item = historyItem(
+            timestamp: date(year: 2026, month: 5, day: 15, hour: 11, minute: 12),
+            recordingStartedAt: date(year: 2026, month: 5, day: 15, hour: 10, minute: 38),
+            recordingEndedAt: date(year: 2026, month: 5, day: 15, hour: 11, minute: 12),
+            transcript: "Morning notes"
+        )
+
+        let data = NoteListRowDisplayData(item: item, retryingIDs: [])
+
+        assert(data.rowDate == "5월 15일 오전 10:38", "Unexpected row date: \(data.rowDate)")
+    }
+
+    private static func testFormatsMorningToAfternoonRowDateStartTime() {
+        let item = historyItem(
+            timestamp: date(year: 2026, month: 5, day: 15, hour: 12, minute: 12),
+            recordingStartedAt: date(year: 2026, month: 5, day: 15, hour: 10, minute: 38),
+            recordingEndedAt: date(year: 2026, month: 5, day: 15, hour: 12, minute: 12),
+            transcript: "Noon notes"
+        )
+
+        let data = NoteListRowDisplayData(item: item, retryingIDs: [])
+
+        assert(data.rowDate == "5월 15일 오전 10:38", "Unexpected row date: \(data.rowDate)")
+    }
+
+    private static func testFormatsCrossDateRowDateStartTime() {
+        let item = historyItem(
+            timestamp: date(year: 2026, month: 5, day: 16, hour: 0, minute: 10),
+            recordingStartedAt: date(year: 2026, month: 5, day: 15, hour: 23, minute: 40),
+            recordingEndedAt: date(year: 2026, month: 5, day: 16, hour: 0, minute: 10),
+            transcript: "Late notes"
+        )
+
+        let data = NoteListRowDisplayData(item: item, retryingIDs: [])
+
+        assert(data.rowDate == "5월 15일 오후 11:40", "Unexpected row date: \(data.rowDate)")
+    }
+
+    private static func testFormatsSameMorningRecordingInterval() {
+        let item = historyItem(
+            timestamp: date(year: 2026, month: 5, day: 15, hour: 11, minute: 12),
+            recordingStartedAt: date(year: 2026, month: 5, day: 15, hour: 10, minute: 38),
+            recordingEndedAt: date(year: 2026, month: 5, day: 15, hour: 11, minute: 12),
+            transcript: "Morning notes"
+        )
+
+        let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
+
+        assert(formatted == "2026년 5월 15일 오전 10:38 - 11:12", "Unexpected interval: \(formatted)")
+    }
+
+    private static func testFormatsMorningToAfternoonRecordingInterval() {
+        let item = historyItem(
+            timestamp: date(year: 2026, month: 5, day: 15, hour: 12, minute: 12),
+            recordingStartedAt: date(year: 2026, month: 5, day: 15, hour: 10, minute: 38),
+            recordingEndedAt: date(year: 2026, month: 5, day: 15, hour: 12, minute: 12),
+            transcript: "Noon notes"
+        )
+
+        let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
+
+        assert(formatted == "2026년 5월 15일 오전 10:38 - 오후 12:12", "Unexpected interval: \(formatted)")
+    }
+
+    private static func testFormatsSameAfternoonRecordingInterval() {
+        let item = historyItem(
+            timestamp: date(year: 2026, month: 5, day: 15, hour: 14, minute: 22),
+            recordingStartedAt: date(year: 2026, month: 5, day: 15, hour: 13, minute: 5),
+            recordingEndedAt: date(year: 2026, month: 5, day: 15, hour: 14, minute: 22),
+            transcript: "Afternoon notes"
+        )
+
+        let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
+
+        assert(formatted == "2026년 5월 15일 오후 1:05 - 2:22", "Unexpected interval: \(formatted)")
+    }
+
+    private static func testFormatsCrossDateRecordingInterval() {
+        let item = historyItem(
+            timestamp: date(year: 2026, month: 5, day: 16, hour: 0, minute: 10),
+            recordingStartedAt: date(year: 2026, month: 5, day: 15, hour: 23, minute: 40),
+            recordingEndedAt: date(year: 2026, month: 5, day: 16, hour: 0, minute: 10),
+            transcript: "Late notes"
+        )
+
+        let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
+
+        assert(formatted == "2026년 5월 15일 오후 11:40 - 2026년 5월 16일 오전 12:10", "Unexpected interval: \(formatted)")
+    }
+
+    private static func testUsesSingleTimestampWhenRecordingIntervalIsMissing() {
+        let item = historyItem(
+            timestamp: date(year: 2026, month: 5, day: 15, hour: 10, minute: 38),
+            transcript: "Imported notes"
+        )
+
+        let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
+
+        assert(formatted == "2026년 5월 15일 오전 10:38", "Unexpected timestamp: \(formatted)")
     }
 
     private static func testUsesItemCustomTitleAndContentPreview() {
@@ -114,6 +216,8 @@ struct NoteListRowDisplayDataTests {
     private static func historyItem(
         id: UUID = UUID(),
         timestamp: Date = Date(timeIntervalSince1970: 1),
+        recordingStartedAt: Date? = nil,
+        recordingEndedAt: Date? = nil,
         transcript: String,
         postProcessingStatus: String = "Post-processing succeeded",
         customTitle: String? = nil
@@ -121,6 +225,8 @@ struct NoteListRowDisplayDataTests {
         PipelineHistoryItem(
             id: id,
             timestamp: timestamp,
+            recordingStartedAt: recordingStartedAt,
+            recordingEndedAt: recordingEndedAt,
             rawTranscript: transcript,
             postProcessedTranscript: transcript,
             postProcessingPrompt: nil,
@@ -133,5 +239,17 @@ struct NoteListRowDisplayDataTests {
             customVocabulary: "",
             customTitle: customTitle
         )
+    }
+
+    private static func date(year: Int, month: Int, day: Int, hour: Int, minute: Int) -> Date {
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = .current
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        return components.date!
     }
 }

--- a/Tests/PipelineHistoryCalendarMetadataTests.swift
+++ b/Tests/PipelineHistoryCalendarMetadataTests.swift
@@ -9,7 +9,23 @@ struct PipelineHistoryCalendarMetadataTests {
         try testLegacyEncodedHistoryItemDecodesMissingCalendarMetadataAsNil()
         try testCustomTitlePersistsThroughPipelineHistoryStore()
         try testCalendarMetadataPersistsThroughPipelineHistoryStore()
+        testStartupTokenLoadPolicyOnlyLoadsForEnabledRemindersWithSelectedCalendars()
         print("PipelineHistoryCalendarMetadataTests passed")
+    }
+
+    private static func testStartupTokenLoadPolicyOnlyLoadsForEnabledRemindersWithSelectedCalendars() {
+        assert(!GoogleCalendarStartupTokenLoadPolicy.shouldLoadToken(
+            remindersEnabled: false,
+            selectedCalendarIDs: ["primary"]
+        ))
+        assert(!GoogleCalendarStartupTokenLoadPolicy.shouldLoadToken(
+            remindersEnabled: true,
+            selectedCalendarIDs: []
+        ))
+        assert(GoogleCalendarStartupTokenLoadPolicy.shouldLoadToken(
+            remindersEnabled: true,
+            selectedCalendarIDs: ["primary"]
+        ))
     }
 
     private static func testCustomTitleRoundTripsThroughPipelineHistoryItemCodable() throws {

--- a/Tests/PipelineHistoryCalendarMetadataTests.swift
+++ b/Tests/PipelineHistoryCalendarMetadataTests.swift
@@ -9,12 +9,18 @@ struct PipelineHistoryCalendarMetadataTests {
         try testLegacyEncodedHistoryItemDecodesMissingCalendarMetadataAsNil()
         try testCustomTitlePersistsThroughPipelineHistoryStore()
         try testCalendarMetadataPersistsThroughPipelineHistoryStore()
-        testStartupTokenLoadPolicyDisallowsAuthenticationUI()
+        testGoogleCalendarConnectionMetadataBuildsConnectedState()
         print("PipelineHistoryCalendarMetadataTests passed")
     }
 
-    private static func testStartupTokenLoadPolicyDisallowsAuthenticationUI() {
-        assert(!GoogleCalendarStartupTokenLoadPolicy.allowsAuthenticationUI)
+    private static func testGoogleCalendarConnectionMetadataBuildsConnectedState() {
+        let metadata = GoogleCalendarConnectionMetadata(accountEmail: "user@example.com")
+        let state = metadata.connectionState(selectedCalendarIDs: ["primary"])
+
+        assert(state.isConnected)
+        assert(state.accountEmail == "user@example.com")
+        assert(state.selectedCalendarIDs == ["primary"])
+        assert(state.lastErrorMessage == nil)
     }
 
     private static func testCustomTitleRoundTripsThroughPipelineHistoryItemCodable() throws {

--- a/Tests/PipelineHistoryCalendarMetadataTests.swift
+++ b/Tests/PipelineHistoryCalendarMetadataTests.swift
@@ -9,23 +9,11 @@ struct PipelineHistoryCalendarMetadataTests {
         try testLegacyEncodedHistoryItemDecodesMissingCalendarMetadataAsNil()
         try testCustomTitlePersistsThroughPipelineHistoryStore()
         try testCalendarMetadataPersistsThroughPipelineHistoryStore()
-        testStartupTokenLoadPolicyAlwaysAttemptsSilentLoad()
+        testStartupTokenLoadPolicyDisallowsAuthenticationUI()
         print("PipelineHistoryCalendarMetadataTests passed")
     }
 
-    private static func testStartupTokenLoadPolicyAlwaysAttemptsSilentLoad() {
-        assert(GoogleCalendarStartupTokenLoadPolicy.shouldLoadToken(
-            remindersEnabled: false,
-            selectedCalendarIDs: ["primary"]
-        ))
-        assert(GoogleCalendarStartupTokenLoadPolicy.shouldLoadToken(
-            remindersEnabled: true,
-            selectedCalendarIDs: []
-        ))
-        assert(GoogleCalendarStartupTokenLoadPolicy.shouldLoadToken(
-            remindersEnabled: true,
-            selectedCalendarIDs: ["primary"]
-        ))
+    private static func testStartupTokenLoadPolicyDisallowsAuthenticationUI() {
         assert(!GoogleCalendarStartupTokenLoadPolicy.allowsAuthenticationUI)
     }
 

--- a/Tests/PipelineHistoryCalendarMetadataTests.swift
+++ b/Tests/PipelineHistoryCalendarMetadataTests.swift
@@ -9,16 +9,16 @@ struct PipelineHistoryCalendarMetadataTests {
         try testLegacyEncodedHistoryItemDecodesMissingCalendarMetadataAsNil()
         try testCustomTitlePersistsThroughPipelineHistoryStore()
         try testCalendarMetadataPersistsThroughPipelineHistoryStore()
-        testStartupTokenLoadPolicyOnlyLoadsForEnabledRemindersWithSelectedCalendars()
+        testStartupTokenLoadPolicyAlwaysAttemptsSilentLoad()
         print("PipelineHistoryCalendarMetadataTests passed")
     }
 
-    private static func testStartupTokenLoadPolicyOnlyLoadsForEnabledRemindersWithSelectedCalendars() {
-        assert(!GoogleCalendarStartupTokenLoadPolicy.shouldLoadToken(
+    private static func testStartupTokenLoadPolicyAlwaysAttemptsSilentLoad() {
+        assert(GoogleCalendarStartupTokenLoadPolicy.shouldLoadToken(
             remindersEnabled: false,
             selectedCalendarIDs: ["primary"]
         ))
-        assert(!GoogleCalendarStartupTokenLoadPolicy.shouldLoadToken(
+        assert(GoogleCalendarStartupTokenLoadPolicy.shouldLoadToken(
             remindersEnabled: true,
             selectedCalendarIDs: []
         ))
@@ -26,6 +26,7 @@ struct PipelineHistoryCalendarMetadataTests {
             remindersEnabled: true,
             selectedCalendarIDs: ["primary"]
         ))
+        assert(!GoogleCalendarStartupTokenLoadPolicy.allowsAuthenticationUI)
     }
 
     private static func testCustomTitleRoundTripsThroughPipelineHistoryItemCodable() throws {


### PR DESCRIPTION
## Summary
- Show recording intervals in the note detail header using recording start/end metadata.
- Keep the note list compact by showing only each recording's start time.
- Avoid unnecessary Google Calendar token reads during startup unless reminders need them.

## Test plan
- [x] make test
- [x] Build the Quill Dev app with the Makefile
- [x] Launch build/Quill Dev.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Google Calendar 연결 복구가 사용자별 메타데이터 기반으로 개선되어 더 안정적으로 초기화 및 동기화됩니다.
  * 노트 상세의 메타 영역이 구조화되어 헤더 표시가 더 일관되고 안정적으로 렌더링됩니다.
  * 행 타임스탬프 처리 로직이 분리되어 날짜/시간 표시가 더 정확해졌습니다.

* **Tests**
  * Google Calendar 메타데이터 복원/오류 처리 테스트 추가
  * 타임스탬프 포맷팅 규칙 검증 테스트 확대

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/freeflow/pull/99)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->