### PR TITLE
Fix overlay display ID bridging

### DIFF
--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -52,11 +52,17 @@ enum RecordingOverlayLayout: String, CaseIterable, Identifiable {
 
 // MARK: - NSScreen Helpers
 
+extension Dictionary where Key == NSDeviceDescriptionKey, Value == Any {
+    var displayID: CGDirectDisplayID? {
+        (self[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value
+    }
+}
+
 extension NSScreen {
     /// CoreGraphics display identifier for this screen, or nil if the device
     /// description is missing the key.
     var displayID: CGDirectDisplayID? {
-        deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
+        deviceDescription.displayID
     }
 }
 

--- a/Tests/RecordingOverlayGeometryTests.swift
+++ b/Tests/RecordingOverlayGeometryTests.swift
@@ -8,6 +8,7 @@ struct RecordingOverlayGeometryTests {
         testTranscribingWidthFallsBackToCenteredWidthAfterNotchSideRecording()
         testTranscribingWidthKeepsExistingLockOnRepeatedTranscribingUpdate()
         testNotchSideLayoutPhaseEligibility()
+        testNSScreenNumberBridgesThroughNSNumber()
         testRecordingOverlayUsesSharedScreenGeometry()
         try testNotchSideOverlayAvoidsContainerAudioLevelAnimation()
         try testHostingViewsUseFixedIntrinsicContentSize()
@@ -78,6 +79,14 @@ struct RecordingOverlayGeometryTests {
             phase: .recording,
             hasNotchGeometry: false
         ))
+    }
+
+    private static func testNSScreenNumberBridgesThroughNSNumber() {
+        let deviceDescription: [NSDeviceDescriptionKey: Any] = [
+            NSDeviceDescriptionKey("NSScreenNumber"): NSNumber(value: UInt32(42))
+        ]
+
+        assert(deviceDescription.displayID == 42)
     }
 
     private static func testRecordingOverlayUsesSharedScreenGeometry() {


### PR DESCRIPTION
## Summary
- Fix `NSScreenNumber` bridging by reading the device description value as `NSNumber` before converting to `CGDirectDisplayID`.
- Add a regression check so the overlay display picker can resolve display IDs from AppKit-style screen metadata.

## Test Plan
- [x] `swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/RecordingOverlay.swift Tests/RecordingOverlayGeometryTests.swift -o /tmp/RecordingOverlayGeometryTests && /tmp/RecordingOverlayGeometryTests`
- [x] `make test`
- [x] `make all CODESIGN_IDENTITY="Quill"`

Addresses review comment on #129: https://github.com/woosublee/quill/pull/129#discussion_r3329040289

🤖 Generated with [Claude Code](https://claude.com/claude-code)
