### PR TITLE
Fix reminder overlay geometry and transitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,9 +229,11 @@ test:
 	@/tmp/SetupFlowTests
 	@swiftc -parse-as-library Sources/TranscriptionModel.swift Tests/TranscriptionModelCacheTests.swift -o /tmp/TranscriptionModelCacheTests
 	@/tmp/TranscriptionModelCacheTests
-	@swiftc -parse-as-library Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/RecordingOverlay.swift Tests/RecordingOverlayGeometryTests.swift -o /tmp/RecordingOverlayGeometryTests
+	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Tests/OverlayScreenGeometryTests.swift -o /tmp/OverlayScreenGeometryTests
+	@/tmp/OverlayScreenGeometryTests
+	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/RecordingOverlay.swift Tests/RecordingOverlayGeometryTests.swift -o /tmp/RecordingOverlayGeometryTests
 	@/tmp/RecordingOverlayGeometryTests
-	@swiftc -parse-as-library Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/RecordingOverlay.swift Sources/CalendarIntegrationModels.swift Sources/AppNotificationManager.swift Sources/CalendarRecordingReminderScheduler.swift Sources/MeetingReminderOverlay.swift Tests/MeetingReminderOverlayGeometryTests.swift -o /tmp/MeetingReminderOverlayGeometryTests
+	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/RecordingOverlay.swift Sources/CalendarIntegrationModels.swift Sources/AppNotificationManager.swift Sources/CalendarRecordingReminderScheduler.swift Sources/MeetingReminderOverlay.swift Tests/MeetingReminderOverlayGeometryTests.swift -o /tmp/MeetingReminderOverlayGeometryTests
 	@/tmp/MeetingReminderOverlayGeometryTests
 	@swiftc -parse-as-library -target $(shell uname -m)-apple-macosx13.0 $(filter-out Sources/App.swift,$(SOURCES)) Tests/AppStateTranscriptionConfigurationTests.swift -o /tmp/AppStateTranscriptionConfigurationTests
 	@/tmp/AppStateTranscriptionConfigurationTests

--- a/Sources/MeetingReminderOverlay.swift
+++ b/Sources/MeetingReminderOverlay.swift
@@ -167,6 +167,8 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
 
     private var panel: NSPanel?
     private var viewModel: MeetingReminderOverlayViewModel?
+    private var contentContainer: FixedHostingContainer<AnyView>?
+    private var isHidingVisibleReminder = false
     private var visibleReminder: QueuedReminder?
     private var queue: [QueuedReminder] = []
     private var queuedIdentifiers: Set<String> = []
@@ -235,7 +237,7 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
     }
 
     private func showNextIfNeeded() -> Bool {
-        guard visibleReminder == nil, !queue.isEmpty else { return true }
+        guard !isHidingVisibleReminder, visibleReminder == nil, !queue.isEmpty else { return true }
         let reminder = queue.removeFirst()
         queuedIdentifiers.remove(reminder.schedule.identifier)
         queuedReminderGroupIdentifiers.remove(reminder.schedule.reminderGroupIdentifier)
@@ -263,50 +265,105 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
             variant: variant,
             centerOverlayWidth: MeetingReminderOverlayGeometry.centerRecordingOverlayWidth(for: geometry)
         )
-        let panel = panel ?? makePanel(frame: frame)
-        panel.ignoresMouseEvents = false
-        let viewModel = MeetingReminderOverlayViewModel(displayData: displayData)
+
+        if let panel, let viewModel, let contentContainer {
+            updateExistingPresentation(
+                panel: panel,
+                viewModel: viewModel,
+                contentContainer: contentContainer,
+                displayData: displayData,
+                frame: frame,
+                animated: animated
+            )
+        } else {
+            let viewModel = MeetingReminderOverlayViewModel(displayData: displayData, frameSize: frame.size)
+            let container = makeContentContainer(viewModel: viewModel, frame: frame)
+            let panel = panel ?? makePanel(frame: frame)
+            panel.contentView = container
+            self.viewModel = viewModel
+            self.contentContainer = container
+            self.panel = panel
+            presentNewPanel(panel, frame: frame, screen: screen, animated: animated)
+        }
+
+        panel?.ignoresMouseEvents = false
+        panel?.level = variant.isRecordingContext ? Self.recordingContextLevel : .screenSaver
+
+        if markPresented {
+            reminder.onPresented(schedule)
+        }
+        return true
+    }
+
+    private func makeContentContainer(
+        viewModel: MeetingReminderOverlayViewModel,
+        frame: NSRect
+    ) -> FixedHostingContainer<AnyView> {
         let rootView = MeetingReminderOverlayRootView(
             viewModel: viewModel,
             onStart: { [weak self] in self?.handleStart() },
             onDismiss: { [weak self] in self?.handleDismiss() }
         )
         let container = FixedHostingContainer(
-            rootView: AnyView(rootView.frame(width: frame.width, height: frame.height)),
+            rootView: AnyView(rootView),
             size: frame.size
         )
         container.autoresizingMask = [.width, .height]
-        panel.contentView = container
-        self.viewModel = viewModel
-        panel.level = variant.isRecordingContext ? Self.recordingContextLevel : .screenSaver
-        self.panel = panel
+        return container
+    }
 
