### PR TITLE
Update repository URLs for Quill rename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
             echo
             echo "## Download"
             echo
-            echo "**[Quill.dmg](https://github.com/woosublee/freeflow/releases/download/${{ steps.version.outputs.tag }}/Quill.dmg)** — Universal build for all Macs (Apple Silicon + Intel)."
+            echo "**[Quill.dmg](https://github.com/woosublee/quill/releases/download/${{ steps.version.outputs.tag }}/Quill.dmg)** — Universal build for all Macs (Apple Silicon + Intel)."
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Then:
 </p>
 
 <p align="center">
-  <a href="https://github.com/woosublee/freeflow/releases/latest/download/Quill.dmg"><b>⬇ Download Quill.dmg</b></a><br>
+  <a href="https://github.com/woosublee/quill/releases/latest/download/Quill.dmg"><b>⬇ Download Quill.dmg</b></a><br>
   <sub>Works on all Macs (Apple Silicon + Intel)</sub>
 </p>
 
@@ -78,7 +78,7 @@ Quill is a free Mac dictation app inspired by [Wispr Flow](https://wisprflow.ai/
 
 ## Quick Start
 
-1. Download the app from above or [click here](https://github.com/woosublee/freeflow/releases/latest/download/Quill.dmg)
+1. Download the app from above or [click here](https://github.com/woosublee/quill/releases/latest/download/Quill.dmg)
 2. Get a free Groq API key from [groq.com](https://groq.com/)
 3. Hold `Fn` to talk, or tap `Command-Fn` to start and stop dictation, and have whatever you say pasted into the current text field
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Quill is a free Mac dictation app inspired by [Wispr Flow](https://wisprflow.ai/
 
 ## Quick Start
 
-1. Download the app from above or [click here](https://github.com/woosublee/quill/releases/latest/download/Quill.dmg)
+1. Download the app from above or [download Quill.dmg](https://github.com/woosublee/quill/releases/latest/download/Quill.dmg)
 2. Get a free Groq API key from [groq.com](https://groq.com/)
 3. Hold `Fn` to talk, or tap `Command-Fn` to start and stop dictation, and have whatever you say pasted into the current text field
 

--- a/Sources/UpdateManager.swift
+++ b/Sources/UpdateManager.swift
@@ -221,7 +221,7 @@ final class UpdateManager: ObservableObject {
         set { UserDefaults.standard.set(newValue, forKey: "updateLastPostTranscriptionReminderDate") }
     }
 
-    private let releasesURL = URL(string: "https://api.github.com/repos/woosublee/freeflow/releases?per_page=100")!
+    private let releasesURL = URL(string: "https://api.github.com/repos/woosublee/quill/releases?per_page=100")!
     private let stabilityBufferDays: TimeInterval = 3
     private let checkIntervalSeconds: TimeInterval = 7 * 24 * 60 * 60 // 7 days
     private let postTranscriptionReminderInterval: TimeInterval = 24 * 60 * 60 // 1 day

--- a/website/index.html
+++ b/website/index.html
@@ -17,7 +17,7 @@
     <link rel="apple-touch-icon" href="/assets/quill-app-icon.png">
     <link rel="preload" href="/assets/demo.gif" as="image">
     <link rel="stylesheet" href="/assets/site.css">
-    <link rel="license" href="https://github.com/woosublee/freeflow/blob/main/LICENSE">
+    <link rel="license" href="https://github.com/woosublee/quill/blob/main/LICENSE">
     <link rel="help" href="/support/">
     <link rel="alternate" type="text/plain" href="/llms.txt" title="Quill information for AI agents">
     <meta property="og:type" content="website">
@@ -63,8 +63,8 @@
             "applicationCategory": "ProductivityApplication",
             "operatingSystem": "macOS 13 or later",
             "isAccessibleForFree": true,
-            "codeRepository": "https://github.com/woosublee/freeflow",
-            "license": "https://github.com/woosublee/freeflow/blob/main/LICENSE",
+            "codeRepository": "https://github.com/woosublee/quill",
+            "license": "https://github.com/woosublee/quill/blob/main/LICENSE",
             "image": "https://quill.vicals.com/assets/quill-app-icon.png",
             "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
             "featureList": [
@@ -75,7 +75,7 @@
               "custom vocabulary",
               "optional read-only Google Calendar note title suggestions"
             ],
-            "sameAs": ["https://github.com/woosublee/freeflow"]
+            "sameAs": ["https://github.com/woosublee/quill"]
           }
         ]
       }
@@ -94,7 +94,7 @@
           <a href="/privacy/">Privacy</a>
           <a href="/terms/">Terms</a>
           <a href="/support/">Support</a>
-          <a href="https://github.com/woosublee/freeflow">GitHub</a>
+          <a href="https://github.com/woosublee/quill">GitHub</a>
         </div>
       </nav>
     </header>
@@ -107,8 +107,8 @@
             <h1>Dictate, clean up, and edit text on your Mac.</h1>
             <p class="lede">Quill helps you speak into any focused text field, clean up transcripts with your configured AI provider, and transform selected text with voice commands. Calendar access is optional and read-only.</p>
             <div class="actions">
-              <a class="button primary" href="https://github.com/woosublee/freeflow">View on GitHub</a>
-              <a class="button" href="https://github.com/woosublee/freeflow/releases">Releases</a>
+              <a class="button primary" href="https://github.com/woosublee/quill">View on GitHub</a>
+              <a class="button" href="https://github.com/woosublee/quill/releases">Releases</a>
             </div>
           </div>
           <div class="preview-card" aria-label="Quill demo preview">

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -3,8 +3,8 @@
 Quill is an open-source macOS dictation app and a maintained fork of FreeFlow.
 
 Canonical site: https://quill.vicals.com/
-Source code: https://github.com/woosublee/freeflow
-Releases: https://github.com/woosublee/freeflow/releases
+Source code: https://github.com/woosublee/quill
+Releases: https://github.com/woosublee/quill/releases
 License: MIT
 Platform: macOS 13 or later on Apple Silicon and Intel Macs
 

--- a/website/privacy/index.html
+++ b/website/privacy/index.html
@@ -24,7 +24,7 @@
           <a href="/privacy/">Privacy</a>
           <a href="/terms/">Terms</a>
           <a href="/support/">Support</a>
-          <a href="https://github.com/woosublee/freeflow">GitHub</a>
+          <a href="https://github.com/woosublee/quill">GitHub</a>
         </div>
       </nav>
     </header>
@@ -81,7 +81,7 @@
         <p>You can also revoke Quill's Google access from your Google Account permissions page.</p>
 
         <h2>Open source and support</h2>
-        <p>Quill is open source. You can inspect the source code at <a href="https://github.com/woosublee/freeflow">github.com/woosublee/freeflow</a>. For support, visit <a href="/support/">Quill Support</a>.</p>
+        <p>Quill is open source. You can inspect the source code at <a href="https://github.com/woosublee/quill">github.com/woosublee/quill</a>. For support, visit <a href="/support/">Quill Support</a>.</p>
       </article>
     </main>
 

--- a/website/support/index.html
+++ b/website/support/index.html
@@ -24,7 +24,7 @@
           <a href="/privacy/">Privacy</a>
           <a href="/terms/">Terms</a>
           <a href="/support/">Support</a>
-          <a href="https://github.com/woosublee/freeflow">GitHub</a>
+          <a href="https://github.com/woosublee/quill">GitHub</a>
         </div>
       </nav>
     </header>
@@ -33,7 +33,7 @@
       <article class="wrap legal-card">
         <h1>Support</h1>
         <p>Use the public GitHub issue tracker for bug reports, feature requests, and support questions.</p>
-        <p><a class="button primary" href="https://github.com/woosublee/freeflow/issues">Open GitHub Issues</a></p>
+        <p><a class="button primary" href="https://github.com/woosublee/quill/issues">Open GitHub Issues</a></p>
 
         <h2>Do not post sensitive information</h2>
         <p>GitHub issues are public. Do not include any of the following in public issues:</p>
@@ -50,7 +50,7 @@
         <p>You can also revoke Quill's Google access from your Google Account permissions page.</p>
 
         <h2>Installation and updates</h2>
-        <p>Release notes, builds, and source code are available from the <a href="https://github.com/woosublee/freeflow/releases">GitHub Releases</a> page and the <a href="https://github.com/woosublee/freeflow">GitHub repository</a>.</p>
+        <p>Release notes, builds, and source code are available from the <a href="https://github.com/woosublee/quill/releases">GitHub Releases</a> page and the <a href="https://github.com/woosublee/quill">GitHub repository</a>.</p>
 
         <h2>Privacy questions</h2>
         <p>Review the <a href="/privacy/">Privacy Policy</a> for details about local storage, provider API calls, and optional Google Calendar access.</p>

--- a/website/terms/index.html
+++ b/website/terms/index.html
@@ -24,7 +24,7 @@
           <a href="/privacy/">Privacy</a>
           <a href="/terms/">Terms</a>
           <a href="/support/">Support</a>
-          <a href="https://github.com/woosublee/freeflow">GitHub</a>
+          <a href="https://github.com/woosublee/quill">GitHub</a>
         </div>
       </nav>
     </header>
@@ -48,7 +48,7 @@
         <p>Data handling is described in the <a href="/privacy/">Privacy Policy</a>. Please review it before connecting Google Calendar or configuring third-party providers.</p>
 
         <h2>Open-source license</h2>
-        <p>Quill source code is available under the MIT License. The source repository and license are available at <a href="https://github.com/woosublee/freeflow">github.com/woosublee/freeflow</a>.</p>
+        <p>Quill source code is available under the MIT License. The source repository and license are available at <a href="https://github.com/woosublee/quill">github.com/woosublee/quill</a>.</p>
 
         <h2>No warranty</h2>
         <p>Quill is provided without warranties of any kind. To the maximum extent permitted by law, the project maintainers are not liable for losses or damages arising from use of the app or third-party services configured with the app.</p>


### PR DESCRIPTION
## Summary
- Point updater release checks at `woosublee/quill`.
- Update README download links, release workflow DMG links, and public website GitHub links for the renamed repository.

## Test plan
- [x] `make test`
- [x] Checked that old `woosublee/freeflow` origin references no longer remain in project files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 웹사이트 및 README의 다운로드 링크, GitHub 저장소 참조가 정확한 저장소로 업데이트되었습니다.

* **수정사항**
  * 앱의 자동 업데이트 확인 시스템이 올바른 저장소의 릴리스 정보를 참조하도록 수정되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/quill/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->