### PR TITLE
Merge upstream permission polling fix

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7,7 +7,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var settingsWindow: NSWindow?
     private var noteBrowserWindow: NSWindow?
     private var mcpServer: MCPServer?
-    private var setupWindowCloseObserver: NSObjectProtocol?
+    private var shouldRestoreAfterSetupWindowClose = false
 
     private func patchSettingsMenuItem() {
         guard let appMenu = NSApp.mainMenu?.items.first?.submenu else { return }
@@ -122,6 +122,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return true
     }
 
+    @MainActor
     @objc func handleShowSetup() {
         // Single wizard at a time — opening a second leaks the first's
         // willClose observer and breaks the bail-restore.
@@ -131,10 +132,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        if let setupWindowCloseObserver {
-            NotificationCenter.default.removeObserver(setupWindowCloseObserver)
-            self.setupWindowCloseObserver = nil
+        if let setupWindow {
+            NotificationCenter.default.removeObserver(self, name: NSWindow.willCloseNotification, object: setupWindow)
         }
+        shouldRestoreAfterSetupWindowClose = false
 
         let wasCompleted = appState.hasCompletedSetup
         appState.hasCompletedSetup = false
@@ -146,25 +147,32 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // completeSetup() flips hasCompletedSetup back to true before window.close(),
         // so the !hasCompletedSetup check below correctly skips the restore there.
         if wasCompleted, let window = setupWindow {
-            setupWindowCloseObserver = NotificationCenter.default.addObserver(
-                forName: NSWindow.willCloseNotification,
-                object: window,
-                queue: .main
-            ) { [weak self] _ in
-                guard let self = self else { return }
-                if let setupWindowCloseObserver = self.setupWindowCloseObserver {
-                    NotificationCenter.default.removeObserver(setupWindowCloseObserver)
-                    self.setupWindowCloseObserver = nil
-                }
-                if !self.appState.hasCompletedSetup {
-                    self.appState.hasCompletedSetup = true
-                    self.appState.startHotkeyMonitoring()
-                    self.appState.startAccessibilityPolling()
-                }
-                self.setupWindow = nil
-                self.updateActivationPolicy()
-            }
+            shouldRestoreAfterSetupWindowClose = true
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(handleSetupWindowDidClose),
+                name: NSWindow.willCloseNotification,
+                object: window
+            )
         }
+    }
+
+    @MainActor
+    @objc private func handleSetupWindowDidClose(_ notification: Notification) {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: NSWindow.willCloseNotification,
+            object: notification.object
+        )
+        let shouldRestore = shouldRestoreAfterSetupWindowClose
+        shouldRestoreAfterSetupWindowClose = false
+        if shouldRestore, !appState.hasCompletedSetup {
+            appState.hasCompletedSetup = true
+            appState.startHotkeyMonitoring()
+            appState.startAccessibilityPolling()
+        }
+        setupWindow = nil
+        updateActivationPolicy()
     }
 
     @objc private func handleShowSettings() {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1241,12 +1241,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     func startAccessibilityPolling() {
         accessibilityTimer?.invalidate()
+        accessibilityTimer = nil
         hasAccessibility = AXIsProcessTrusted()
         hasScreenRecordingPermission = hasScreenCapturePermission()
+        if hasAccessibility && hasScreenRecordingPermission {
+            return
+        }
         accessibilityTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
             DispatchQueue.main.async {
-                self?.hasAccessibility = AXIsProcessTrusted()
-                self?.hasScreenRecordingPermission = self?.hasScreenCapturePermission() ?? false
+                guard let self else { return }
+                self.hasAccessibility = AXIsProcessTrusted()
+                self.hasScreenRecordingPermission = self.hasScreenCapturePermission()
+                if self.hasAccessibility && self.hasScreenRecordingPermission {
+                    self.accessibilityTimer?.invalidate()
+                    self.accessibilityTimer = nil
+                }
             }
         }
     }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1925,7 +1925,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         startedAt: CFAbsoluteTime? = nil
     ) -> Bool {
         activeRecordingTriggerMode = triggerMode
-        guard hasAccessibility else {
+        let isAccessibilityTrusted = AXIsProcessTrusted()
+        hasAccessibility = isAccessibilityTrusted
+        guard isAccessibilityTrusted else {
             errorMessage = "Accessibility permission required. Grant access in System Settings > Privacy & Security > Accessibility."
             statusText = "No Accessibility"
             activeRecordingTriggerMode = nil

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2592,6 +2592,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
     func startAccessibilityPolling() {
         accessibilityTimer?.invalidate()
         accessibilityTimer = nil
@@ -2616,6 +2617,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @MainActor
     func stopAccessibilityPolling() {
         accessibilityTimer?.invalidate()
         accessibilityTimer = nil


### PR DESCRIPTION
## Summary
- Merge upstream PR #230's permission polling behavior into Quill.
- Stop accessibility/screen-recording polling once both permissions are granted.
- Keep Quill's shared permission status update helper and re-check Accessibility trust before recording starts.

## Verification
- `make test`
- `make all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 접근성 권한이 이미 허용된 경우 더 빠르게 인식하도록 개선
  * 녹화 시작 시점에 접근성 권한 상태를 다시 확인하여 최신 상태 반영

<!-- end of auto-generated comment: release notes by coderabbit.ai -->