### PR TITLE
Enable safe in-app updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,8 @@ test:
 	@/tmp/LegacyNoteTitleMigrationTests
 	@swiftc -parse-as-library Tests/ManualReleaseWorkflowTests.swift -o /tmp/ManualReleaseWorkflowTests
 	@/tmp/ManualReleaseWorkflowTests
+	@swiftc -parse-as-library Sources/UpdateManager.swift Tests/UpdateManagerSafetyTests.swift -o /tmp/UpdateManagerSafetyTests
+	@/tmp/UpdateManagerSafetyTests
 	@swiftc -parse-as-library Tests/BuildMetadataTests.swift -o /tmp/BuildMetadataTests
 	@/tmp/BuildMetadataTests
 	@swiftc -parse-as-library Tests/ReleaseSDKCompatibilityTests.swift -o /tmp/ReleaseSDKCompatibilityTests

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -91,10 +91,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             appState.startHotkeyMonitoring()
             appState.startAccessibilityPolling()
-            // Quill releases are not distributed through the in-app updater yet.
-            // Task { @MainActor in
-            //     UpdateManager.shared.startPeriodicChecks()
-            // }
+            Task { @MainActor in
+                UpdateManager.shared.startPeriodicChecks()
+            }
 
             if !AXIsProcessTrusted() {
                 appState.showAccessibilityAlert()
@@ -305,10 +304,9 @@ private func showNoteBrowserWindow() {
         appState.startAccessibilityPolling()
         appState.startCalendarRecordingReminderScheduling()
         appState.startGoogleCalendarHealthCheck()
-        // Quill releases are not distributed through the in-app updater yet.
-        // Task { @MainActor in
-        //     UpdateManager.shared.startPeriodicChecks()
-        // }
+        Task { @MainActor in
+            UpdateManager.shared.startPeriodicChecks()
+        }
 
         if !AXIsProcessTrusted() {
             Task { @MainActor in

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1223,104 +1223,6 @@ struct GeneralSettingsView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
-                    // GitHub card
-                    VStack(spacing: 10) {
-                        HStack(spacing: 8) {
-                            AsyncImage(url: URL(string: "https://avatars.githubusercontent.com/u/992248")) { phase in
-                                switch phase {
-                                case .success(let image):
-                                    image.resizable().aspectRatio(contentMode: .fill)
-                                default:
-                                    Color.gray.opacity(0.2)
-                                }
-                            }
-                            .frame(width: 22, height: 22)
-                            .clipShape(Circle())
-
-                            Button {
-                                openURL(upstreamRepoURL)
-                            } label: {
-                                Text("zachlatta/freeflow")
-                                    .font(.system(.caption, design: .monospaced).weight(.medium))
-                            }
-                            .buttonStyle(.plain)
-                            .foregroundStyle(.blue)
-
-                            Spacer()
-
-                            HStack(spacing: 4) {
-                                Image(systemName: "star.fill")
-                                    .foregroundStyle(.yellow)
-                                    .font(.caption2)
-                                if githubCache.isLoading {
-                                    ProgressView().scaleEffect(0.5)
-                                } else if let count = githubCache.starCount {
-                                    Text("\(count.formatted()) \(count == 1 ? "star" : "stars")")
-                                        .font(.caption2.weight(.semibold))
-                                        .foregroundStyle(.secondary)
-                                }
-                            }
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .background(Capsule().fill(Color.yellow.opacity(0.14)))
-
-                            Button {
-                                openURL(upstreamRepoURL)
-                            } label: {
-                                HStack(spacing: 4) {
-                                    Image(systemName: "star")
-                                    Text("Star")
-                                }
-                                .font(.caption.weight(.semibold))
-                                .padding(.horizontal, 10)
-                                .padding(.vertical, 5)
-                                .background(Capsule().fill(Color.yellow.opacity(0.18)))
-                            }
-                            .buttonStyle(.plain)
-                        }
-
-                        if !githubCache.recentStargazers.isEmpty {
-                            Divider()
-                            HStack(spacing: 8) {
-                                HStack(spacing: -6) {
-                                    ForEach(githubCache.recentStargazers) { star in
-                                        Button {
-                                            openURL(star.user.htmlUrl)
-                                        } label: {
-                                            AsyncImage(url: star.user.avatarThumbnailUrl) { phase in
-                                                switch phase {
-                                                case .success(let image):
-                                                    image.resizable().aspectRatio(contentMode: .fill)
-                                                default:
-                                                    Color.gray.opacity(0.2)
-                                                }
-                                            }
-                                            .frame(width: 22, height: 22)
-                                            .clipShape(Circle())
-                                            .overlay(Circle().stroke(Color(nsColor: .windowBackgroundColor), lineWidth: 1.5))
-                                        }
-                                        .buttonStyle(.plain)
-                                    }
-                                }
-                                .clipped()
-                                Text("recently starred")
-                                    .font(.caption2)
-                                    .foregroundStyle(.tertiary)
-                                    .fixedSize()
-                                Spacer()
-                            }
-                            .clipped()
-                        }
-                    }
-                    .padding(12)
-                    .background(
-                        RoundedRectangle(cornerRadius: 12)
-                            .fill(.ultraThinMaterial)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 12)
-                                    .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-                            )
-                    )
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.top, 4)
@@ -1329,10 +1231,9 @@ struct GeneralSettingsView: View {
                 SettingsCard("App", icon: "power") {
                     startupSection
                 }
-                // Quill releases are not distributed through the in-app updater yet.
-                // SettingsCard("Updates", icon: "arrow.triangle.2.circlepath") {
-                //     updatesSection
-                // }
+                SettingsCard("Updates", icon: "arrow.triangle.2.circlepath") {
+                    updatesSection
+                }
                 SettingsCard("Transcription", icon: "waveform.badge.magnifyingglass") {
                     transcriptionSection
                 }
@@ -1378,7 +1279,6 @@ struct GeneralSettingsView: View {
             checkMicPermission()
             refreshNotificationAuthorizationStatus()
             appState.refreshLaunchAtLoginStatus()
-            Task { await githubCache.fetchIfNeeded() }
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             refreshNotificationAuthorizationStatus()

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -224,9 +224,6 @@ struct SetupView: View {
             checkMicPermission()
             checkAccessibility()
             refreshNotificationAuthorizationStatus()
-            Task {
-                await githubCache.fetchIfNeeded()
-            }
         }
         .onDisappear {
             accessibilityTimer?.invalidate()
@@ -308,105 +305,6 @@ struct SetupView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            VStack(spacing: 10) {
-                HStack(spacing: 8) {
-                    AsyncImage(url: URL(string: "https://avatars.githubusercontent.com/u/992248")) { phase in
-                        switch phase {
-                        case .success(let image):
-                            image.resizable().aspectRatio(contentMode: .fill)
-                        default:
-                            Color.gray.opacity(0.2)
-                        }
-                    }
-                    .frame(width: 26, height: 26)
-                    .clipShape(Circle())
-
-                    Button {
-                        openURL(upstreamRepoURL)
-                    } label: {
-                        Text("zachlatta/freeflow")
-                            .font(.system(.caption, design: .monospaced).weight(.medium))
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.blue)
-
-                    Spacer()
-
-                    HStack(spacing: 4) {
-                        Image(systemName: "star.fill")
-                            .foregroundStyle(.yellow)
-                            .font(.caption2)
-                        if githubCache.isLoading {
-                            ProgressView().scaleEffect(0.5)
-                        } else if let count = githubCache.starCount {
-                            Text("\(count.formatted()) \(count == 1 ? "star" : "stars")")
-                                .font(.caption2.weight(.semibold))
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(Capsule().fill(Color.yellow.opacity(0.14)))
-
-                    Button {
-                        openURL(upstreamRepoURL)
-                    } label: {
-                        HStack(spacing: 4) {
-                            Image(systemName: "star")
-                            Text("Star")
-                        }
-                        .font(.caption.weight(.semibold))
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 5)
-                        .background(Capsule().fill(Color.yellow.opacity(0.18)))
-                    }
-                    .buttonStyle(.plain)
-                }
-
-                if !githubCache.recentContributors.isEmpty {
-                    Divider()
-                    HStack(spacing: 8) {
-                        HStack(spacing: -6) {
-                            ForEach(githubCache.recentContributors) { contributor in
-                                Button {
-                                    openURL(contributor.htmlUrl)
-                                } label: {
-                                    AsyncImage(url: contributor.avatarThumbnailUrl) { phase in
-                                        switch phase {
-                                        case .success(let image):
-                                            image.resizable().aspectRatio(contentMode: .fill)
-                                        default:
-                                            Color.gray.opacity(0.2)
-                                        }
-                                    }
-                                    .frame(width: 22, height: 22)
-                                    .clipShape(Circle())
-                                    .overlay(Circle().stroke(Color(nsColor: .windowBackgroundColor), lineWidth: 1.5))
-                                }
-                                .buttonStyle(.plain)
-                                .accessibilityLabel(Text(contributor.login))
-                                .accessibilityHint(Text("Open contributor profile"))
-                            }
-                        }
-                        .clipped()
-                        Text("recent contributors")
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                            .fixedSize()
-                        Spacer()
-                    }
-                    .clipped()
-                }
-            }
-            .padding(12)
-            .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(.ultraThinMaterial)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-                    )
-            )
 
         }
     }

--- a/Sources/UpdateManager.swift
+++ b/Sources/UpdateManager.swift
@@ -116,6 +116,14 @@ private struct SemanticRelease {
     let releaseDateString: String
 }
 
+struct UpdateValidationCommandResult: Sendable {
+    let terminationStatus: Int32
+    let standardOutput: String
+    let standardError: String
+}
+
+typealias UpdateValidationCommandRunner = (_ executablePath: String, _ arguments: [String]) throws -> UpdateValidationCommandResult
+
 // MARK: - Update Status
 
 enum UpdateStatus: Equatable {
@@ -197,6 +205,110 @@ final class UpdateManager: ObservableObject {
         lastCheckDate = UserDefaults.standard.object(forKey: "updateLastCheckDate") as? Date
     }
 
+    nonisolated static func installableDMGAsset(for release: GitHubRelease) -> GitHubReleaseAsset? {
+        release.assets.first { $0.name == "Quill.dmg" }
+    }
+
+    nonisolated static func isReleaseBuildTagForAutomaticChecks(_ buildTag: String?) -> Bool {
+        guard let buildTag,
+              buildTag.hasPrefix("v") || buildTag.hasPrefix("V") else {
+            return false
+        }
+
+        return SemanticVersion(buildTag) != nil
+    }
+
+    nonisolated static func runValidationCommand(
+        executablePath: String,
+        arguments: [String]
+    ) throws -> UpdateValidationCommandResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+
+        return UpdateValidationCommandResult(
+            terminationStatus: process.terminationStatus,
+            standardOutput: String(data: outputData, encoding: .utf8) ?? "",
+            standardError: String(data: errorData, encoding: .utf8) ?? ""
+        )
+    }
+
+    nonisolated static func validateDownloadedDMG(
+        at dmgURL: URL,
+        commandRunner: UpdateValidationCommandRunner = runValidationCommand
+    ) throws {
+        let result = try commandRunner("/usr/sbin/spctl", [
+            "--assess",
+            "--type", "open",
+            "--context", "context:primary-signature",
+            "--verbose=4",
+            dmgURL.path
+        ])
+
+        guard result.terminationStatus == 0 else {
+            throw NSError(domain: "UpdateManager", code: 4, userInfo: [
+                NSLocalizedDescriptionKey: "spctl assessment failed with exit code \(result.terminationStatus): \(result.standardError)"
+            ])
+        }
+    }
+
+    nonisolated static func validateStagedApp(
+        at appURL: URL,
+        expectedBundleIdentifier: String,
+        expectedShortVersion: String,
+        expectedBuildTag: String,
+        commandRunner: UpdateValidationCommandRunner = runValidationCommand
+    ) throws {
+        guard appURL.pathExtension == "app" else {
+            throw NSError(domain: "UpdateManager", code: 5, userInfo: [
+                NSLocalizedDescriptionKey: "Staged app is not an .app bundle"
+            ])
+        }
+
+        let infoPlistURL = appURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Info.plist")
+        let infoPlistData = try Data(contentsOf: infoPlistURL)
+        guard let infoPlist = try PropertyListSerialization.propertyList(from: infoPlistData, format: nil) as? [String: Any] else {
+            throw NSError(domain: "UpdateManager", code: 5, userInfo: [
+                NSLocalizedDescriptionKey: "Could not parse staged app Info.plist"
+            ])
+        }
+
+        guard infoPlist["CFBundleIdentifier"] as? String == expectedBundleIdentifier,
+              infoPlist["CFBundleShortVersionString"] as? String == expectedShortVersion,
+              infoPlist["QuillBuildTag"] as? String == expectedBuildTag else {
+            throw NSError(domain: "UpdateManager", code: 6, userInfo: [
+                NSLocalizedDescriptionKey: "Staged app metadata does not match the expected release"
+            ])
+        }
+
+        let result = try commandRunner("/usr/bin/codesign", [
+            "--verify",
+            "--deep",
+            "--strict",
+            "--verbose=2",
+            appURL.path
+        ])
+
+        guard result.terminationStatus == 0 else {
+            throw NSError(domain: "UpdateManager", code: 7, userInfo: [
+                NSLocalizedDescriptionKey: "codesign verification failed with exit code \(result.terminationStatus): \(result.standardError)"
+            ])
+        }
+    }
+
     // MARK: - Periodic Checks
 
     func startPeriodicChecks() {
@@ -235,8 +347,8 @@ final class UpdateManager: ObservableObject {
         let currentBuildTag = Bundle.main.infoDictionary?["QuillBuildTag"] as? String
         let currentVersionString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
 
-        // Dev builds (no embedded tag): skip auto-checks, but allow manual checks
-        if !userInitiated && currentBuildTag == nil {
+        // Dev/local builds: skip auto-checks, but allow manual checks
+        if !userInitiated && !Self.isReleaseBuildTagForAutomaticChecks(currentBuildTag) {
             return
         }
 
@@ -500,7 +612,6 @@ final class UpdateManager: ObservableObject {
             showRecentReleaseAlert(daysSincePublished: daysSincePublished)
         default:
             suppressPostTranscriptionReminder(for: release.tagName)
-            updateAvailable = false
         }
     }
 
@@ -605,7 +716,7 @@ final class UpdateManager: ObservableObject {
     }
 
     func downloadAndInstall(release: GitHubRelease) {
-        guard let dmgAsset = release.assets.first(where: { $0.name.hasSuffix(".dmg") }) else {
+        guard let dmgAsset = Self.installableDMGAsset(for: release) else {
             if let url = URL(string: release.htmlUrl) {
                 NSWorkspace.shared.open(url)
             }
@@ -616,11 +727,11 @@ final class UpdateManager: ObservableObject {
 
         activeDownloadTask?.cancel()
         activeDownloadTask = Task {
-            await performUpdate(downloadURL: downloadURL, expectedSize: dmgAsset.size)
+            await performUpdate(downloadURL: downloadURL, expectedSize: dmgAsset.size, release: release)
         }
     }
 
-    private func performUpdate(downloadURL: URL, expectedSize: Int) async {
+    private func performUpdate(downloadURL: URL, expectedSize: Int, release: GitHubRelease) async {
         let fm = FileManager.default
         let tempDir = fm.temporaryDirectory.appendingPathComponent("quill-update-\(UUID().uuidString)")
 
@@ -709,7 +820,13 @@ final class UpdateManager: ObservableObject {
         updateStatus = .installing
         downloadProgress = nil
 
+        var stagingDirForCleanup: URL?
+
         do {
+            try await Task.detached {
+                try Self.validateDownloadedDMG(at: dmgPath)
+            }.value
+
             let mountPoint = try await Task.detached {
                 try self.mountDMG(at: dmgPath)
             }.value
@@ -734,9 +851,22 @@ final class UpdateManager: ObservableObject {
 
             // Copy app to staging directory
             let stagingDir = fm.temporaryDirectory.appendingPathComponent("quill-staged-\(UUID().uuidString)")
+            stagingDirForCleanup = stagingDir
             try fm.createDirectory(at: stagingDir, withIntermediateDirectories: true)
             let stagedApp = stagingDir.appendingPathComponent(appBundle.lastPathComponent)
             try fm.copyItem(at: appBundle, to: stagedApp)
+
+            let expectedBundleIdentifier = Bundle.main.bundleIdentifier ?? "com.woosublee.quill"
+            let expectedShortVersion = normalizedVersionString(from: release.tagName)
+            let expectedBuildTag = release.tagName
+            try await Task.detached {
+                try Self.validateStagedApp(
+                    at: stagedApp,
+                    expectedBundleIdentifier: expectedBundleIdentifier,
+                    expectedShortVersion: expectedShortVersion,
+                    expectedBuildTag: expectedBuildTag
+                )
+            }.value
 
             // Clean up DMG (detach happens in defer above, delete temp dir)
             try? fm.removeItem(at: tempDir)
@@ -748,13 +878,16 @@ final class UpdateManager: ObservableObject {
         } catch {
             updateStatus = .error("Install failed: \(error.localizedDescription)")
             try? fm.removeItem(at: tempDir)
+            if let stagingDirForCleanup {
+                try? fm.removeItem(at: stagingDirForCleanup)
+            }
         }
     }
 
     nonisolated private func mountDMG(at path: URL) throws -> String {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
-        process.arguments = ["attach", path.path, "-nobrowse", "-noverify", "-noautoopen", "-plist"]
+        process.arguments = ["attach", path.path, "-nobrowse", "-noautoopen", "-plist"]
 
         let pipe = Pipe()
         process.standardOutput = pipe

--- a/Sources/UpdateManager.swift
+++ b/Sources/UpdateManager.swift
@@ -122,6 +122,23 @@ struct UpdateValidationCommandResult: Sendable {
     let standardError: String
 }
 
+private final class UpdateValidationDataBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func set(_ data: Data) {
+        lock.lock()
+        self.data = data
+        lock.unlock()
+    }
+
+    func contents() -> Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return data
+    }
+}
+
 typealias UpdateValidationCommandRunner = (_ executablePath: String, _ arguments: [String]) throws -> UpdateValidationCommandResult
 
 // MARK: - Update Status
@@ -231,11 +248,28 @@ final class UpdateManager: ObservableObject {
         process.standardOutput = outputPipe
         process.standardError = errorPipe
 
-        try process.run()
-        process.waitUntilExit()
+        let outputDataBox = UpdateValidationDataBox()
+        let errorDataBox = UpdateValidationDataBox()
+        let readerGroup = DispatchGroup()
 
-        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        try process.run()
+
+        readerGroup.enter()
+        DispatchQueue.global(qos: .utility).async {
+            outputDataBox.set(outputPipe.fileHandleForReading.readDataToEndOfFile())
+            readerGroup.leave()
+        }
+        readerGroup.enter()
+        DispatchQueue.global(qos: .utility).async {
+            errorDataBox.set(errorPipe.fileHandleForReading.readDataToEndOfFile())
+            readerGroup.leave()
+        }
+
+        process.waitUntilExit()
+        readerGroup.wait()
+
+        let outputData = outputDataBox.contents()
+        let errorData = errorDataBox.contents()
 
         return UpdateValidationCommandResult(
             terminationStatus: process.terminationStatus,
@@ -263,11 +297,41 @@ final class UpdateManager: ObservableObject {
         }
     }
 
+    nonisolated static func currentAppRequirement(
+        commandRunner: UpdateValidationCommandRunner = runValidationCommand
+    ) throws -> String {
+        try appRequirement(at: Bundle.main.bundleURL, commandRunner: commandRunner)
+    }
+
+    nonisolated static func appRequirement(
+        at appURL: URL,
+        commandRunner: UpdateValidationCommandRunner = runValidationCommand
+    ) throws -> String {
+        let result = try commandRunner("/usr/bin/codesign", ["-d", "-r-", appURL.path])
+        guard result.terminationStatus == 0 else {
+            throw NSError(domain: "UpdateManager", code: 8, userInfo: [
+                NSLocalizedDescriptionKey: "codesign requirement extraction failed with exit code \(result.terminationStatus): \(result.standardError)"
+            ])
+        }
+
+        let combinedOutput = [result.standardOutput, result.standardError].joined(separator: "\n")
+        guard let requirementLine = combinedOutput
+            .split(separator: "\n")
+            .first(where: { $0.hasPrefix("designated => ") }) else {
+            throw NSError(domain: "UpdateManager", code: 8, userInfo: [
+                NSLocalizedDescriptionKey: "Could not read current app designated requirement"
+            ])
+        }
+
+        return String(requirementLine.dropFirst("designated => ".count))
+    }
+
     nonisolated static func validateStagedApp(
         at appURL: URL,
         expectedBundleIdentifier: String,
         expectedShortVersion: String,
         expectedBuildTag: String,
+        expectedRequirement: String,
         commandRunner: UpdateValidationCommandRunner = runValidationCommand
     ) throws {
         guard appURL.pathExtension == "app" else {
@@ -299,6 +363,7 @@ final class UpdateManager: ObservableObject {
             "--deep",
             "--strict",
             "--verbose=2",
+            "-R=\(expectedRequirement)",
             appURL.path
         ])
 
@@ -859,12 +924,16 @@ final class UpdateManager: ObservableObject {
             let expectedBundleIdentifier = Bundle.main.bundleIdentifier ?? "com.woosublee.quill"
             let expectedShortVersion = normalizedVersionString(from: release.tagName)
             let expectedBuildTag = release.tagName
+            let expectedRequirement = try await Task.detached {
+                try Self.currentAppRequirement()
+            }.value
             try await Task.detached {
                 try Self.validateStagedApp(
                     at: stagedApp,
                     expectedBundleIdentifier: expectedBundleIdentifier,
                     expectedShortVersion: expectedShortVersion,
-                    expectedBuildTag: expectedBuildTag
+                    expectedBuildTag: expectedBuildTag,
+                    expectedRequirement: expectedRequirement
                 )
             }.value
 

--- a/Tests/UpdateManagerSafetyTests.swift
+++ b/Tests/UpdateManagerSafetyTests.swift
@@ -8,8 +8,10 @@ struct UpdateManagerSafetyTests {
         try testTimingPoliciesRemainConservative()
         try testDownloadedDMGValidationUsesSpctl()
         try testDownloadedDMGValidationRejectsFailedAssessment()
+        try testValidationCommandDrainsPipesBeforeWaiting()
         try testStagedAppValidationChecksMetadataAndCodesign()
         try testStagedAppValidationRejectsMetadataMismatch()
+        try testStagedAppValidationRejectsSignerMismatch()
         try testInstallFlowValidatesBeforeReplacing()
         try testStagedAppValidationRejectsNonAppBeforeCodesign()
         try testMountDMGDoesNotDisableVerification()
@@ -89,6 +91,28 @@ struct UpdateManagerSafetyTests {
         }
     }
 
+    private static func testValidationCommandDrainsPipesBeforeWaiting() throws {
+        let source = try String(contentsOfFile: "Sources/UpdateManager.swift", encoding: .utf8)
+        let methodSource = extract(
+            source,
+            from: "nonisolated static func runValidationCommand(",
+            to: "nonisolated static func validateDownloadedDMG("
+        )
+
+        assertOrdered(
+            methodSource,
+            "outputPipe.fileHandleForReading.readDataToEndOfFile()",
+            before: "process.waitUntilExit()",
+            message: "Expected stdout to be drained before waiting for the process"
+        )
+        assertOrdered(
+            methodSource,
+            "errorPipe.fileHandleForReading.readDataToEndOfFile()",
+            before: "process.waitUntilExit()",
+            message: "Expected stderr to be drained before waiting for the process"
+        )
+    }
+
     private static func testStagedAppValidationChecksMetadataAndCodesign() throws {
         let appURL = try makeTemporaryApp(
             bundleIdentifier: "com.classmethod.Quill",
@@ -98,11 +122,13 @@ struct UpdateManagerSafetyTests {
         var recordedExecutablePath: String?
         var recordedArguments: [String]?
 
+        let expectedRequirement = "identifier \"com.classmethod.Quill\" and anchor apple generic"
         try UpdateManager.validateStagedApp(
             at: appURL,
             expectedBundleIdentifier: "com.classmethod.Quill",
             expectedShortVersion: "1.2.3",
-            expectedBuildTag: "v1.2.3"
+            expectedBuildTag: "v1.2.3",
+            expectedRequirement: expectedRequirement
         ) { executablePath, arguments in
             recordedExecutablePath = executablePath
             recordedArguments = arguments
@@ -115,6 +141,7 @@ struct UpdateManagerSafetyTests {
             "--deep",
             "--strict",
             "--verbose=2",
+            "-R=\(expectedRequirement)",
             appURL.path
         ], "Expected codesign verification arguments")
     }
@@ -132,7 +159,8 @@ struct UpdateManagerSafetyTests {
                 at: appURL,
                 expectedBundleIdentifier: "com.classmethod.Quill",
                 expectedShortVersion: "1.2.4",
-                expectedBuildTag: "v1.2.3"
+                expectedBuildTag: "v1.2.3",
+                expectedRequirement: "identifier \"com.classmethod.Quill\" and anchor apple generic"
             ) { _, _ in
                 didRunCodesign = true
                 return UpdateValidationCommandResult(terminationStatus: 0, standardOutput: "valid", standardError: "")
@@ -142,18 +170,49 @@ struct UpdateManagerSafetyTests {
         precondition(!didRunCodesign, "Expected metadata mismatch to fail before codesign")
     }
 
+    private static func testStagedAppValidationRejectsSignerMismatch() throws {
+        let appURL = try makeTemporaryApp(
+            bundleIdentifier: "com.classmethod.Quill",
+            shortVersion: "1.2.3",
+            buildTag: "v1.2.3"
+        )
+
+        assertThrows {
+            try UpdateManager.validateStagedApp(
+                at: appURL,
+                expectedBundleIdentifier: "com.classmethod.Quill",
+                expectedShortVersion: "1.2.3",
+                expectedBuildTag: "v1.2.3",
+                expectedRequirement: "identifier \"com.classmethod.Quill\" and anchor apple generic"
+            ) { _, _ in
+                UpdateValidationCommandResult(terminationStatus: 1, standardOutput: "", standardError: "explicit requirement failed")
+            }
+        }
+    }
+
     private static func testInstallFlowValidatesBeforeReplacing() throws {
         let source = try String(contentsOfFile: "Sources/UpdateManager.swift", encoding: .utf8)
 
         assertContains(source, "private func performUpdate(downloadURL: URL, expectedSize: Int, release: GitHubRelease) async")
-        assertOrdered(
+        let performUpdateSource = extract(
             source,
+            from: "private func performUpdate(downloadURL: URL, expectedSize: Int, release: GitHubRelease) async",
+            to: "nonisolated private func mountDMG"
+        )
+        assertOrdered(
+            performUpdateSource,
+            "currentAppRequirement()",
+            before: "validateStagedApp(",
+            message: "Expected current app signer requirement before staged app validation"
+        )
+        assertOrdered(
+            performUpdateSource,
             "validateDownloadedDMG(at: dmgPath)",
             before: "mountDMG(at: dmgPath)",
             message: "Expected downloaded DMG validation before mounting"
         )
         assertOrdered(
-            source,
+            performUpdateSource,
             "validateStagedApp(",
             before: "replaceAndRelaunch(stagedApp: stagedApp, stagingDir: stagingDir)",
             message: "Expected staged app validation before replacement"
@@ -181,7 +240,8 @@ struct UpdateManagerSafetyTests {
                 at: directoryURL,
                 expectedBundleIdentifier: "com.classmethod.Quill",
                 expectedShortVersion: "1.2.3",
-                expectedBuildTag: "v1.2.3"
+                expectedBuildTag: "v1.2.3",
+                expectedRequirement: "identifier \"com.classmethod.Quill\" and anchor apple generic"
             ) { _, _ in
                 didRunCodesign = true
                 return UpdateValidationCommandResult(terminationStatus: 0, standardOutput: "valid", standardError: "")
@@ -246,13 +306,17 @@ struct UpdateManagerSafetyTests {
         let settingsView = try String(contentsOfFile: "Sources/SettingsView.swift", encoding: .utf8)
 
         let setupWelcomeStep = extract(setupView, from: "var welcomeStep: some View", to: "var apiKeyStep: some View")
-        let settingsHeader = extract(settingsView, from: "// App branding header", to: "SettingsCard(\"App\", icon: \"power\")")
+        let settingsHeader = extract(
+            settingsView,
+            from: "Image(nsImage: NSApp.applicationIconImage)",
+            to: "SettingsCard(\"App\", icon: \"power\")"
+        )
 
         assertDoesNotContain(setupWelcomeStep, "zachlatta/freeflow")
-        assertDoesNotContain(setupWelcomeStep, "recent contributors")
+        assertDoesNotContain(setupWelcomeStep, "contributors")
         assertDoesNotContain(settingsHeader, "zachlatta/freeflow")
-        assertDoesNotContain(settingsHeader, "recently starred")
-        assertDoesNotContain(settingsView, "Task { await githubCache.fetchIfNeeded() }")
+        assertDoesNotContain(settingsHeader, "starred")
+        assertDoesNotContain(settingsView, "githubCache.fetchIfNeeded(")
     }
 
     private static func asset(named name: String) -> GitHubReleaseAsset {

--- a/Tests/UpdateManagerSafetyTests.swift
+++ b/Tests/UpdateManagerSafetyTests.swift
@@ -1,0 +1,335 @@
+import Foundation
+
+@main
+struct UpdateManagerSafetyTests {
+    static func main() throws {
+        testInstallableAssetSelection()
+        testReleaseBuildTagEligibility()
+        try testTimingPoliciesRemainConservative()
+        try testDownloadedDMGValidationUsesSpctl()
+        try testDownloadedDMGValidationRejectsFailedAssessment()
+        try testStagedAppValidationChecksMetadataAndCodesign()
+        try testStagedAppValidationRejectsMetadataMismatch()
+        try testInstallFlowValidatesBeforeReplacing()
+        try testStagedAppValidationRejectsNonAppBeforeCodesign()
+        try testMountDMGDoesNotDisableVerification()
+        try testAppDelegateStartsPeriodicUpdateChecks()
+        try testSettingsShowsUpdatesCard()
+        try testRecentReleaseWaitPreservesAvailableUpdate()
+        try testTopLevelUpstreamAttributionIsHidden()
+        print("UpdateManagerSafetyTests passed")
+    }
+
+    private static func testInstallableAssetSelection() {
+        let expectedAsset = asset(named: "Quill.dmg")
+        let releaseWithQuillAsset = release(assets: [
+            asset(named: "Quill-Dev.dmg"),
+            expectedAsset,
+            asset(named: "Quill-Unsigned.dmg"),
+            asset(named: "FreeFlow.dmg")
+        ])
+
+        let selectedAsset = UpdateManager.installableDMGAsset(for: releaseWithQuillAsset)
+        precondition(selectedAsset?.name == "Quill.dmg", "Expected Quill.dmg to be selected")
+        precondition(selectedAsset?.browserDownloadUrl == expectedAsset.browserDownloadUrl, "Expected the exact Quill.dmg asset")
+
+        precondition(UpdateManager.installableDMGAsset(for: release(assets: [asset(named: "Quill-Dev.dmg")])) == nil)
+        precondition(UpdateManager.installableDMGAsset(for: release(assets: [asset(named: "Quill-Unsigned.dmg")])) == nil)
+        precondition(UpdateManager.installableDMGAsset(for: release(assets: [asset(named: "FreeFlow.dmg")])) == nil)
+        precondition(UpdateManager.installableDMGAsset(for: release(assets: [asset(named: "Quill.zip")])) == nil)
+        precondition(UpdateManager.installableDMGAsset(for: release(assets: [])) == nil)
+    }
+
+    private static func testReleaseBuildTagEligibility() {
+        precondition(UpdateManager.isReleaseBuildTagForAutomaticChecks("v0.1.0"))
+        precondition(UpdateManager.isReleaseBuildTagForAutomaticChecks("v1.2.3-beta.1"))
+
+        precondition(!UpdateManager.isReleaseBuildTagForAutomaticChecks(nil))
+        precondition(!UpdateManager.isReleaseBuildTagForAutomaticChecks("local-abc123"))
+        precondition(!UpdateManager.isReleaseBuildTagForAutomaticChecks("dev-abc123"))
+        precondition(!UpdateManager.isReleaseBuildTagForAutomaticChecks("0.1.0"))
+        precondition(!UpdateManager.isReleaseBuildTagForAutomaticChecks("quill-v0.1.0"))
+    }
+
+    private static func testTimingPoliciesRemainConservative() throws {
+        let source = try String(contentsOfFile: "Sources/UpdateManager.swift", encoding: .utf8)
+
+        assertContains(source, "private let stabilityBufferDays: TimeInterval = 3")
+        assertContains(source, "private let checkIntervalSeconds: TimeInterval = 7 * 24 * 60 * 60")
+    }
+
+    private static func testDownloadedDMGValidationUsesSpctl() throws {
+        let dmgURL = URL(fileURLWithPath: "/tmp/Quill.dmg")
+        var recordedExecutablePath: String?
+        var recordedArguments: [String]?
+
+        try UpdateManager.validateDownloadedDMG(at: dmgURL) { executablePath, arguments in
+            recordedExecutablePath = executablePath
+            recordedArguments = arguments
+            return UpdateValidationCommandResult(terminationStatus: 0, standardOutput: "accepted", standardError: "")
+        }
+
+        precondition(recordedExecutablePath == "/usr/sbin/spctl", "Expected spctl to assess downloaded DMG")
+        precondition(recordedArguments == [
+            "--assess",
+            "--type", "open",
+            "--context", "context:primary-signature",
+            "--verbose=4",
+            dmgURL.path
+        ], "Expected spctl assessment arguments")
+    }
+
+    private static func testDownloadedDMGValidationRejectsFailedAssessment() throws {
+        let dmgURL = URL(fileURLWithPath: "/tmp/Quill.dmg")
+
+        assertThrows {
+            try UpdateManager.validateDownloadedDMG(at: dmgURL) { _, _ in
+                UpdateValidationCommandResult(terminationStatus: 3, standardOutput: "", standardError: "rejected")
+            }
+        }
+    }
+
+    private static func testStagedAppValidationChecksMetadataAndCodesign() throws {
+        let appURL = try makeTemporaryApp(
+            bundleIdentifier: "com.classmethod.Quill",
+            shortVersion: "1.2.3",
+            buildTag: "v1.2.3"
+        )
+        var recordedExecutablePath: String?
+        var recordedArguments: [String]?
+
+        try UpdateManager.validateStagedApp(
+            at: appURL,
+            expectedBundleIdentifier: "com.classmethod.Quill",
+            expectedShortVersion: "1.2.3",
+            expectedBuildTag: "v1.2.3"
+        ) { executablePath, arguments in
+            recordedExecutablePath = executablePath
+            recordedArguments = arguments
+            return UpdateValidationCommandResult(terminationStatus: 0, standardOutput: "valid", standardError: "")
+        }
+
+        precondition(recordedExecutablePath == "/usr/bin/codesign", "Expected codesign to verify staged app")
+        precondition(recordedArguments == [
+            "--verify",
+            "--deep",
+            "--strict",
+            "--verbose=2",
+            appURL.path
+        ], "Expected codesign verification arguments")
+    }
+
+    private static func testStagedAppValidationRejectsMetadataMismatch() throws {
+        let appURL = try makeTemporaryApp(
+            bundleIdentifier: "com.classmethod.Quill",
+            shortVersion: "1.2.3",
+            buildTag: "v1.2.3"
+        )
+        var didRunCodesign = false
+
+        assertThrows {
+            try UpdateManager.validateStagedApp(
+                at: appURL,
+                expectedBundleIdentifier: "com.classmethod.Quill",
+                expectedShortVersion: "1.2.4",
+                expectedBuildTag: "v1.2.3"
+            ) { _, _ in
+                didRunCodesign = true
+                return UpdateValidationCommandResult(terminationStatus: 0, standardOutput: "valid", standardError: "")
+            }
+        }
+
+        precondition(!didRunCodesign, "Expected metadata mismatch to fail before codesign")
+    }
+
+    private static func testInstallFlowValidatesBeforeReplacing() throws {
+        let source = try String(contentsOfFile: "Sources/UpdateManager.swift", encoding: .utf8)
+
+        assertContains(source, "private func performUpdate(downloadURL: URL, expectedSize: Int, release: GitHubRelease) async")
+        assertOrdered(
+            source,
+            "validateDownloadedDMG(at: dmgPath)",
+            before: "mountDMG(at: dmgPath)",
+            message: "Expected downloaded DMG validation before mounting"
+        )
+        assertOrdered(
+            source,
+            "validateStagedApp(",
+            before: "replaceAndRelaunch(stagedApp: stagedApp, stagingDir: stagingDir)",
+            message: "Expected staged app validation before replacement"
+        )
+        assertContains(source, "performUpdate(downloadURL: downloadURL, expectedSize: dmgAsset.size, release: release)")
+    }
+
+    private static func testStagedAppValidationRejectsNonAppBeforeCodesign() throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Quill-")
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let contentsURL = directoryURL.appendingPathComponent("Contents", isDirectory: true)
+        try FileManager.default.createDirectory(at: contentsURL, withIntermediateDirectories: true)
+        let infoPlist: [String: Any] = [
+            "CFBundleIdentifier": "com.classmethod.Quill",
+            "CFBundleShortVersionString": "1.2.3",
+            "QuillBuildTag": "v1.2.3"
+        ]
+        let infoPlistData = try PropertyListSerialization.data(fromPropertyList: infoPlist, format: .xml, options: 0)
+        try infoPlistData.write(to: contentsURL.appendingPathComponent("Info.plist"))
+        var didRunCodesign = false
+
+        assertThrows {
+            try UpdateManager.validateStagedApp(
+                at: directoryURL,
+                expectedBundleIdentifier: "com.classmethod.Quill",
+                expectedShortVersion: "1.2.3",
+                expectedBuildTag: "v1.2.3"
+            ) { _, _ in
+                didRunCodesign = true
+                return UpdateValidationCommandResult(terminationStatus: 0, standardOutput: "valid", standardError: "")
+            }
+        }
+
+        precondition(!didRunCodesign, "Expected non-.app path to fail before codesign")
+    }
+
+    private static func testMountDMGDoesNotDisableVerification() throws {
+        let source = try String(contentsOfFile: "Sources/UpdateManager.swift", encoding: .utf8)
+        precondition(!source.contains("\"-noverify\""), "DMG mounting must not disable verification")
+    }
+
+    private static func testAppDelegateStartsPeriodicUpdateChecks() throws {
+        let source = try String(contentsOfFile: "Sources/AppDelegate.swift", encoding: .utf8)
+        let activeLines = source
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+        let activeCallCount = activeLines.filter {
+            $0.contains("UpdateManager.shared.startPeriodicChecks()")
+        }.count
+
+        precondition(activeCallCount == 2, "Expected exactly 2 active periodic update check calls")
+        precondition(
+            !source.contains("Quill releases are not distributed through the in-app updater yet."),
+            "Expected obsolete in-app updater disabled message to be removed"
+        )
+    }
+
+    private static func testSettingsShowsUpdatesCard() throws {
+        let source = try String(contentsOfFile: "Sources/SettingsView.swift", encoding: .utf8)
+        let activeText = source
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+
+        assertContains(activeText, "SettingsCard(\"Updates\", icon: \"arrow.triangle.2.circlepath\")")
+        assertContains(activeText, "updatesSection")
+        assertContains(source, "Automatically check for updates")
+        assertContains(source, "Check for Updates Now")
+        assertContains(source, "Update Now")
+        assertContains(source, "downloadAndInstall(release: release)")
+    }
+
+    private static func testRecentReleaseWaitPreservesAvailableUpdate() throws {
+        let source = try String(contentsOfFile: "Sources/UpdateManager.swift", encoding: .utf8)
+        guard let methodRange = source.range(of: "private func showRecentReleaseAlert(daysSincePublished: Double)") else {
+            preconditionFailure("Expected showRecentReleaseAlert implementation")
+        }
+        let methodSource = String(source[methodRange.lowerBound...])
+        let endRange = methodSource.range(of: "\n    func showUpToDateAlert()")
+        let recentReleaseAlert = endRange.map { String(methodSource[..<$0.lowerBound]) } ?? methodSource
+
+        assertDoesNotContain(recentReleaseAlert, "updateAvailable = false")
+    }
+
+    private static func testTopLevelUpstreamAttributionIsHidden() throws {
+        let setupView = try String(contentsOfFile: "Sources/SetupView.swift", encoding: .utf8)
+        let settingsView = try String(contentsOfFile: "Sources/SettingsView.swift", encoding: .utf8)
+
+        let setupWelcomeStep = extract(setupView, from: "var welcomeStep: some View", to: "var apiKeyStep: some View")
+        let settingsHeader = extract(settingsView, from: "// App branding header", to: "SettingsCard(\"App\", icon: \"power\")")
+
+        assertDoesNotContain(setupWelcomeStep, "zachlatta/freeflow")
+        assertDoesNotContain(setupWelcomeStep, "recent contributors")
+        assertDoesNotContain(settingsHeader, "zachlatta/freeflow")
+        assertDoesNotContain(settingsHeader, "recently starred")
+        assertDoesNotContain(settingsView, "Task { await githubCache.fetchIfNeeded() }")
+    }
+
+    private static func asset(named name: String) -> GitHubReleaseAsset {
+        GitHubReleaseAsset(
+            name: name,
+            browserDownloadUrl: "https://example.com/\(name)",
+            size: 123
+        )
+    }
+
+    private static func release(assets: [GitHubReleaseAsset]) -> GitHubRelease {
+        GitHubRelease(
+            tagName: "v0.1.0",
+            name: "Quill v0.1.0",
+            body: nil,
+            htmlUrl: "https://example.com/releases/v0.1.0",
+            publishedAt: "2026-05-20T00:00:00Z",
+            assets: assets
+        )
+    }
+
+    private static func makeTemporaryApp(
+        bundleIdentifier: String,
+        shortVersion: String,
+        buildTag: String
+    ) throws -> URL {
+        let appURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Quill-\(UUID().uuidString)")
+            .appendingPathExtension("app")
+        let contentsURL = appURL.appendingPathComponent("Contents", isDirectory: true)
+        try FileManager.default.createDirectory(at: contentsURL, withIntermediateDirectories: true)
+
+        let infoPlist: [String: Any] = [
+            "CFBundleIdentifier": bundleIdentifier,
+            "CFBundleShortVersionString": shortVersion,
+            "QuillBuildTag": buildTag
+        ]
+        let infoPlistData = try PropertyListSerialization.data(fromPropertyList: infoPlist, format: .xml, options: 0)
+        try infoPlistData.write(to: contentsURL.appendingPathComponent("Info.plist"))
+
+        return appURL
+    }
+
+    private static func assertContains(_ text: String, _ expected: String) {
+        precondition(text.contains(expected), "Expected source to contain \(expected)")
+    }
+
+    private static func extract(_ text: String, from start: String, to end: String) -> String {
+        guard let startRange = text.range(of: start) else {
+            preconditionFailure("Expected source to contain start marker \(start)")
+        }
+        guard let endRange = text[startRange.upperBound...].range(of: end) else {
+            preconditionFailure("Expected source to contain end marker \(end)")
+        }
+        return String(text[startRange.lowerBound..<endRange.lowerBound])
+    }
+
+    private static func assertDoesNotContain(_ text: String, _ unexpected: String) {
+        precondition(!text.contains(unexpected), "Expected source not to contain \(unexpected)")
+    }
+
+    private static func assertOrdered(_ text: String, _ earlier: String, before later: String, message: String) {
+        guard let earlierRange = text.range(of: earlier) else {
+            preconditionFailure("Expected source to contain \(earlier)")
+        }
+        guard let laterRange = text.range(of: later) else {
+            preconditionFailure("Expected source to contain \(later)")
+        }
+        precondition(earlierRange.lowerBound < laterRange.lowerBound, message)
+    }
+
+    private static func assertThrows(_ operation: () throws -> Void) {
+        do {
+            try operation()
+            preconditionFailure("Expected operation to throw")
+        } catch {
+            return
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Re-enable Quill's in-app update checks and restore the Settings Updates card.
- Restrict installable update assets to `Quill.dmg` and validate downloaded DMGs/staged apps before replacement.
- Remove the top-level upstream GitHub attribution cards from onboarding and settings while keeping README/website attribution intact.

## Test plan
- [x] `make test`
- [x] `make`
- [x] Manual dev-build smoke test with `make run APP_VERSION=0.0.9 BUILD_NUMBER=1 BUILD_TAG=v0.0.9`
- [x] Manual normal dev-build smoke test with `make run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 설정 화면의 업데이트 섹션이 다시 활성화되었습니다.
  * 앱 시작 시 자동 업데이트 주기 체크가 활성화되었습니다.

* **개선 사항**
  * 업데이트 다운로드·설치 흐름에 대한 서명·검증 절차가 강화되었습니다.
  * 설치 전 검증과 스테이징 검증이 추가되어 보안이 향상되었습니다.

* **테스트**
  * 업데이트 안전성 및 검증 경로를 확인하는 통합 안전성 테스트가 추가되었습니다.
* **기타**
  * 설정 및 초기 설정의 GitHub 카드/패널이 제거되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/freeflow/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->