### PR TITLE
Support multiple meeting reminder lead times

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1077,6 +1077,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
             calendarRecordingReminderLeadMinutes = CalendarRecordingReminderScheduler.normalizedLeadMinutes(
                 storedCalendarRecordingReminderLeadMinuteList
             )
+            if calendarRecordingReminderLeadMinutes != storedCalendarRecordingReminderLeadMinuteList {
+                UserDefaults.standard.set(
+                    calendarRecordingReminderLeadMinutes,
+                    forKey: calendarRecordingReminderLeadMinutesListStorageKey
+                )
+            }
         } else {
             let storedCalendarRecordingReminderLeadMinutes = UserDefaults.standard.object(
                 forKey: legacyCalendarRecordingReminderLeadMinutesStorageKey

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -288,7 +288,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let recordingOverlayLayoutStorageKey = "recording_overlay_layout"
     private let googleCalendarSelectedIDsStorageKey = "google_calendar_selected_ids"
     private let calendarRecordingRemindersEnabledStorageKey = "calendar_recording_reminders_enabled"
-    private let calendarRecordingReminderLeadMinutesStorageKey = "calendar_recording_reminder_lead_minutes"
+    private let legacyCalendarRecordingReminderLeadMinutesStorageKey = "calendar_recording_reminder_lead_minutes"
+    private let calendarRecordingReminderLeadMinutesListStorageKey = "calendar_recording_reminder_lead_minutes_list"
     private let calendarRecordingReminderRefreshIntervalMinutesStorageKey = "calendar_recording_reminder_refresh_interval_minutes"
     private let pendingMutedAudioRestoreStorageKey = "pending_muted_audio_restore"
     private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
@@ -539,14 +540,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    @Published var calendarRecordingReminderLeadMinutes: Int {
+    @Published var calendarRecordingReminderLeadMinutes: [Int] {
         didSet {
             let normalized = CalendarRecordingReminderScheduler.normalizedLeadMinutes(calendarRecordingReminderLeadMinutes)
             if normalized != calendarRecordingReminderLeadMinutes {
                 calendarRecordingReminderLeadMinutes = normalized
                 return
             }
-            UserDefaults.standard.set(calendarRecordingReminderLeadMinutes, forKey: calendarRecordingReminderLeadMinutesStorageKey)
+            UserDefaults.standard.set(calendarRecordingReminderLeadMinutes, forKey: calendarRecordingReminderLeadMinutesListStorageKey)
             scheduleCalendarRecordingReminderRefreshFromPropertyChange()
         }
     }
@@ -733,6 +734,19 @@ final class AppState: ObservableObject, @unchecked Sendable {
         googleCalendarConnection.selectedCalendarIDs = selected
         Self.saveStringSet(selected, forKey: googleCalendarSelectedIDsStorageKey)
         scheduleCalendarRecordingReminderRefresh()
+    }
+
+    @MainActor
+    func setCalendarRecordingReminderLeadTime(_ minutes: Int, isSelected: Bool) {
+        var selection = Set(calendarRecordingReminderLeadMinutes)
+        if isSelected {
+            selection.insert(minutes)
+        } else if selection.count > 1 {
+            selection.remove(minutes)
+        }
+        let normalized = CalendarRecordingReminderScheduler.normalizedLeadMinutes(Array(selection))
+        guard normalized != calendarRecordingReminderLeadMinutes else { return }
+        calendarRecordingReminderLeadMinutes = normalized
     }
 
     @MainActor
@@ -1056,10 +1070,23 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let selectedGoogleCalendarIDs = Self.loadStringSet(forKey: googleCalendarSelectedIDsStorageKey)
         let storedGoogleCalendarConnectionMetadata = Self.loadGoogleCalendarConnectionMetadata()
         let calendarRecordingRemindersEnabled = UserDefaults.standard.bool(forKey: calendarRecordingRemindersEnabledStorageKey)
-        let storedCalendarRecordingReminderLeadMinutes = UserDefaults.standard.object(forKey: calendarRecordingReminderLeadMinutesStorageKey) != nil
-            ? UserDefaults.standard.integer(forKey: calendarRecordingReminderLeadMinutesStorageKey)
-            : CalendarRecordingReminderScheduler.defaultLeadMinutes
-        let calendarRecordingReminderLeadMinutes = CalendarRecordingReminderScheduler.normalizedLeadMinutes(storedCalendarRecordingReminderLeadMinutes)
+        let calendarRecordingReminderLeadMinutes: [Int]
+        if let storedCalendarRecordingReminderLeadMinuteList = UserDefaults.standard.array(
+            forKey: calendarRecordingReminderLeadMinutesListStorageKey
+        ) as? [Int] {
+            calendarRecordingReminderLeadMinutes = CalendarRecordingReminderScheduler.normalizedLeadMinutes(
+                storedCalendarRecordingReminderLeadMinuteList
+            )
+        } else {
+            let storedCalendarRecordingReminderLeadMinutes = UserDefaults.standard.object(
+                forKey: legacyCalendarRecordingReminderLeadMinutesStorageKey
+            ) != nil
+                ? UserDefaults.standard.integer(forKey: legacyCalendarRecordingReminderLeadMinutesStorageKey)
+                : CalendarRecordingReminderScheduler.defaultLeadMinutes
+            calendarRecordingReminderLeadMinutes = CalendarRecordingReminderScheduler.normalizedLeadMinutes([
+                storedCalendarRecordingReminderLeadMinutes
+            ])
+        }
         let storedCalendarRecordingReminderRefreshIntervalMinutes = UserDefaults.standard.object(forKey: calendarRecordingReminderRefreshIntervalMinutesStorageKey) != nil
             ? UserDefaults.standard.integer(forKey: calendarRecordingReminderRefreshIntervalMinutesStorageKey)
             : CalendarRecordingReminderScheduler.defaultRefreshIntervalMinutes

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1086,6 +1086,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
             calendarRecordingReminderLeadMinutes = CalendarRecordingReminderScheduler.normalizedLeadMinutes([
                 storedCalendarRecordingReminderLeadMinutes
             ])
+            UserDefaults.standard.set(
+                calendarRecordingReminderLeadMinutes,
+                forKey: calendarRecordingReminderLeadMinutesListStorageKey
+            )
         }
         let storedCalendarRecordingReminderRefreshIntervalMinutes = UserDefaults.standard.object(forKey: calendarRecordingReminderRefreshIntervalMinutesStorageKey) != nil
             ? UserDefaults.standard.integer(forKey: calendarRecordingReminderRefreshIntervalMinutesStorageKey)

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -965,7 +965,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var googleCalendarConnectionTask: Task<Void, Never>?
     @MainActor
     private lazy var calendarRecordingReminderScheduler = CalendarRecordingReminderScheduler(
-        notificationManager: .shared
+        notificationManager: AppNotificationManager.shared
     ) { [weak self] timeMin, timeMax in
         guard let self else { return [] }
         return try await self.fetchCalendarRecordingReminderEvents(timeMin: timeMin, timeMax: timeMax)

--- a/Sources/CalendarRecordingReminderScheduler.swift
+++ b/Sources/CalendarRecordingReminderScheduler.swift
@@ -160,9 +160,10 @@ final class CalendarRecordingReminderScheduler {
         guard generation == refreshGeneration else { return 0 }
         let planIDs = Set((plan.scheduled + plan.immediate).map(\.identifier))
         notifiedReminderIdentifiers = notifiedReminderIdentifiers.intersection(planIDs)
-        let immediateNotifiedIDs = pendingIDs.union(deliveredIDs).union(notifiedReminderIdentifiers)
+        let immediateNotifiedIDs = deliveredIDs.union(notifiedReminderIdentifiers)
         let scheduledIDs = Set(plan.scheduled.map(\.identifier))
-        let pendingToRemove = pendingIDs.subtracting(scheduledIDs)
+        let immediateIDs = Set(plan.immediate.map(\.identifier))
+        var pendingToRemove = pendingIDs.subtracting(scheduledIDs).subtracting(immediateIDs)
         try Task.checkCancellation()
         guard generation == refreshGeneration else { return 0 }
 
@@ -174,6 +175,9 @@ final class CalendarRecordingReminderScheduler {
                 try Task.checkCancellation()
                 guard generation == refreshGeneration else { return deliveredCount }
                 notifiedReminderIdentifiers.insert(schedule.identifier)
+                if pendingIDs.contains(schedule.identifier) {
+                    pendingToRemove.insert(schedule.identifier)
+                }
                 deliveredCount += 1
             }
         }

--- a/Sources/CalendarRecordingReminderScheduler.swift
+++ b/Sources/CalendarRecordingReminderScheduler.swift
@@ -286,8 +286,14 @@ final class CalendarRecordingReminderScheduler {
         min(max(value, 1), 120)
     }
 
+    nonisolated static func normalizedLeadMinuteOption(_ value: Int) -> Int {
+        leadMinuteOptions.min { lhs, rhs in
+            abs(lhs - value) < abs(rhs - value)
+        } ?? defaultLeadMinutes
+    }
+
     nonisolated static func normalizedLeadMinutes(_ values: [Int]) -> [Int] {
-        let normalized = Set(values.map(normalizedLeadMinutes)).sorted()
+        let normalized = Set(values.map(normalizedLeadMinuteOption)).sorted()
         return normalized.isEmpty ? [defaultLeadMinutes] : normalized
     }
 

--- a/Sources/CalendarRecordingReminderScheduler.swift
+++ b/Sources/CalendarRecordingReminderScheduler.swift
@@ -19,6 +19,18 @@ struct CalendarRecordingReminderSchedule: Equatable {
 }
 
 @MainActor
+protocol CalendarRecordingReminderNotificationManaging: AnyObject {
+    func canShowAlerts() async -> Bool
+    func add(_ request: UNNotificationRequest) async throws
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String])
+    func pendingNotificationRequestIdentifiers() async -> [String]
+    func deliveredNotificationRequestIdentifiers() async -> [String]
+    func sendImmediateNotification(_ request: UNNotificationRequest) async -> Bool
+}
+
+extension AppNotificationManager: CalendarRecordingReminderNotificationManaging {}
+
+@MainActor
 final class CalendarRecordingReminderScheduler {
     typealias EventProvider = (_ timeMin: Date, _ timeMax: Date) async throws -> [GoogleCalendarEvent]
 
@@ -31,7 +43,7 @@ final class CalendarRecordingReminderScheduler {
     nonisolated static let scheduleWindow: TimeInterval = 24 * 60 * 60
     nonisolated static let startedMeetingGracePeriod: TimeInterval = 5 * 60
 
-    private let notificationManager: AppNotificationManager
+    private let notificationManager: CalendarRecordingReminderNotificationManaging
     private let eventProvider: EventProvider
     private var refreshTimer: Timer?
     private var refreshTask: Task<Void, Never>?
@@ -41,7 +53,7 @@ final class CalendarRecordingReminderScheduler {
     private var notifiedReminderIdentifiers: Set<String> = []
 
     init(
-        notificationManager: AppNotificationManager,
+        notificationManager: CalendarRecordingReminderNotificationManaging,
         eventProvider: @escaping EventProvider
     ) {
         self.notificationManager = notificationManager
@@ -127,12 +139,11 @@ final class CalendarRecordingReminderScheduler {
         try Task.checkCancellation()
         guard generation == refreshGeneration else { return 0 }
         guard !requiresStarted || isStarted else { return 0 }
-        let deliveredCount = try await replacePendingNotifications(
+        return try await replacePendingNotifications(
             plan: plan,
             calendar: .current,
             generation: refreshGeneration
         )
-        return plan.scheduled.count + deliveredCount
     }
 
     private func replacePendingNotifications(
@@ -154,9 +165,6 @@ final class CalendarRecordingReminderScheduler {
         let pendingToRemove = pendingIDs.subtracting(scheduledIDs)
         try Task.checkCancellation()
         guard generation == refreshGeneration else { return 0 }
-        if !pendingToRemove.isEmpty {
-            notificationManager.removePendingNotificationRequests(withIdentifiers: Array(pendingToRemove))
-        }
 
         var deliveredCount = 0
         for schedule in plan.immediate where !immediateNotifiedIDs.contains(schedule.identifier) {
@@ -169,15 +177,26 @@ final class CalendarRecordingReminderScheduler {
                 deliveredCount += 1
             }
         }
+
+        var scheduledCount = 0
+        var didFailScheduledAdd = false
         for schedule in plan.scheduled where !deliveredIDs.contains(schedule.identifier) {
             try Task.checkCancellation()
-            guard generation == refreshGeneration else { return deliveredCount }
+            guard generation == refreshGeneration else { return deliveredCount + scheduledCount }
             do {
                 try await notificationManager.add(Self.notificationRequest(for: schedule, calendar: calendar))
+                scheduledCount += 1
             } catch {
+                didFailScheduledAdd = true
             }
         }
-        return deliveredCount
+
+        try Task.checkCancellation()
+        guard generation == refreshGeneration else { return deliveredCount + scheduledCount }
+        if !didFailScheduledAdd && !pendingToRemove.isEmpty {
+            notificationManager.removePendingNotificationRequests(withIdentifiers: Array(pendingToRemove))
+        }
+        return deliveredCount + scheduledCount
     }
 
     private static func notificationRequest(
@@ -211,7 +230,7 @@ final class CalendarRecordingReminderScheduler {
         return UNNotificationRequest(identifier: schedule.identifier, content: content, trigger: trigger)
     }
 
-    private static func pendingCalendarReminderIdentifiers(notificationManager: AppNotificationManager) async -> [String] {
+    private static func pendingCalendarReminderIdentifiers(notificationManager: CalendarRecordingReminderNotificationManaging) async -> [String] {
         calendarReminderIdentifiers(in: await notificationManager.pendingNotificationRequestIdentifiers())
     }
 
@@ -297,7 +316,8 @@ final class CalendarRecordingReminderScheduler {
 
     nonisolated static func notificationIdentifier(for event: GoogleCalendarEvent, leadMinutes: Int) -> String {
         let startTimestamp = Int(event.start.timeIntervalSince1970.rounded())
-        return "\(notificationIdentifierPrefix):\(event.calendarID):\(event.id):\(startTimestamp):\(normalizedLeadMinutes(leadMinutes))"
+        let normalizedLeadMinutes = normalizedLeadMinuteOption(leadMinutes)
+        return "\(notificationIdentifierPrefix):\(event.calendarID):\(event.id):\(startTimestamp):\(normalizedLeadMinutes)"
     }
 
     nonisolated static func isCalendarReminderIdentifier(_ identifier: String) -> Bool {

--- a/Sources/CalendarRecordingReminderScheduler.swift
+++ b/Sources/CalendarRecordingReminderScheduler.swift
@@ -82,7 +82,8 @@ final class CalendarRecordingReminderScheduler {
 
     @discardableResult
     func rescheduleNow(leadMinutes: [Int]) async throws -> Int {
-        try await refresh(leadMinutes: leadMinutes, requiresStarted: false)
+        let refreshGeneration = generation
+        return try await refresh(leadMinutes: leadMinutes, generation: refreshGeneration, requiresStarted: false)
     }
 
     private func stopTimer() {
@@ -92,9 +93,10 @@ final class CalendarRecordingReminderScheduler {
 
     private func scheduleRefresh(leadMinutes: [Int]) {
         refreshTask?.cancel()
+        let refreshGeneration = generation
         refreshTask = Task {
             do {
-                _ = try await refresh(leadMinutes: leadMinutes)
+                _ = try await refresh(leadMinutes: leadMinutes, generation: refreshGeneration)
             } catch is CancellationError {
             } catch {
             }
@@ -102,13 +104,19 @@ final class CalendarRecordingReminderScheduler {
     }
 
     @discardableResult
-    private func refresh(leadMinutes: [Int], requiresStarted: Bool = true) async throws -> Int {
+    private func refresh(
+        leadMinutes: [Int],
+        generation refreshGeneration: Int,
+        requiresStarted: Bool = true
+    ) async throws -> Int {
         guard await notificationManager.canShowAlerts() else { return 0 }
         try Task.checkCancellation()
+        guard generation == refreshGeneration else { return 0 }
         guard !requiresStarted || isStarted else { return 0 }
         let now = Date()
         let events = try await eventProvider(now, now.addingTimeInterval(Self.scheduleWindow))
         try Task.checkCancellation()
+        guard generation == refreshGeneration else { return 0 }
         guard !requiresStarted || isStarted else { return 0 }
         let plan = Self.reminderPlan(
             for: events,
@@ -117,35 +125,53 @@ final class CalendarRecordingReminderScheduler {
             calendar: .current
         )
         try Task.checkCancellation()
+        guard generation == refreshGeneration else { return 0 }
         guard !requiresStarted || isStarted else { return 0 }
-        let deliveredCount = await replacePendingNotifications(plan: plan, calendar: .current)
+        let deliveredCount = try await replacePendingNotifications(
+            plan: plan,
+            calendar: .current,
+            generation: refreshGeneration
+        )
         return plan.scheduled.count + deliveredCount
     }
 
     private func replacePendingNotifications(
         plan: CalendarRecordingReminderPlan,
-        calendar: Calendar
-    ) async -> Int {
+        calendar: Calendar,
+        generation refreshGeneration: Int
+    ) async throws -> Int {
         let pendingIDs = Set(await Self.pendingCalendarReminderIdentifiers(notificationManager: notificationManager))
+        try Task.checkCancellation()
+        guard generation == refreshGeneration else { return 0 }
         let deliveredIDs = Set(await notificationManager.deliveredNotificationRequestIdentifiers())
             .filter(Self.isCalendarReminderIdentifier)
+        try Task.checkCancellation()
+        guard generation == refreshGeneration else { return 0 }
         let planIDs = Set((plan.scheduled + plan.immediate).map(\.identifier))
         notifiedReminderIdentifiers = notifiedReminderIdentifiers.intersection(planIDs)
         let immediateNotifiedIDs = pendingIDs.union(deliveredIDs).union(notifiedReminderIdentifiers)
         let scheduledIDs = Set(plan.scheduled.map(\.identifier))
         let pendingToRemove = pendingIDs.subtracting(scheduledIDs)
+        try Task.checkCancellation()
+        guard generation == refreshGeneration else { return 0 }
         if !pendingToRemove.isEmpty {
             notificationManager.removePendingNotificationRequests(withIdentifiers: Array(pendingToRemove))
         }
 
         var deliveredCount = 0
         for schedule in plan.immediate where !immediateNotifiedIDs.contains(schedule.identifier) {
+            try Task.checkCancellation()
+            guard generation == refreshGeneration else { return deliveredCount }
             if await notificationManager.sendImmediateNotification(Self.notificationRequest(for: schedule, calendar: calendar)) {
+                try Task.checkCancellation()
+                guard generation == refreshGeneration else { return deliveredCount }
                 notifiedReminderIdentifiers.insert(schedule.identifier)
                 deliveredCount += 1
             }
         }
         for schedule in plan.scheduled where !deliveredIDs.contains(schedule.identifier) {
+            try Task.checkCancellation()
+            guard generation == refreshGeneration else { return deliveredCount }
             do {
                 try await notificationManager.add(Self.notificationRequest(for: schedule, calendar: calendar))
             } catch {

--- a/Sources/CalendarRecordingReminderScheduler.swift
+++ b/Sources/CalendarRecordingReminderScheduler.swift
@@ -48,17 +48,18 @@ final class CalendarRecordingReminderScheduler {
         self.eventProvider = eventProvider
     }
 
-    func start(leadMinutes: Int, refreshIntervalMinutes: Int) {
+    func start(leadMinutes: [Int], refreshIntervalMinutes: Int) {
+        let normalizedLeadMinuteValues = Self.normalizedLeadMinutes(leadMinutes)
         generation += 1
         cleanupTask?.cancel()
         cleanupTask = nil
         isStarted = true
         stopTimer()
-        scheduleRefresh(leadMinutes: leadMinutes)
+        scheduleRefresh(leadMinutes: normalizedLeadMinuteValues)
         let interval = TimeInterval(Self.normalizedRefreshIntervalMinutes(refreshIntervalMinutes) * 60)
         refreshTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             Task { @MainActor in
-                self?.scheduleRefresh(leadMinutes: leadMinutes)
+                self?.scheduleRefresh(leadMinutes: normalizedLeadMinuteValues)
             }
         }
     }
@@ -80,7 +81,7 @@ final class CalendarRecordingReminderScheduler {
     }
 
     @discardableResult
-    func rescheduleNow(leadMinutes: Int) async throws -> Int {
+    func rescheduleNow(leadMinutes: [Int]) async throws -> Int {
         try await refresh(leadMinutes: leadMinutes, requiresStarted: false)
     }
 
@@ -89,7 +90,7 @@ final class CalendarRecordingReminderScheduler {
         refreshTimer = nil
     }
 
-    private func scheduleRefresh(leadMinutes: Int) {
+    private func scheduleRefresh(leadMinutes: [Int]) {
         refreshTask?.cancel()
         refreshTask = Task {
             do {
@@ -101,7 +102,7 @@ final class CalendarRecordingReminderScheduler {
     }
 
     @discardableResult
-    private func refresh(leadMinutes: Int, requiresStarted: Bool = true) async throws -> Int {
+    private func refresh(leadMinutes: [Int], requiresStarted: Bool = true) async throws -> Int {
         guard await notificationManager.canShowAlerts() else { return 0 }
         try Task.checkCancellation()
         guard !requiresStarted || isStarted else { return 0 }
@@ -190,7 +191,7 @@ final class CalendarRecordingReminderScheduler {
 
     nonisolated static func schedules(
         for events: [GoogleCalendarEvent],
-        leadMinutes: Int,
+        leadMinutes: [Int],
         now: Date,
         calendar: Calendar
     ) -> [CalendarRecordingReminderSchedule] {
@@ -199,32 +200,34 @@ final class CalendarRecordingReminderScheduler {
 
     nonisolated static func reminderPlan(
         for events: [GoogleCalendarEvent],
-        leadMinutes: Int,
+        leadMinutes: [Int],
         now: Date,
         calendar: Calendar
     ) -> CalendarRecordingReminderPlan {
-        let normalizedLeadMinutes = normalizedLeadMinutes(leadMinutes)
-        let schedules = events.compactMap { event -> CalendarRecordingReminderSchedule? in
-            guard isReminderEligible(event) else { return nil }
-            let fireDate = event.start.addingTimeInterval(TimeInterval(-normalizedLeadMinutes * 60))
-            let identifier = notificationIdentifier(for: event, leadMinutes: normalizedLeadMinutes)
-            if fireDate > now {
+        let normalizedLeadMinuteValues = normalizedLeadMinutes(leadMinutes)
+        let schedules = events.flatMap { event -> [CalendarRecordingReminderSchedule] in
+            guard isReminderEligible(event) else { return [] }
+            return normalizedLeadMinuteValues.compactMap { normalizedLeadMinutes in
+                let fireDate = event.start.addingTimeInterval(TimeInterval(-normalizedLeadMinutes * 60))
+                let identifier = notificationIdentifier(for: event, leadMinutes: normalizedLeadMinutes)
+                if fireDate > now {
+                    return CalendarRecordingReminderSchedule(
+                        identifier: identifier,
+                        fireDate: fireDate,
+                        event: event,
+                        delivery: .scheduled
+                    )
+                }
+                guard event.start > now || now.timeIntervalSince(event.start) <= startedMeetingGracePeriod else {
+                    return nil
+                }
                 return CalendarRecordingReminderSchedule(
                     identifier: identifier,
-                    fireDate: fireDate,
+                    fireDate: now,
                     event: event,
-                    delivery: .scheduled
+                    delivery: .immediate
                 )
             }
-            guard event.start > now || now.timeIntervalSince(event.start) <= startedMeetingGracePeriod else {
-                return nil
-            }
-            return CalendarRecordingReminderSchedule(
-                identifier: identifier,
-                fireDate: now,
-                event: event,
-                delivery: .immediate
-            )
         }
         .sorted {
             if $0.fireDate != $1.fireDate { return $0.fireDate < $1.fireDate }
@@ -281,6 +284,11 @@ final class CalendarRecordingReminderScheduler {
 
     nonisolated static func normalizedLeadMinutes(_ value: Int) -> Int {
         min(max(value, 1), 120)
+    }
+
+    nonisolated static func normalizedLeadMinutes(_ values: [Int]) -> [Int] {
+        let normalized = Set(values.map(normalizedLeadMinutes)).sorted()
+        return normalized.isEmpty ? [defaultLeadMinutes] : normalized
     }
 
     nonisolated static func normalizedRefreshIntervalMinutes(_ value: Int) -> Int {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1006,17 +1006,34 @@ struct CalendarSettingsView: View {
             }
 
             VStack(alignment: .leading, spacing: 8) {
-                Text("Reminder time")
+                Text("Reminder times")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
-                Picker("Reminder time", selection: $appState.calendarRecordingReminderLeadMinutes) {
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 112), spacing: 8)],
+                    alignment: .leading,
+                    spacing: 8
+                ) {
                     ForEach(CalendarRecordingReminderScheduler.leadMinuteOptions, id: \.self) { minutes in
-                        Text("\(minutes) min before").tag(minutes)
+                        let isSelected = appState.calendarRecordingReminderLeadMinutes.contains(minutes)
+                        Button {
+                            appState.setCalendarRecordingReminderLeadTime(minutes, isSelected: !isSelected)
+                        } label: {
+                            Label(
+                                "\(minutes) min before",
+                                systemImage: isSelected ? "checkmark.circle.fill" : "circle"
+                            )
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .disabled(
+                            calendarReminderSettingsDisabled
+                                || !appState.calendarRecordingRemindersEnabled
+                                || (isSelected && appState.calendarRecordingReminderLeadMinutes.count == 1)
+                        )
                     }
                 }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .disabled(calendarReminderSettingsDisabled || !appState.calendarRecordingRemindersEnabled)
             }
         }
     }

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -385,6 +385,7 @@ struct AppStateTranscriptionConfigurationTests {
         let appState = AppState()
 
         assert(appState.calendarRecordingReminderLeadMinutes == [30])
+        assert(defaults.array(forKey: "calendar_recording_reminder_lead_minutes_list") as? [Int] == [30])
     }
 
     private static func testCalendarRecordingReminderLeadMinutesPersistNormalizedSelection() {
@@ -392,10 +393,10 @@ struct AppStateTranscriptionConfigurationTests {
         let defaults = UserDefaults.standard
         let appState = AppState()
 
-        appState.calendarRecordingReminderLeadMinutes = [60, 5, 5, -1]
+        appState.calendarRecordingReminderLeadMinutes = [60, 5, 5, -1, 14, 500]
 
-        assert(appState.calendarRecordingReminderLeadMinutes == [1, 5, 60])
-        assert(defaults.array(forKey: "calendar_recording_reminder_lead_minutes_list") as? [Int] == [1, 5, 60])
+        assert(appState.calendarRecordingReminderLeadMinutes == [1, 5, 15, 60])
+        assert(defaults.array(forKey: "calendar_recording_reminder_lead_minutes_list") as? [Int] == [1, 5, 15, 60])
 
         appState.calendarRecordingReminderLeadMinutes = []
 

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -26,6 +26,8 @@ struct AppStateTranscriptionConfigurationTests {
         try testGoogleCalendarConnectionMetadataRestoresStartupState()
         testGoogleCalendarConnectionMetadataClearsCorruptValue()
         testCalendarRecordingReminderLeadMinutesMigrateLegacyValue()
+        testCalendarRecordingReminderLeadMinutesNormalizesStoredSelection()
+        testCalendarRecordingReminderLeadMinutesDefaultsStoredEmptySelection()
         testCalendarRecordingReminderLeadMinutesPersistNormalizedSelection()
         await testGoogleCalendarStoredCustomOAuthCredentialsAreIgnored()
         await testGoogleCalendarRefreshMarksNeedsReconnectWhenTokenMissing()
@@ -386,6 +388,28 @@ struct AppStateTranscriptionConfigurationTests {
 
         assert(appState.calendarRecordingReminderLeadMinutes == [30])
         assert(defaults.array(forKey: "calendar_recording_reminder_lead_minutes_list") as? [Int] == [30])
+    }
+
+    private static func testCalendarRecordingReminderLeadMinutesNormalizesStoredSelection() {
+        resetDefaults()
+        let defaults = UserDefaults.standard
+        defaults.set([120, 14, 14], forKey: "calendar_recording_reminder_lead_minutes_list")
+
+        let appState = AppState()
+
+        assert(appState.calendarRecordingReminderLeadMinutes == [15, 60])
+        assert(defaults.array(forKey: "calendar_recording_reminder_lead_minutes_list") as? [Int] == [15, 60])
+    }
+
+    private static func testCalendarRecordingReminderLeadMinutesDefaultsStoredEmptySelection() {
+        resetDefaults()
+        let defaults = UserDefaults.standard
+        defaults.set([], forKey: "calendar_recording_reminder_lead_minutes_list")
+
+        let appState = AppState()
+
+        assert(appState.calendarRecordingReminderLeadMinutes == [CalendarRecordingReminderScheduler.defaultLeadMinutes])
+        assert(defaults.array(forKey: "calendar_recording_reminder_lead_minutes_list") as? [Int] == [CalendarRecordingReminderScheduler.defaultLeadMinutes])
     }
 
     private static func testCalendarRecordingReminderLeadMinutesPersistNormalizedSelection() {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -25,6 +25,8 @@ struct AppStateTranscriptionConfigurationTests {
         testStoppedTranscriptionSettingsSnapshotCapturesHistoryMetadata()
         try testGoogleCalendarConnectionMetadataRestoresStartupState()
         testGoogleCalendarConnectionMetadataClearsCorruptValue()
+        testCalendarRecordingReminderLeadMinutesMigrateLegacyValue()
+        testCalendarRecordingReminderLeadMinutesPersistNormalizedSelection()
         await testGoogleCalendarStoredCustomOAuthCredentialsAreIgnored()
         await testGoogleCalendarRefreshMarksNeedsReconnectWhenTokenMissing()
         await testGoogleCalendarRefreshMarksNeedsReconnectWhenRefreshTokenIsMissing()
@@ -374,6 +376,33 @@ struct AppStateTranscriptionConfigurationTests {
         assert(UserDefaults.standard.data(forKey: GoogleCalendarConnectionMetadata.storageKey) == nil)
     }
 
+    private static func testCalendarRecordingReminderLeadMinutesMigrateLegacyValue() {
+        resetDefaults()
+        let defaults = UserDefaults.standard
+        defaults.set(30, forKey: "calendar_recording_reminder_lead_minutes")
+        defaults.removeObject(forKey: "calendar_recording_reminder_lead_minutes_list")
+
+        let appState = AppState()
+
+        assert(appState.calendarRecordingReminderLeadMinutes == [30])
+    }
+
+    private static func testCalendarRecordingReminderLeadMinutesPersistNormalizedSelection() {
+        resetDefaults()
+        let defaults = UserDefaults.standard
+        let appState = AppState()
+
+        appState.calendarRecordingReminderLeadMinutes = [60, 5, 5, -1]
+
+        assert(appState.calendarRecordingReminderLeadMinutes == [1, 5, 60])
+        assert(defaults.array(forKey: "calendar_recording_reminder_lead_minutes_list") as? [Int] == [1, 5, 60])
+
+        appState.calendarRecordingReminderLeadMinutes = []
+
+        assert(appState.calendarRecordingReminderLeadMinutes == [CalendarRecordingReminderScheduler.defaultLeadMinutes])
+        assert(defaults.array(forKey: "calendar_recording_reminder_lead_minutes_list") as? [Int] == [CalendarRecordingReminderScheduler.defaultLeadMinutes])
+    }
+
     private static func testGoogleCalendarStoredCustomOAuthCredentialsAreIgnored() async {
         resetDefaults()
         let customClientID = "custom-client-id.apps.googleusercontent.com"
@@ -597,6 +626,7 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.removeObject(forKey: "google_calendar_selected_ids")
         defaults.removeObject(forKey: "calendar_recording_reminders_enabled")
         defaults.removeObject(forKey: "calendar_recording_reminder_lead_minutes")
+        defaults.removeObject(forKey: "calendar_recording_reminder_lead_minutes_list")
         defaults.removeObject(forKey: "calendar_recording_reminder_refresh_interval_minutes")
         defaults.removeObject(forKey: GoogleCalendarConnectionMetadata.storageKey)
     }

--- a/Tests/CalendarRecordingReminderSchedulerTests.swift
+++ b/Tests/CalendarRecordingReminderSchedulerTests.swift
@@ -4,14 +4,17 @@ import Foundation
 struct CalendarRecordingReminderSchedulerTests {
     static func main() {
         testLeadMinutesAffectFireDate()
+        testMultipleLeadMinutesCreateMultipleSchedules()
         testPastReminderTimeForUpcomingMeetingBecomesImmediate()
         testRecentlyStartedMeetingBecomesImmediate()
+        testMixedImmediateAndScheduledLeadTimesForSameEvent()
         testSkipsMeetingsStartedOutsideGracePeriod()
         testExcludesAllDayTitlelessInvalidAndSelfDeclinedEvents()
         testNotificationIdentifierIsStable()
         testCalendarReminderIdentifierFilteringUsesPrefix()
         testNotificationTitleDescribesRelativeStartTime()
         testNormalizesLeadMinutes()
+        testNormalizesLeadMinuteSelections()
         testNormalizesRefreshIntervalMinutesToSupportedOptions()
         print("CalendarRecordingReminderSchedulerTests passed")
     }
@@ -22,7 +25,7 @@ struct CalendarRecordingReminderSchedulerTests {
 
         let schedules = CalendarRecordingReminderScheduler.schedules(
             for: [event],
-            leadMinutes: 10,
+            leadMinutes: [10],
             now: now,
             calendar: .current
         )
@@ -31,13 +34,32 @@ struct CalendarRecordingReminderSchedulerTests {
         assert(schedules[0].fireDate == Date(timeIntervalSince1970: 1_300))
     }
 
+    private static func testMultipleLeadMinutesCreateMultipleSchedules() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let event = calendarEvent(calendarID: "calendar", id: "meeting", start: 4_600, end: 4_900)
+
+        let schedules = CalendarRecordingReminderScheduler.schedules(
+            for: [event],
+            leadMinutes: [10, 30, 1],
+            now: now,
+            calendar: .current
+        )
+
+        assert(schedules.map { Int($0.fireDate.timeIntervalSince1970) } == [2_800, 4_000, 4_540])
+        assert(schedules.map(\.identifier) == [
+            "calendar-recording-reminder:calendar:meeting:4600:30",
+            "calendar-recording-reminder:calendar:meeting:4600:10",
+            "calendar-recording-reminder:calendar:meeting:4600:1",
+        ])
+    }
+
     private static func testPastReminderTimeForUpcomingMeetingBecomesImmediate() {
         let now = Date(timeIntervalSince1970: 1_000)
         let event = calendarEvent(id: "soon", start: 1_100, end: 1_500)
 
         let plan = CalendarRecordingReminderScheduler.reminderPlan(
             for: [event],
-            leadMinutes: 10,
+            leadMinutes: [10],
             now: now,
             calendar: .current
         )
@@ -52,7 +74,7 @@ struct CalendarRecordingReminderSchedulerTests {
 
         let plan = CalendarRecordingReminderScheduler.reminderPlan(
             for: [event],
-            leadMinutes: 10,
+            leadMinutes: [10],
             now: now,
             calendar: .current
         )
@@ -61,13 +83,30 @@ struct CalendarRecordingReminderSchedulerTests {
         assert(plan.immediate.map { $0.event.id } == ["started"])
     }
 
+    private static func testMixedImmediateAndScheduledLeadTimesForSameEvent() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let event = calendarEvent(calendarID: "calendar", id: "soon", start: 1_300, end: 1_700)
+
+        let plan = CalendarRecordingReminderScheduler.reminderPlan(
+            for: [event],
+            leadMinutes: [10, 1],
+            now: now,
+            calendar: .current
+        )
+
+        assert(plan.immediate.map(\.identifier) == ["calendar-recording-reminder:calendar:soon:1300:10"])
+        assert(plan.immediate.map { $0.fireDate } == [now])
+        assert(plan.scheduled.map(\.identifier) == ["calendar-recording-reminder:calendar:soon:1300:1"])
+        assert(plan.scheduled.map { Int($0.fireDate.timeIntervalSince1970) } == [1_240])
+    }
+
     private static func testSkipsMeetingsStartedOutsideGracePeriod() {
         let now = Date(timeIntervalSince1970: 1_000)
         let event = calendarEvent(id: "old", start: 600, end: 1_500)
 
         let plan = CalendarRecordingReminderScheduler.reminderPlan(
             for: [event],
-            leadMinutes: 10,
+            leadMinutes: [10],
             now: now,
             calendar: .current
         )
@@ -91,7 +130,7 @@ struct CalendarRecordingReminderSchedulerTests {
 
         let schedules = CalendarRecordingReminderScheduler.schedules(
             for: [allDay, titleless, invalid, declined, valid],
-            leadMinutes: 5,
+            leadMinutes: [5],
             now: now,
             calendar: .current
         )
@@ -147,6 +186,11 @@ struct CalendarRecordingReminderSchedulerTests {
         assert(CalendarRecordingReminderScheduler.normalizedLeadMinutes(-1) == 1)
         assert(CalendarRecordingReminderScheduler.normalizedLeadMinutes(10) == 10)
         assert(CalendarRecordingReminderScheduler.normalizedLeadMinutes(500) == 120)
+    }
+
+    private static func testNormalizesLeadMinuteSelections() {
+        assert(CalendarRecordingReminderScheduler.normalizedLeadMinutes([30, 10, 10, -1, 500]) == [1, 10, 30, 120])
+        assert(CalendarRecordingReminderScheduler.normalizedLeadMinutes([]) == [CalendarRecordingReminderScheduler.defaultLeadMinutes])
     }
 
     private static func testNormalizesRefreshIntervalMinutesToSupportedOptions() {

--- a/Tests/CalendarRecordingReminderSchedulerTests.swift
+++ b/Tests/CalendarRecordingReminderSchedulerTests.swift
@@ -20,6 +20,7 @@ struct CalendarRecordingReminderSchedulerTests {
         testNormalizesRefreshIntervalMinutesToSupportedOptions()
         await testRescheduleReturnsSuccessfulNotificationCount()
         await testRescheduleKeepsStalePendingWhenScheduledAddFails()
+        await testRescheduleSendsImmediateNotificationForPendingIdentifier()
         await testRescheduleRemovesStalePendingAfterScheduledAddSucceeds()
         print("CalendarRecordingReminderSchedulerTests passed")
     }
@@ -241,6 +242,21 @@ struct CalendarRecordingReminderSchedulerTests {
 
         assert(count == 0)
         assert(notificationManager.removedIdentifiers.isEmpty)
+    }
+
+    @MainActor
+    private static func testRescheduleSendsImmediateNotificationForPendingIdentifier() async {
+        let start = Date().addingTimeInterval(300).timeIntervalSince1970
+        let event = calendarEvent(id: "meeting", start: start, end: start + 1_800)
+        let identifier = CalendarRecordingReminderScheduler.notificationIdentifier(for: event, leadMinutes: 10)
+        let notificationManager = FakeNotificationManager(pendingIdentifiers: [identifier])
+        let scheduler = CalendarRecordingReminderScheduler(notificationManager: notificationManager) { _, _ in [event] }
+
+        let count = try! await scheduler.rescheduleNow(leadMinutes: [10])
+
+        assert(count == 1)
+        assert(notificationManager.addedIdentifiers == [identifier])
+        assert(notificationManager.removedIdentifiers == [identifier])
     }
 
     @MainActor

--- a/Tests/CalendarRecordingReminderSchedulerTests.swift
+++ b/Tests/CalendarRecordingReminderSchedulerTests.swift
@@ -189,7 +189,7 @@ struct CalendarRecordingReminderSchedulerTests {
     }
 
     private static func testNormalizesLeadMinuteSelections() {
-        assert(CalendarRecordingReminderScheduler.normalizedLeadMinutes([30, 10, 10, -1, 500]) == [1, 10, 30, 120])
+        assert(CalendarRecordingReminderScheduler.normalizedLeadMinutes([30, 10, 10, -1, 14, 500]) == [1, 10, 15, 30, 60])
         assert(CalendarRecordingReminderScheduler.normalizedLeadMinutes([]) == [CalendarRecordingReminderScheduler.defaultLeadMinutes])
     }
 

--- a/Tests/CalendarRecordingReminderSchedulerTests.swift
+++ b/Tests/CalendarRecordingReminderSchedulerTests.swift
@@ -1,8 +1,9 @@
 import Foundation
+import UserNotifications
 
 @main
 struct CalendarRecordingReminderSchedulerTests {
-    static func main() {
+    static func main() async {
         testLeadMinutesAffectFireDate()
         testMultipleLeadMinutesCreateMultipleSchedules()
         testPastReminderTimeForUpcomingMeetingBecomesImmediate()
@@ -11,11 +12,15 @@ struct CalendarRecordingReminderSchedulerTests {
         testSkipsMeetingsStartedOutsideGracePeriod()
         testExcludesAllDayTitlelessInvalidAndSelfDeclinedEvents()
         testNotificationIdentifierIsStable()
+        testNotificationIdentifierNormalizesUnsupportedLeadMinutes()
         testCalendarReminderIdentifierFilteringUsesPrefix()
         testNotificationTitleDescribesRelativeStartTime()
         testNormalizesLeadMinutes()
         testNormalizesLeadMinuteSelections()
         testNormalizesRefreshIntervalMinutesToSupportedOptions()
+        await testRescheduleReturnsSuccessfulNotificationCount()
+        await testRescheduleKeepsStalePendingWhenScheduledAddFails()
+        await testRescheduleRemovesStalePendingAfterScheduledAddSucceeds()
         print("CalendarRecordingReminderSchedulerTests passed")
     }
 
@@ -146,6 +151,14 @@ struct CalendarRecordingReminderSchedulerTests {
         assert(identifier == "calendar-recording-reminder:calendar:event:2000:10")
     }
 
+    private static func testNotificationIdentifierNormalizesUnsupportedLeadMinutes() {
+        let event = calendarEvent(calendarID: "calendar", id: "event", start: 2_000, end: 2_500)
+
+        let identifier = CalendarRecordingReminderScheduler.notificationIdentifier(for: event, leadMinutes: 14)
+
+        assert(identifier == "calendar-recording-reminder:calendar:event:2000:15")
+    }
+
     private static func testCalendarReminderIdentifierFilteringUsesPrefix() {
         let identifiers = CalendarRecordingReminderScheduler.calendarReminderIdentifiers(in: [
             "calendar-recording-reminder:calendar:event:2000:10",
@@ -200,6 +213,50 @@ struct CalendarRecordingReminderSchedulerTests {
         assert(CalendarRecordingReminderScheduler.normalizedRefreshIntervalMinutes(50) == 60)
     }
 
+    @MainActor
+    private static func testRescheduleReturnsSuccessfulNotificationCount() async {
+        let start = Date().addingTimeInterval(3_600).timeIntervalSince1970
+        let event = calendarEvent(id: "meeting", start: start, end: start + 1_800)
+        let notificationManager = FakeNotificationManager()
+        let scheduler = CalendarRecordingReminderScheduler(notificationManager: notificationManager) { _, _ in [event] }
+
+        let count = try! await scheduler.rescheduleNow(leadMinutes: [10])
+
+        assert(count == 1)
+        assert(notificationManager.addedIdentifiers == [
+            CalendarRecordingReminderScheduler.notificationIdentifier(for: event, leadMinutes: 10)
+        ])
+    }
+
+    @MainActor
+    private static func testRescheduleKeepsStalePendingWhenScheduledAddFails() async {
+        let start = Date().addingTimeInterval(3_600).timeIntervalSince1970
+        let event = calendarEvent(id: "meeting", start: start, end: start + 1_800)
+        let staleIdentifier = CalendarRecordingReminderScheduler.notificationIdentifier(for: event, leadMinutes: 5)
+        let notificationManager = FakeNotificationManager(pendingIdentifiers: [staleIdentifier])
+        notificationManager.shouldFailAdd = true
+        let scheduler = CalendarRecordingReminderScheduler(notificationManager: notificationManager) { _, _ in [event] }
+
+        let count = try! await scheduler.rescheduleNow(leadMinutes: [10])
+
+        assert(count == 0)
+        assert(notificationManager.removedIdentifiers.isEmpty)
+    }
+
+    @MainActor
+    private static func testRescheduleRemovesStalePendingAfterScheduledAddSucceeds() async {
+        let start = Date().addingTimeInterval(3_600).timeIntervalSince1970
+        let event = calendarEvent(id: "meeting", start: start, end: start + 1_800)
+        let staleIdentifier = CalendarRecordingReminderScheduler.notificationIdentifier(for: event, leadMinutes: 5)
+        let notificationManager = FakeNotificationManager(pendingIdentifiers: [staleIdentifier])
+        let scheduler = CalendarRecordingReminderScheduler(notificationManager: notificationManager) { _, _ in [event] }
+
+        let count = try! await scheduler.rescheduleNow(leadMinutes: [10])
+
+        assert(count == 1)
+        assert(notificationManager.removedIdentifiers == [staleIdentifier])
+    }
+
     private static func calendarEvent(
         calendarID: String = "calendar",
         id: String,
@@ -218,5 +275,49 @@ struct CalendarRecordingReminderSchedulerTests {
             isAllDay: isAllDay,
             attendees: attendees
         )
+    }
+
+    private enum TestNotificationError: Error {
+        case addFailed
+    }
+
+    @MainActor
+    private final class FakeNotificationManager: CalendarRecordingReminderNotificationManaging {
+        var shouldFailAdd = false
+        var addedIdentifiers: [String] = []
+        var removedIdentifiers: [String] = []
+        private let pendingIdentifiers: [String]
+
+        init(pendingIdentifiers: [String] = []) {
+            self.pendingIdentifiers = pendingIdentifiers
+        }
+
+        func canShowAlerts() async -> Bool {
+            true
+        }
+
+        func add(_ request: UNNotificationRequest) async throws {
+            if shouldFailAdd {
+                throw TestNotificationError.addFailed
+            }
+            addedIdentifiers.append(request.identifier)
+        }
+
+        func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
+            removedIdentifiers.append(contentsOf: identifiers)
+        }
+
+        func pendingNotificationRequestIdentifiers() async -> [String] {
+            pendingIdentifiers
+        }
+
+        func deliveredNotificationRequestIdentifiers() async -> [String] {
+            []
+        }
+
+        func sendImmediateNotification(_ request: UNNotificationRequest) async -> Bool {
+            addedIdentifiers.append(request.identifier)
+            return true
+        }
     }
 }

--- a/docs/superpowers/specs/2026-05-16-multiple-meeting-reminders-design.md
+++ b/docs/superpowers/specs/2026-05-16-multiple-meeting-reminders-design.md
@@ -1,0 +1,69 @@
+# Multiple Meeting Reminder Lead Times Design
+
+## Context
+
+GitHub issue #100 asks Quill to let users select multiple Meeting Recording Reminder lead times instead of a single reminder time. The current implementation stores one lead time, fetches eligible calendar events, and schedules one macOS notification per event. Notification identifiers already include the lead time, which gives us stable identity for multiple reminders per event.
+
+## Goals
+
+- Let users choose multiple reminder lead times from the existing options: 1, 5, 10, 15, 30, and 60 minutes.
+- Schedule one notification per selected lead time for each eligible calendar event.
+- Preserve existing single-value settings by migrating the stored value into a one-item selection.
+- Keep notification identifiers stable and distinct across event ID, event start, and lead time.
+- Clean up stale pending reminders when selected lead times change.
+
+## Non-goals
+
+- Do not add custom lead time entry.
+- Do not change the Google Calendar event fetch window or eligibility rules.
+- Do not remove delivered notifications; keep using them only for duplicate suppression.
+
+## Architecture
+
+`AppState` will own a multi-value reminder setting and pass the selected lead times to `CalendarRecordingReminderScheduler`. The scheduler will fetch calendar events once per refresh, then expand each eligible event across the selected lead times to build a single reminder plan.
+
+The existing notification identifier format remains unchanged:
+
+```text
+calendar-recording-reminder:<calendarID>:<eventID>:<startTimestamp>:<leadMinutes>
+```
+
+Because the identifier already includes `leadMinutes`, reminders for the same event at different lead times remain stable and distinct.
+
+## Settings persistence and migration
+
+Add a new array-backed storage key, for example `calendar_recording_reminder_lead_minutes_list`. During initialization, if the new key has no value, read the legacy `calendar_recording_reminder_lead_minutes` integer, normalize it, and use it as a one-item selection. If neither value exists, default to `[10]`.
+
+Persisted selections will be normalized by clamping each value, removing duplicates, sorting ascending, and falling back to `[10]` if the input is empty. The legacy key remains only as a migration source.
+
+## Settings UI
+
+Replace the single segmented picker with a multi-select control over the existing lead time options. Users may select any combination of the existing values, but the UI will prevent removing the last selected value. The reminder toggle remains the top-level enable/disable control.
+
+## Scheduler behavior
+
+Update scheduler APIs to accept multiple lead times, including:
+
+- `start(leadMinutes: [Int], refreshIntervalMinutes:)`
+- `rescheduleNow(leadMinutes: [Int])`
+- `reminderPlan(... leadMinutes: [Int] ...)`
+
+For each eligible event and normalized lead time, the scheduler applies the existing scheduled/immediate rules independently. A single event may therefore produce both an immediate reminder for one elapsed lead time and scheduled reminders for later lead times.
+
+Immediate duplicate suppression remains identifier-based. Since lead time is part of the identifier, duplicate suppression applies per event and lead time.
+
+## Cleanup behavior
+
+`replacePendingNotifications` continues to remove pending calendar reminder IDs that are not in the new scheduled plan. When selected lead times change, identifiers for removed lead times disappear from the plan and their pending notifications are removed. Delivered notification IDs continue to suppress duplicate immediate delivery but are not removed.
+
+## Testing
+
+Extend `CalendarRecordingReminderSchedulerTests` to cover:
+
+- one event producing multiple scheduled reminders for multiple lead times;
+- stable identifiers differing by lead time;
+- one event producing immediate and scheduled reminders at different lead times;
+- multi-value normalization: clamping, de-duplication, sorting, and empty fallback;
+- existing eligibility, title, and refresh interval behavior.
+
+Add AppState-level coverage where practical for migration from the legacy single lead time and defaults cleanup for the new storage key.


### PR DESCRIPTION
## Summary
- Allow Meeting Recording Reminders to use multiple selected lead times from the existing options.
- Migrate legacy single lead-time settings into the new persisted selection and normalize stored values to supported options.
- Keep notification IDs distinct per event and lead time, and make refresh reconciliation generation-aware.

## Test plan
- [x] make test
- [x] make run CODESIGN_IDENTITY="Quill" opened the built app
- [x] Confirmed the Quill process launched from build/Quill.app

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 캘린더 녹음 알림에서 여러 개의 미리알림 시간을 선택할 수 있습니다(다중 선택). 마지막 하나는 제거 불가입니다.
  * 알림 스케줄러가 다중 리드타임을 지원하도록 확장되어 리드타임별로 별도 알림이 생성됩니다.

* **버그 수정 / 안정성**
  * 기존 단일 값에서 자동 마이그레이션 및 입력 정규화(중복/범위/빈값 처리)로 알림 동작 일관성 향상.
  * 즉시/예약 알림 처리 및 중복 억제 로직이 강화되었습니다.

* **문서**
  * 다중 미리알림 동작 설계 문서 추가.

* **테스트**
  * 다중 리드타임 및 재스케줄 동작을 검증하는 테스트들이 추가/확장됨.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/freeflow/pull/102)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->