### PR TITLE
Remove retired signing certificate from updater allowlist

### DIFF
--- a/Sources/UpdateManager.swift
+++ b/Sources/UpdateManager.swift
@@ -128,7 +128,6 @@ enum DownloadedDMGTrustPath: Equatable, Sendable {
 }
 
 private let allowedCertificateLeaves = [
-    "0CB0C8717D9317864A1B93312AB4DD166E254DDF",
     "7172DCFFF89F1A17F40FD14BAC80F975536C97ED"
 ]
 

--- a/Tests/UpdateManagerSafetyTests.swift
+++ b/Tests/UpdateManagerSafetyTests.swift
@@ -147,7 +147,6 @@ struct UpdateManagerSafetyTests {
         precondition(
             Set(pinnedLeaves) == Set([
                 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "0CB0C8717D9317864A1B93312AB4DD166E254DDF",
                 "7172DCFFF89F1A17F40FD14BAC80F975536C97ED"
             ]),
             "Expected exact pinned leaf set for temporary self-signed fallback requirement"


### PR DESCRIPTION
## Summary
- Remove the retired self-signed certificate hash from `allowedCertificateLeaves`
- Only the active certificate (`7172DCFFF89F1A17F40FD14BAC80F975536C97ED`) remains

## Test plan
- [ ] Build and verify app signs correctly with the remaining certificate
- [ ] Confirm update validation still accepts DMGs signed with the active cert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 애플리케이션 서명 검증이 강화되어 특정 인증된 인증서만 임시 대체 메커니즘에서 허용됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/quill/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->