### PR TITLE
Disable unavailable Note Browser API modes

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -701,6 +701,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     func isNoteBrowserTranscriptionModeAvailable(_ mode: NoteBrowserTranscriptionMode) -> Bool {
+        switch mode {
+        case .apiStandard, .apiRealtime:
+            guard hasTranscriptionAPIKey else { return false }
+        case .localWhisper, .localAppleLive:
+            break
+        }
+
         guard AudioInputDevice.isSystemDefaultAndSystemAudio(selectedMicrophoneID) else { return true }
         switch mode {
         case .apiRealtime, .localAppleLive:
@@ -723,14 +730,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func normalizedNoteBrowserTranscriptionMode(_ mode: NoteBrowserTranscriptionMode) -> NoteBrowserTranscriptionMode {
         guard !isNoteBrowserTranscriptionModeAvailable(mode) else { return mode }
+        let fallbackModes: [NoteBrowserTranscriptionMode]
         switch mode {
         case .apiRealtime:
-            return .apiStandard
-        case .localAppleLive:
-            return .localWhisper
-        case .apiStandard, .localWhisper:
-            return mode
+            fallbackModes = [.apiStandard, .localWhisper]
+        case .apiStandard, .localAppleLive:
+            fallbackModes = [.localWhisper]
+        case .localWhisper:
+            fallbackModes = []
         }
+        return fallbackModes.first(where: isNoteBrowserTranscriptionModeAvailable) ?? mode
     }
 
     private func applyNoteBrowserTranscriptionMode(_ mode: NoteBrowserTranscriptionMode) {

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -514,6 +514,7 @@ struct NoteBrowserView: View {
                         Section("API") {
                             Text("Standard")
                                 .tag(NoteBrowserTranscriptionMode.apiStandard)
+                                .disabled(!appState.isNoteBrowserTranscriptionModeAvailable(.apiStandard))
                             Text("Realtime")
                                 .tag(NoteBrowserTranscriptionMode.apiRealtime)
                                 .disabled(!appState.isNoteBrowserTranscriptionModeAvailable(.apiRealtime))

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -26,6 +26,7 @@ struct AppStateTranscriptionConfigurationTests {
         await testSystemDefaultAndSystemAudioConvertsAPIRealtimeToStandard()
         await testSystemDefaultAndSystemAudioConvertsAppleLiveToWhisper()
         await testSystemDefaultAndSystemAudioRejectsLiveModeSelections()
+        await testMissingTranscriptionAPIKeyRejectsAPIModeSelections()
         await testSystemDefaultAndSystemAudioNormalizesStoredAPIRealtimeOnStartup()
         await testSystemDefaultAndSystemAudioNormalizesStoredAppleLiveOnStartup()
         try testGoogleCalendarConnectionMetadataRestoresStartupState()
@@ -405,6 +406,24 @@ struct AppStateTranscriptionConfigurationTests {
         }
     }
 
+    private static func testMissingTranscriptionAPIKeyRejectsAPIModeSelections() async {
+        resetDefaults()
+        await MainActor.run {
+            let appState = appStateWithNoTranscriptionAPIKey()
+            precondition(!appState.hasTranscriptionAPIKey)
+            precondition(!appState.isNoteBrowserTranscriptionModeAvailable(.apiStandard))
+            precondition(!appState.isNoteBrowserTranscriptionModeAvailable(.apiRealtime))
+            precondition(appState.isNoteBrowserTranscriptionModeAvailable(.localWhisper))
+            precondition(appState.isNoteBrowserTranscriptionModeAvailable(.localAppleLive))
+
+            appState.setNoteBrowserTranscriptionMode(.apiStandard)
+            precondition(appState.currentNoteBrowserTranscriptionMode == .localWhisper)
+
+            appState.setNoteBrowserTranscriptionMode(.apiRealtime)
+            precondition(appState.currentNoteBrowserTranscriptionMode == .localWhisper)
+        }
+    }
+
     private static func testSystemDefaultAndSystemAudioNormalizesStoredAPIRealtimeOnStartup() async {
         resetDefaults()
         let defaults = UserDefaults.standard
@@ -713,6 +732,25 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(snapshot.transcriptionLanguage.code == "en")
         precondition(snapshot.usedContextCapture)
         precondition(!snapshot.usedPostProcessing)
+    }
+
+    private static func appStateWithNoTranscriptionAPIKey() -> AppState {
+        let storedAPIKey = AppSettingsStorage.load(account: "groq_api_key")
+        let storedTranscriptionAPIKey = AppSettingsStorage.load(account: "transcription_api_key")
+        AppSettingsStorage.delete(account: "groq_api_key")
+        AppSettingsStorage.delete(account: "transcription_api_key")
+        let appState = AppState()
+        restoreStoredAPIValue(storedAPIKey, account: "groq_api_key")
+        restoreStoredAPIValue(storedTranscriptionAPIKey, account: "transcription_api_key")
+        return appState
+    }
+
+    private static func restoreStoredAPIValue(_ value: String?, account: String) {
+        if let value {
+            AppSettingsStorage.save(value, account: account)
+        } else {
+            AppSettingsStorage.delete(account: account)
+        }
     }
 
     private static func resetDefaults() {


### PR DESCRIPTION
## Summary
- Disable Note Browser API transcription modes when no transcription API key is configured.
- Fall back to local Whisper when an unavailable API mode is selected.
- Add coverage for missing API key mode normalization.

## Test plan
- [x] `swiftc -parse-as-library -target $(uname -m)-apple-macosx13.0 $(find Sources -name '*.swift' -type f | LC_ALL=C sort | grep -v 'Sources/App.swift') Tests/AppStateTranscriptionConfigurationTests.swift -o /tmp/AppStateTranscriptionConfigurationTests && /tmp/AppStateTranscriptionConfigurationTests`
- [x] `make test`
- [x] `make all CODESIGN_IDENTITY="Quill"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * API 키 미존재 시 API 기반 음성 전사 모드가 올바르게 비활성화되도록 수정
  * 음성 전사 모드 선택 메뉴에서 사용 불가 항목에 비활성화 표시 추가

* **개선 사항**
  * 음성 전사 모드 폴백 메커니즘을 우선순위 기반으로 개선

* **테스트**
  * API 키 부재 시 전사 모드 처리에 대한 테스트 케이스 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/freeflow/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->