### PR TITLE
Merge upstream model dropdown and transcription timeout updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ This project uses semantic versioning for public releases. Use `MAJOR.MINOR.PATC
 - `MINOR` changes add user-visible features and improvements.
 - `PATCH` changes fix bugs, polish existing behavior, or make small internal improvements.
 
+## [1.1.0] - 2026-06-03
+
+### Added
+
+- Model pickers in Settings for post-processing, fallback, context, and transcription models, including Qwen 3 32B and custom model entries.
+- A recording overlay display picker for choosing the active window, primary display, or a specific connected monitor.
+- In-pill error notifications so transient failures such as network or provider errors are visible without opening logs.
+- Advanced timeout overrides for local model and slow network setups.
+
+### Improved
+
+- Retried dictations now place the successful transcript on the clipboard and update Paste Again.
+- Paste Again now preserves the latest raw transcript earlier in the dictation flow, so it remains useful if later cleanup or pasting fails.
+- Post-processing handles reasoning-oriented model output more cleanly, including Qwen thinking tags and providerless model aliases.
+
+### Fixed
+
+- Fixed cases where transcription could hang indefinitely when a provider accepted a connection but never returned a response.
+- Fixed false screen-recording permission alerts from unrelated permission messages.
+- Fixed duplicate in-pill error notifications being dismissed by an older timer.
+
 ## [1.0.0] - 2026-05-20
 
 FreeFlow is now considered feature-complete and stable enough for a 1.0 release.

--- a/Sources/ModelConfiguration.swift
+++ b/Sources/ModelConfiguration.swift
@@ -163,7 +163,7 @@ public struct ModelConfiguration {
         var cleaned = text
         
         // First, replace fully closed tags: <think>...</think>
-        let closedRegexPattern = "<think>[\\s\\S]*?</think>"
+        let closedRegexPattern = "^\\s*<think>[\\s\\S]*?</think>"
         if let regex = try? NSRegularExpression(pattern: closedRegexPattern, options: []) {
             let range = NSRange(cleaned.startIndex..<cleaned.endIndex, in: cleaned)
             cleaned = regex.stringByReplacingMatches(in: cleaned, options: [], range: range, withTemplate: "")
@@ -171,7 +171,7 @@ public struct ModelConfiguration {
         
         // Next, if there is an unclosed <think> tag remaining (meaning it started thinking but got truncated),
         // we strip from the opening <think> tag to the very end of the string.
-        let openRegexPattern = "<think>[\\s\\S]*$"
+        let openRegexPattern = "^\\s*<think>[\\s\\S]*$"
         if let regex = try? NSRegularExpression(pattern: openRegexPattern, options: []) {
             let range = NSRange(cleaned.startIndex..<cleaned.endIndex, in: cleaned)
             cleaned = regex.stringByReplacingMatches(in: cleaned, options: [], range: range, withTemplate: "")

--- a/Sources/ModelConfiguration.swift
+++ b/Sources/ModelConfiguration.swift
@@ -41,7 +41,7 @@ public struct ModelConfiguration {
         
         if cleanModel == "openai/gpt-oss-20b" {
             return ModelConfig(
-                maxCompletionTokens: 1024,
+                maxCompletionTokens: 4096,
                 reasoningEffort: "low",
                 includeReasoning: false,
                 shouldStripThinkTags: false

--- a/Sources/ModelConfiguration.swift
+++ b/Sources/ModelConfiguration.swift
@@ -169,16 +169,16 @@ public struct ModelConfiguration {
         var cleaned = text
         
         // First, replace fully closed tags: <think>...</think>
-        // We use a group with + to catch multiple consecutive think blocks.
-        let closedRegexPattern = "^(?:\\s*<think>[\\s\\S]*?</think>)+"
+        // Match anywhere in the text so blocks after leading content are stripped too.
+        let closedRegexPattern = "<think>[\\s\\S]*?</think>"
         if let regex = try? NSRegularExpression(pattern: closedRegexPattern, options: []) {
             let range = NSRange(cleaned.startIndex..<cleaned.endIndex, in: cleaned)
             cleaned = regex.stringByReplacingMatches(in: cleaned, options: [], range: range, withTemplate: "")
         }
         
         // Next, if there is an unclosed <think> tag remaining (meaning it started thinking but got truncated),
-        // we strip from the opening <think> tag to the very end of the string.
-        let openRegexPattern = "^\\s*<think>[\\s\\S]*$"
+        // strip from the first remaining <think> tag to the very end of the string.
+        let openRegexPattern = "<think>[\\s\\S]*$"
         if let regex = try? NSRegularExpression(pattern: openRegexPattern, options: []) {
             let range = NSRange(cleaned.startIndex..<cleaned.endIndex, in: cleaned)
             cleaned = regex.stringByReplacingMatches(in: cleaned, options: [], range: range, withTemplate: "")

--- a/Sources/ModelConfiguration.swift
+++ b/Sources/ModelConfiguration.swift
@@ -31,7 +31,13 @@ public struct ModelConfiguration {
     ]
 
     public static func config(for model: String) -> ModelConfig {
-        let cleanModel = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        var cleanModel = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        
+        // Normalize providerless aliases
+        if cleanModel == "qwen3-32b" { cleanModel = "qwen/qwen3-32b" }
+        else if cleanModel == "gpt-oss-20b" { cleanModel = "openai/gpt-oss-20b" }
+        else if cleanModel == "gpt-oss-120b" { cleanModel = "openai/gpt-oss-120b" }
+        else if cleanModel == "gpt-oss-safeguard-20b" { cleanModel = "openai/gpt-oss-safeguard-20b" }
         
         if cleanModel == "openai/gpt-oss-20b" {
             return ModelConfig(
@@ -163,7 +169,8 @@ public struct ModelConfiguration {
         var cleaned = text
         
         // First, replace fully closed tags: <think>...</think>
-        let closedRegexPattern = "^\\s*<think>[\\s\\S]*?</think>"
+        // We use a group with + to catch multiple consecutive think blocks.
+        let closedRegexPattern = "^(?:\\s*<think>[\\s\\S]*?</think>)+"
         if let regex = try? NSRegularExpression(pattern: closedRegexPattern, options: []) {
             let range = NSRange(cleaned.startIndex..<cleaned.endIndex, in: cleaned)
             cleaned = regex.stringByReplacingMatches(in: cleaned, options: [], range: range, withTemplate: "")

--- a/Sources/ModelConfiguration.swift
+++ b/Sources/ModelConfiguration.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+public struct ModelConfig {
+    public let maxCompletionTokens: Int?
+    public let reasoningEffort: String?
+    public let includeReasoning: Bool?
+    public let shouldStripThinkTags: Bool
+}
+
+public struct ModelConfiguration {
+    public static let llmModels = [
+        "llama-3.3-70b-versatile",
+        "llama-3.1-8b-instant",
+        "meta-llama/llama-4-scout-17b-16e-instruct",
+        "openai/gpt-oss-20b",
+        "openai/gpt-oss-120b",
+        "openai/gpt-oss-safeguard-20b",
+        "qwen/qwen3-32b",
+        "allam-2-7b",
+        "groq/compound",
+        "groq/compound-mini",
+        "canopylabs/orpheus-arabic-saudi",
+        "canopylabs/orpheus-v1-english",
+        "meta-llama/llama-prompt-guard-2-22m",
+        "meta-llama/llama-prompt-guard-2-86m"
+    ]
+
+    public static let transcriptionModels = [
+        "whisper-large-v3",
+        "whisper-large-v3-turbo"
+    ]
+
+    public static func config(for model: String) -> ModelConfig {
+        let cleanModel = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        
+        if cleanModel == "openai/gpt-oss-20b" {
+            return ModelConfig(
+                maxCompletionTokens: 1024,
+                reasoningEffort: "low",
+                includeReasoning: false,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "openai/gpt-oss-120b" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "openai/gpt-oss-safeguard-20b" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "qwen/qwen3-32b" {
+ // Model that requires sanitization of thought tags
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: true
+            )
+        } else if cleanModel == "llama-3.1-8b-instant" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "llama-3.3-70b-versatile" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "meta-llama/llama-4-scout-17b-16e-instruct" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "meta-llama/llama-prompt-guard-2-22m" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "meta-llama/llama-prompt-guard-2-86m" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "allam-2-7b" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "canopylabs/orpheus-arabic-saudi" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "canopylabs/orpheus-v1-english" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "groq/compound" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "groq/compound-mini" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "whisper-large-v3" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        } else if cleanModel == "whisper-large-v3-turbo" {
+            return ModelConfig(
+                maxCompletionTokens: nil,
+                reasoningEffort: nil,
+                includeReasoning: nil,
+                shouldStripThinkTags: false
+            )
+        }
+        
+        // Fallback genérico para qualquer outro modelo que não esteja na lista acima
+        return ModelConfig(
+            maxCompletionTokens: nil,
+            reasoningEffort: nil,
+            includeReasoning: nil,
+            shouldStripThinkTags: false
+        )
+    }
+    
+    /// Utility method to remove <think>...</think> tags and everything inside them.
+    /// This also handles unclosed tags gracefully (e.g. if the model runs out of tokens).
+    public static func stripThinkTags(_ text: String) -> String {
+        var cleaned = text
+        
+        // First, replace fully closed tags: <think>...</think>
+        let closedRegexPattern = "<think>[\\s\\S]*?</think>"
+        if let regex = try? NSRegularExpression(pattern: closedRegexPattern, options: []) {
+            let range = NSRange(cleaned.startIndex..<cleaned.endIndex, in: cleaned)
+            cleaned = regex.stringByReplacingMatches(in: cleaned, options: [], range: range, withTemplate: "")
+        }
+        
+        // Next, if there is an unclosed <think> tag remaining (meaning it started thinking but got truncated),
+        // we strip from the opening <think> tag to the very end of the string.
+        let openRegexPattern = "<think>[\\s\\S]*$"
+        if let regex = try? NSRegularExpression(pattern: openRegexPattern, options: []) {
+            let range = NSRange(cleaned.startIndex..<cleaned.endIndex, in: cleaned)
+            cleaned = regex.stringByReplacingMatches(in: cleaned, options: [], range: range, withTemplate: "")
+        }
+        
+        return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/ModelDropdownView.swift
+++ b/Sources/ModelDropdownView.swift
@@ -86,5 +86,11 @@ struct ModelDropdownView: View {
                 isCustom = true
             }
         }
+        .onChange(of: textDraft) { newValue in
+            let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                isCustom = !predefinedModels.contains(trimmed)
+            }
+        }
     }
 }

--- a/Sources/ModelDropdownView.swift
+++ b/Sources/ModelDropdownView.swift
@@ -88,7 +88,7 @@ struct ModelDropdownView: View {
         }
         .onChange(of: textDraft) { newValue in
             let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
+            if !trimmed.isEmpty && !isEditingCustom {
                 isCustom = !predefinedModels.contains(trimmed)
             }
         }

--- a/Sources/ModelDropdownView.swift
+++ b/Sources/ModelDropdownView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+/// A reusable dropdown for selecting a model from predefined options,
+/// or providing a custom model string if "Custom..." is chosen.
+struct ModelDropdownView: View {
+    let title: String
+    let subtitle: String?
+    let predefinedModels: [String]
+    let defaultModel: String
+    
+    @Binding var textDraft: String
+    let onCommit: () -> Void
+    let onReset: () -> Void
+    
+    @State private var isCustom: Bool = false
+    @FocusState private var isEditingCustom: Bool
+    
+    private var effectiveSelection: Binding<String> {
+        Binding(
+            get: {
+                if predefinedModels.contains(textDraft) && !isCustom {
+                    return textDraft
+                } else {
+                    return "Custom..."
+                }
+            },
+            set: { newValue in
+                if newValue == "Custom..." {
+                    isCustom = true
+                    if predefinedModels.contains(textDraft) {
+                        textDraft = ""
+                    }
+                } else {
+                    isCustom = false
+                    textDraft = newValue
+                    onCommit()
+                }
+            }
+        )
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+            
+            HStack(spacing: 8) {
+                Picker("", selection: effectiveSelection) {
+                    ForEach(predefinedModels, id: \.self) { model in
+                        Text(model).tag(model)
+                    }
+                    Divider()
+                    Text("Custom...").tag("Custom...")
+                }
+                .labelsHidden()
+                
+                if effectiveSelection.wrappedValue == "Custom..." {
+                    TextField(defaultModel, text: $textDraft)
+                        .textFieldStyle(.roundedBorder)
+                        .focused($isEditingCustom)
+                        .onSubmit {
+                            onCommit()
+                        }
+                        .onChange(of: isEditingCustom) { isEditing in
+                            if !isEditing {
+                                onCommit()
+                            }
+                        }
+                }
+                
+                Button("Reset to Default") {
+                    isCustom = false
+                    onReset()
+                }
+                .font(.caption)
+            }
+            
+            if let subtitle = subtitle {
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .onAppear {
+            if !predefinedModels.contains(textDraft) && !textDraft.isEmpty {
+                isCustom = true
+            }
+        }
+    }
+}

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -422,9 +422,20 @@ Model: \(model)
                 ]
             ]
         ]
-        if model == defaultModel {
+        let config = ModelConfiguration.config(for: model)
+        if let maxTokens = config.maxCompletionTokens {
+            payload["max_completion_tokens"] = maxTokens
+        } else if model == defaultModel {
             payload["max_completion_tokens"] = postProcessingMaxCompletionTokens
+        }
+        if let effort = config.reasoningEffort {
+            payload["reasoning_effort"] = effort
+        } else if model == defaultModel {
             payload["reasoning_effort"] = defaultModelReasoningEffort
+        }
+        if let include = config.includeReasoning {
+            payload["include_reasoning"] = include
+        } else if model == defaultModel {
             payload["include_reasoning"] = false
         }
 
@@ -444,8 +455,13 @@ Model: \(model)
               let choices = json["choices"] as? [[String: Any]],
               let firstChoice = choices.first,
               let message = firstChoice["message"] as? [String: Any],
-              let content = message["content"] as? String else {
+              let rawContent = message["content"] as? String else {
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
+        }
+        
+        var content = rawContent
+        if config.shouldStripThinkTags {
+            content = ModelConfiguration.stripThinkTags(content)
         }
 
         guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -530,9 +546,20 @@ Model: \(model)
                 ]
             ]
         ]
-        if model == defaultModel {
+        let config = ModelConfiguration.config(for: model)
+        if let maxTokens = config.maxCompletionTokens {
+            payload["max_completion_tokens"] = maxTokens
+        } else if model == defaultModel {
             payload["max_completion_tokens"] = postProcessingMaxCompletionTokens
+        }
+        if let effort = config.reasoningEffort {
+            payload["reasoning_effort"] = effort
+        } else if model == defaultModel {
             payload["reasoning_effort"] = defaultModelReasoningEffort
+        }
+        if let include = config.includeReasoning {
+            payload["include_reasoning"] = include
+        } else if model == defaultModel {
             payload["include_reasoning"] = false
         }
 
@@ -552,8 +579,13 @@ Model: \(model)
               let choices = json["choices"] as? [[String: Any]],
               let firstChoice = choices.first,
               let message = firstChoice["message"] as? [String: Any],
-              let content = message["content"] as? String else {
+              let rawContent = message["content"] as? String else {
             throw PostProcessingError.invalidResponse("Missing choices[0].message.content")
+        }
+        
+        var content = rawContent
+        if config.shouldStripThinkTags {
+            content = ModelConfiguration.stripThinkTags(content)
         }
 
         guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -151,109 +151,57 @@ struct ProviderSettingsFields: View {
                     .foregroundStyle(.secondary)
             }
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Post-Processing Model")
-                    .font(.caption.weight(.semibold))
-                HStack(spacing: 8) {
-                    TextField(AppState.defaultPostProcessingModel, text: $postProcessingModelDraft)
-                        .textFieldStyle(.roundedBorder)
-                        .focused($isEditingPostProcessingModel)
-                        .onSubmit {
-                            commitPostProcessingModel()
-                        }
-                        .onChange(of: isEditingPostProcessingModel) { isEditing in
-                            if !isEditing {
-                                commitPostProcessingModel()
-                            }
-                        }
-                    Button("Reset to Default") {
-                        postProcessingModelDraft = AppState.defaultPostProcessingModel
-                        appState.postProcessingModel = AppState.defaultPostProcessingModel
-                    }
-                    .font(.caption)
+            ModelDropdownView(
+                title: "Post-Processing Model",
+                subtitle: "Used for transcript cleanup and Edit Mode transforms.",
+                predefinedModels: ModelConfiguration.llmModels,
+                defaultModel: AppState.defaultPostProcessingModel,
+                textDraft: $postProcessingModelDraft,
+                onCommit: commitPostProcessingModel,
+                onReset: {
+                    postProcessingModelDraft = AppState.defaultPostProcessingModel
+                    appState.postProcessingModel = AppState.defaultPostProcessingModel
                 }
-                Text("Used for transcript cleanup and Edit Mode transforms.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+            )
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Post-Processing Fallback Model")
-                    .font(.caption.weight(.semibold))
-                HStack(spacing: 8) {
-                    TextField(AppState.defaultPostProcessingFallbackModel, text: $postProcessingFallbackModelDraft)
-                        .textFieldStyle(.roundedBorder)
-                        .focused($isEditingPostProcessingFallbackModel)
-                        .onSubmit {
-                            commitPostProcessingFallbackModel()
-                        }
-                        .onChange(of: isEditingPostProcessingFallbackModel) { isEditing in
-                            if !isEditing {
-                                commitPostProcessingFallbackModel()
-                            }
-                        }
-                    Button("Reset to Default") {
-                        postProcessingFallbackModelDraft = AppState.defaultPostProcessingFallbackModel
-                        appState.postProcessingFallbackModel = AppState.defaultPostProcessingFallbackModel
-                    }
-                    .font(.caption)
+            ModelDropdownView(
+                title: "Post-Processing Fallback Model",
+                subtitle: "Used as the explicit retry model for transcript cleanup and Edit Mode transforms.",
+                predefinedModels: ModelConfiguration.llmModels,
+                defaultModel: AppState.defaultPostProcessingFallbackModel,
+                textDraft: $postProcessingFallbackModelDraft,
+                onCommit: commitPostProcessingFallbackModel,
+                onReset: {
+                    postProcessingFallbackModelDraft = AppState.defaultPostProcessingFallbackModel
+                    appState.postProcessingFallbackModel = AppState.defaultPostProcessingFallbackModel
                 }
-                Text("Used as the explicit retry model for transcript cleanup and Edit Mode transforms.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+            )
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Context Model")
-                    .font(.caption.weight(.semibold))
-                HStack(spacing: 8) {
-                    TextField(AppState.defaultContextModel, text: $contextModelDraft)
-                        .textFieldStyle(.roundedBorder)
-                        .focused($isEditingContextModel)
-                        .onSubmit {
-                            commitContextModel()
-                        }
-                        .onChange(of: isEditingContextModel) { isEditing in
-                            if !isEditing {
-                                commitContextModel()
-                            }
-                        }
-                    Button("Reset to Default") {
-                        contextModelDraft = AppState.defaultContextModel
-                        appState.contextModel = AppState.defaultContextModel
-                    }
-                    .font(.caption)
+            ModelDropdownView(
+                title: "Context Model",
+                subtitle: "Used for context inference, with a text-only retry when screenshot analysis fails.",
+                predefinedModels: ModelConfiguration.llmModels,
+                defaultModel: AppState.defaultContextModel,
+                textDraft: $contextModelDraft,
+                onCommit: commitContextModel,
+                onReset: {
+                    contextModelDraft = AppState.defaultContextModel
+                    appState.contextModel = AppState.defaultContextModel
                 }
-                Text("Used for context inference, with a text-only retry when screenshot analysis fails.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+            )
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Transcription Model")
-                    .font(.caption.weight(.semibold))
-                HStack(spacing: 8) {
-                    TextField(AppState.defaultTranscriptionModel, text: $transcriptionModelDraft)
-                        .textFieldStyle(.roundedBorder)
-                        .focused($isEditingTranscriptionModel)
-                        .onSubmit {
-                            commitTranscriptionModel()
-                        }
-                        .onChange(of: isEditingTranscriptionModel) { isEditing in
-                            if !isEditing {
-                                commitTranscriptionModel()
-                            }
-                        }
-                    Button("Reset to Default") {
-                        transcriptionModelDraft = AppState.defaultTranscriptionModel
-                        appState.transcriptionModel = AppState.defaultTranscriptionModel
-                    }
-                    .font(.caption)
+            ModelDropdownView(
+                title: "Transcription Model",
+                subtitle: "Used for speech-to-text transcription.",
+                predefinedModels: ModelConfiguration.transcriptionModels,
+                defaultModel: AppState.defaultTranscriptionModel,
+                textDraft: $transcriptionModelDraft,
+                onCommit: commitTranscriptionModel,
+                onReset: {
+                    transcriptionModelDraft = AppState.defaultTranscriptionModel
+                    appState.transcriptionModel = AppState.defaultTranscriptionModel
                 }
-                Text("Used for speech-to-text transcription.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+            )
 
             VStack(alignment: .leading, spacing: 6) {
                 Text("Transcription Language")

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -53,10 +53,30 @@ class TranscriptionService {
             throw CancellationError()
         }
 
-        do {
-            return try await transcribeAudio(fileURL: fileURL)
-        } catch let urlError as URLError where urlError.code == .timedOut {
-            throw TranscriptionError.transcriptionTimedOut(transcriptionTimeoutSeconds)
+        let timeoutSeconds = transcriptionTimeoutSeconds
+        return try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask { [weak self] in
+                guard let self else {
+                    throw TranscriptionError.transcriptionFailed("Transcription service deallocated")
+                }
+                return try await self.transcribeAudio(fileURL: fileURL)
+            }
+
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+                throw TranscriptionError.transcriptionTimedOut(timeoutSeconds)
+            }
+
+            do {
+                guard let result = try await group.next() else {
+                    throw TranscriptionError.transcriptionFailed("No transcription result")
+                }
+                group.cancelAll()
+                return result
+            } catch {
+                group.cancelAll()
+                throw error
+            }
         }
     }
 

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -1,5 +1,4 @@
 import AVFoundation
-import AVFoundation
 import Foundation
 import Speech
 import os.log
@@ -81,7 +80,7 @@ class TranscriptionService {
                 }
 
                 group.addTask {
-                    try await Task.sleep(nanoseconds: UInt64(self.localTranscriptionTimeoutSeconds * 1_000_000_000))
+                    try await Task.sleep(for: .seconds(self.localTranscriptionTimeoutSeconds))
                     throw TranscriptionError.transcriptionTimedOut(self.localTranscriptionTimeoutSeconds)
                 }
 
@@ -117,7 +116,7 @@ class TranscriptionService {
 
                 let timeoutTask = Task {
                     do {
-                        try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+                        try await Task.sleep(for: .seconds(timeoutSeconds))
                         raceState.finish(.failure(TranscriptionError.transcriptionTimedOut(timeoutSeconds)))
                     } catch is CancellationError {
                     } catch {
@@ -653,7 +652,7 @@ enum TranscriptionError: LocalizedError {
     }
 }
 
-private final class TranscriptionTimeoutRaceState {
+private final class TranscriptionTimeoutRaceState: @unchecked Sendable {
     private let lock = NSLock()
     private var didFinish = false
     private var continuation: CheckedContinuation<String, Error>?

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -54,29 +54,41 @@ class TranscriptionService {
         }
 
         let timeoutSeconds = transcriptionTimeoutSeconds
-        return try await withThrowingTaskGroup(of: String.self) { group in
-            group.addTask { [weak self] in
-                guard let self else {
-                    throw TranscriptionError.transcriptionFailed("Transcription service deallocated")
-                }
-                return try await self.transcribeAudio(fileURL: fileURL)
-            }
+        let raceState = TranscriptionTimeoutRaceState()
 
-            group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
-                throw TranscriptionError.transcriptionTimedOut(timeoutSeconds)
-            }
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                raceState.setContinuation(continuation)
 
-            do {
-                guard let result = try await group.next() else {
-                    throw TranscriptionError.transcriptionFailed("No transcription result")
+                let transcriptionTask = Task { [weak self] in
+                    do {
+                        guard let self else {
+                            throw TranscriptionError.transcriptionFailed("Transcription service deallocated")
+                        }
+                        let result = try await self.transcribeAudio(fileURL: fileURL)
+                        raceState.finish(.success(result))
+                    } catch {
+                        raceState.finish(.failure(Self.transcriptionTimeoutErrorIfNeeded(
+                            error,
+                            timeoutSeconds: timeoutSeconds
+                        )))
+                    }
                 }
-                group.cancelAll()
-                return result
-            } catch {
-                group.cancelAll()
-                throw error
+
+                let timeoutTask = Task {
+                    do {
+                        try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+                        raceState.finish(.failure(TranscriptionError.transcriptionTimedOut(timeoutSeconds)))
+                    } catch is CancellationError {
+                    } catch {
+                        raceState.finish(.failure(error))
+                    }
+                }
+
+                raceState.setTasks([transcriptionTask, timeoutTask])
             }
+        } onCancel: {
+            raceState.cancel()
         }
     }
 
@@ -228,6 +240,16 @@ class TranscriptionService {
         }
     }
 
+    private static func transcriptionTimeoutErrorIfNeeded(
+        _ error: Error,
+        timeoutSeconds: TimeInterval
+    ) -> Error {
+        if let urlError = error as? URLError, urlError.code == .timedOut {
+            return TranscriptionError.transcriptionTimedOut(timeoutSeconds)
+        }
+        return error
+    }
+
     private static func normalizedBaseURL(from baseURL: String) throws -> URL {
         let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
@@ -358,6 +380,65 @@ enum TranscriptionError: LocalizedError {
         case .pollFailed(let msg): return "Polling failed: \(msg)"
         case .audioPreparationFailed(let msg): return "Audio preparation failed: \(msg)"
         }
+    }
+}
+
+private final class TranscriptionTimeoutRaceState {
+    private let lock = NSLock()
+    private var didFinish = false
+    private var continuation: CheckedContinuation<String, Error>?
+    private var tasks: [Task<Void, Never>] = []
+
+    func setContinuation(_ continuation: CheckedContinuation<String, Error>) {
+        lock.lock()
+        if didFinish {
+            lock.unlock()
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    func setTasks(_ tasks: [Task<Void, Never>]) {
+        lock.lock()
+        if didFinish {
+            lock.unlock()
+            tasks.forEach { $0.cancel() }
+            return
+        }
+
+        self.tasks = tasks
+        lock.unlock()
+    }
+
+    func finish(_ result: Result<String, Error>) {
+        lock.lock()
+        guard !didFinish else {
+            lock.unlock()
+            return
+        }
+
+        didFinish = true
+        let continuation = self.continuation
+        self.continuation = nil
+        let tasks = self.tasks
+        self.tasks = []
+        lock.unlock()
+
+        tasks.forEach { $0.cancel() }
+
+        switch result {
+        case .success(let value):
+            continuation?.resume(returning: value)
+        case .failure(let error):
+            continuation?.resume(throwing: error)
+        }
+    }
+
+    func cancel() {
+        finish(.failure(CancellationError()))
     }
 }
 


### PR DESCRIPTION
## Summary

Merge `zachlatta/freeflow` v1.1.0 into Quill, following the upstream-first + preserve-Quill-customizations policy.

### Upstream changes brought in
- **Dropdown model selection** with qwen3-32b support — new `ModelConfiguration.swift`, `ModelDropdownView.swift`
- **Race-based transcription timeout** that prevents indefinite hangs when a provider accepts the connection but never responds
- **Post-processing improvements**: `<think>` tag stripping for reasoning models, providerless model alias normalization

### Conflicts resolved
- **`TranscriptionService.swift`**: kept Quill's local-transcription branch and timeout overrides (`transcription_timeout_seconds`, local transcription), adopted upstream's race-based timeout for the remote path. Kept both helpers (`sanitizeNonFiniteJSONNumbers` + `transcriptionTimeoutErrorIfNeeded`).
- **`CHANGELOG.md`**: kept the Quill release line (`[0.1.4]`), dropped upstream FreeFlow version blocks (`[1.1.0]`/`[1.0.0]`). The model dropdown will be recorded under a future Quill release.

### Auto-merged cleanly
`PostProcessingService.swift`, `SettingsView.swift` (Quill overlay display picker + settings sections preserved alongside upstream model pickers).

### Verification
- `UpstreamMergeBehaviorTests` pass — all Quill customizations preserved (local transcription, timeout overrides, overlay display picker, in-pill errors, etc.)
- Swift compile + dev build + app launch verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 설정에서 모델 선택을 위한 드롭다운 UI 추가
  * 모델별 응답에서 사고 프로세스 태그 자동 제거 기능 추가

* **개선 사항**
  * 전사 타임아웃 처리 메커니즘 개선
  * 모델 설정 및 파라미터 처리 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->