### PR TITLE
Fix notched meeting reminder overlay sizing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,9 +229,9 @@ test:
 	@/tmp/SetupFlowTests
 	@swiftc -parse-as-library Sources/TranscriptionModel.swift Tests/TranscriptionModelCacheTests.swift -o /tmp/TranscriptionModelCacheTests
 	@/tmp/TranscriptionModelCacheTests
-	@swiftc -parse-as-library Sources/ShortcutCore/ShortcutModels.swift Sources/RecordingOverlay.swift Tests/RecordingOverlayGeometryTests.swift -o /tmp/RecordingOverlayGeometryTests
+	@swiftc -parse-as-library Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/RecordingOverlay.swift Tests/RecordingOverlayGeometryTests.swift -o /tmp/RecordingOverlayGeometryTests
 	@/tmp/RecordingOverlayGeometryTests
-	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/AppNotificationManager.swift Sources/CalendarRecordingReminderScheduler.swift Sources/MeetingReminderOverlay.swift Tests/MeetingReminderOverlayGeometryTests.swift -o /tmp/MeetingReminderOverlayGeometryTests
+	@swiftc -parse-as-library Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/RecordingOverlay.swift Sources/CalendarIntegrationModels.swift Sources/AppNotificationManager.swift Sources/CalendarRecordingReminderScheduler.swift Sources/MeetingReminderOverlay.swift Tests/MeetingReminderOverlayGeometryTests.swift -o /tmp/MeetingReminderOverlayGeometryTests
 	@/tmp/MeetingReminderOverlayGeometryTests
 	@swiftc -parse-as-library -target $(shell uname -m)-apple-macosx13.0 $(filter-out Sources/App.swift,$(SOURCES)) Tests/AppStateTranscriptionConfigurationTests.swift -o /tmp/AppStateTranscriptionConfigurationTests
 	@/tmp/AppStateTranscriptionConfigurationTests

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -3480,6 +3480,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
     private func prepareRecordingStart(
         triggerMode: RecordingTriggerMode,
         selectionSnapshot: AppSelectionSnapshot? = nil,

--- a/Sources/FixedIntrinsicHostingView.swift
+++ b/Sources/FixedIntrinsicHostingView.swift
@@ -11,15 +11,11 @@ final class FixedIntrinsicHostingView<Content: View>: NSHostingView<Content> {
     }
 
     @MainActor @preconcurrency required dynamic init?(coder: NSCoder) {
-        self.fixedIntrinsicContentSize = .zero
-        super.init(coder: coder)
-        sizingOptions = []
+        return nil
     }
 
     @MainActor @preconcurrency required dynamic init(rootView: Content) {
-        self.fixedIntrinsicContentSize = .zero
-        super.init(rootView: rootView)
-        sizingOptions = []
+        fatalError("init(rootView:) is not supported on FixedIntrinsicHostingView. Use init(rootView:size:) instead.")
     }
 
     override var intrinsicContentSize: NSSize {

--- a/Sources/FixedIntrinsicHostingView.swift
+++ b/Sources/FixedIntrinsicHostingView.swift
@@ -1,0 +1,55 @@
+import AppKit
+import SwiftUI
+
+final class FixedIntrinsicHostingView<Content: View>: NSHostingView<Content> {
+    private var fixedIntrinsicContentSize: NSSize
+
+    init(rootView: Content, size: NSSize) {
+        self.fixedIntrinsicContentSize = size
+        super.init(rootView: rootView)
+        sizingOptions = []
+    }
+
+    @MainActor @preconcurrency required dynamic init?(coder: NSCoder) {
+        self.fixedIntrinsicContentSize = .zero
+        super.init(coder: coder)
+        sizingOptions = []
+    }
+
+    @MainActor @preconcurrency required dynamic init(rootView: Content) {
+        self.fixedIntrinsicContentSize = .zero
+        super.init(rootView: rootView)
+        sizingOptions = []
+    }
+
+    override var intrinsicContentSize: NSSize {
+        fixedIntrinsicContentSize
+    }
+
+    func setFixedIntrinsicContentSize(_ size: NSSize) {
+        fixedIntrinsicContentSize = size
+        invalidateIntrinsicContentSize()
+    }
+}
+
+final class FixedHostingContainer<Content: View>: NSView {
+    private let hostingView: FixedIntrinsicHostingView<Content>
+
+    init(rootView: Content, size: NSSize) {
+        self.hostingView = FixedIntrinsicHostingView(rootView: rootView, size: size)
+        super.init(frame: NSRect(origin: .zero, size: size))
+        hostingView.frame = bounds
+        hostingView.autoresizingMask = [.width, .height]
+        addSubview(hostingView)
+    }
+
+    @MainActor @preconcurrency required dynamic init?(coder: NSCoder) {
+        return nil
+    }
+
+    func setFixedContentSize(_ size: NSSize) {
+        setFrameSize(size)
+        hostingView.frame = bounds
+        hostingView.setFixedIntrinsicContentSize(size)
+    }
+}

--- a/Sources/MeetingReminderOverlay.swift
+++ b/Sources/MeetingReminderOverlay.swift
@@ -3,7 +3,6 @@ import Combine
 import SwiftUI
 
 private let meetingReminderContentTransitionAnimation = Animation.spring(response: 0.28, dampingFraction: 0.88, blendDuration: 0.08)
-private let meetingReminderCenterOverlayWidth: CGFloat = 150
 
 struct MeetingReminderOverlayContext: Equatable {
     var phase: Phase
@@ -39,10 +38,11 @@ struct MeetingReminderOverlayGeometry {
     static let defaultSize = CGSize(width: 336, height: 92)
     static let horizontalScreenMargin: CGFloat = 16
     static let notchSideHeight: CGFloat = 88
-    static let notchCenterSize = CGSize(width: 388, height: 112)
+    static let notchCenterSize = CGSize(width: 360, height: 112)
 
     private static let notchSideRegionWidth: CGFloat = 92
     private static let notchSideHorizontalInset: CGFloat = 8
+    private static let centerRecordingBaseWidth: CGFloat = 150
 
     static func size(forScreenWidth screenWidth: CGFloat) -> CGSize {
         CGSize(
@@ -78,12 +78,15 @@ struct MeetingReminderOverlayGeometry {
     ) -> CGSize {
         switch variant {
         case .defaultReminder:
-            return size(forScreenWidth: screenWidth)
+            let defaultSize = size(forScreenWidth: screenWidth)
+            guard let notchSideWidth else { return defaultSize }
+            return CGSize(width: max(defaultSize.width, notchSideWidth), height: defaultSize.height)
         case .notchSidesRecording, .notchSidesProcessing:
             return CGSize(width: max(280, notchSideWidth ?? defaultSize.width), height: defaultSize.height)
         case .notchCenterRecording, .notchCenterProcessing:
+            let width = max(notchCenterSize.width, notchSideWidth ?? 0)
             return CGSize(
-                width: min(notchCenterSize.width, max(280, screenWidth - horizontalScreenMargin * 2)),
+                width: min(width, max(280, screenWidth - horizontalScreenMargin * 2)),
                 height: notchCenterSize.height
             )
         case .centerRecording, .centerProcessing:
@@ -118,11 +121,34 @@ struct MeetingReminderOverlayGeometry {
         guard hasNotchGeometry(for: screen),
               let leftArea = screen.auxiliaryTopLeftArea,
               let rightArea = screen.auxiliaryTopRightArea else { return nil }
-        let availableSideWidth = min(leftArea.width, rightArea.width)
+        return notchSideWidth(
+            leftAreaWidth: leftArea.width,
+            rightAreaWidth: rightArea.width,
+            screenWidth: screen.frame.width
+        )
+    }
+
+    static func notchSideWidth(leftAreaWidth: CGFloat, rightAreaWidth: CGFloat, screenWidth: CGFloat) -> CGFloat? {
+        let availableSideWidth = min(leftAreaWidth, rightAreaWidth)
         let contentWidth = min(notchSideRegionWidth, max(0, availableSideWidth - notchSideHorizontalInset * 2))
         guard contentWidth >= 64 else { return nil }
-        let notchWidth = screen.frame.width - leftArea.width - rightArea.width
+        let notchWidth = screenWidth - leftAreaWidth - rightAreaWidth
         return notchWidth + contentWidth * 2
+    }
+
+    static func centerRecordingOverlayWidth(leftAreaWidth: CGFloat, rightAreaWidth: CGFloat, screenWidth: CGFloat) -> CGFloat {
+        max(screenWidth - leftAreaWidth - rightAreaWidth, centerRecordingBaseWidth)
+    }
+
+    static func centerRecordingOverlayWidth(for screen: NSScreen) -> CGFloat {
+        guard hasNotchGeometry(for: screen),
+              let leftArea = screen.auxiliaryTopLeftArea,
+              let rightArea = screen.auxiliaryTopRightArea else { return centerRecordingBaseWidth }
+        return centerRecordingOverlayWidth(
+            leftAreaWidth: leftArea.width,
+            rightAreaWidth: rightArea.width,
+            screenWidth: screen.frame.width
+        )
     }
 }
 
@@ -133,6 +159,7 @@ struct MeetingReminderOverlayDisplayData: Equatable {
     let startTimeText: String
     let context: MeetingReminderOverlayContext
     let variant: MeetingReminderOverlayVariant
+    let centerOverlayWidth: CGFloat
 
     var showsStartButton: Bool { variant == .defaultReminder }
 }
@@ -211,25 +238,27 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
             for: context,
             hasNotchGeometry: MeetingReminderOverlayGeometry.hasNotchGeometry(for: screen)
         )
-        let displayData = displayData(for: schedule, context: context, variant: variant)
+        let displayData = displayData(
+            for: schedule,
+            context: context,
+            variant: variant,
+            centerOverlayWidth: MeetingReminderOverlayGeometry.centerRecordingOverlayWidth(for: screen)
+        )
         let panel = panel ?? makePanel(frame: frame)
         panel.ignoresMouseEvents = false
-        if let viewModel, panel.contentView != nil {
-            withAnimation(meetingReminderContentTransitionAnimation) {
-                viewModel.displayData = displayData
-            }
-            panel.contentView?.frame = NSRect(origin: .zero, size: frame.size)
-        } else {
-            let viewModel = MeetingReminderOverlayViewModel(displayData: displayData)
-            let hostingView = NSHostingView(rootView: MeetingReminderOverlayRootView(
-                viewModel: viewModel,
-                onStart: { [weak self] in self?.handleStart() },
-                onDismiss: { [weak self] in self?.handleDismiss() }
-            ))
-            hostingView.frame = NSRect(origin: .zero, size: frame.size)
-            panel.contentView = hostingView
-            self.viewModel = viewModel
-        }
+        let viewModel = MeetingReminderOverlayViewModel(displayData: displayData)
+        let rootView = MeetingReminderOverlayRootView(
+            viewModel: viewModel,
+            onStart: { [weak self] in self?.handleStart() },
+            onDismiss: { [weak self] in self?.handleDismiss() }
+        )
+        let container = FixedHostingContainer(
+            rootView: AnyView(rootView.frame(width: frame.width, height: frame.height)),
+            size: frame.size
+        )
+        container.autoresizingMask = [.width, .height]
+        panel.contentView = container
+        self.viewModel = viewModel
         panel.level = variant.isRecordingContext ? Self.recordingContextLevel : .screenSaver
         self.panel = panel
 
@@ -328,7 +357,8 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
     private func displayData(
         for schedule: CalendarRecordingReminderSchedule,
         context: MeetingReminderOverlayContext,
-        variant: MeetingReminderOverlayVariant
+        variant: MeetingReminderOverlayVariant,
+        centerOverlayWidth: CGFloat
     ) -> MeetingReminderOverlayDisplayData {
         MeetingReminderOverlayDisplayData(
             identifier: schedule.identifier,
@@ -336,7 +366,8 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
             startText: Self.startText(for: schedule.event.start),
             startTimeText: Self.startTimeText(for: schedule.event.start),
             context: context,
-            variant: variant
+            variant: variant,
+            centerOverlayWidth: centerOverlayWidth
         )
     }
 
@@ -400,7 +431,7 @@ private struct MeetingReminderOverlayView: View {
             CenterMeetingReminderOverlayView(
                 displayData: displayData,
                 animationNamespace: animationNamespace,
-                topContentHeight: 62,
+                topContentHeight: 77,
                 rowTop: 76,
                 onDismiss: onDismiss
             )
@@ -428,7 +459,7 @@ private struct DefaultMeetingReminderOverlayView: View {
                 .matchedGeometryEffect(id: "background", in: animationNamespace)
             VStack(spacing: 0) {
                 GeometryReader { proxy in
-                    let topSideAreaWidth = max(0, (proxy.size.width - meetingReminderCenterOverlayWidth) / 2)
+                    let topSideAreaWidth = max(0, (proxy.size.width - displayData.centerOverlayWidth) / 2)
                     ZStack(alignment: .topLeading) {
                         HStack(spacing: 6) {
                             AppIconView(size: 22, cornerRadius: 6)
@@ -510,7 +541,7 @@ private struct CenterMeetingReminderOverlayView: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let topSideAreaWidth = max(0, (proxy.size.width - meetingReminderCenterOverlayWidth) / 2)
+            let topSideAreaWidth = max(0, (proxy.size.width - displayData.centerOverlayWidth) / 2)
             ZStack(alignment: .topLeading) {
                 OverlayBackground(cornerRadius: displayData.variant == .centerRecording || displayData.variant == .centerProcessing ? 22 : 24)
                     .matchedGeometryEffect(id: "background", in: animationNamespace)

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -79,8 +79,9 @@ private func makeNotchContent<V: View>(
         .background(Color.black)
         .clipShape(UnevenRoundedRectangle(bottomLeadingRadius: cornerRadius, bottomTrailingRadius: cornerRadius))
 
-    let hosting = NSHostingView(rootView: shaped)
-    hosting.frame = NSRect(x: 0, y: 0, width: width, height: height)
+    let size = NSSize(width: width, height: height)
+    let hosting = FixedIntrinsicHostingView(rootView: shaped, size: size)
+    hosting.frame = NSRect(origin: .zero, size: size)
     hosting.autoresizingMask = [.width, .height]
     return hosting
 }
@@ -90,8 +91,9 @@ private func makeTransparentContent<V: View>(
     height: CGFloat,
     rootView: V
 ) -> NSView {
-    let hosting = NSHostingView(rootView: rootView.frame(width: width, height: height))
-    hosting.frame = NSRect(x: 0, y: 0, width: width, height: height)
+    let size = NSSize(width: width, height: height)
+    let hosting = FixedIntrinsicHostingView(rootView: rootView.frame(width: width, height: height), size: size)
+    hosting.frame = NSRect(origin: .zero, size: size)
     hosting.autoresizingMask = [.width, .height]
     return hosting
 }

--- a/Tests/MeetingReminderOverlayGeometryTests.swift
+++ b/Tests/MeetingReminderOverlayGeometryTests.swift
@@ -3,7 +3,7 @@ import Foundation
 
 @main
 struct MeetingReminderOverlayGeometryTests {
-    static func main() async {
+    static func main() async throws {
         testDefaultSize()
         testUsesCompactWidthWhenScreenAllows()
         testClampsToScreenMargins()
@@ -12,7 +12,9 @@ struct MeetingReminderOverlayGeometryTests {
         testProcessingKeepsNotchSideVariant()
         testRecordingCenterWithNotchUsesNotchCenterVariant()
         testRecordingCenterWithoutNotchUsesCenterVariant()
+        testNotchSideWidthMatchesRecordingOverlayGeometry()
         testContextualSizesMatchFinalDesign()
+        try testHostingViewsUseFixedIntrinsicContentSize()
         await testPresenterFailureWhenScreenUnavailableFallsBack()
         print("MeetingReminderOverlayGeometryTests passed")
     }
@@ -71,14 +73,52 @@ struct MeetingReminderOverlayGeometryTests {
         assert(variant == .centerRecording)
     }
 
+    private static func testNotchSideWidthMatchesRecordingOverlayGeometry() {
+        let recordingGeometry = RecordingOverlayGeometry.notchSideGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1512, height: 944),
+            leftArea: CGRect(x: 0, y: 944, width: 682, height: 38),
+            rightArea: CGRect(x: 830, y: 944, width: 682, height: 38),
+            regionWidth: 92,
+            panelHeight: 38,
+            horizontalInset: 8
+        )
+
+        assert(recordingGeometry != nil)
+        let reminderWidth = MeetingReminderOverlayGeometry.notchSideWidth(
+            leftAreaWidth: 682,
+            rightAreaWidth: 682,
+            screenWidth: 1512
+        )
+
+        assert(reminderWidth == recordingGeometry?.frame.width)
+        assert(MeetingReminderOverlayGeometry.size(for: .notchSidesRecording, screenWidth: 1512, notchSideWidth: reminderWidth) == CGSize(width: reminderWidth!, height: 92))
+        assert(MeetingReminderOverlayGeometry.size(for: .notchSidesProcessing, screenWidth: 1512, notchSideWidth: reminderWidth) == CGSize(width: reminderWidth!, height: 92))
+    }
+
     private static func testContextualSizesMatchFinalDesign() {
         assert(MeetingReminderOverlayGeometry.size(for: .defaultReminder, screenWidth: 1_440, notchSideWidth: nil) == CGSize(width: 336, height: 92))
+        assert(MeetingReminderOverlayGeometry.size(for: .defaultReminder, screenWidth: 1_440, notchSideWidth: 404) == CGSize(width: 404, height: 92))
         assert(MeetingReminderOverlayGeometry.size(for: .notchSidesRecording, screenWidth: 1_440, notchSideWidth: 330) == CGSize(width: 330, height: 92))
         assert(MeetingReminderOverlayGeometry.size(for: .notchSidesProcessing, screenWidth: 1_440, notchSideWidth: 330) == CGSize(width: 330, height: 92))
-        assert(MeetingReminderOverlayGeometry.size(for: .notchCenterRecording, screenWidth: 1_440, notchSideWidth: nil) == CGSize(width: 388, height: 112))
-        assert(MeetingReminderOverlayGeometry.size(for: .notchCenterProcessing, screenWidth: 1_440, notchSideWidth: nil) == CGSize(width: 388, height: 112))
+        assert(MeetingReminderOverlayGeometry.size(for: .notchCenterRecording, screenWidth: 1_440, notchSideWidth: nil) == CGSize(width: 360, height: 112))
+        assert(MeetingReminderOverlayGeometry.size(for: .notchCenterProcessing, screenWidth: 1_440, notchSideWidth: nil) == CGSize(width: 360, height: 112))
+        assert(MeetingReminderOverlayGeometry.size(for: .notchCenterRecording, screenWidth: 2_056, notchSideWidth: 404) == CGSize(width: 404, height: 112))
+        assert(MeetingReminderOverlayGeometry.size(for: .notchCenterProcessing, screenWidth: 2_056, notchSideWidth: 404) == CGSize(width: 404, height: 112))
         assert(MeetingReminderOverlayGeometry.size(for: .centerRecording, screenWidth: 1_440, notchSideWidth: nil) == CGSize(width: 336, height: 92))
         assert(MeetingReminderOverlayGeometry.size(for: .centerProcessing, screenWidth: 1_440, notchSideWidth: nil) == CGSize(width: 336, height: 92))
+    }
+
+    private static func testHostingViewsUseFixedIntrinsicContentSize() throws {
+        let sharedHostSource = try String(contentsOfFile: "Sources/FixedIntrinsicHostingView.swift", encoding: .utf8)
+        let source = try String(contentsOfFile: "Sources/MeetingReminderOverlay.swift", encoding: .utf8)
+        assert(sharedHostSource.contains("final class FixedIntrinsicHostingView"))
+        assert(sharedHostSource.contains("override var intrinsicContentSize"))
+        assert(sharedHostSource.contains("sizingOptions = []"), "Fixed hosting views must opt out of window sizing")
+        assert(source.contains("FixedHostingContainer("), "Meeting reminders must host SwiftUI inside a plain NSView container")
+        assert(source.contains("rootView: AnyView(rootView.frame("), "Meeting reminders must give SwiftUI a fixed panel-sized root frame")
+        assert(source.contains("centerOverlayWidth: MeetingReminderOverlayGeometry.centerRecordingOverlayWidth(for: screen)"), "Center reminder layout must reserve the actual center recording overlay width")
+        assert(!source.contains("panel.contentView = hostingView"), "Meeting reminders must not install NSHostingView directly as the panel content view")
     }
 
     @MainActor

--- a/Tests/MeetingReminderOverlayGeometryTests.swift
+++ b/Tests/MeetingReminderOverlayGeometryTests.swift
@@ -115,6 +115,8 @@ struct MeetingReminderOverlayGeometryTests {
         assert(sharedHostSource.contains("final class FixedIntrinsicHostingView"))
         assert(sharedHostSource.contains("override var intrinsicContentSize"))
         assert(sharedHostSource.contains("sizingOptions = []"), "Fixed hosting views must opt out of window sizing")
+        assert(sharedHostSource.contains("required dynamic init?(coder: NSCoder) {\n        return nil\n    }"), "Fixed hosting views must not support storyboard/XIB initialization")
+        assert(sharedHostSource.contains("fatalError(\"init(rootView:) is not supported on FixedIntrinsicHostingView. Use init(rootView:size:) instead.\")"), "Fixed hosting views must require an explicit fixed size")
         assert(source.contains("FixedHostingContainer("), "Meeting reminders must host SwiftUI inside a plain NSView container")
         assert(source.contains("rootView: AnyView(rootView.frame("), "Meeting reminders must give SwiftUI a fixed panel-sized root frame")
         assert(source.contains("centerOverlayWidth: MeetingReminderOverlayGeometry.centerRecordingOverlayWidth(for: screen)"), "Center reminder layout must reserve the actual center recording overlay width")

--- a/Tests/RecordingOverlayGeometryTests.swift
+++ b/Tests/RecordingOverlayGeometryTests.swift
@@ -10,6 +10,7 @@ struct RecordingOverlayGeometryTests {
         testCenteredFrameUsesUpdatedMainScreenGeometry()
         testNotchSideLayoutPhaseEligibility()
         try testNotchSideOverlayAvoidsContainerAudioLevelAnimation()
+        try testHostingViewsUseFixedIntrinsicContentSize()
         print("RecordingOverlayGeometryTests passed")
     }
 
@@ -124,5 +125,13 @@ struct RecordingOverlayGeometryTests {
             !viewSource.contains("value: state.audioLevel"),
             "NotchSideOverlayView must not animate the whole container for high-frequency audioLevel updates"
         )
+    }
+
+    private static func testHostingViewsUseFixedIntrinsicContentSize() throws {
+        let sharedHostSource = try String(contentsOfFile: "Sources/FixedIntrinsicHostingView.swift", encoding: .utf8)
+        let source = try String(contentsOfFile: "Sources/RecordingOverlay.swift", encoding: .utf8)
+        assert(sharedHostSource.contains("final class FixedIntrinsicHostingView"))
+        assert(sharedHostSource.contains("override var intrinsicContentSize"))
+        assert(source.contains("FixedIntrinsicHostingView(rootView:"))
     }
 }


### PR DESCRIPTION
## Summary
- Add fixed-size SwiftUI hosting wrappers so overlay content does not trigger AppKit window sizing loops.
- Keep notched meeting reminder panels wide enough for the notch/recording overlay geometry in Notch Sides and Center Dropdown Fill layouts.
- Add geometry and source-level regression coverage for the notched overlay sizing paths.

## Current status
- Draft PR: the crash path is addressed, but final visual polish may still need follow-up after manual review on a notched Mac.

## Test plan
- [x] make test
- [x] Manual/smoke verification on a notched display for Center Dropdown Fill recording, processing, and default reminder frames
- [x] Rebuilt and opened Quill Dev locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 미팅 미리 알림 오버레이의 크기 계산을 화면 기하학에 따라 동적으로 조정하도록 개선했습니다.
  * 녹화 오버레이의 호스팅 뷰 구현을 개선하여 안정성을 향상시켰습니다.

* **테스트**
  * 오버레이 기하학 및 호스팅 뷰 동작을 검증하는 테스트를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/freeflow/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->