### PR TITLE
Improve Google Calendar sync status

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -102,6 +102,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
             startMCPServer()
             appState.startCalendarRecordingReminderScheduling()
+            appState.startGoogleCalendarHealthCheck()
         }
 
     }
@@ -303,6 +304,7 @@ private func showNoteBrowserWindow() {
         appState.startHotkeyMonitoring()
         appState.startAccessibilityPolling()
         appState.startCalendarRecordingReminderScheduling()
+        appState.startGoogleCalendarHealthCheck()
         // Quill releases are not distributed through the in-app updater yet.
         // Task { @MainActor in
         //     UpdateManager.shared.startPeriodicChecks()

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -224,16 +224,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     static var googleCalendarServiceFactory: () -> GoogleCalendarService = {
         GoogleCalendarService()
     }
-    static var googleCalendarReconnectPrompter: (String) -> Bool = { message in
-        let alert = NSAlert()
-        alert.messageText = "Reconnect Google Calendar?"
-        alert.informativeText = message
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: "Reconnect")
-        alert.addButton(withTitle: "Later")
-        alert.icon = NSImage(systemSymbolName: "calendar.badge.exclamationmark", accessibilityDescription: nil)
-        return alert.runModal() == .alertFirstButtonReturn
-    }
 
     private struct TranscriptionJob {
         let id: UUID
@@ -952,7 +942,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var currentRecordingLiveNoteID: UUID?
     private var activeRecordingStartedAt: Date?
     private var isCancelConfirmationShowing = false
-    private var hasShownGoogleCalendarReconnectPrompt = false
     private var overlayTranscriptionID: UUID = UUID()
     private var foregroundTranscriptionJobID: UUID?
     private var activeTranscriptionJobs: [UUID: TranscriptionJob] = [:]
@@ -1612,9 +1601,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func markGoogleCalendarNeedsReconnect(feature: GoogleCalendarHealthFeature, message: String) {
-        let shouldPrompt = googleCalendarConnection.isConnected
-            && googleCalendarConnection.health.status != .needsReconnect
-            && !hasShownGoogleCalendarReconnectPrompt
         googleCalendarConnection.lastErrorMessage = message
         googleCalendarConnection.health = GoogleCalendarHealth(
             status: .needsReconnect,
@@ -1622,13 +1608,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
             message: message,
             affectedFeature: feature
         )
-        guard shouldPrompt else { return }
-        hasShownGoogleCalendarReconnectPrompt = true
-        let shouldReconnect = Self.googleCalendarReconnectPrompter(message)
-        guard shouldReconnect else { return }
-        DispatchQueue.main.async { [weak self] in
-            self?.connectGoogleCalendar()
-        }
     }
 
     @MainActor

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1471,7 +1471,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         "Google Calendar needs reconnecting. Reconnect to restore meeting reminders and calendar-based note titles."
     }
 