-        if panel.isVisible, animated {
-            NSAnimationContext.runAnimationGroup { animationContext in
-                animationContext.duration = 0.18
-                animationContext.timingFunction = CAMediaTimingFunction(controlPoints: 0.34, 1.56, 0.64, 1.0)
-                panel.animator().setFrame(frame, display: true)
-            }
-        } else if animated {
-            let hiddenFrame = NSRect(x: frame.origin.x, y: screen.frame.maxY, width: frame.width, height: frame.height)
-            panel.setFrame(hiddenFrame, display: true)
-            panel.alphaValue = 1
-            panel.orderFrontRegardless()
-            NSAnimationContext.runAnimationGroup { animationContext in
-                animationContext.duration = 0.18
-                animationContext.timingFunction = CAMediaTimingFunction(controlPoints: 0.34, 1.56, 0.64, 1.0)
-                panel.animator().setFrame(frame, display: true)
-            }
-        } else {
+    private func updateExistingPresentation(
+        panel: NSPanel,
+        viewModel: MeetingReminderOverlayViewModel,
+        contentContainer: FixedHostingContainer<AnyView>,
+        displayData: MeetingReminderOverlayDisplayData,
+        frame: NSRect,
+        animated: Bool
+    ) {
+        contentContainer.setFixedContentSize(frame.size)
+        viewModel.update(displayData: displayData, frameSize: frame.size, animated: animated)
+        resize(panel: panel, to: frame, animated: animated)
+        panel.alphaValue = 1
+        panel.orderFrontRegardless()
+    }
+
+    private func presentNewPanel(
+        _ panel: NSPanel,
+        frame: NSRect,
+        screen: NSScreen,
+        animated: Bool
+    ) {
+        guard animated else {
             panel.setFrame(frame, display: true)
             panel.alphaValue = 1
             panel.orderFrontRegardless()
+            return
         }
 
-        if markPresented {
-            reminder.onPresented(schedule)
+        let hiddenFrame = NSRect(x: frame.origin.x, y: screen.frame.maxY, width: frame.width, height: frame.height)
+        panel.setFrame(hiddenFrame, display: true)
+        panel.alphaValue = 1
+        panel.orderFrontRegardless()
+        NSAnimationContext.runAnimationGroup { animationContext in
+            animationContext.duration = 0.18
+            animationContext.timingFunction = CAMediaTimingFunction(controlPoints: 0.34, 1.56, 0.64, 1.0)
+            panel.animator().setFrame(frame, display: true)
         }
-        return true
+    }
+
+    private func resize(panel: NSPanel, to frame: NSRect, animated: Bool) {
+        guard animated else {
+            panel.setFrame(frame, display: true)
+            panel.alphaValue = 1
+            panel.orderFrontRegardless()
+            return
+        }
+
+        NSAnimationContext.runAnimationGroup { animationContext in
+            animationContext.duration = 0.18
+            animationContext.timingFunction = CAMediaTimingFunction(controlPoints: 0.34, 1.56, 0.64, 1.0)
+            panel.animator().setFrame(frame, display: true)
+        }
     }
 
     private static var recordingContextLevel: NSWindow.Level {
@@ -349,16 +406,23 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
 
     private func hideVisibleReminder(animated: Bool, completion: @escaping () -> Void) {
         visibleReminder = nil
+        isHidingVisibleReminder = true
         guard let panel, panel.isVisible, let screen = NSScreen.main else {
             panel?.orderOut(nil)
+            resetPresentationHost()
+            isHidingVisibleReminder = false
             completion()
+            _ = showNextIfNeeded()
             return
         }
         let currentFrame = panel.frame
         let hiddenFrame = NSRect(x: currentFrame.origin.x, y: screen.frame.maxY, width: currentFrame.width, height: currentFrame.height)
         guard animated else {
             panel.orderOut(nil)
+            resetPresentationHost()
+            isHidingVisibleReminder = false
             completion()
+            _ = showNextIfNeeded()
             return
         }
         NSAnimationContext.runAnimationGroup { animationContext in
@@ -366,11 +430,25 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
             animationContext.timingFunction = CAMediaTimingFunction(name: .easeIn)
             panel.animator().setFrame(hiddenFrame, display: true)
             panel.animator().alphaValue = 0
-        } completionHandler: {
+        } completionHandler: { [weak self] in
             panel.orderOut(nil)
             panel.alphaValue = 1
-            completion()
+            MainActor.assumeIsolated {
+                self?.resetPresentationHost()
+                self?.isHidingVisibleReminder = false
+                completion()
+                _ = self?.showNextIfNeeded()
+            }
         }
+    }
+
+    private func resetPresentationHost() {
+        if let panel {
+            panel.contentView = nil
+        }
+        panel = nil
+        viewModel = nil
+        contentContainer = nil
     }
 
     private func displayData(
@@ -402,9 +480,27 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
 @MainActor
 private final class MeetingReminderOverlayViewModel: ObservableObject {
     @Published var displayData: MeetingReminderOverlayDisplayData
+    @Published var frameSize: CGSize
 
-    init(displayData: MeetingReminderOverlayDisplayData) {
+    init(displayData: MeetingReminderOverlayDisplayData, frameSize: CGSize) {
         self.displayData = displayData
+        self.frameSize = frameSize
+    }
+
+    func update(displayData: MeetingReminderOverlayDisplayData, frameSize: CGSize, animated: Bool) {
+        if animated {
+            withAnimation(meetingReminderContentTransitionAnimation) {
+                self.displayData = displayData
+                self.frameSize = frameSize
+            }
+        } else {
+            var transaction = Transaction(animation: nil)
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                self.displayData = displayData
+                self.frameSize = frameSize
+            }
+        }
     }
 }
 
@@ -421,6 +517,7 @@ private struct MeetingReminderOverlayRootView: View {
             onStart: onStart,
             onDismiss: onDismiss
         )
+        .frame(width: viewModel.frameSize.width, height: viewModel.frameSize.height)
         .animation(meetingReminderContentTransitionAnimation, value: viewModel.displayData)
     }
 }

--- a/Sources/MeetingReminderOverlay.swift
+++ b/Sources/MeetingReminderOverlay.swift
@@ -95,60 +95,54 @@ struct MeetingReminderOverlayGeometry {
     }
 
     static func frame(for screen: NSScreen, context: MeetingReminderOverlayContext) -> NSRect {
-        let hasNotchGeometry = hasNotchGeometry(for: screen)
-        let variant = variant(for: context, hasNotchGeometry: hasNotchGeometry)
+        frame(for: OverlayScreenGeometry(screen: screen), context: context)
+    }
+
+    static func frame(for geometry: OverlayScreenGeometry, context: MeetingReminderOverlayContext) -> NSRect {
+        let variant = variant(for: context, hasNotchGeometry: hasNotchGeometry(for: geometry))
         let size = size(
             for: variant,
-            screenWidth: screen.frame.width,
-            notchSideWidth: notchSideWidth(for: screen)
+            screenWidth: geometry.screenFrame.width,
+            notchSideWidth: notchSideWidth(for: geometry)
         )
-        return NSRect(
-            x: screen.frame.midX - size.width / 2,
-            y: screen.frame.maxY - size.height,
-            width: size.width,
-            height: size.height
-        )
+        if (variant == .notchSidesRecording || variant == .notchSidesProcessing),
+           let notchSideGeometry = geometry.notchSideGeometry(
+               regionWidth: notchSideRegionWidth,
+               panelHeight: size.height,
+               horizontalInset: notchSideHorizontalInset
+           ) {
+            return notchSideGeometry.frame
+        }
+        return geometry.centeredTopFrame(width: size.width, height: size.height)
     }
 
     static func hasNotchGeometry(for screen: NSScreen) -> Bool {
-        guard screen.safeAreaInsets.top > 0 else { return false }
-        guard let leftArea = screen.auxiliaryTopLeftArea,
-              let rightArea = screen.auxiliaryTopRightArea else { return false }
-        return rightArea.minX > leftArea.maxX
+        hasNotchGeometry(for: OverlayScreenGeometry(screen: screen))
+    }
+
+    static func hasNotchGeometry(for geometry: OverlayScreenGeometry) -> Bool {
+        geometry.hasNotchGeometry
     }
 
     static func notchSideWidth(for screen: NSScreen) -> CGFloat? {
-        guard hasNotchGeometry(for: screen),
-              let leftArea = screen.auxiliaryTopLeftArea,
-              let rightArea = screen.auxiliaryTopRightArea else { return nil }
-        return notchSideWidth(
-            leftAreaWidth: leftArea.width,
-            rightAreaWidth: rightArea.width,
-            screenWidth: screen.frame.width
-        )
+        notchSideWidth(for: OverlayScreenGeometry(screen: screen))
     }
 
-    static func notchSideWidth(leftAreaWidth: CGFloat, rightAreaWidth: CGFloat, screenWidth: CGFloat) -> CGFloat? {
-        let availableSideWidth = min(leftAreaWidth, rightAreaWidth)
-        let contentWidth = min(notchSideRegionWidth, max(0, availableSideWidth - notchSideHorizontalInset * 2))
-        guard contentWidth >= 64 else { return nil }
-        let notchWidth = screenWidth - leftAreaWidth - rightAreaWidth
-        return notchWidth + contentWidth * 2
-    }
-
-    static func centerRecordingOverlayWidth(leftAreaWidth: CGFloat, rightAreaWidth: CGFloat, screenWidth: CGFloat) -> CGFloat {
-        max(screenWidth - leftAreaWidth - rightAreaWidth, centerRecordingBaseWidth)
+    static func notchSideWidth(for geometry: OverlayScreenGeometry) -> CGFloat? {
+        geometry.notchSideGeometry(
+            regionWidth: notchSideRegionWidth,
+            panelHeight: defaultSize.height,
+            horizontalInset: notchSideHorizontalInset
+        )?.frame.width
     }
 
     static func centerRecordingOverlayWidth(for screen: NSScreen) -> CGFloat {
-        guard hasNotchGeometry(for: screen),
-              let leftArea = screen.auxiliaryTopLeftArea,
-              let rightArea = screen.auxiliaryTopRightArea else { return centerRecordingBaseWidth }
-        return centerRecordingOverlayWidth(
-            leftAreaWidth: leftArea.width,
-            rightAreaWidth: rightArea.width,
-            screenWidth: screen.frame.width
-        )
+        centerRecordingOverlayWidth(for: OverlayScreenGeometry(screen: screen))
+    }
+
+    static func centerRecordingOverlayWidth(for geometry: OverlayScreenGeometry) -> CGFloat {
+        guard let notchWidth = geometry.notchWidth else { return centerRecordingBaseWidth }
+        return max(notchWidth, centerRecordingBaseWidth)
     }
 }
 
@@ -179,6 +173,7 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
     private var queuedReminderGroupIdentifiers: Set<String> = []
     private let contextProvider: () -> MeetingReminderOverlayContext
     private let screenProvider: () -> NSScreen?
+    private var screenParametersObserver: NSObjectProtocol?
 
     var onStart: (@MainActor (CalendarRecordingReminderSchedule) -> Void)?
     var onDismiss: (@MainActor (CalendarRecordingReminderSchedule) -> Void)?
@@ -189,6 +184,21 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
     ) {
         self.contextProvider = contextProvider
         self.screenProvider = screenProvider
+        screenParametersObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.handleScreenParametersChanged()
+            }
+        }
+    }
+
+    deinit {
+        if let screenParametersObserver {
+            NotificationCenter.default.removeObserver(screenParametersObserver)
+        }
     }
 
     func presentCalendarRecordingReminder(
@@ -199,8 +209,16 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
     }
 
     func refreshVisibleReminder() {
+        refreshVisibleReminder(animated: true)
+    }
+
+    private func refreshVisibleReminder(animated: Bool) {
         guard let visibleReminder else { return }
-        _ = render(visibleReminder, markPresented: false, animated: true)
+        _ = render(visibleReminder, markPresented: false, animated: animated)
+    }
+
+    private func handleScreenParametersChanged() {
+        refreshVisibleReminder(animated: false)
     }
 
     private func enqueue(_ schedule: CalendarRecordingReminderSchedule, onPresented: @escaping CalendarRecordingReminderPresentedHandler) -> Bool {
@@ -233,16 +251,17 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
         let schedule = reminder.schedule
         guard let screen = screenProvider() else { return false }
         let context = contextProvider()
-        let frame = MeetingReminderOverlayGeometry.frame(for: screen, context: context)
+        let geometry = OverlayScreenGeometry(screen: screen)
+        let frame = MeetingReminderOverlayGeometry.frame(for: geometry, context: context)
         let variant = MeetingReminderOverlayGeometry.variant(
             for: context,
-            hasNotchGeometry: MeetingReminderOverlayGeometry.hasNotchGeometry(for: screen)
+            hasNotchGeometry: MeetingReminderOverlayGeometry.hasNotchGeometry(for: geometry)
         )
         let displayData = displayData(
             for: schedule,
             context: context,
             variant: variant,
-            centerOverlayWidth: MeetingReminderOverlayGeometry.centerRecordingOverlayWidth(for: screen)
+            centerOverlayWidth: MeetingReminderOverlayGeometry.centerRecordingOverlayWidth(for: geometry)
         )
         let panel = panel ?? makePanel(frame: frame)
         panel.ignoresMouseEvents = false

--- a/Sources/MeetingReminderOverlay.swift
+++ b/Sources/MeetingReminderOverlay.swift
@@ -2,7 +2,8 @@ import AppKit
 import Combine
 import SwiftUI
 
-private let meetingReminderContentTransitionAnimation = Animation.spring(response: 0.28, dampingFraction: 0.88, blendDuration: 0.08)
+private let meetingReminderPanelResizeDuration: TimeInterval = 0.28
+private let meetingReminderContentTransitionAnimation = Animation.spring(response: meetingReminderPanelResizeDuration, dampingFraction: 0.88, blendDuration: 0.08)
 
 struct MeetingReminderOverlayContext: Equatable {
     var phase: Phase
@@ -345,7 +346,7 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
         panel.alphaValue = 1
         panel.orderFrontRegardless()
         NSAnimationContext.runAnimationGroup { animationContext in
-            animationContext.duration = 0.18
+            animationContext.duration = meetingReminderPanelResizeDuration
             animationContext.timingFunction = CAMediaTimingFunction(controlPoints: 0.34, 1.56, 0.64, 1.0)
             panel.animator().setFrame(frame, display: true)
         }
@@ -360,7 +361,7 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
         }
 
         NSAnimationContext.runAnimationGroup { animationContext in
-            animationContext.duration = 0.18
+            animationContext.duration = meetingReminderPanelResizeDuration
             animationContext.timingFunction = CAMediaTimingFunction(controlPoints: 0.34, 1.56, 0.64, 1.0)
             panel.animator().setFrame(frame, display: true)
         }
@@ -407,7 +408,7 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
     private func hideVisibleReminder(animated: Bool, completion: @escaping () -> Void) {
         visibleReminder = nil
         isHidingVisibleReminder = true
-        guard let panel, panel.isVisible, let screen = NSScreen.main else {
+        guard let panel, panel.isVisible, let screen = panel.screen ?? screenProvider() ?? NSScreen.main else {
             panel?.orderOut(nil)
             resetPresentationHost()
             isHidingVisibleReminder = false

--- a/Sources/OverlayScreenGeometry.swift
+++ b/Sources/OverlayScreenGeometry.swift
@@ -1,0 +1,109 @@
+import AppKit
+import CoreGraphics
+
+struct OverlayScreenGeometry {
+    struct NotchSideGeometry {
+        let frame: NSRect
+        let leftContentFrame: CGRect
+        let rightContentFrame: CGRect
+    }
+
+    let screenFrame: CGRect
+    let visibleFrame: CGRect
+    let safeAreaInsets: NSEdgeInsets
+    let auxiliaryTopLeftArea: CGRect?
+    let auxiliaryTopRightArea: CGRect?
+
+    init(screen: NSScreen) {
+        self.init(
+            screenFrame: screen.frame,
+            visibleFrame: screen.visibleFrame,
+            safeAreaInsets: screen.safeAreaInsets,
+            auxiliaryTopLeftArea: screen.auxiliaryTopLeftArea,
+            auxiliaryTopRightArea: screen.auxiliaryTopRightArea
+        )
+    }
+
+    init(
+        screenFrame: CGRect,
+        visibleFrame: CGRect,
+        safeAreaInsets: NSEdgeInsets = NSEdgeInsets(top: 0, left: 0, bottom: 0, right: 0),
+        auxiliaryTopLeftArea: CGRect? = nil,
+        auxiliaryTopRightArea: CGRect? = nil
+    ) {
+        self.screenFrame = screenFrame
+        self.visibleFrame = visibleFrame
+        self.safeAreaInsets = safeAreaInsets
+        self.auxiliaryTopLeftArea = auxiliaryTopLeftArea
+        self.auxiliaryTopRightArea = auxiliaryTopRightArea
+    }
+
+    var hasTopSafeArea: Bool {
+        safeAreaInsets.top > 0
+    }
+
+    var hasNotchGeometry: Bool {
+        guard hasTopSafeArea,
+              let leftArea = auxiliaryTopLeftArea,
+              let rightArea = auxiliaryTopRightArea else { return false }
+        return rightArea.minX > leftArea.maxX
+    }
+
+    var notchWidth: CGFloat? {
+        guard hasNotchGeometry,
+              let leftArea = auxiliaryTopLeftArea,
+              let rightArea = auxiliaryTopRightArea else { return nil }
+        return rightArea.minX - leftArea.maxX
+    }
+
+    var notchOverlap: CGFloat {
+        max(0, screenFrame.maxY - visibleFrame.maxY)
+    }
+
+    func centeredTopFrame(width: CGFloat, height: CGFloat) -> NSRect {
+        NSRect(
+            x: screenFrame.midX - width / 2,
+            y: screenFrame.maxY - height,
+            width: width,
+            height: height
+        )
+    }
+
+    func notchSideGeometry(
+        regionWidth: CGFloat,
+        panelHeight: CGFloat,
+        horizontalInset: CGFloat
+    ) -> NotchSideGeometry? {
+        guard hasNotchGeometry,
+              let leftArea = auxiliaryTopLeftArea,
+              let rightArea = auxiliaryTopRightArea else { return nil }
+
+        let availableSideWidth = min(leftArea.width, rightArea.width)
+        let contentWidth = min(regionWidth, max(0, availableSideWidth - horizontalInset * 2))
+        guard contentWidth >= 64 else { return nil }
+
+        let panelMinX = leftArea.maxX - contentWidth
+        let panelMaxX = rightArea.minX + contentWidth
+        let frame = NSRect(
+            x: panelMinX,
+            y: screenFrame.maxY - panelHeight,
+            width: panelMaxX - panelMinX,
+            height: panelHeight
+        )
+
+        let leftFrame = CGRect(
+            x: 0,
+            y: 0,
+            width: contentWidth,
+            height: panelHeight
+        )
+        let rightFrame = CGRect(
+            x: frame.width - contentWidth,
+            y: 0,
+            width: contentWidth,
+            height: panelHeight
+        )
+
+        return NotchSideGeometry(frame: frame, leftContentFrame: leftFrame, rightContentFrame: rightFrame)
+    }
+}

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -99,54 +99,6 @@ private func makeTransparentContent<V: View>(
 }
 
 struct RecordingOverlayGeometry {
-    struct NotchSideGeometry {
-        let frame: NSRect
-        let leftContentFrame: CGRect
-        let rightContentFrame: CGRect
-    }
-
-    static func notchSideGeometry(
-        screenFrame: CGRect,
-        visibleFrame: CGRect,
-        leftArea: CGRect,
-        rightArea: CGRect,
-        regionWidth: CGFloat,
-        panelHeight: CGFloat,
-        horizontalInset: CGFloat
-    ) -> NotchSideGeometry? {
-        let availableSideWidth = min(leftArea.width, rightArea.width)
-        let contentWidth = min(regionWidth, max(0, availableSideWidth - horizontalInset * 2))
-        guard contentWidth >= 64 else { return nil }
-
-        let notchMinX = leftArea.maxX
-        let notchMaxX = rightArea.minX
-        guard notchMaxX > notchMinX else { return nil }
-
-        let panelMinX = leftArea.maxX - contentWidth
-        let panelMaxX = rightArea.minX + contentWidth
-        let frame = NSRect(
-            x: panelMinX,
-            y: screenFrame.maxY - panelHeight,
-            width: panelMaxX - panelMinX,
-            height: panelHeight
-        )
-
-        let leftFrame = CGRect(
-            x: 0,
-            y: 0,
-            width: contentWidth,
-            height: panelHeight
-        )
-        let rightFrame = CGRect(
-            x: frame.width - contentWidth,
-            y: 0,
-            width: contentWidth,
-            height: panelHeight
-        )
-
-        return NotchSideGeometry(frame: frame, leftContentFrame: leftFrame, rightContentFrame: rightFrame)
-    }
-
     static func lockedTranscribingWidth(
         existingLockedWidth: CGFloat?,
         currentPanelWidth: CGFloat,
@@ -155,15 +107,6 @@ struct RecordingOverlayGeometry {
     ) -> CGFloat {
         if let existingLockedWidth { return existingLockedWidth }
         return wasNotchSideRecordingLayout ? centeredTranscribingWidth : currentPanelWidth
-    }
-
-    static func centeredFrame(screenFrame: CGRect, width: CGFloat, height: CGFloat) -> NSRect {
-        NSRect(
-            x: screenFrame.midX - width / 2,
-            y: screenFrame.maxY - height,
-            width: width,
-            height: height
-        )
     }
 
     static func usesNotchSideLayout(
@@ -193,7 +136,7 @@ final class RecordingOverlayManager {
     private let notchSidePanelHeight: CGFloat = 38
     private let notchSideHorizontalInset: CGFloat = 8
 
-    private typealias NotchSideGeometry = RecordingOverlayGeometry.NotchSideGeometry
+    private typealias NotchSideGeometry = OverlayScreenGeometry.NotchSideGeometry
 
     var onStopButtonPressed: (() -> Void)?
     var onUpdateOverlayPressed: (() -> Void)?
@@ -214,21 +157,21 @@ final class RecordingOverlayManager {
         }
     }
 
-    private var screenHasNotch: Bool {
-        guard let screen = NSScreen.main else { return false }
-        return screen.safeAreaInsets.top > 0
+    private var screenGeometry: OverlayScreenGeometry? {
+        guard let screen = NSScreen.main else { return nil }
+        return OverlayScreenGeometry(screen: screen)
+    }
+
+    private var screenHasTopSafeArea: Bool {
+        screenGeometry?.hasTopSafeArea ?? false
     }
 
     private var notchWidth: CGFloat {
-        guard let screen = NSScreen.main, screenHasNotch else { return 0 }
-        guard let leftArea = screen.auxiliaryTopLeftArea,
-              let rightArea = screen.auxiliaryTopRightArea else { return 0 }
-        return screen.frame.width - leftArea.width - rightArea.width
+        screenGeometry?.notchWidth ?? 0
     }
 
     private var notchOverlap: CGFloat {
-        guard let screen = NSScreen.main else { return 0 }
-        return screen.frame.maxY - screen.visibleFrame.maxY
+        screenGeometry?.notchOverlap ?? 0
     }
 
     private var usesNotchSideLayout: Bool {
@@ -240,15 +183,7 @@ final class RecordingOverlayManager {
     }
 
     private var notchSideGeometry: NotchSideGeometry? {
-        guard let screen = NSScreen.main, screenHasNotch else { return nil }
-        guard let leftArea = screen.auxiliaryTopLeftArea,
-              let rightArea = screen.auxiliaryTopRightArea else { return nil }
-
-        return RecordingOverlayGeometry.notchSideGeometry(
-            screenFrame: screen.frame,
-            visibleFrame: screen.visibleFrame,
-            leftArea: leftArea,
-            rightArea: rightArea,
+        screenGeometry?.notchSideGeometry(
             regionWidth: notchSideRegionWidth,
             panelHeight: notchSidePanelHeight,
             horizontalInset: notchSideHorizontalInset
@@ -406,7 +341,7 @@ final class RecordingOverlayManager {
         return makeNotchContent(
             width: frame.width,
             height: frame.height,
-            cornerRadius: screenHasNotch ? 18 : 12,
+            cornerRadius: screenHasTopSafeArea ? 18 : 12,
             rootView: RecordingOverlayView(
                 state: overlayState,
                 onStopButtonPressed: { [weak self] in
@@ -416,7 +351,7 @@ final class RecordingOverlayManager {
                     self?.onUpdateOverlayPressed?()
                 }
             )
-            .padding(.top, screenHasNotch ? notchOverlap : 0)
+            .padding(.top, screenHasTopSafeArea ? notchOverlap : 0)
         )
     }
 
@@ -449,21 +384,21 @@ final class RecordingOverlayManager {
     }
 
     private var overlayFrame: NSRect {
-        guard let screen = NSScreen.main else { return .zero }
+        guard let screenGeometry else { return .zero }
         if let geometry = notchSideGeometry,
            usesNotchSideLayout {
             return geometry.frame
         }
 
         let width = overlayWidth
-        let overlap = screenHasNotch ? notchOverlap : 0
+        let overlap = screenHasTopSafeArea ? notchOverlap : 0
         let height: CGFloat = 38 + overlap
-        return RecordingOverlayGeometry.centeredFrame(screenFrame: screen.frame, width: width, height: height)
+        return screenGeometry.centeredTopFrame(width: width, height: height)
     }
 
     private var centeredTranscribingOverlayWidth: CGFloat {
         let defaultWidth: CGFloat = 92
-        guard screenHasNotch else { return defaultWidth }
+        guard screenHasTopSafeArea else { return defaultWidth }
         return max(notchWidth, defaultWidth)
     }
 
@@ -474,13 +409,13 @@ final class RecordingOverlayManager {
 
         if overlayState.phase == .feedback {
             let feedbackWidth: CGFloat = 92
-            guard screenHasNotch else { return feedbackWidth }
+            guard screenHasTopSafeArea else { return feedbackWidth }
             return max(notchWidth, feedbackWidth)
         }
 
         if overlayState.phase == .updateAvailable {
             let updateWidth: CGFloat = 190
-            guard screenHasNotch else { return updateWidth }
+            guard screenHasTopSafeArea else { return updateWidth }
             return max(notchWidth, updateWidth)
         }
 
@@ -497,7 +432,7 @@ final class RecordingOverlayManager {
             baseWidth = defaultWidth
         }
 
-        guard screenHasNotch else { return baseWidth }
+        guard screenHasTopSafeArea else { return baseWidth }
         return max(notchWidth, baseWidth)
     }
 

--- a/Tests/MeetingReminderOverlayGeometryTests.swift
+++ b/Tests/MeetingReminderOverlayGeometryTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CoreGraphics
 import Foundation
 
@@ -14,6 +15,10 @@ struct MeetingReminderOverlayGeometryTests {
         testRecordingCenterWithoutNotchUsesCenterVariant()
         testNotchSideWidthMatchesRecordingOverlayGeometry()
         testContextualSizesMatchFinalDesign()
+        testFrameUsesSharedScreenGeometryForUpdatedFrames()
+        testFrameUsesSharedNotchSideGeometryWidth()
+        try testMeetingReminderUsesSharedScreenGeometry()
+        try testMeetingReminderObservesScreenParameterChanges()
         try testHostingViewsUseFixedIntrinsicContentSize()
         await testPresenterFailureWhenScreenUnavailableFallsBack()
         print("MeetingReminderOverlayGeometryTests passed")
@@ -74,22 +79,21 @@ struct MeetingReminderOverlayGeometryTests {
     }
 
     private static func testNotchSideWidthMatchesRecordingOverlayGeometry() {
-        let recordingGeometry = RecordingOverlayGeometry.notchSideGeometry(
+        let geometry = OverlayScreenGeometry(
             screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
             visibleFrame: CGRect(x: 0, y: 0, width: 1512, height: 944),
-            leftArea: CGRect(x: 0, y: 944, width: 682, height: 38),
-            rightArea: CGRect(x: 830, y: 944, width: 682, height: 38),
+            safeAreaInsets: NSEdgeInsets(top: 38, left: 0, bottom: 0, right: 0),
+            auxiliaryTopLeftArea: CGRect(x: 0, y: 944, width: 682, height: 38),
+            auxiliaryTopRightArea: CGRect(x: 830, y: 944, width: 682, height: 38)
+        )
+        let recordingGeometry = geometry.notchSideGeometry(
             regionWidth: 92,
-            panelHeight: 38,
+            panelHeight: 92,
             horizontalInset: 8
         )
 
         assert(recordingGeometry != nil)
-        let reminderWidth = MeetingReminderOverlayGeometry.notchSideWidth(
-            leftAreaWidth: 682,
-            rightAreaWidth: 682,
-            screenWidth: 1512
-        )
+        let reminderWidth = MeetingReminderOverlayGeometry.notchSideWidth(for: geometry)
 
         assert(reminderWidth == recordingGeometry?.frame.width)
         assert(MeetingReminderOverlayGeometry.size(for: .notchSidesRecording, screenWidth: 1512, notchSideWidth: reminderWidth) == CGSize(width: reminderWidth!, height: 92))
@@ -109,6 +113,60 @@ struct MeetingReminderOverlayGeometryTests {
         assert(MeetingReminderOverlayGeometry.size(for: .centerProcessing, screenWidth: 1_440, notchSideWidth: nil) == CGSize(width: 336, height: 92))
     }
 
+    private static func testFrameUsesSharedScreenGeometryForUpdatedFrames() {
+        let context = MeetingReminderOverlayContext(phase: .idle, layout: .centerDropdownFill)
+        let oldGeometry = OverlayScreenGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1512, height: 944)
+        )
+        let updatedGeometry = OverlayScreenGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1728, height: 1117),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1728, height: 1079)
+        )
+
+        let oldFrame = MeetingReminderOverlayGeometry.frame(for: oldGeometry, context: context)
+        let updatedFrame = MeetingReminderOverlayGeometry.frame(for: updatedGeometry, context: context)
+
+        assert(oldFrame.origin.x == 588)
+        assert(oldFrame.origin.y == 890)
+        assert(updatedFrame.origin.x == 696)
+        assert(updatedFrame.origin.y == 1025)
+    }
+
+    private static func testFrameUsesSharedNotchSideGeometryWidth() {
+        let context = MeetingReminderOverlayContext(phase: .recording, layout: .notchSides)
+        let geometry = OverlayScreenGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1512, height: 944),
+            safeAreaInsets: NSEdgeInsets(top: 38, left: 0, bottom: 0, right: 0),
+            auxiliaryTopLeftArea: CGRect(x: 0, y: 944, width: 600, height: 38),
+            auxiliaryTopRightArea: CGRect(x: 830, y: 944, width: 682, height: 38)
+        )
+
+        let frame = MeetingReminderOverlayGeometry.frame(for: geometry, context: context)
+
+        assert(frame.width == 414)
+        assert(frame.origin.x == 508)
+        assert(frame.origin.y == 890)
+    }
+
+    private static func testMeetingReminderUsesSharedScreenGeometry() throws {
+        let source = try String(contentsOfFile: "Sources/MeetingReminderOverlay.swift", encoding: .utf8)
+        assert(source.contains("OverlayScreenGeometry(screen: screen)"))
+        assert(source.contains("static func frame(for geometry: OverlayScreenGeometry"))
+        assert(source.contains("geometry.centeredTopFrame("))
+        assert(source.contains("centerOverlayWidth: MeetingReminderOverlayGeometry.centerRecordingOverlayWidth(for: geometry)"))
+    }
+
+    private static func testMeetingReminderObservesScreenParameterChanges() throws {
+        let source = try String(contentsOfFile: "Sources/MeetingReminderOverlay.swift", encoding: .utf8)
+        assert(source.contains("private var screenParametersObserver: NSObjectProtocol?"))
+        assert(source.contains("NSApplication.didChangeScreenParametersNotification"))
+        assert(source.contains("handleScreenParametersChanged()"))
+        assert(source.contains("refreshVisibleReminder(animated: false)"))
+        assert(source.contains("NotificationCenter.default.removeObserver(screenParametersObserver)"))
+    }
+
     private static func testHostingViewsUseFixedIntrinsicContentSize() throws {
         let sharedHostSource = try String(contentsOfFile: "Sources/FixedIntrinsicHostingView.swift", encoding: .utf8)
         let source = try String(contentsOfFile: "Sources/MeetingReminderOverlay.swift", encoding: .utf8)
@@ -119,7 +177,7 @@ struct MeetingReminderOverlayGeometryTests {
         assert(sharedHostSource.contains("fatalError(\"init(rootView:) is not supported on FixedIntrinsicHostingView. Use init(rootView:size:) instead.\")"), "Fixed hosting views must require an explicit fixed size")
         assert(source.contains("FixedHostingContainer("), "Meeting reminders must host SwiftUI inside a plain NSView container")
         assert(source.contains("rootView: AnyView(rootView.frame("), "Meeting reminders must give SwiftUI a fixed panel-sized root frame")
-        assert(source.contains("centerOverlayWidth: MeetingReminderOverlayGeometry.centerRecordingOverlayWidth(for: screen)"), "Center reminder layout must reserve the actual center recording overlay width")
+        assert(source.contains("centerOverlayWidth: MeetingReminderOverlayGeometry.centerRecordingOverlayWidth(for: geometry)"), "Center reminder layout must reserve the actual center recording overlay width")
         assert(!source.contains("panel.contentView = hostingView"), "Meeting reminders must not install NSHostingView directly as the panel content view")
     }
 

--- a/Tests/MeetingReminderOverlayGeometryTests.swift
+++ b/Tests/MeetingReminderOverlayGeometryTests.swift
@@ -19,6 +19,8 @@ struct MeetingReminderOverlayGeometryTests {
         testFrameUsesSharedNotchSideGeometryWidth()
         try testMeetingReminderUsesSharedScreenGeometry()
         try testMeetingReminderObservesScreenParameterChanges()
+        try testMeetingReminderKeepsPersistentAnimationHost()
+        try testMeetingReminderDefersNextReminderWhileHiding()
         try testHostingViewsUseFixedIntrinsicContentSize()
         await testPresenterFailureWhenScreenUnavailableFallsBack()
         print("MeetingReminderOverlayGeometryTests passed")
@@ -167,6 +169,32 @@ struct MeetingReminderOverlayGeometryTests {
         assert(source.contains("NotificationCenter.default.removeObserver(screenParametersObserver)"))
     }
 
+    private static func testMeetingReminderKeepsPersistentAnimationHost() throws {
+        let source = try String(contentsOfFile: "Sources/MeetingReminderOverlay.swift", encoding: .utf8)
+        assert(source.contains("private var contentContainer: FixedHostingContainer<AnyView>?"))
+        assert(source.contains("if let panel, let viewModel, let contentContainer"))
+        assert(source.contains("viewModel.update(displayData: displayData, frameSize: frame.size, animated: animated)"))
+        assert(source.contains("contentContainer.setFixedContentSize(frame.size)"))
+        assert(source.contains(".frame(width: viewModel.frameSize.width, height: viewModel.frameSize.height)"))
+        assert(source.contains("transaction.disablesAnimations = true"))
+        assert(source.contains("makeContentContainer("))
+        assert(source.contains("resetPresentationHost()"))
+        assert(source.contains("panel.contentView = nil"))
+        assert(source.contains("viewModel = nil"))
+        assert(source.contains("contentContainer = nil"))
+        assert(source.contains("refreshVisibleReminder(animated: false)"))
+    }
+
+    private static func testMeetingReminderDefersNextReminderWhileHiding() throws {
+        let source = try String(contentsOfFile: "Sources/MeetingReminderOverlay.swift", encoding: .utf8)
+        assert(source.contains("private var isHidingVisibleReminder = false"))
+        assert(source.contains("guard !isHidingVisibleReminder, visibleReminder == nil, !queue.isEmpty else { return true }"))
+        assert(source.contains("isHidingVisibleReminder = true"))
+        assert(source.contains("isHidingVisibleReminder = false"))
+        assert(source.contains("resetPresentationHost()"))
+        assert(source.contains("_ = showNextIfNeeded()"))
+    }
+
     private static func testHostingViewsUseFixedIntrinsicContentSize() throws {
         let sharedHostSource = try String(contentsOfFile: "Sources/FixedIntrinsicHostingView.swift", encoding: .utf8)
         let source = try String(contentsOfFile: "Sources/MeetingReminderOverlay.swift", encoding: .utf8)
@@ -176,7 +204,7 @@ struct MeetingReminderOverlayGeometryTests {
         assert(sharedHostSource.contains("required dynamic init?(coder: NSCoder) {\n        return nil\n    }"), "Fixed hosting views must not support storyboard/XIB initialization")
         assert(sharedHostSource.contains("fatalError(\"init(rootView:) is not supported on FixedIntrinsicHostingView. Use init(rootView:size:) instead.\")"), "Fixed hosting views must require an explicit fixed size")
         assert(source.contains("FixedHostingContainer("), "Meeting reminders must host SwiftUI inside a plain NSView container")
-        assert(source.contains("rootView: AnyView(rootView.frame("), "Meeting reminders must give SwiftUI a fixed panel-sized root frame")
+        assert(source.contains(".frame(width: viewModel.frameSize.width, height: viewModel.frameSize.height)"), "Meeting reminders must give SwiftUI a fixed panel-sized root frame")
         assert(source.contains("centerOverlayWidth: MeetingReminderOverlayGeometry.centerRecordingOverlayWidth(for: geometry)"), "Center reminder layout must reserve the actual center recording overlay width")
         assert(!source.contains("panel.contentView = hostingView"), "Meeting reminders must not install NSHostingView directly as the panel content view")
     }

--- a/Tests/MeetingReminderOverlayGeometryTests.swift
+++ b/Tests/MeetingReminderOverlayGeometryTests.swift
@@ -183,6 +183,9 @@ struct MeetingReminderOverlayGeometryTests {
         assert(source.contains("viewModel = nil"))
         assert(source.contains("contentContainer = nil"))
         assert(source.contains("refreshVisibleReminder(animated: false)"))
+        assert(source.contains("let screen = panel.screen ?? screenProvider() ?? NSScreen.main"))
+        assert(source.contains("meetingReminderPanelResizeDuration"))
+        assert(source.contains("animationContext.duration = meetingReminderPanelResizeDuration"))
     }
 
     private static func testMeetingReminderDefersNextReminderWhileHiding() throws {

--- a/Tests/OverlayScreenGeometryTests.swift
+++ b/Tests/OverlayScreenGeometryTests.swift
@@ -1,0 +1,93 @@
+import AppKit
+import CoreGraphics
+
+@main
+struct OverlayScreenGeometryTests {
+    static func main() {
+        testCenteredTopFrameUsesUpdatedScreenFrame()
+        testNotchSideGeometryMatchesExistingRecordingExpectations()
+        testNotchOverlapUsesVisibleFrameGap()
+        testNoNotchGeometryWithoutAuxiliaryAreas()
+        testNotchWidthUsesAuxiliaryAreas()
+        print("OverlayScreenGeometryTests passed")
+    }
+
+    private static func testCenteredTopFrameUsesUpdatedScreenFrame() {
+        let oldGeometry = OverlayScreenGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1512, height: 944)
+        )
+        let updatedGeometry = OverlayScreenGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1728, height: 1117),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1728, height: 1079)
+        )
+
+        let oldFrame = oldGeometry.centeredTopFrame(width: 92, height: 76)
+        let updatedFrame = updatedGeometry.centeredTopFrame(width: 92, height: 76)
+
+        assert(oldFrame.origin.x == 710)
+        assert(oldFrame.origin.y == 906)
+        assert(updatedFrame.origin.x == 818)
+        assert(updatedFrame.origin.y == 1041)
+    }
+
+    private static func testNotchSideGeometryMatchesExistingRecordingExpectations() {
+        let geometry = OverlayScreenGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1512, height: 944),
+            safeAreaInsets: NSEdgeInsets(top: 38, left: 0, bottom: 0, right: 0),
+            auxiliaryTopLeftArea: CGRect(x: 0, y: 944, width: 682, height: 38),
+            auxiliaryTopRightArea: CGRect(x: 830, y: 944, width: 682, height: 38)
+        )
+
+        let notchSideGeometry = geometry.notchSideGeometry(
+            regionWidth: 92,
+            panelHeight: 38,
+            horizontalInset: 8
+        )
+
+        assert(notchSideGeometry != nil)
+        assert(notchSideGeometry?.frame.maxX == 922)
+        assert(notchSideGeometry?.frame.minX == 590)
+        assert(notchSideGeometry?.frame.height == 38)
+        assert(notchSideGeometry?.leftContentFrame.origin.x == 0)
+        assert(notchSideGeometry?.leftContentFrame.origin.y == 0)
+        assert(notchSideGeometry?.rightContentFrame.maxX == notchSideGeometry?.frame.width)
+        assert(notchSideGeometry?.rightContentFrame.origin.y == 0)
+    }
+
+    private static func testNotchOverlapUsesVisibleFrameGap() {
+        let geometry = OverlayScreenGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1512, height: 944)
+        )
+
+        assert(geometry.notchOverlap == 38)
+    }
+
+    private static func testNoNotchGeometryWithoutAuxiliaryAreas() {
+        let geometry = OverlayScreenGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1440, height: 875),
+            safeAreaInsets: NSEdgeInsets(top: 25, left: 0, bottom: 0, right: 0)
+        )
+
+        assert(geometry.hasTopSafeArea)
+        assert(!geometry.hasNotchGeometry)
+        assert(geometry.notchWidth == nil)
+        assert(geometry.notchSideGeometry(regionWidth: 92, panelHeight: 38, horizontalInset: 8) == nil)
+    }
+
+    private static func testNotchWidthUsesAuxiliaryAreas() {
+        let geometry = OverlayScreenGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1512, height: 944),
+            safeAreaInsets: NSEdgeInsets(top: 38, left: 0, bottom: 0, right: 0),
+            auxiliaryTopLeftArea: CGRect(x: 0, y: 944, width: 682, height: 38),
+            auxiliaryTopRightArea: CGRect(x: 830, y: 944, width: 682, height: 38)
+        )
+
+        assert(geometry.hasNotchGeometry)
+        assert(geometry.notchWidth == 148)
+    }
+}

