### PR TITLE
Unify transcript post-processing into a single shared function

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2568,7 +2568,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
     }
 
-
     func updatePermissionStatus(accessibility: Bool, screenRecording: Bool) {
         if hasAccessibility != accessibility {
             hasAccessibility = accessibility

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -4405,7 +4405,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         postProcessingService: PostProcessingService,
         customVocabulary: String,
         customSystemPrompt: String,
-        outputLanguage: String
+        outputLanguage: String,
+        postProcessingEnabled: Bool
     ) async -> (finalTranscript: String, outcome: TranscriptProcessingOutcome, prompt: String) {
         let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -4434,7 +4435,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return (macro.payload, .voiceMacro(command: macro.command), "")
         }
 
-        if disablePostProcessing {
+        if !postProcessingEnabled {
             return (rawTranscript, .postProcessingDisabled, "")
         }
 
@@ -4501,6 +4502,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         customVocabulary: String,
         customSystemPrompt: String,
         outputLanguage: String,
+        postProcessingEnabled: Bool,
         pressEnterCommandEnabled: Bool
     ) async throws -> StoppedTranscriptionCompletionSummary {
         let parsedTranscript = Self.parseTranscriptCommands(
@@ -4518,7 +4520,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             postProcessingService: postProcessingService,
             customVocabulary: customVocabulary,
             customSystemPrompt: customSystemPrompt,
-            outputLanguage: outputLanguage
+            outputLanguage: outputLanguage,
+            postProcessingEnabled: postProcessingEnabled
         )
         try Task.checkCancellation()
         let processingStatus = Self.statusMessage(
@@ -4760,6 +4763,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         customVocabulary: capturedCustomVocabulary,
                         customSystemPrompt: capturedCustomSystemPrompt,
                         outputLanguage: capturedOutputLanguage,
+                        postProcessingEnabled: capturedSettings.usedPostProcessing,
                         pressEnterCommandEnabled: capturedPressEnterCommandEnabled
                     )
                     try await self.runSuccessfulStoppedTranscriptionCompletionPipeline(
@@ -4912,6 +4916,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         customVocabulary: capturedCustomVocabulary,
                         customSystemPrompt: capturedCustomSystemPrompt,
                         outputLanguage: capturedOutputLanguage,
+                        postProcessingEnabled: capturedSettings.usedPostProcessing,
                         pressEnterCommandEnabled: capturedPressEnterCommandEnabled
                     )
                     try await self.runSuccessfulStoppedTranscriptionCompletionPipeline(

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2469,10 +2469,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     from: rawTranscript,
                     pressEnterCommandEnabled: self.isPressEnterVoiceCommandEnabled
                 )
-                let result = await self.processTranscriptForRetry(
+                let result = await self.processTranscript(
                     parsedTranscript.transcript,
-                    snapshot: snapshot,
-                    postProcessingService: postProcessingService
+                    intent: snapshot.restoredIntent,
+                    context: snapshot.restoredContext,
+                    postProcessingService: postProcessingService,
+                    customVocabulary: snapshot.customVocabulary,
+                    customSystemPrompt: snapshot.customSystemPrompt,
+                    outputLanguage: snapshot.outputLanguage,
+                    postProcessingEnabled: snapshot.postProcessingEnabled
                 )
                 updatedItem = self.makeRetryHistoryItem(
                     from: snapshot,
@@ -2596,56 +2601,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
     }
 
-    private func processTranscriptForRetry(
-        _ rawTranscript: String,
-        snapshot: RetrySnapshot,
-        postProcessingService: PostProcessingService
-    ) async -> (finalTranscript: String, outcome: TranscriptProcessingOutcome, prompt: String) {
-        let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        guard !trimmedRawTranscript.isEmpty else {
-            return ("", .skippedEmptyRawTranscript, "")
-        }
-
-        if case .command(let invocation, let selectedText) = snapshot.restoredIntent {
-            do {
-                let result = try await postProcessingService.commandTransform(
-                    selectedText: selectedText,
-                    voiceCommand: rawTranscript,
-                    context: snapshot.restoredContext,
-                    customVocabulary: snapshot.customVocabulary,
-                    outputLanguage: snapshot.outputLanguage
-                )
-                return (result.transcript, .commandModeSucceeded(invocation: invocation), result.prompt)
-            } catch {
-                os_log(.error, log: recordingLog, "Edit mode failed: %{public}@", error.localizedDescription)
-                return (selectedText, .commandModeFailedFallback(invocation: invocation), "")
-            }
-        }
-
-        if let macro = findMatchingMacro(for: trimmedRawTranscript) {
-            os_log(.info, log: recordingLog, "Voice macro triggered: %{public}@", macro.command)
-            return (macro.payload, .voiceMacro(command: macro.command), "")
-        }
-
-        if !snapshot.postProcessingEnabled {
-            return (rawTranscript, .postProcessingDisabled, "")
-        }
-
-        do {
-            let result = try await postProcessingService.postProcess(
-                transcript: trimmedRawTranscript,
-                context: snapshot.restoredContext,
-                customVocabulary: snapshot.customVocabulary,
-                customSystemPrompt: snapshot.customSystemPrompt,
-                outputLanguage: snapshot.outputLanguage
-            )
-            return (result.transcript, .postProcessingSucceeded, result.prompt)
-        } catch {
-            os_log(.error, log: recordingLog, "Post-processing failed: %{public}@", error.localizedDescription)
-            return (trimmedRawTranscript, .postProcessingFailedFallback, "")
-        }
-    }
 
     func updatePermissionStatus(accessibility: Bool, screenRecording: Bool) {
         if hasAccessibility != accessibility {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2334,8 +2334,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     from: rawTranscript,
                     pressEnterCommandEnabled: capturedPressEnterCommandEnabled
                 )
-                let result = await self.processImportedTranscript(
+                let result = await self.processTranscript(
                     parsedTranscript.transcript,
+                    intent: .dictation,
                     context: importedContext,
                     postProcessingService: postProcessingService,
                     customVocabulary: capturedCustomVocabulary,
@@ -2393,40 +2394,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
         }
         updateTranscriptionJob(jobID) { $0.task = task }
-    }
-
-    @MainActor
-    private func processImportedTranscript(
-        _ rawTranscript: String,
-        context: AppContext,
-        postProcessingService: PostProcessingService,
-        customVocabulary: String,
-        customSystemPrompt: String,
-        outputLanguage: String,
-        postProcessingEnabled: Bool
-    ) async -> (finalTranscript: String, outcome: TranscriptProcessingOutcome, prompt: String) {
-        let trimmedRawTranscript = rawTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedRawTranscript.isEmpty else {
-            return ("", .skippedEmptyRawTranscript, "")
-        }
-        if let macro = findMatchingMacro(for: trimmedRawTranscript) {
-            return (macro.payload, .voiceMacro(command: macro.command), "")
-        }
-        guard postProcessingEnabled else {
-            return (rawTranscript, .postProcessingDisabled, "")
-        }
-        do {
-            let result = try await postProcessingService.postProcess(
-                transcript: trimmedRawTranscript,
-                context: context,
-                customVocabulary: customVocabulary,
-                customSystemPrompt: customSystemPrompt,
-                outputLanguage: outputLanguage
-            )
-            return (result.transcript, .postProcessingSucceeded, result.prompt)
-        } catch {
-            return (trimmedRawTranscript, .postProcessingFailedFallback, "")
-        }
     }
 
     @MainActor

--- a/docs/superpowers/specs/2026-05-29-unify-process-transcript-design.md
+++ b/docs/superpowers/specs/2026-05-29-unify-process-transcript-design.md
@@ -1,0 +1,57 @@
+# Unify Transcript Post-Processing Flow
+
+**Date:** 2026-05-29
+**Issue:** #46
+
+## Problem
+
+세 가지 녹음 경로(방금 녹음, 재시도, 오디오 import)가 거의 동일한 포스트프로세싱 로직을 각각 별도 함수로 구현하고 있다.
+
+- `processTranscript()` — 방금 녹음
+- `processTranscriptForRetry()` — 재시도
+- `processImportedTranscript()` — 오디오 import
+
+로직 변경 시 3군데를 모두 수정해야 하고, 누락 시 경로별로 동작이 달라지는 버그가 생길 수 있다.
+
+## Design
+
+### 통합 함수 시그니처
+
+```swift
+private func processTranscript(
+    _ rawTranscript: String,
+    intent: SessionIntent,
+    context: AppContext,
+    postProcessingService: PostProcessingService,
+    customVocabulary: String,
+    customSystemPrompt: String,
+    outputLanguage: String,
+    postProcessingEnabled: Bool
+) async -> (finalTranscript: String, outcome: TranscriptProcessingOutcome, prompt: String)
+```
+
+기존 `processTranscript()`에 `postProcessingEnabled: Bool` 파라미터를 추가한다. 기존에 `self.disablePostProcessing`을 직접 읽던 방식을 제거하고 호출부가 명시적으로 넘기도록 변경한다.
+
+### 호출부 변경
+
+| 경로 | intent | postProcessingEnabled |
+|---|---|---|
+| 방금 녹음 | 기존 그대로 | `capturedPostProcessingEnabled` (이미 캡처됨) |
+| 재시도 | `snapshot.restoredIntent` | `snapshot.postProcessingEnabled` |
+| 오디오 import | `.dictation` | `capturedPostProcessingEnabled` |
+
+import 경로는 `intent: .dictation`을 넘겨 Edit Mode 분기를 자연스럽게 건너뛴다.
+
+### 제거 대상
+
+- `processTranscriptForRetry()` 함수 전체
+- `processImportedTranscript()` 함수 전체
+
+### 내부 로직
+
+현재 `processTranscript()` 로직을 그대로 유지한다. 변경은 파라미터 추가와 `self.disablePostProcessing` 참조 제거뿐이다.
+
+## 변경 범위
+
+- `Sources/AppState.swift` 한 파일만 수정
+- 행동 변화 없음 — 순수 리팩터링


### PR DESCRIPTION
## Summary

- Removes `processTranscriptForRetry` and `processImportedTranscript` — both were near-identical copies of `processTranscript`
- Adds `postProcessingEnabled: Bool` parameter to `processTranscript`, removing the direct `self.disablePostProcessing` reference
- All three recording paths (live recording, retry, audio import) now go through the same function

Closes #46

## Test Plan

- [ ] `make test` passes (all 20 test suites)
- [ ] Live recording post-processing works as before
- [ ] Retry from history works as before
- [ ] Audio import post-processing works as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 전사 처리 파이프라인을 통합하여 모든 전사 경로(녹음, 재시도, 오디오 임포트)에서 일관된 후처리 제어 로직을 적용했습니다. 이를 통해 코드 복잡도를 감소하고 유지보수성을 개선했습니다.

* **Documentation**
  * 전사 처리 통합 설계에 대한 기술 사양 문서를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woosublee/quill/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->