-    private static func isGoogleCalendarReconnectError(_ error: Error) -> Bool {
+    static func isGoogleCalendarReconnectError(_ error: Error) -> Bool {
         if error is GoogleCalendarHealthError { return true }
         guard let oauthError = error as? GoogleCalendarAuthService.OAuthError else { return false }
         switch oauthError {
@@ -1480,7 +1480,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         case .requestFailed:
             return false
         case .response(let code, _):
-            return ["invalid_grant", "invalid_client", "unauthorized_client"].contains(code)
+            return code == "invalid_grant"
         }
     }
 
@@ -1590,7 +1590,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
-    private func markGoogleCalendarHealthy(feature: GoogleCalendarHealthFeature) {
+    func markGoogleCalendarHealthy(feature: GoogleCalendarHealthFeature) {
+        if googleCalendarConnection.health.status != .healthy,
+           let affectedFeature = googleCalendarConnection.health.affectedFeature,
+           affectedFeature != feature {
+            return
+        }
         googleCalendarConnection.lastErrorMessage = nil
         googleCalendarConnection.health = GoogleCalendarHealth(
             status: .healthy,
@@ -1611,7 +1616,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
-    private func markGoogleCalendarTemporarilyUnavailable(feature: GoogleCalendarHealthFeature, message: String) {
+    func markGoogleCalendarTemporarilyUnavailable(feature: GoogleCalendarHealthFeature, message: String) {
         googleCalendarConnection.lastErrorMessage = message
         googleCalendarConnection.health = GoogleCalendarHealth(
             status: .temporaryFailure,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -218,6 +218,23 @@ private enum SessionIntent {
 }
 
 final class AppState: ObservableObject, @unchecked Sendable {
+    static var googleCalendarTokenLoader: (Bool) -> GoogleCalendarOAuthToken? = { allowsAuthenticationUI in
+        GoogleCalendarTokenStore.load(allowsAuthenticationUI: allowsAuthenticationUI)
+    }
+    static var googleCalendarServiceFactory: () -> GoogleCalendarService = {
+        GoogleCalendarService()
+    }
+    static var googleCalendarReconnectPrompter: (String) -> Bool = { message in
+        let alert = NSAlert()
+        alert.messageText = "Reconnect Google Calendar?"
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Reconnect")
+        alert.addButton(withTitle: "Later")
+        alert.icon = NSImage(systemSymbolName: "calendar.badge.exclamationmark", accessibilityDescription: nil)
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
     private struct TranscriptionJob {
         let id: UUID
         let startedAt: Date
@@ -279,8 +296,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let realtimeStreamingModelStorageKey = "realtime_streaming_model"
     private let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
     private let recordingOverlayLayoutStorageKey = "recording_overlay_layout"
-    private let googleCalendarClientIDStorageKey = "google_calendar_client_id"
-    private let googleCalendarClientSecretStorageKey = "google_calendar_client_secret"
     private let googleCalendarSelectedIDsStorageKey = "google_calendar_selected_ids"
     private let calendarRecordingRemindersEnabledStorageKey = "calendar_recording_reminders_enabled"
     private let calendarRecordingReminderLeadMinutesStorageKey = "calendar_recording_reminder_lead_minutes"
@@ -522,27 +537,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    @Published var googleCalendarClientID: String {
-        didSet {
-            let trimmed = googleCalendarClientID.trimmingCharacters(in: .whitespacesAndNewlines)
-            UserDefaults.standard.set(trimmed, forKey: googleCalendarClientIDStorageKey)
-            guard trimmed != oldValue.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
-            Task { @MainActor in
-                self.clearGoogleCalendarConnectionState()
-            }
-        }
-    }
-
-    @Published var googleCalendarClientSecret: String {
-        didSet {
-            persistOptionalAPIValue(googleCalendarClientSecret, account: googleCalendarClientSecretStorageKey)
-            guard googleCalendarClientSecret.trimmingCharacters(in: .whitespacesAndNewlines) != oldValue.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
-            Task { @MainActor in
-                self.clearGoogleCalendarConnectionState()
-            }
-        }
-    }
-
     @Published private(set) var googleCalendarConnection = GoogleCalendarConnectionState.disconnected
     @Published private(set) var availableGoogleCalendars: [GoogleCalendarInfo] = []
     @Published private(set) var isGoogleCalendarBusy = false
@@ -578,9 +572,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
             scheduleCalendarRecordingReminderRefreshFromPropertyChange()
         }
     }
-
-    @Published private(set) var isRefreshingCalendarRecordingReminders = false
-    @Published private(set) var calendarRecordingReminderStatusMessage: String?
 
     private var builtInGoogleCalendarClientID: String {
         Bundle.main.object(forInfoDictionaryKey: "GoogleCalendarOAuthClientID") as? String ?? ""
@@ -767,9 +758,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     var googleCalendarOAuthConfiguration: GoogleCalendarOAuthConfiguration {
         GoogleCalendarOAuthConfiguration(
             builtInClientID: builtInGoogleCalendarClientID,
-            builtInClientSecret: builtInGoogleCalendarClientSecret,
-            customClientID: googleCalendarClientID,
-            customClientSecret: googleCalendarClientSecret
+            builtInClientSecret: builtInGoogleCalendarClientSecret
         )
     }
 
@@ -795,7 +784,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         availableGoogleCalendars = []
         googleCalendarConnection = .disconnected
         UserDefaults.standard.removeObject(forKey: googleCalendarSelectedIDsStorageKey)
-        calendarRecordingReminderScheduler.stop()
+        stopCalendarRecordingReminderSchedulerIfNeeded()
     }
 
     @MainActor
@@ -807,6 +796,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func loadStoredGoogleCalendarConnection() {
+        guard !isGoogleCalendarBusy else { return }
+        Task { [weak self] in
+            await self?.loadGoogleCalendars(force: true)
+        }
+    }
+
+    @MainActor
+    func startGoogleCalendarHealthCheck() {
+        guard googleCalendarConnection.isConnected else { return }
         guard !isGoogleCalendarBusy else { return }
         Task { [weak self] in
             await self?.loadGoogleCalendars(force: true)
@@ -954,6 +952,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var currentRecordingLiveNoteID: UUID?
     private var activeRecordingStartedAt: Date?
     private var isCancelConfirmationShowing = false
+    private var hasShownGoogleCalendarReconnectPrompt = false
     private var overlayTranscriptionID: UUID = UUID()
     private var foregroundTranscriptionJobID: UUID?
     private var activeTranscriptionJobs: [UUID: TranscriptionJob] = [:]
@@ -968,6 +967,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         guard let self else { return [] }
         return try await self.fetchCalendarRecordingReminderEvents(timeMin: timeMin, timeMax: timeMax)
     }
+    private var isCalendarRecordingReminderSchedulerActive = false
     private var hasShownScreenshotPermissionAlert = false
     private var isEscapeCancelAlertPresented = false
     private var shouldTerminateAfterTranscription = false
@@ -1064,8 +1064,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let recordingOverlayLayout = RecordingOverlayLayout.find(
             rawValue: UserDefaults.standard.string(forKey: recordingOverlayLayoutStorageKey)
         )
-        let googleCalendarClientID = UserDefaults.standard.string(forKey: googleCalendarClientIDStorageKey) ?? ""
-        let googleCalendarClientSecret = Self.loadOptionalStoredAPIValue(account: googleCalendarClientSecretStorageKey)
         let selectedGoogleCalendarIDs = Self.loadStringSet(forKey: googleCalendarSelectedIDsStorageKey)
         let storedGoogleCalendarConnectionMetadata = Self.loadGoogleCalendarConnectionMetadata()
         let calendarRecordingRemindersEnabled = UserDefaults.standard.bool(forKey: calendarRecordingRemindersEnabledStorageKey)
@@ -1179,8 +1177,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.realtimeStreamingModel = realtimeStreamingModel
         self.dictationAudioInterruptionEnabled = dictationAudioInterruptionEnabled
         self.recordingOverlayLayout = recordingOverlayLayout
-        self.googleCalendarClientID = googleCalendarClientID
-        self.googleCalendarClientSecret = googleCalendarClientSecret
         self.googleCalendarConnection = storedGoogleCalendarConnectionMetadata?.connectionState(
             selectedCalendarIDs: selectedGoogleCalendarIDs
         ) ?? .disconnected
@@ -1471,19 +1467,47 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return trimmed.isEmpty ? apiKey : trimmed
     }
 
-    private func validGoogleCalendarToken() async throws -> GoogleCalendarOAuthToken? {
-        guard var token = GoogleCalendarTokenStore.load() else { return nil }
-        let oauthConfiguration = await MainActor.run {
-            googleCalendarOAuthConfiguration
+    private enum GoogleCalendarHealthError: LocalizedError {
+        case needsReconnect
+
+        var errorDescription: String? {
+            switch self {
+            case .needsReconnect:
+                return "Google Calendar needs reconnecting."
+            }
         }
-        guard oauthConfiguration.isConfigured else { return nil }
+    }
+
+    private static func googleCalendarReconnectMessage() -> String {
+        "Google Calendar needs reconnecting. Reconnect to restore meeting reminders and calendar-based note titles."
+    }
+
+    private static func isGoogleCalendarReconnectError(_ error: Error) -> Bool {
+        if error is GoogleCalendarHealthError { return true }
+        guard let oauthError = error as? GoogleCalendarAuthService.OAuthError else { return false }
+        switch oauthError {
+        case .missingRefreshToken:
+            return true
+        case .requestFailed:
+            return false
+        case .response(let code, _):
+            return ["invalid_grant", "invalid_client", "unauthorized_client"].contains(code)
+        }
+    }
+
+    private func validGoogleCalendarToken(allowsAuthenticationUI: Bool = true) async throws -> GoogleCalendarOAuthToken? {
+        guard var token = Self.googleCalendarTokenLoader(allowsAuthenticationUI) else { return nil }
         if token.needsRefresh {
+            let oauthConfiguration = await MainActor.run {
+                googleCalendarOAuthConfiguration
+            }
+            guard oauthConfiguration.isConfigured else { return nil }
             token = try await GoogleCalendarAuthService.refreshToken(
                 clientID: oauthConfiguration.clientID,
                 clientSecret: oauthConfiguration.clientSecret,
                 token: token
             )
-            try GoogleCalendarTokenStore.save(token)
+            try GoogleCalendarTokenStore.save(token, allowsAuthenticationUI: allowsAuthenticationUI)
         }
         return token
     }
@@ -1491,13 +1515,51 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func fetchCalendarRecordingReminderEvents(timeMin: Date, timeMax: Date) async throws -> [GoogleCalendarEvent] {
         let selectedCalendarIDs = await MainActor.run { googleCalendarConnection.selectedCalendarIDs }
         guard !selectedCalendarIDs.isEmpty else { return [] }
-        guard let token = try await validGoogleCalendarToken() else { return [] }
-        return await GoogleCalendarService().fetchEventsSkippingFailures(
+        let token: GoogleCalendarOAuthToken
+        do {
+            guard let loadedToken = try await validGoogleCalendarToken() else {
+                await MainActor.run {
+                    markGoogleCalendarNeedsReconnect(
+                        feature: .recordingReminders,
+                        message: "Google Calendar needs reconnecting. Reconnect to restore meeting reminders."
+                    )
+                }
+                throw GoogleCalendarHealthError.needsReconnect
+            }
+            token = loadedToken
+        } catch {
+            await MainActor.run {
+                if Self.isGoogleCalendarReconnectError(error) {
+                    markGoogleCalendarNeedsReconnect(
+                        feature: .recordingReminders,
+                        message: "Google Calendar needs reconnecting. Reconnect to restore meeting reminders."
+                    )
+                } else {
+                    markGoogleCalendarTemporarilyUnavailable(
+                        feature: .recordingReminders,
+                        message: "Unable to refresh Google Calendar reminders: \(error.localizedDescription)"
+                    )
+                }
+            }
+            throw error
+        }
+        let fetchResult = await Self.googleCalendarServiceFactory().fetchEventsWithDiagnostics(
             accessToken: token.accessToken,
             calendarIDs: Array(selectedCalendarIDs),
             timeMin: timeMin,
             timeMax: timeMax
         )
+        await MainActor.run {
+            if fetchResult.failedCalendarIDs.isEmpty {
+                markGoogleCalendarHealthy(feature: .recordingReminders)
+            } else {
+                markGoogleCalendarTemporarilyUnavailable(
+                    feature: .recordingReminders,
+                    message: "Some Google calendars could not be refreshed. Reminders may be incomplete."
+                )
+            }
+        }
+        return fetchResult.events
     }
 
     @MainActor
@@ -1507,41 +1569,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func stopCalendarRecordingReminderScheduling() {
-        calendarRecordingReminderScheduler.stop()
+        stopCalendarRecordingReminderSchedulerIfNeeded()
     }
 
     @MainActor
-    func refreshCalendarRecordingRemindersNow() {
-        guard calendarRecordingRemindersEnabled,
-              googleCalendarConnection.isConnected,
-              !googleCalendarConnection.selectedCalendarIDs.isEmpty else {
-            calendarRecordingReminderScheduler.stop()
-            calendarRecordingReminderStatusMessage = "Connect Google Calendar, select calendars, and enable reminders first."
-            return
-        }
-        guard !isRefreshingCalendarRecordingReminders else { return }
-        let leadMinutes = calendarRecordingReminderLeadMinutes
-        isRefreshingCalendarRecordingReminders = true
-        calendarRecordingReminderStatusMessage = "Refreshing reminders..."
-        Task { [weak self] in
-            guard let self else { return }
-            do {
-                let count = try await self.calendarRecordingReminderScheduler.rescheduleNow(
-                    leadMinutes: leadMinutes
-                )
-                await MainActor.run {
-                    self.calendarRecordingReminderStatusMessage = count == 1
-                        ? "Scheduled 1 meeting reminder."
-                        : "Scheduled \(count) meeting reminders."
-                    self.isRefreshingCalendarRecordingReminders = false
-                }
-            } catch {
-                await MainActor.run {
-                    self.calendarRecordingReminderStatusMessage = "Unable to refresh reminders: \(error.localizedDescription)"
-                    self.isRefreshingCalendarRecordingReminders = false
-                }
-            }
-        }
+    private func stopCalendarRecordingReminderSchedulerIfNeeded() {
+        guard isCalendarRecordingReminderSchedulerActive else { return }
+        calendarRecordingReminderScheduler.stop()
+        isCalendarRecordingReminderSchedulerActive = false
     }
 
     private func scheduleCalendarRecordingReminderRefreshFromPropertyChange() {
@@ -1555,37 +1590,90 @@ final class AppState: ObservableObject, @unchecked Sendable {
         guard calendarRecordingRemindersEnabled,
               googleCalendarConnection.isConnected,
               !googleCalendarConnection.selectedCalendarIDs.isEmpty else {
-            calendarRecordingReminderScheduler.stop()
+            stopCalendarRecordingReminderSchedulerIfNeeded()
             return
         }
         calendarRecordingReminderScheduler.start(
             leadMinutes: calendarRecordingReminderLeadMinutes,
             refreshIntervalMinutes: calendarRecordingReminderRefreshIntervalMinutes
         )
+        isCalendarRecordingReminderSchedulerActive = true
     }
 
     @MainActor
-    private func loadGoogleCalendars(force: Bool = false) async {
+    private func markGoogleCalendarHealthy(feature: GoogleCalendarHealthFeature) {
+        googleCalendarConnection.lastErrorMessage = nil
+        googleCalendarConnection.health = GoogleCalendarHealth(
+            status: .healthy,
+            checkedAt: Date(),
+            affectedFeature: feature
+        )
+    }
+
+    @MainActor
+    private func markGoogleCalendarNeedsReconnect(feature: GoogleCalendarHealthFeature, message: String) {
+        let shouldPrompt = googleCalendarConnection.isConnected
+            && googleCalendarConnection.health.status != .needsReconnect
+            && !hasShownGoogleCalendarReconnectPrompt
+        googleCalendarConnection.lastErrorMessage = message
+        googleCalendarConnection.health = GoogleCalendarHealth(
+            status: .needsReconnect,
+            checkedAt: Date(),
+            message: message,
+            affectedFeature: feature
+        )
+        guard shouldPrompt else { return }
+        hasShownGoogleCalendarReconnectPrompt = true
+        let shouldReconnect = Self.googleCalendarReconnectPrompter(message)
+        guard shouldReconnect else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.connectGoogleCalendar()
+        }
+    }
+
+    @MainActor
+    private func markGoogleCalendarTemporarilyUnavailable(feature: GoogleCalendarHealthFeature, message: String) {
+        googleCalendarConnection.lastErrorMessage = message
+        googleCalendarConnection.health = GoogleCalendarHealth(
+            status: .temporaryFailure,
+            checkedAt: Date(),
+            message: message,
+            affectedFeature: feature
+        )
+    }
+
+    @MainActor
+    func loadGoogleCalendars(force: Bool = false) async {
         guard force || !isGoogleCalendarBusy else { return }
         isGoogleCalendarBusy = true
         defer { isGoogleCalendarBusy = false }
         do {
             guard let token = try await validGoogleCalendarToken() else {
-                calendarRecordingReminderScheduler.stop()
-                Self.clearGoogleCalendarConnectionMetadata()
-                googleCalendarConnection = .disconnected
-                availableGoogleCalendars = []
+                markGoogleCalendarNeedsReconnect(
+                    feature: .calendarList,
+                    message: Self.googleCalendarReconnectMessage()
+                )
                 return
             }
-            let calendars = try await GoogleCalendarService().fetchCalendars(accessToken: token.accessToken)
+            let calendars = try await Self.googleCalendarServiceFactory().fetchCalendars(accessToken: token.accessToken)
             Self.saveGoogleCalendarConnectionMetadata(accountEmail: token.accountEmail)
             availableGoogleCalendars = calendars
             googleCalendarConnection.isConnected = true
             googleCalendarConnection.accountEmail = token.accountEmail
-            googleCalendarConnection.lastErrorMessage = nil
+            markGoogleCalendarHealthy(feature: .calendarList)
             scheduleCalendarRecordingReminderRefresh()
         } catch {
-            googleCalendarConnection.lastErrorMessage = error.localizedDescription
+            if Self.isGoogleCalendarReconnectError(error) {
+                markGoogleCalendarNeedsReconnect(
+                    feature: .calendarList,
+                    message: Self.googleCalendarReconnectMessage()
+                )
+            } else {
+                markGoogleCalendarTemporarilyUnavailable(
+                    feature: .calendarList,
+                    message: "Unable to refresh Google Calendar: \(error.localizedDescription)"
+                )
+            }
         }
     }
 
@@ -4690,6 +4778,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         do {
             guard let token = try await validGoogleCalendarToken() else {
                 os_log(.info, log: calendarLog, "Calendar match skipped: no valid Google Calendar token for job %{public}@", jobID.uuidString)
+                await MainActor.run {
+                    markGoogleCalendarNeedsReconnect(
+                        feature: .recordingMatch,
+                        message: "Google Calendar needs reconnecting. Calendar-based note titles may be unavailable."
+                    )
+                }
                 return nil
             }
             os_log(
@@ -4701,13 +4795,19 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 Self.logTimestamp(recordingStartedAt),
                 Self.logTimestamp(recordingEndedAt)
             )
-            let fetchResult = await GoogleCalendarService().fetchEventsWithDiagnostics(
+            let fetchResult = await Self.googleCalendarServiceFactory().fetchEventsWithDiagnostics(
                 accessToken: token.accessToken,
                 calendarIDs: Array(selectedCalendarIDs),
                 timeMin: recordingStartedAt,
                 timeMax: recordingEndedAt
             )
             if !fetchResult.failedCalendarIDs.isEmpty {
+                await MainActor.run {
+                    markGoogleCalendarTemporarilyUnavailable(
+                        feature: .recordingMatch,
+                        message: "Some Google calendars could not be refreshed. Calendar-based note titles may be incomplete."
+                    )
+                }
                 os_log(
                     .error,
                     log: calendarLog,
@@ -4717,6 +4817,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     fetchResult.events.count
                 )
             } else {
+                await MainActor.run {
+                    markGoogleCalendarHealthy(feature: .recordingMatch)
+                }
                 os_log(
                     .info,
                     log: calendarLog,
@@ -4765,7 +4868,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 error.localizedDescription
             )
             await MainActor.run {
-                googleCalendarConnection.lastErrorMessage = error.localizedDescription
+                if Self.isGoogleCalendarReconnectError(error) {
+                    markGoogleCalendarNeedsReconnect(
+                        feature: .recordingMatch,
+                        message: "Google Calendar needs reconnecting. Calendar-based note titles may be unavailable."
+                    )
+                } else {
+                    markGoogleCalendarTemporarilyUnavailable(
+                        feature: .recordingMatch,
+                        message: "Unable to refresh Google Calendar for note titles: \(error.localizedDescription)"
+                    )
+                }
             }
             return nil
         }

--- a/Sources/CalendarIntegrationModels.swift
+++ b/Sources/CalendarIntegrationModels.swift
@@ -175,13 +175,79 @@ struct GoogleCalendarEvent: Identifiable, Equatable {
     }
 }
 
+enum GoogleCalendarHealthStatus: String, Codable, Equatable {
+    case unknown
+    case healthy
+    case needsReconnect
+    case temporaryFailure
+}
+
+enum GoogleCalendarHealthFeature: String, Codable, Equatable {
+    case calendarList
+    case recordingReminders
+    case recordingMatch
+}
+
+struct GoogleCalendarHealth: Codable, Equatable {
+    var status: GoogleCalendarHealthStatus
+    var checkedAt: Date?
+    var message: String?
+    var affectedFeature: GoogleCalendarHealthFeature?
+
+    static let unknown = GoogleCalendarHealth(status: .unknown)
+
+    init(
+        status: GoogleCalendarHealthStatus,
+        checkedAt: Date? = nil,
+        message: String? = nil,
+        affectedFeature: GoogleCalendarHealthFeature? = nil
+    ) {
+        self.status = status
+        self.checkedAt = checkedAt
+        self.message = message
+        self.affectedFeature = affectedFeature
+    }
+}
+
 struct GoogleCalendarConnectionState: Codable, Equatable {
     var isConnected: Bool
     var accountEmail: String?
     var selectedCalendarIDs: Set<String>
     var lastErrorMessage: String?
+    var health: GoogleCalendarHealth
 
     static let disconnected = GoogleCalendarConnectionState(isConnected: false, accountEmail: nil, selectedCalendarIDs: [], lastErrorMessage: nil)
+
+    init(
+        isConnected: Bool,
+        accountEmail: String?,
+        selectedCalendarIDs: Set<String>,
+        lastErrorMessage: String?,
+        health: GoogleCalendarHealth = .unknown
+    ) {
+        self.isConnected = isConnected
+        self.accountEmail = accountEmail
+        self.selectedCalendarIDs = selectedCalendarIDs
+        self.lastErrorMessage = lastErrorMessage
+        self.health = health
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case isConnected
+        case accountEmail
+        case selectedCalendarIDs
+        case lastErrorMessage
+        case health
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        isConnected = try container.decode(Bool.self, forKey: .isConnected)
+        accountEmail = try container.decodeIfPresent(String.self, forKey: .accountEmail)
+        selectedCalendarIDs = try container.decode(Set<String>.self, forKey: .selectedCalendarIDs)
+        lastErrorMessage = try container.decodeIfPresent(String.self, forKey: .lastErrorMessage)
+        health = try container.decodeIfPresent(GoogleCalendarHealth.self, forKey: .health) ?? .unknown
+    }
 }
 
 struct GoogleCalendarConnectionMetadata: Codable, Equatable {
@@ -225,8 +291,6 @@ struct GoogleCalendarConnectionControls: Equatable {
 struct GoogleCalendarOAuthConfiguration: Equatable {
     let builtInClientID: String
     let builtInClientSecret: String
-    let customClientID: String
-    let customClientSecret: String
 
     private var trimmedBuiltInClientID: String {
         builtInClientID.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -236,25 +300,15 @@ struct GoogleCalendarOAuthConfiguration: Equatable {
         builtInClientSecret.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private var trimmedCustomClientID: String {
-        customClientID.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var trimmedCustomClientSecret: String {
-        customClientSecret.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    var usesCustomCredentials: Bool {
-        !trimmedCustomClientID.isEmpty
-    }
+    var usesCustomCredentials: Bool { false }
 
     var clientID: String {
-        usesCustomCredentials ? trimmedCustomClientID : trimmedBuiltInClientID
+        trimmedBuiltInClientID
     }
 
     var clientSecret: String {
         guard isConfigured else { return "" }
-        return usesCustomCredentials ? trimmedCustomClientSecret : trimmedBuiltInClientSecret
+        return trimmedBuiltInClientSecret
     }
 
     var isConfigured: Bool {

--- a/Sources/GoogleCalendarTokenStore.swift
+++ b/Sources/GoogleCalendarTokenStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import LocalAuthentication
 import Security
 
 struct GoogleCalendarOAuthToken: Codable, Equatable {
@@ -16,14 +17,30 @@ enum GoogleCalendarTokenStore {
     private static let service = (Bundle.main.bundleIdentifier ?? "com.woosublee.quill") + ".google-calendar"
     private static let account = "oauth-token"
 
-    static func load() -> GoogleCalendarOAuthToken? {
-        let query: [String: Any] = [
+    static func itemQuery(allowsAuthenticationUI: Bool) -> [String: Any] {
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne
+            kSecAttrAccount as String: account
         ]
+        if !allowsAuthenticationUI {
+            let context = LAContext()
+            context.interactionNotAllowed = true
+            query[kSecUseAuthenticationContext as String] = context
+            query[kSecUseAuthenticationUI as String] = "fail"
+        }
+        return query
+    }
+
+    static func loadQuery(allowsAuthenticationUI: Bool) -> [String: Any] {
+        var query = itemQuery(allowsAuthenticationUI: allowsAuthenticationUI)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        return query
+    }
+
+    static func load(allowsAuthenticationUI: Bool = true) -> GoogleCalendarOAuthToken? {
+        let query = loadQuery(allowsAuthenticationUI: allowsAuthenticationUI)
         var result: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         guard status == errSecSuccess,
@@ -33,13 +50,9 @@ enum GoogleCalendarTokenStore {
         return try? JSONDecoder().decode(GoogleCalendarOAuthToken.self, from: data)
     }
 
-    static func save(_ token: GoogleCalendarOAuthToken) throws {
+    static func save(_ token: GoogleCalendarOAuthToken, allowsAuthenticationUI: Bool = true) throws {
         let data = try JSONEncoder().encode(token)
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account
-        ]
+        let query = itemQuery(allowsAuthenticationUI: allowsAuthenticationUI)
         let update: [String: Any] = [kSecValueData as String: data]
         let status = SecItemUpdate(query as CFDictionary, update as CFDictionary)
         if status == errSecSuccess { return }
@@ -55,12 +68,8 @@ enum GoogleCalendarTokenStore {
         throw KeychainError(status: status)
     }
 
-    static func delete() {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account
-        ]
+    static func delete(allowsAuthenticationUI: Bool = true) {
+        let query = itemQuery(allowsAuthenticationUI: allowsAuthenticationUI)
         SecItemDelete(query as CFDictionary)
     }
 

--- a/Sources/KeychainStorage.swift
+++ b/Sources/KeychainStorage.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Security
 
 enum AppSettingsStorage {
     private static let bundleID = Bundle.main.bundleIdentifier ?? "com.woosublee.quill"
@@ -66,52 +65,10 @@ enum AppSettingsStorage {
     private static let migrationDoneKey = "keychain_migration_done"
 
     private static func migrateFromKeychainIfNeeded(account: String) {
-        let dict = loadSettings()
+        var dict = loadSettings()
         if dict[migrationDoneKey] != nil { return }
-
-        // Try to load from Keychain
-        if let keychainValue = loadFromKeychain(account: account),
-           !keychainValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            var updated = dict
-            updated[account] = keychainValue
-            updated[migrationDoneKey] = "true"
-            writeSettings(updated)
-            // Clean up old keychain entry
-            deleteFromKeychain(account: account)
-        } else {
-            // Mark migration as done even if nothing was in Keychain
-            var updated = dict
-            updated[migrationDoneKey] = "true"
-            writeSettings(updated)
-        }
+        dict[migrationDoneKey] = "true"
+        writeSettings(dict)
     }
 
-    // MARK: - Legacy Keychain helpers (for migration only)
-
-    private static func loadFromKeychain(account: String) -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: bundleID,
-            kSecAttrAccount as String: account,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne
-        ]
-        var result: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess,
-              let data = result as? Data,
-              let value = String(data: data, encoding: .utf8) else {
-            return nil
-        }
-        return value
-    }
-
-    private static func deleteFromKeychain(account: String) {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: bundleID,
-            kSecAttrAccount as String: account
-        ]
-        SecItemDelete(query as CFDictionary)
-    }
 }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -719,7 +719,6 @@ struct OverlayLayoutPreview: View {
 
 struct CalendarSettingsView: View {
     @EnvironmentObject var appState: AppState
-    @State private var showsAdvancedGoogleCalendarSettings = false
     @State private var notificationAuthorizationStatus: UNAuthorizationStatus = .notDetermined
 
     private var selectedCalendarCount: Int {
@@ -732,6 +731,17 @@ struct CalendarSettingsView: View {
 
     private var connectionControls: GoogleCalendarConnectionControls {
         appState.googleCalendarConnectionControls
+    }
+
+    private var calendarRecordingRemindersEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { appState.calendarRecordingRemindersEnabled },
+            set: { enabled in
+                appState.calendarRecordingRemindersEnabled = enabled
+                guard enabled else { return }
+                handleCalendarReminderNotificationAuthorization()
+            }
+        )
     }
 
     var body: some View {
@@ -760,6 +770,88 @@ struct CalendarSettingsView: View {
         }
     }
 
+    @ViewBuilder
+    private var googleCalendarConnectionStatusLabel: some View {
+        if appState.googleCalendarConnection.isConnected {
+            switch appState.googleCalendarConnection.health.status {
+            case .unknown:
+                Label("Connected · Not checked yet", systemImage: "questionmark.circle")
+                    .foregroundStyle(.secondary)
+            case .healthy:
+                Label(googleCalendarHealthyStatusTitle, systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            case .needsReconnect:
+                Label("Reconnect required", systemImage: "calendar.badge.exclamationmark")
+                    .foregroundStyle(.red)
+            case .temporaryFailure:
+                Label("Calendar refresh issue", systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+            }
+        } else {
+            Label("Not connected", systemImage: "xmark.circle")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var googleCalendarHealthyStatusTitle: String {
+        guard let checkedAt = appState.googleCalendarConnection.health.checkedAt else {
+            return "Connected"
+        }
+        return "Connected · Last checked \(checkedAt.formatted(date: .omitted, time: .shortened))"
+    }
+
+    private var googleCalendarHealthMessage: String? {
+        guard appState.googleCalendarConnection.isConnected else { return nil }
+        let health = appState.googleCalendarConnection.health
+        switch health.status {
+        case .unknown, .healthy:
+            return nil
+        case .needsReconnect:
+            return health.message ?? "Quill can’t access Google Calendar. Reconnect to restore meeting reminders and calendar-based note titles."
+        case .temporaryFailure:
+            return health.message ?? "Quill couldn’t refresh Google Calendar just now. Recording still works; reminders or note titles may be incomplete."
+        }
+    }
+
+    private var googleCalendarReminderHealthMessage: String? {
+        guard appState.googleCalendarConnection.isConnected else { return nil }
+        let health = appState.googleCalendarConnection.health
+        guard health.affectedFeature == .recordingReminders else { return nil }
+        switch health.status {
+        case .needsReconnect:
+            return "Reconnect Google Calendar to keep meeting recording reminders working."
+        case .temporaryFailure:
+            return "Calendar reminders may be incomplete until the next successful refresh."
+        case .unknown, .healthy:
+            return nil
+        }
+    }
+
+    private var googleCalendarHealthMessageIcon: String {
+        appState.googleCalendarConnection.health.status == .needsReconnect
+            ? "calendar.badge.exclamationmark"
+            : "exclamationmark.triangle.fill"
+    }
+
+    private var googleCalendarHealthMessageColor: Color {
+        appState.googleCalendarConnection.health.status == .needsReconnect ? .red : .orange
+    }
+
+    private func calendarRefreshIntervalTitle(_ minutes: Int) -> String {
+        minutes == 60 ? "Every hour" : "Every \(minutes) minutes"
+    }
+
+    @ViewBuilder
+    private func refreshActivityIndicator(isVisible: Bool) -> some View {
+        if isVisible {
+            ProgressView()
+                .controlSize(.small)
+                .scaleEffect(0.7)
+                .allowsHitTesting(false)
+                .accessibilityLabel("Refreshing")
+        }
+    }
+
     private var googleCalendarSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             VStack(alignment: .leading, spacing: 6) {
@@ -767,7 +859,7 @@ struct CalendarSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 if !appState.googleCalendarOAuthConfiguration.isConfigured {
-                    Text("Google Calendar sign-in is not configured. Add a Google OAuth Desktop client ID in Advanced settings.")
+                    Text("Google Calendar sign-in is not configured for this build.")
                         .font(.caption)
                         .foregroundStyle(.orange)
                         .fixedSize(horizontal: false, vertical: true)
@@ -775,22 +867,22 @@ struct CalendarSettingsView: View {
             }
 
             HStack(spacing: 8) {
-                if appState.googleCalendarConnection.isConnected {
-                    Label("Connected", systemImage: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
-                    if let email = appState.googleCalendarConnection.accountEmail, !email.isEmpty {
-                        Text(email)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                } else {
-                    Label("Not connected", systemImage: "xmark.circle")
+                googleCalendarConnectionStatusLabel
+                if appState.googleCalendarConnection.isConnected,
+                   let email = appState.googleCalendarConnection.accountEmail,
+                   !email.isEmpty {
+                    Text(email)
+                        .font(.caption)
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
-                if appState.isGoogleCalendarBusy {
-                    ProgressView().scaleEffect(0.7)
-                }
+            }
+
+            if let healthMessage = googleCalendarHealthMessage {
+                Label(healthMessage, systemImage: googleCalendarHealthMessageIcon)
+                    .font(.caption)
+                    .foregroundStyle(googleCalendarHealthMessageColor)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             HStack {
@@ -803,7 +895,7 @@ struct CalendarSettingsView: View {
                 }
                 .disabled(!connectionControls.allowsPrimaryAction)
 
-                Button("Refresh Calendars") {
+                Button("Sync Now") {
                     appState.refreshGoogleCalendars()
                 }
                 .disabled(!connectionControls.allowsRefresh)
@@ -813,29 +905,38 @@ struct CalendarSettingsView: View {
                 }
                 .disabled(!connectionControls.allowsDisconnect)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .overlay(alignment: .trailing) {
+                refreshActivityIndicator(isVisible: appState.isGoogleCalendarBusy)
+            }
 
-            DisclosureGroup("Advanced OAuth credentials", isExpanded: $showsAdvancedGoogleCalendarSettings) {
+            if appState.googleCalendarConnection.isConnected {
+                Divider()
+
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Use custom Google OAuth Desktop app credentials for development or personal testing. Leave these empty to use the built-in app configuration.")
+                    HStack {
+                        Text("Refresh calendars")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Picker("Refresh calendars", selection: $appState.calendarRecordingReminderRefreshIntervalMinutes) {
+                            ForEach(CalendarRecordingReminderScheduler.refreshIntervalMinuteOptions, id: \.self) { minutes in
+                                Text(calendarRefreshIntervalTitle(minutes)).tag(minutes)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .labelsHidden()
+                        .disabled(!appState.googleCalendarConnection.isConnected)
+                    }
+                    Text("Quill re-reads selected Google Calendar events on this interval to keep meeting reminders and calendar-based note titles current.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                    Text("Google OAuth Desktop client ID")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                    TextField("client-id.apps.googleusercontent.com", text: $appState.googleCalendarClientID)
-                        .textFieldStyle(.roundedBorder)
-                    Text("Google OAuth client secret")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                    SecureField("Optional for some Google OAuth clients", text: $appState.googleCalendarClientSecret)
-                        .textFieldStyle(.roundedBorder)
                 }
-                .padding(.top, 6)
             }
-            .font(.caption.weight(.semibold))
 
-            if let error = appState.googleCalendarConnection.lastErrorMessage, !error.isEmpty {
+            if googleCalendarHealthMessage == nil,
+               let error = appState.googleCalendarConnection.lastErrorMessage,
+               !error.isEmpty {
                 Text(error)
                     .font(.caption)
                     .foregroundStyle(.red)
@@ -850,7 +951,7 @@ struct CalendarSettingsView: View {
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(.secondary)
                     if appState.availableGoogleCalendars.isEmpty {
-                        Text("No calendars loaded. Click Refresh Calendars after connecting.")
+                        Text("No calendars loaded. Click Sync Now after connecting.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     } else {
@@ -872,7 +973,7 @@ struct CalendarSettingsView: View {
         VStack(alignment: .leading, spacing: 12) {
             Toggle(
                 "Remind me before meetings to record",
-                isOn: $appState.calendarRecordingRemindersEnabled
+                isOn: calendarRecordingRemindersEnabledBinding
             )
             .disabled(calendarReminderSettingsDisabled)
 
@@ -891,40 +992,17 @@ struct CalendarSettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
+            if let reminderHealthMessage = googleCalendarReminderHealthMessage {
+                Label(reminderHealthMessage, systemImage: "calendar.badge.exclamationmark")
+                    .font(.caption)
+                    .foregroundStyle(googleCalendarHealthMessageColor)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
             if notificationAuthorizationStatus == .denied {
                 Label("Notifications are disabled in System Settings.", systemImage: "bell.slash")
                     .font(.caption)
                     .foregroundStyle(.orange)
-            }
-
-            Divider()
-
-            VStack(alignment: .leading, spacing: 6) {
-                HStack(spacing: 8) {
-                    Button(appState.isRefreshingCalendarRecordingReminders ? "Refreshing..." : "Refresh Reminders Now") {
-                        appState.refreshCalendarRecordingRemindersNow()
-                    }
-                    .disabled(
-                        calendarReminderSettingsDisabled
-                        || !appState.calendarRecordingRemindersEnabled
-                        || appState.isRefreshingCalendarRecordingReminders
-                    )
-
-                    if appState.isRefreshingCalendarRecordingReminders {
-                        ProgressView()
-                            .controlSize(.small)
-                    }
-
-                    Text("Fetches upcoming events now and rebuilds scheduled reminders.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                if let message = appState.calendarRecordingReminderStatusMessage {
-                    Text(message)
-                        .font(.caption)
-                        .foregroundStyle(message.hasPrefix("Unable") ? .red : .secondary)
-                }
             }
 
             VStack(alignment: .leading, spacing: 8) {
@@ -940,23 +1018,36 @@ struct CalendarSettingsView: View {
                 .labelsHidden()
                 .disabled(calendarReminderSettingsDisabled || !appState.calendarRecordingRemindersEnabled)
             }
+        }
+    }
 
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Calendar refresh")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                Picker("Calendar refresh", selection: $appState.calendarRecordingReminderRefreshIntervalMinutes) {
-                    ForEach(CalendarRecordingReminderScheduler.refreshIntervalMinuteOptions, id: \.self) { minutes in
-                        Text("Every \(minutes) min").tag(minutes)
-                    }
+    private func handleCalendarReminderNotificationAuthorization() {
+        Task {
+            let settings = await AppNotificationManager.shared.notificationSettings()
+            await MainActor.run {
+                notificationAuthorizationStatus = settings.authorizationStatus
+                switch settings.authorizationStatus {
+                case .denied:
+                    openNotificationSettings()
+                case .notDetermined:
+                    requestNotificationPermission()
+                default:
+                    break
                 }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .disabled(calendarReminderSettingsDisabled || !appState.calendarRecordingRemindersEnabled)
-                Text("Quill refreshes upcoming events while the app is running, then lets macOS deliver the scheduled reminders.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
+        }
+    }
+
+    private func requestNotificationPermission() {
+        Task {
+            _ = await AppNotificationManager.shared.requestAuthorization()
+            refreshNotificationAuthorizationStatus()
+        }
+    }
+
+    private func openNotificationSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.notifications") {
+            NSWorkspace.shared.open(url)
         }
     }
 

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -28,7 +28,6 @@ struct AppStateTranscriptionConfigurationTests {
         await testGoogleCalendarStoredCustomOAuthCredentialsAreIgnored()
         await testGoogleCalendarRefreshMarksNeedsReconnectWhenTokenMissing()
         await testGoogleCalendarRefreshMarksNeedsReconnectWhenRefreshTokenIsMissing()
-        await testGoogleCalendarNeedsReconnectShowsPromptOnce()
         await testGoogleCalendarHealthCheckRunsForConnectedMetadataWithoutSelectedCalendars()
         await testGoogleCalendarRefreshMarksTemporaryFailureWhenCalendarListFails()
         await testGoogleCalendarRefreshMarksHealthyWhenCalendarListLoads()
@@ -375,14 +374,15 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testGoogleCalendarStoredCustomOAuthCredentialsAreIgnored() async {
         resetDefaults()
-        UserDefaults.standard.set("custom-client-id.apps.googleusercontent.com", forKey: "google_calendar_client_id")
+        let customClientID = "custom-client-id.apps.googleusercontent.com"
+        UserDefaults.standard.set(customClientID, forKey: "google_calendar_client_id")
 
         let configuration = await MainActor.run {
             AppState().googleCalendarOAuthConfiguration
         }
 
         assert(!configuration.usesCustomCredentials)
-        assert(configuration.clientID.isEmpty)
+        assert(configuration.clientID != customClientID)
     }
 
     private static func testGoogleCalendarRefreshMarksNeedsReconnectWhenTokenMissing() async {
@@ -394,13 +394,10 @@ struct AppStateTranscriptionConfigurationTests {
             forKey: GoogleCalendarConnectionMetadata.storageKey
         )
         let originalTokenLoader = AppState.googleCalendarTokenLoader
-        let originalReconnectPrompter = AppState.googleCalendarReconnectPrompter
         defer {
             AppState.googleCalendarTokenLoader = originalTokenLoader
-            AppState.googleCalendarReconnectPrompter = originalReconnectPrompter
         }
         AppState.googleCalendarTokenLoader = { _ in nil }
-        AppState.googleCalendarReconnectPrompter = { _ in false }
 
         let appState = AppState()
         await appState.loadGoogleCalendars(force: true)
@@ -420,15 +417,12 @@ struct AppStateTranscriptionConfigurationTests {
             forKey: GoogleCalendarConnectionMetadata.storageKey
         )
         let originalTokenLoader = AppState.googleCalendarTokenLoader
-        let originalReconnectPrompter = AppState.googleCalendarReconnectPrompter
         defer {
             AppState.googleCalendarTokenLoader = originalTokenLoader
-            AppState.googleCalendarReconnectPrompter = originalReconnectPrompter
         }
         AppState.googleCalendarTokenLoader = { _ in
             GoogleCalendarOAuthToken(accessToken: "expired-token", refreshToken: nil, expiresAt: Date(timeIntervalSince1970: 0), accountEmail: "user@example.com")
         }
-        AppState.googleCalendarReconnectPrompter = { _ in false }
 
         let appState = AppState()
         await appState.loadGoogleCalendars(force: true)
@@ -438,33 +432,6 @@ struct AppStateTranscriptionConfigurationTests {
         assert(appState.googleCalendarConnection.health.affectedFeature == .calendarList)
     }
 
-    private static func testGoogleCalendarNeedsReconnectShowsPromptOnce() async {
-        resetDefaults()
-        UserDefaults.standard.set(
-            try! JSONEncoder().encode(GoogleCalendarConnectionMetadata(accountEmail: "user@example.com")),
-            forKey: GoogleCalendarConnectionMetadata.storageKey
-        )
-        let originalTokenLoader = AppState.googleCalendarTokenLoader
-        let originalReconnectPrompter = AppState.googleCalendarReconnectPrompter
-        var promptCount = 0
-        defer {
-            AppState.googleCalendarTokenLoader = originalTokenLoader
-            AppState.googleCalendarReconnectPrompter = originalReconnectPrompter
-        }
-        AppState.googleCalendarTokenLoader = { _ in nil }
-        AppState.googleCalendarReconnectPrompter = { message in
-            promptCount += 1
-            assert(message.contains("Google Calendar"))
-            return false
-        }
-
-        let appState = AppState()
-        await appState.loadGoogleCalendars(force: true)
-        await appState.loadGoogleCalendars(force: true)
-
-        assert(promptCount == 1)
-    }
-
     private static func testGoogleCalendarHealthCheckRunsForConnectedMetadataWithoutSelectedCalendars() async {
         resetDefaults()
         UserDefaults.standard.set(
@@ -472,24 +439,16 @@ struct AppStateTranscriptionConfigurationTests {
             forKey: GoogleCalendarConnectionMetadata.storageKey
         )
         let originalTokenLoader = AppState.googleCalendarTokenLoader
-        let originalReconnectPrompter = AppState.googleCalendarReconnectPrompter
-        var promptCount = 0
         defer {
             AppState.googleCalendarTokenLoader = originalTokenLoader
-            AppState.googleCalendarReconnectPrompter = originalReconnectPrompter
         }
         AppState.googleCalendarTokenLoader = { _ in nil }
-        AppState.googleCalendarReconnectPrompter = { _ in
-            promptCount += 1
-            return false
-        }
 
         let appState = AppState()
         await appState.startGoogleCalendarHealthCheck()
-        await waitUntil { promptCount == 1 }
+        await waitUntil { appState.googleCalendarConnection.health.status == .needsReconnect }
 
         assert(appState.googleCalendarConnection.health.status == .needsReconnect)
-        assert(promptCount == 1)
     }
 
     private static func testGoogleCalendarRefreshMarksTemporaryFailureWhenCalendarListFails() async {
@@ -556,7 +515,7 @@ struct AppStateTranscriptionConfigurationTests {
     }
 
     private static func waitUntil(
-        timeoutNanoseconds: UInt64 = 500_000_000,
+        timeoutNanoseconds: UInt64 = 1_000_000_000,
         condition: @escaping () -> Bool
     ) async {
         let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -28,6 +28,8 @@ struct AppStateTranscriptionConfigurationTests {
         await testGoogleCalendarStoredCustomOAuthCredentialsAreIgnored()
         await testGoogleCalendarRefreshMarksNeedsReconnectWhenTokenMissing()
         await testGoogleCalendarRefreshMarksNeedsReconnectWhenRefreshTokenIsMissing()
+        testGoogleCalendarReconnectErrorClassificationSeparatesClientConfigurationFailures()
+        await testGoogleCalendarHealthyDoesNotClearDifferentFeatureFailure()
         await testGoogleCalendarHealthCheckRunsForConnectedMetadataWithoutSelectedCalendars()
         await testGoogleCalendarRefreshMarksTemporaryFailureWhenCalendarListFails()
         await testGoogleCalendarRefreshMarksHealthyWhenCalendarListLoads()
@@ -430,6 +432,32 @@ struct AppStateTranscriptionConfigurationTests {
         assert(appState.googleCalendarConnection.isConnected)
         assert(appState.googleCalendarConnection.health.status == .needsReconnect)
         assert(appState.googleCalendarConnection.health.affectedFeature == .calendarList)
+    }
+
+    private static func testGoogleCalendarReconnectErrorClassificationSeparatesClientConfigurationFailures() {
+        assert(AppState.isGoogleCalendarReconnectError(GoogleCalendarAuthService.OAuthError.response("invalid_grant", "Bad refresh token")))
+        assert(!AppState.isGoogleCalendarReconnectError(GoogleCalendarAuthService.OAuthError.response("invalid_client", "Bad client")))
+        assert(!AppState.isGoogleCalendarReconnectError(GoogleCalendarAuthService.OAuthError.response("unauthorized_client", "Unauthorized client")))
+    }
+
+    private static func testGoogleCalendarHealthyDoesNotClearDifferentFeatureFailure() async {
+        resetDefaults()
+        UserDefaults.standard.set(
+            try! JSONEncoder().encode(GoogleCalendarConnectionMetadata(accountEmail: "user@example.com")),
+            forKey: GoogleCalendarConnectionMetadata.storageKey
+        )
+        let appState = AppState()
+        await MainActor.run {
+            appState.markGoogleCalendarTemporarilyUnavailable(
+                feature: .recordingReminders,
+                message: "Reminder refresh failed"
+            )
+            appState.markGoogleCalendarHealthy(feature: .recordingMatch)
+        }
+
+        assert(appState.googleCalendarConnection.health.status == .temporaryFailure)
+        assert(appState.googleCalendarConnection.health.affectedFeature == .recordingReminders)
+        assert(appState.googleCalendarConnection.lastErrorMessage == "Reminder refresh failed")
     }
 
     private static func testGoogleCalendarHealthCheckRunsForConnectedMetadataWithoutSelectedCalendars() async {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -3,7 +3,7 @@ import Foundation
 
 @main
 struct AppStateTranscriptionConfigurationTests {
-    static func main() throws {
+    static func main() async throws {
         try testMakeTranscriptionServiceUsesLocalConfiguration()
         try testMakeTranscriptionServiceMapsEmptyLocalWhisperPathToNil()
         testPermissionStatusUpdateSkipsUnchangedValues()
@@ -25,6 +25,13 @@ struct AppStateTranscriptionConfigurationTests {
         testStoppedTranscriptionSettingsSnapshotCapturesHistoryMetadata()
         try testGoogleCalendarConnectionMetadataRestoresStartupState()
         testGoogleCalendarConnectionMetadataClearsCorruptValue()
+        await testGoogleCalendarStoredCustomOAuthCredentialsAreIgnored()
+        await testGoogleCalendarRefreshMarksNeedsReconnectWhenTokenMissing()
+        await testGoogleCalendarRefreshMarksNeedsReconnectWhenRefreshTokenIsMissing()
+        await testGoogleCalendarNeedsReconnectShowsPromptOnce()
+        await testGoogleCalendarHealthCheckRunsForConnectedMetadataWithoutSelectedCalendars()
+        await testGoogleCalendarRefreshMarksTemporaryFailureWhenCalendarListFails()
+        await testGoogleCalendarRefreshMarksHealthyWhenCalendarListLoads()
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
@@ -352,6 +359,8 @@ struct AppStateTranscriptionConfigurationTests {
         assert(appState.googleCalendarConnection.isConnected)
         assert(appState.googleCalendarConnection.accountEmail == "user@example.com")
         assert(appState.googleCalendarConnection.selectedCalendarIDs == selectedCalendarIDs)
+        assert(appState.googleCalendarConnection.health.status == .unknown)
+        assert(appState.googleCalendarConnection.health.checkedAt == nil)
     }
 
     private static func testGoogleCalendarConnectionMetadataClearsCorruptValue() {
@@ -363,6 +372,202 @@ struct AppStateTranscriptionConfigurationTests {
         assert(!appState.googleCalendarConnection.isConnected)
         assert(UserDefaults.standard.data(forKey: GoogleCalendarConnectionMetadata.storageKey) == nil)
     }
+
+    private static func testGoogleCalendarStoredCustomOAuthCredentialsAreIgnored() async {
+        resetDefaults()
+        UserDefaults.standard.set("custom-client-id.apps.googleusercontent.com", forKey: "google_calendar_client_id")
+
+        let configuration = await MainActor.run {
+            AppState().googleCalendarOAuthConfiguration
+        }
+
+        assert(!configuration.usesCustomCredentials)
+        assert(configuration.clientID.isEmpty)
+    }
+
+    private static func testGoogleCalendarRefreshMarksNeedsReconnectWhenTokenMissing() async {
+        resetDefaults()
+        let selectedCalendarIDs: Set<String> = ["primary"]
+        UserDefaults.standard.set(try! JSONEncoder().encode(Array(selectedCalendarIDs).sorted()), forKey: "google_calendar_selected_ids")
+        UserDefaults.standard.set(
+            try! JSONEncoder().encode(GoogleCalendarConnectionMetadata(accountEmail: "user@example.com")),
+            forKey: GoogleCalendarConnectionMetadata.storageKey
+        )
+        let originalTokenLoader = AppState.googleCalendarTokenLoader
+        let originalReconnectPrompter = AppState.googleCalendarReconnectPrompter
+        defer {
+            AppState.googleCalendarTokenLoader = originalTokenLoader
+            AppState.googleCalendarReconnectPrompter = originalReconnectPrompter
+        }
+        AppState.googleCalendarTokenLoader = { _ in nil }
+        AppState.googleCalendarReconnectPrompter = { _ in false }
+
+        let appState = AppState()
+        await appState.loadGoogleCalendars(force: true)
+
+        assert(appState.googleCalendarConnection.isConnected)
+        assert(appState.googleCalendarConnection.accountEmail == "user@example.com")
+        assert(appState.googleCalendarConnection.selectedCalendarIDs == selectedCalendarIDs)
+        assert(appState.googleCalendarConnection.health.status == .needsReconnect)
+        assert(appState.googleCalendarConnection.health.affectedFeature == .calendarList)
+    }
+
+    private static func testGoogleCalendarRefreshMarksNeedsReconnectWhenRefreshTokenIsMissing() async {
+        resetDefaults()
+        UserDefaults.standard.set("client-id.apps.googleusercontent.com", forKey: "google_calendar_client_id")
+        UserDefaults.standard.set(
+            try! JSONEncoder().encode(GoogleCalendarConnectionMetadata(accountEmail: "user@example.com")),
+            forKey: GoogleCalendarConnectionMetadata.storageKey
+        )
+        let originalTokenLoader = AppState.googleCalendarTokenLoader
+        let originalReconnectPrompter = AppState.googleCalendarReconnectPrompter
+        defer {
+            AppState.googleCalendarTokenLoader = originalTokenLoader
+            AppState.googleCalendarReconnectPrompter = originalReconnectPrompter
+        }
+        AppState.googleCalendarTokenLoader = { _ in
+            GoogleCalendarOAuthToken(accessToken: "expired-token", refreshToken: nil, expiresAt: Date(timeIntervalSince1970: 0), accountEmail: "user@example.com")
+        }
+        AppState.googleCalendarReconnectPrompter = { _ in false }
+
+        let appState = AppState()
+        await appState.loadGoogleCalendars(force: true)
+
+        assert(appState.googleCalendarConnection.isConnected)
+        assert(appState.googleCalendarConnection.health.status == .needsReconnect)
+        assert(appState.googleCalendarConnection.health.affectedFeature == .calendarList)
+    }
+
+    private static func testGoogleCalendarNeedsReconnectShowsPromptOnce() async {
+        resetDefaults()
+        UserDefaults.standard.set(
+            try! JSONEncoder().encode(GoogleCalendarConnectionMetadata(accountEmail: "user@example.com")),
+            forKey: GoogleCalendarConnectionMetadata.storageKey
+        )
+        let originalTokenLoader = AppState.googleCalendarTokenLoader
+        let originalReconnectPrompter = AppState.googleCalendarReconnectPrompter
+        var promptCount = 0
+        defer {
+            AppState.googleCalendarTokenLoader = originalTokenLoader
+            AppState.googleCalendarReconnectPrompter = originalReconnectPrompter
+        }
+        AppState.googleCalendarTokenLoader = { _ in nil }
+        AppState.googleCalendarReconnectPrompter = { message in
+            promptCount += 1
+            assert(message.contains("Google Calendar"))
+            return false
+        }
+
+        let appState = AppState()
+        await appState.loadGoogleCalendars(force: true)
+        await appState.loadGoogleCalendars(force: true)
+
+        assert(promptCount == 1)
+    }
+
+    private static func testGoogleCalendarHealthCheckRunsForConnectedMetadataWithoutSelectedCalendars() async {
+        resetDefaults()
+        UserDefaults.standard.set(
+            try! JSONEncoder().encode(GoogleCalendarConnectionMetadata(accountEmail: "user@example.com")),
+            forKey: GoogleCalendarConnectionMetadata.storageKey
+        )
+        let originalTokenLoader = AppState.googleCalendarTokenLoader
+        let originalReconnectPrompter = AppState.googleCalendarReconnectPrompter
+        var promptCount = 0
+        defer {
+            AppState.googleCalendarTokenLoader = originalTokenLoader
+            AppState.googleCalendarReconnectPrompter = originalReconnectPrompter
+        }
+        AppState.googleCalendarTokenLoader = { _ in nil }
+        AppState.googleCalendarReconnectPrompter = { _ in
+            promptCount += 1
+            return false
+        }
+
+        let appState = AppState()
+        await appState.startGoogleCalendarHealthCheck()
+        await waitUntil { promptCount == 1 }
+
+        assert(appState.googleCalendarConnection.health.status == .needsReconnect)
+        assert(promptCount == 1)
+    }
+
+    private static func testGoogleCalendarRefreshMarksTemporaryFailureWhenCalendarListFails() async {
+        resetDefaults()
+        UserDefaults.standard.set("client-id.apps.googleusercontent.com", forKey: "google_calendar_client_id")
+        UserDefaults.standard.set(
+            try! JSONEncoder().encode(GoogleCalendarConnectionMetadata(accountEmail: "user@example.com")),
+            forKey: GoogleCalendarConnectionMetadata.storageKey
+        )
+        let originalTokenLoader = AppState.googleCalendarTokenLoader
+        let originalServiceFactory = AppState.googleCalendarServiceFactory
+        defer {
+            AppState.googleCalendarTokenLoader = originalTokenLoader
+            AppState.googleCalendarServiceFactory = originalServiceFactory
+        }
+        AppState.googleCalendarTokenLoader = { _ in
+            GoogleCalendarOAuthToken(accessToken: "access-token", refreshToken: "refresh-token", expiresAt: Date().addingTimeInterval(3600), accountEmail: "user@example.com")
+        }
+        AppState.googleCalendarServiceFactory = {
+            GoogleCalendarService { _ in throw CalendarListFailure() }
+        }
+
+        let appState = AppState()
+        await appState.loadGoogleCalendars(force: true)
+
+        assert(appState.googleCalendarConnection.isConnected)
+        assert(appState.googleCalendarConnection.health.status == .temporaryFailure)
+        assert(appState.googleCalendarConnection.health.affectedFeature == .calendarList)
+    }
+
+    private static func testGoogleCalendarRefreshMarksHealthyWhenCalendarListLoads() async {
+        resetDefaults()
+        UserDefaults.standard.set("client-id.apps.googleusercontent.com", forKey: "google_calendar_client_id")
+        UserDefaults.standard.set(
+            try! JSONEncoder().encode(GoogleCalendarConnectionMetadata(accountEmail: "user@example.com")),
+            forKey: GoogleCalendarConnectionMetadata.storageKey
+        )
+        let originalTokenLoader = AppState.googleCalendarTokenLoader
+        let originalServiceFactory = AppState.googleCalendarServiceFactory
+        defer {
+            AppState.googleCalendarTokenLoader = originalTokenLoader
+            AppState.googleCalendarServiceFactory = originalServiceFactory
+        }
+        AppState.googleCalendarTokenLoader = { _ in
+            GoogleCalendarOAuthToken(accessToken: "access-token", refreshToken: "refresh-token", expiresAt: Date().addingTimeInterval(3600), accountEmail: "user@example.com")
+        }
+        AppState.googleCalendarServiceFactory = {
+            GoogleCalendarService { request in
+                let data = Data("""
+                {"items":[{"id":"primary","summary":"Work","primary":true,"accessRole":"owner"}]}
+                """.utf8)
+                return (data, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+            }
+        }
+
+        let appState = AppState()
+        await appState.loadGoogleCalendars(force: true)
+
+        assert(appState.googleCalendarConnection.isConnected)
+        assert(appState.googleCalendarConnection.health.status == .healthy)
+        assert(appState.googleCalendarConnection.health.affectedFeature == .calendarList)
+        assert(appState.googleCalendarConnection.lastErrorMessage == nil)
+        assert(appState.availableGoogleCalendars.map(\.id) == ["primary"])
+    }
+
+    private static func waitUntil(
+        timeoutNanoseconds: UInt64 = 500_000_000,
+        condition: @escaping () -> Bool
+    ) async {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            if condition() { return }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        assertionFailure("Timed out waiting for condition")
+    }
+
+    private struct CalendarListFailure: Error {}
 
     private static func testStoppedTranscriptionSettingsSnapshotCapturesHistoryMetadata() {
         let snapshot = StoppedTranscriptionSettingsSnapshot(
@@ -401,7 +606,11 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.removeObject(forKey: "command_mode_enabled")
         defaults.removeObject(forKey: "command_mode_style")
         defaults.removeObject(forKey: "command_mode_manual_modifier")
+        defaults.removeObject(forKey: "google_calendar_client_id")
         defaults.removeObject(forKey: "google_calendar_selected_ids")
+        defaults.removeObject(forKey: "calendar_recording_reminders_enabled")
+        defaults.removeObject(forKey: "calendar_recording_reminder_lead_minutes")
+        defaults.removeObject(forKey: "calendar_recording_reminder_refresh_interval_minutes")
         defaults.removeObject(forKey: GoogleCalendarConnectionMetadata.storageKey)
     }
 

--- a/Tests/GoogleCalendarServiceTests.swift
+++ b/Tests/GoogleCalendarServiceTests.swift
@@ -1,5 +1,7 @@
 import CryptoKit
 import Foundation
+import LocalAuthentication
+import Security
 
 @main
 struct GoogleCalendarServiceTests {
@@ -10,8 +12,7 @@ struct GoogleCalendarServiceTests {
         try await testLoopbackReceiverUsesAssignedPort()
         try await testTokenExchangeSurfacesGoogleErrorResponse()
         testClientSecretMissingMessageExplainsClientTypeMismatch()
-        testOAuthConfigurationUsesCustomCredentialsFirst()
-        testOAuthConfigurationFallsBackToBuiltInCredentials()
+        testOAuthConfigurationUsesBuiltInCredentials()
         testOAuthConfigurationReportsMissingClientID()
         try await testTokenExchangeOmitsClientSecret()
         try await testTokenExchangeIncludesClientSecretWhenProvided()
@@ -22,6 +23,8 @@ struct GoogleCalendarServiceTests {
         testCalendarsGroupMyCalendarsBeforeSharedCalendars()
         testConnectionControlsShowCancelDuringOAuthConnection()
         testConnectionControlsAllowForcedRefreshForStoredToken()
+        testTokenStoreDisablesKeychainUIWhenRequested()
+        testTokenStoreDisablesKeychainUIForSaveWhenRequested()
         testSettingsTabsPlaceCalendarAfterAppearance()
         try await testEventsDecodeMinimalFieldsAndExcludeAllDayLaterInMatcher()
         try await testFetchEventsEncodesCalendarIDAsSinglePathSegment()
@@ -126,26 +129,10 @@ struct GoogleCalendarServiceTests {
         assert(error.localizedDescription.contains("Desktop app client"))
     }
 
-    private static func testOAuthConfigurationUsesCustomCredentialsFirst() {
-        let configuration = GoogleCalendarOAuthConfiguration(
-            builtInClientID: "built-in.apps.googleusercontent.com",
-            builtInClientSecret: "built-in-secret",
-            customClientID: " custom.apps.googleusercontent.com ",
-            customClientSecret: " secret-value "
-        )
-
-        assert(configuration.clientID == "custom.apps.googleusercontent.com")
-        assert(configuration.clientSecret == "secret-value")
-        assert(configuration.usesCustomCredentials)
-        assert(configuration.isConfigured)
-    }
-
-    private static func testOAuthConfigurationFallsBackToBuiltInCredentials() {
+    private static func testOAuthConfigurationUsesBuiltInCredentials() {
         let configuration = GoogleCalendarOAuthConfiguration(
             builtInClientID: " built-in.apps.googleusercontent.com ",
-            builtInClientSecret: " built-in-secret ",
-            customClientID: " ",
-            customClientSecret: " secret-value "
+            builtInClientSecret: " built-in-secret "
         )
 
         assert(configuration.clientID == "built-in.apps.googleusercontent.com")
@@ -157,9 +144,7 @@ struct GoogleCalendarServiceTests {
     private static func testOAuthConfigurationReportsMissingClientID() {
         let configuration = GoogleCalendarOAuthConfiguration(
             builtInClientID: " ",
-            builtInClientSecret: " built-in-secret ",
-            customClientID: " ",
-            customClientSecret: " secret-value "
+            builtInClientSecret: " built-in-secret "
         )
 
         assert(configuration.clientID.isEmpty)
@@ -316,6 +301,22 @@ struct GoogleCalendarServiceTests {
         assert(controls.allowsPrimaryAction)
         assert(controls.allowsRefresh)
         assert(controls.allowsDisconnect)
+    }
+
+    private static func testTokenStoreDisablesKeychainUIWhenRequested() {
+        let query = GoogleCalendarTokenStore.loadQuery(allowsAuthenticationUI: false)
+
+        assert(query[kSecUseAuthenticationUI as String] as? String == "fail")
+        let context = query[kSecUseAuthenticationContext as String] as? LAContext
+        assert(context?.interactionNotAllowed == true)
+    }
+
+    private static func testTokenStoreDisablesKeychainUIForSaveWhenRequested() {
+        let query = GoogleCalendarTokenStore.itemQuery(allowsAuthenticationUI: false)
+
+        assert(query[kSecUseAuthenticationUI as String] as? String == "fail")
+        let context = query[kSecUseAuthenticationContext as String] as? LAContext
+        assert(context?.interactionNotAllowed == true)
     }
 
     private static func testSettingsTabsPlaceCalendarAfterAppearance() {


### PR DESCRIPTION
## Summary
- Add Google Calendar health state for connected accounts so reconnect-required and temporary refresh issues are visible.
- Start an asynchronous calendar health check after launch without blocking app startup.
- Simplify Calendar settings around a single `Sync Now` action, a dropdown refresh interval, and reminder-only controls.

## Test plan
- [x] `make test`
- [x] Built and launched the development app locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 앱 시작 및 설정 완료 직후 Google 캘린더 연결 상태 자동 점검 시작

* **개선 사항**
  * 연결 상태(정상/재연결 필요/일시적 실패)에 따른 명확한 메시지·아이콘·색상 표시
  * "캘린더 새로고침"을 "지금 동기화"로 교체 및 동기화 UI 개선
  * 캘린더 리마인더 설정은 알림 권한 흐름에 따라 안내·차단
  * 인증 UI 허용 여부를 고려한 토큰 접근 동작으로 인증 프롬프트 처리 개선

* **테스트**
  * Google 캘린더 연결·헬스 관련 비동기 테스트 추가 및 검증 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/freeflow/pull/101)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->