--- a/Tests/RecordingOverlayGeometryTests.swift
+++ b/Tests/RecordingOverlayGeometryTests.swift
@@ -1,5 +1,6 @@
-import Foundation
+import AppKit
 import CoreGraphics
+import Foundation
 
 @main
 struct RecordingOverlayGeometryTests {
@@ -7,7 +8,7 @@ struct RecordingOverlayGeometryTests {
         testTranscribingWidthFallsBackToCenteredWidthAfterNotchSideRecording()
         testTranscribingWidthKeepsExistingLockOnRepeatedTranscribingUpdate()
         testNotchSideLayoutPhaseEligibility()
-        try testRecordingOverlayUsesSharedScreenGeometry()
+        testRecordingOverlayUsesSharedScreenGeometry()
         try testNotchSideOverlayAvoidsContainerAudioLevelAnimation()
         try testHostingViewsUseFixedIntrinsicContentSize()
         print("RecordingOverlayGeometryTests passed")
@@ -73,15 +74,31 @@ struct RecordingOverlayGeometryTests {
         ))
     }
 
-    private static func testRecordingOverlayUsesSharedScreenGeometry() throws {
-        let source = try String(contentsOfFile: "Sources/RecordingOverlay.swift", encoding: .utf8)
-        assert(source.contains("private typealias NotchSideGeometry = OverlayScreenGeometry.NotchSideGeometry"))
-        assert(source.contains("OverlayScreenGeometry(screen: screen)"))
-        assert(source.contains("screenGeometry?.notchSideGeometry("))
-        assert(source.contains("screenGeometry?.hasTopSafeArea"))
-        assert(source.contains("screenGeometry.centeredTopFrame("))
-        assert(!source.contains("static func notchSideGeometry("))
-        assert(!source.contains("static func centeredFrame("))
+    private static func testRecordingOverlayUsesSharedScreenGeometry() {
+        let notchGeometry = OverlayScreenGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1512, height: 944),
+            safeAreaInsets: NSEdgeInsets(top: 38, left: 0, bottom: 0, right: 0),
+            auxiliaryTopLeftArea: CGRect(x: 0, y: 944, width: 682, height: 38),
+            auxiliaryTopRightArea: CGRect(x: 830, y: 944, width: 682, height: 38)
+        )
+
+        assert(notchGeometry.hasTopSafeArea)
+        assert(notchGeometry.hasNotchGeometry)
+        assert(notchGeometry.notchOverlap == 38)
+        assert(notchGeometry.notchWidth == 148)
+        assert(notchGeometry.centeredTopFrame(width: 92, height: 76) == NSRect(x: 710, y: 906, width: 92, height: 76))
+        assert(notchGeometry.notchSideGeometry(regionWidth: 92, panelHeight: 38, horizontalInset: 8)?.frame == NSRect(x: 590, y: 944, width: 332, height: 38))
+
+        let safeAreaOnlyGeometry = OverlayScreenGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1440, height: 875),
+            safeAreaInsets: NSEdgeInsets(top: 25, left: 0, bottom: 0, right: 0)
+        )
+
+        assert(safeAreaOnlyGeometry.hasTopSafeArea)
+        assert(!safeAreaOnlyGeometry.hasNotchGeometry)
+        assert(safeAreaOnlyGeometry.notchSideGeometry(regionWidth: 92, panelHeight: 38, horizontalInset: 8) == nil)
     }
 
     private static func testNotchSideOverlayAvoidsContainerAudioLevelAnimation() throws {

--- a/Tests/RecordingOverlayGeometryTests.swift
+++ b/Tests/RecordingOverlayGeometryTests.swift
@@ -4,35 +4,13 @@ import CoreGraphics
 @main
 struct RecordingOverlayGeometryTests {
     static func main() throws {
-        testNotchSideContentStartsAtTopOfVisiblePill()
         testTranscribingWidthFallsBackToCenteredWidthAfterNotchSideRecording()
         testTranscribingWidthKeepsExistingLockOnRepeatedTranscribingUpdate()
-        testCenteredFrameUsesUpdatedMainScreenGeometry()
         testNotchSideLayoutPhaseEligibility()
+        try testRecordingOverlayUsesSharedScreenGeometry()
         try testNotchSideOverlayAvoidsContainerAudioLevelAnimation()
         try testHostingViewsUseFixedIntrinsicContentSize()
         print("RecordingOverlayGeometryTests passed")
-    }
-
-    private static func testNotchSideContentStartsAtTopOfVisiblePill() {
-        let geometry = RecordingOverlayGeometry.notchSideGeometry(
-            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
-            visibleFrame: CGRect(x: 0, y: 0, width: 1512, height: 944),
-            leftArea: CGRect(x: 0, y: 944, width: 682, height: 38),
-            rightArea: CGRect(x: 830, y: 944, width: 682, height: 38),
-            regionWidth: 92,
-            panelHeight: 38,
-            horizontalInset: 8
-        )
-
-        assert(geometry != nil)
-        assert(geometry?.frame.maxX == 922)
-        assert(geometry?.frame.minX == 590)
-        assert(geometry?.leftContentFrame.origin.x == 0)
-        assert(geometry?.rightContentFrame.maxX == geometry?.frame.width)
-        assert(geometry?.leftContentFrame.origin.y == 0)
-        assert(geometry?.rightContentFrame.origin.y == 0)
-        assert(geometry?.frame.height == 38)
     }
 
     private static func testTranscribingWidthFallsBackToCenteredWidthAfterNotchSideRecording() {
@@ -55,23 +33,6 @@ struct RecordingOverlayGeometryTests {
         )
 
         assert(lockedWidth == 148)
-    }
-
-    private static func testCenteredFrameUsesUpdatedMainScreenGeometry() {
-        let oldFrame = RecordingOverlayGeometry.centeredFrame(
-            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
-            width: 92,
-            height: 76
-        )
-        let updatedFrame = RecordingOverlayGeometry.centeredFrame(
-            screenFrame: CGRect(x: 0, y: 0, width: 1728, height: 1117),
-            width: 92,
-            height: 76
-        )
-
-        assert(oldFrame.origin.x == 710)
-        assert(updatedFrame.origin.x == 818)
-        assert(updatedFrame.origin.y == 1041)
     }
 
     private static func testNotchSideLayoutPhaseEligibility() {
@@ -110,6 +71,17 @@ struct RecordingOverlayGeometryTests {
             phase: .recording,
             hasNotchGeometry: false
         ))
+    }
+
+    private static func testRecordingOverlayUsesSharedScreenGeometry() throws {
+        let source = try String(contentsOfFile: "Sources/RecordingOverlay.swift", encoding: .utf8)
+        assert(source.contains("private typealias NotchSideGeometry = OverlayScreenGeometry.NotchSideGeometry"))
+        assert(source.contains("OverlayScreenGeometry(screen: screen)"))
+        assert(source.contains("screenGeometry?.notchSideGeometry("))
+        assert(source.contains("screenGeometry?.hasTopSafeArea"))
+        assert(source.contains("screenGeometry.centeredTopFrame("))
+        assert(!source.contains("static func notchSideGeometry("))
+        assert(!source.contains("static func centeredFrame("))
     }
 
     private static func testNotchSideOverlayAvoidsContainerAudioLevelAnimation() throws {

--- a/docs/superpowers/specs/2026-05-18-overlay-screen-geometry-design.md
+++ b/docs/superpowers/specs/2026-05-18-overlay-screen-geometry-design.md
@@ -1,0 +1,72 @@
+# Overlay Screen Geometry Design
+
+## Goal
+
+Meeting reminder overlays should immediately re-layout when display geometry changes, and both recording overlays and meeting reminder overlays should interpret screen geometry through the same model. This fixes issue #112 and reduces future divergence around notches, menu bars, visible frames, scaling, rotation, and external display changes.
+
+## Current root cause
+
+`RecordingOverlayManager` observes `NSApplication.didChangeScreenParametersNotification` and recomputes its panel frame when the active screen configuration changes. `MeetingReminderOverlayManager` can re-render an existing reminder, but it does not observe screen-parameter changes. A visible reminder can therefore keep the old panel frame until another app state transition refreshes it.
+
+The two overlay systems also calculate screen geometry separately. Recording overlay code already accounts for screen frame, visible frame, safe-area, and notch auxiliary areas. Meeting reminder geometry mostly derives from `screen.frame`, which makes future notch and visible-frame edge cases easier to miss.
+
+## Design
+
+### Shared geometry model
+
+Add `OverlayScreenGeometry` in `Sources/OverlayScreenGeometry.swift`. It will be initialized from `NSScreen` and expose the screen facts needed by top overlays:
+
+- `screenFrame`
+- `visibleFrame`
+- `hasNotchGeometry`
+- `notchOverlap`
+- `notchSideGeometry(regionWidth:panelHeight:horizontalInset:)`
+- `centeredTopFrame(width:height:)`
+
+The shared type owns generic screen interpretation. Overlay-specific types keep only overlay policy.
+
+### Recording overlay changes
+
+`RecordingOverlayManager` will build an `OverlayScreenGeometry` from `NSScreen.main` when computing layout. Existing recording-specific decisions stay in `RecordingOverlayGeometry`, including phase eligibility, locked transcribing width, and width selection.
+
+The current generic helpers `RecordingOverlayGeometry.notchSideGeometry(...)` and `RecordingOverlayGeometry.centeredFrame(...)` will move to the shared geometry model. Recording overlay tests will be updated to assert the same geometry through the new shared API.
+
+### Meeting reminder overlay changes
+
+`MeetingReminderOverlayGeometry` will keep variant and size decisions, but frame calculation will use `OverlayScreenGeometry` instead of interpreting `NSScreen` directly. The reminder overlay will therefore use the same top-centered and notch-side frame semantics as the recording overlay.
+
+`MeetingReminderOverlayManager` will add a `screenParametersObserver`. On `NSApplication.didChangeScreenParametersNotification`, it will refresh the visible reminder without animation so display attach/detach, scaling, rotation, or visible-frame changes snap to the new geometry instead of playing a reminder entrance animation.
+
+The existing public `refreshVisibleReminder()` behavior remains animated for app-state transitions such as recording and transcribing changes. Internally this can delegate to an overload that accepts `animated`.
+
+## Data flow
+
+1. A reminder is queued and shown.
+2. The manager asks its `screenProvider` for the current `NSScreen`.
+3. The screen is converted to `OverlayScreenGeometry`.
+4. `MeetingReminderOverlayGeometry` determines variant, size, center recording width, and final frame from the shared geometry.
+5. If AppKit posts `didChangeScreenParametersNotification` while a reminder is visible, the manager repeats the render path with `animated: false`.
+6. Recording overlay continues to recompute its frame on the same notification, now using the same shared screen interpretation.
+
+## Error handling and edge cases
+
+- If there is no screen, reminder presentation continues to fail without marking the reminder as presented.
+- If a screen has no valid notch auxiliary geometry, notch-side layout falls back to centered/default behavior as it does today.
+- If a screen parameter change occurs with no visible reminder, the refresh is a no-op.
+- The screen observer is removed in `deinit`, matching the recording overlay manager pattern.
+
+## Tests
+
+Add or update tests to cover:
+
+- Shared centered top frame calculation responds to changed screen frame.
+- Shared notch-side geometry preserves the existing frame/content-frame expectations from recording overlay tests.
+- Shared `notchOverlap` reflects the gap between `screenFrame.maxY` and `visibleFrame.maxY`.
+- Recording overlay tests use `OverlayScreenGeometry` for generic geometry assertions while keeping recording-specific tests intact.
+- Meeting reminder frame calculation changes when the supplied screen geometry changes.
+- Meeting reminder source has a screen-parameter observer and unanimated screen-change refresh path.
+- Existing meeting reminder notch sizing tests continue to protect the #115 behavior.
+
+## Verification
+
+Run `make test` after implementation. If possible, build the app and manually inspect the reminder overlay path; actual monitor attach/detach coverage depends on the local environment and should be reported separately from automated verification.

--- a/docs/superpowers/specs/2026-05-19-meeting-reminder-animation-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-05-19-meeting-reminder-animation-lifecycle-design.md
@@ -1,0 +1,90 @@
+# Meeting Reminder Animation Lifecycle Design
+
+## Goal
+
+Improve meeting reminder overlay transitions so recording and processing state changes animate inside one persistent SwiftUI tree instead of replacing the AppKit content view on every refresh. This should make existing `matchedGeometryEffect` transitions visible while preserving screen-geometry snap behavior from issue #112.
+
+## Current root cause
+
+`MeetingReminderOverlayManager.render(...)` currently creates a new `MeetingReminderOverlayViewModel`, a new `MeetingReminderOverlayRootView`, and a new `FixedHostingContainer` on each render. It then assigns the new container to `panel.contentView`.
+
+The SwiftUI root view owns the `@Namespace` used by `matchedGeometryEffect`. Replacing the root view and content view during recording/processing refreshes means SwiftUI does not reliably see one continuous tree changing state. The transition can therefore feel like a redraw instead of an element movement.
+
+## Design
+
+### Persistent presentation host
+
+Keep the presentation host alive while one reminder is visible:
+
+- `panel: NSPanel?`
+- `viewModel: MeetingReminderOverlayViewModel?`
+- `contentContainer: FixedHostingContainer<AnyView>?`
+
+The manager will create these objects only when a reminder first appears or after a previous reminder has been fully reset. While the same reminder remains visible, refreshes update the existing host.
+
+### First presentation path
+
+When no host exists:
+
+1. Calculate `displayData` and target frame.
+2. Create `MeetingReminderOverlayViewModel(displayData:)`.
+3. Create `MeetingReminderOverlayRootView` once with that view model.
+4. Wrap it in `FixedHostingContainer` and assign it to `panel.contentView`.
+5. Show the panel with the existing entrance animation when `animated` is true.
+
+### Existing presentation update path
+
+When the host already exists:
+
+1. Recalculate `displayData` and frame.
+2. Update `viewModel.displayData` instead of replacing the view model.
+3. Update `contentContainer.setFixedContentSize(frame.size)` so SwiftUI's fixed root size follows the AppKit panel.
+4. Update the panel frame.
+   - If the refresh is app-state driven, use the existing panel frame animation.
+   - If the refresh comes from `didChangeScreenParametersNotification`, use `animated: false` and snap to the new frame.
+5. Do not replace `panel.contentView` in this path.
+
+This keeps the same SwiftUI tree and `@Namespace` alive across idle, recording, and processing variants for the same visible reminder.
+
+### Reset path
+
+When a reminder is dismissed and the hide animation completes, reset the presentation host:
+
+- `panel.orderOut(nil)`
+- `panel.alphaValue = 1`
+- `panel.contentView = nil`
+- `panel = nil`
+- `viewModel = nil`
+- `contentContainer = nil`
+
+The next reminder starts with a fresh root view and namespace, preventing old meeting content or animation state from leaking into a different reminder.
+
+### Screen geometry behavior
+
+The screen-change path remains unanimated:
+
+- `handleScreenParametersChanged()` continues to call `refreshVisibleReminder(animated: false)`.
+- The visible host is reused, but the panel frame and fixed content size are updated without animation.
+- This preserves the issue #112 behavior where display changes snap immediately to the new geometry.
+
+## Testing
+
+Add source-level regression tests in `MeetingReminderOverlayGeometryTests` to verify structure because visual animation timing is not practical to assert in the current `swiftc` test harness.
+
+The tests should check that:
+
+- `MeetingReminderOverlayManager` stores `contentContainer`.
+- Existing refreshes update `viewModel.displayData`.
+- Existing refreshes call `contentContainer.setFixedContentSize(frame.size)`.
+- `panel.contentView = container` is limited to the host creation path, not every render.
+- The reset path clears `panel`, `viewModel`, and `contentContainer`.
+- `handleScreenParametersChanged()` still calls `refreshVisibleReminder(animated: false)`.
+
+Run `make test` after implementation. Build and run the development app with `make run CODESIGN_IDENTITY="Quill"` to manually inspect the recording transition when a reminder is visible. Actual visual quality still requires human inspection, but the structure should make matched geometry transitions possible.
+
+## Non-goals
+
+- No new visual design.
+- No new motion style beyond making the existing matched-geometry transitions work.
+- No changes to reminder scheduling, reminder queue policy, or calendar behavior.
+- No change to the screen-change snap policy from issue #112.

--- a/docs/superpowers/specs/2026-05-19-meeting-reminder-animation-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-05-19-meeting-reminder-animation-lifecycle-design.md
@@ -80,7 +80,7 @@ The tests should check that:
 - The reset path clears `panel`, `viewModel`, and `contentContainer`.
 - `handleScreenParametersChanged()` still calls `refreshVisibleReminder(animated: false)`.
 
-Run `make test` after implementation. Build and run the development app with `make run CODESIGN_IDENTITY="Quill"` to manually inspect the recording transition when a reminder is visible. Actual visual quality still requires human inspection, but the structure should make matched geometry transitions possible.
+Run `make test` after implementation. Build and run the development app with `make run` to manually inspect the recording transition when a reminder is visible. If the local setup requires explicit signing, run `make run CODESIGN_IDENTITY="<YOUR_IDENTITY>"`. Actual visual quality still requires human inspection, but the structure should make matched geometry transitions possible.
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary
- Add shared top-overlay screen geometry for recording and meeting reminder overlays.
- Refresh visible meeting reminders immediately on screen-parameter changes without entrance animation.
- Preserve the meeting reminder SwiftUI host across recording/processing refreshes so matched-geometry transitions can animate.

## Test plan
- [x] `make test`
- [x] Makefile app build
- [x] Makefile dev app launch

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 화면용 공통 기하 모델 도입으로 오버레이 배치 로직 통합 및 일관성 향상

* **버그 수정**
  * 노치/안전영역이 있는 다양한 화면 구성에서 오버레이 위치·크기 계산 개선
  * 화면 파라미터 변경 시 표시 리마인더의 즉시(무애니메이션) 갱신 및 전환 제어 향상

* **테스트**
  * 화면 기하 및 오버레이 동작 검증 테스트 추가·갱신

* **문서**
  * 화면 기하 및 리마인더 애니메이션 라이프사이클 설계 명세 추가

* **잡무**
  * 테스트 실행 흐름(빌드/실행 단계) 조정

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/freeflow/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->