### PR TITLE
Add get_meeting_source MCP tool for structured meeting data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,8 @@ test: $(SPARKLE_STAMP)
 	@/tmp/CalendarEventMatcherTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/NoteTitleResolver.swift Tests/NoteTitleResolutionTests.swift -o /tmp/NoteTitleResolutionTests
 	@/tmp/NoteTitleResolutionTests
+	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/MeetingSourcePayload.swift Tests/MeetingSourcePayloadTests.swift -o /tmp/MeetingSourcePayloadTests
+	@/tmp/MeetingSourcePayloadTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/NoteTitleResolver.swift Sources/NoteListRowDisplayData.swift Tests/NoteListRowDisplayDataTests.swift -o /tmp/NoteListRowDisplayDataTests
 	@/tmp/NoteListRowDisplayDataTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/LegacyNoteTitleMigration.swift Tests/LegacyNoteTitleMigrationTests.swift -o /tmp/LegacyNoteTitleMigrationTests

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Available MCP tools:
 - `get_status` — check whether Quill is idle, recording, or transcribing.
 - `list_transcripts` — list recent transcript history entries.
 - `get_transcript` — fetch a specific transcript by id.
+- `get_meeting_source` — fetch structured meeting data for a transcript id as JSON (resolved title, ISO 8601 timestamps, calendar match, attendees, audio file path, transcript, and context) for meeting-note generation.
 
 Notes:
 

--- a/Sources/MCPServer.swift
+++ b/Sources/MCPServer.swift
@@ -239,6 +239,20 @@ final class MCPServer {
                     ],
                     "required": ["id"]
                 ]
+            ],
+            [
+                "name": "get_meeting_source",
+                "description": "Get structured meeting source data (title, timestamps, calendar match, attendees, audio path, transcript) for a transcript id as JSON. Use this for meeting-note generation.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "id": [
+                            "type": "string",
+                            "description": "UUID of the transcript entry from list_transcripts"
+                        ]
+                    ],
+                    "required": ["id"]
+                ]
             ]
         ]
     }
@@ -334,6 +348,28 @@ final class MCPServer {
                 lines.append("context: \(item.contextSummary)")
             }
             return textContent(lines.joined(separator: "\n"))
+
+        case "get_meeting_source":
+            guard let idString = args["id"] as? String, let uuid = UUID(uuidString: idString) else {
+                return textContent("Error: valid 'id' is required.", isError: true)
+            }
+            guard let item = appState.pipelineHistory.first(where: { $0.id == uuid }) else {
+                return textContent("Error: transcript not found.", isError: true)
+            }
+            let isoFormatter = ISO8601DateFormatter()
+            isoFormatter.formatOptions = [.withInternetDateTime]
+            isoFormatter.timeZone = TimeZone.current
+            let payload = MeetingSourcePayload.make(
+                item: item,
+                audioDirectory: AppState.audioStorageDirectory(),
+                fileExists: { FileManager.default.fileExists(atPath: $0.path) },
+                formatter: isoFormatter
+            )
+            guard let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys, .prettyPrinted]),
+                  let json = String(data: data, encoding: .utf8) else {
+                return textContent("Error: failed to encode meeting source.", isError: true)
+            }
+            return textContent(json)
 
         default:
             return textContent("Unknown tool: \(name)", isError: true)

--- a/Sources/MeetingSourcePayload.swift
+++ b/Sources/MeetingSourcePayload.swift
@@ -57,7 +57,7 @@ enum MeetingSourcePayload {
     private static func calendarPayload(_ item: PipelineHistoryItem, formatter: ISO8601DateFormatter) -> Any {
         guard let match = item.calendarMatch else { return NSNull() }
         let attendees: [[String: Any]] = match.attendees.map { a in
-            let isResource = (a.email?.contains(resourceDomain)) ?? false
+            let isResource = (a.email?.hasSuffix(resourceDomain)) ?? false
             return [
                 "display_name": orNull(a.displayName),
                 "email": orNull(a.email),

--- a/Sources/MeetingSourcePayload.swift
+++ b/Sources/MeetingSourcePayload.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Builds the structured JSON payload returned by the MCP `get_meeting_source` tool.
+/// Pure function: filesystem access is injected via `fileExists` so it is unit-testable.
+enum MeetingSourcePayload {
+    private static let resourceDomain = "resource.calendar.google.com"
+
+    static func make(
+        item: PipelineHistoryItem,
+        audioDirectory: URL,
+        fileExists: (URL) -> Bool,
+        formatter: ISO8601DateFormatter
+    ) -> [String: Any] {
+        [
+            "id": item.id.uuidString,
+            "title": titlePayload(item),
+            "timestamps": timestampsPayload(item, formatter: formatter),
+            "calendar": calendarPayload(item, formatter: formatter),
+            "audio": audioPayload(item, audioDirectory: audioDirectory, fileExists: fileExists),
+            "transcript": item.postProcessedTranscript,
+            "raw_transcript": item.rawTranscript,
+            "context": item.contextSummary,
+        ]
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
+    private static func orNull(_ value: String?) -> Any { value ?? NSNull() }
+
+    private static func titlePayload(_ item: PipelineHistoryItem) -> [String: Any] {
+        let custom = nonEmpty(item.customTitle)
+        let calendar = nonEmpty(item.calendarMatch?.title)
+        return [
+            "custom": orNull(custom),
+            "calendar": orNull(calendar),
+            "resolved": orNull(custom ?? calendar),
+        ]
+    }
+
+    private static func iso(_ date: Date?, _ formatter: ISO8601DateFormatter) -> Any {
+        guard let date else { return NSNull() }
+        return formatter.string(from: date)
+    }
+
+    private static func timestampsPayload(_ item: PipelineHistoryItem, formatter: ISO8601DateFormatter) -> [String: Any] {
+        [
+            "recording_started_at": iso(item.recordingStartedAt, formatter),
+            "recording_ended_at": iso(item.recordingEndedAt, formatter),
+            "transcript_created_at": formatter.string(from: item.timestamp),
+        ]
+    }
+
+    private static func calendarPayload(_ item: PipelineHistoryItem, formatter: ISO8601DateFormatter) -> Any {
+        guard let match = item.calendarMatch else { return NSNull() }
+        let attendees: [[String: Any]] = match.attendees.map { a in
+            let isResource = (a.email?.contains(resourceDomain)) ?? false
+            return [
+                "display_name": orNull(a.displayName),
+                "email": orNull(a.email),
+                "response_status": orNull(a.responseStatus),
+                "is_self": a.isSelf,
+                "is_optional": a.isOptional,
+                "is_resource": isResource,
+            ]
+        }
+        return [
+            "title": match.title,
+            "start": formatter.string(from: match.start),
+            "end": formatter.string(from: match.end),
+            "attendees": attendees,
+        ]
+    }
+
+    private static func audioPayload(
+        _ item: PipelineHistoryItem,
+        audioDirectory: URL,
+        fileExists: (URL) -> Bool
+    ) -> Any {
+        guard let name = item.audioFileName, !name.isEmpty else { return NSNull() }
+        let url = audioDirectory.appendingPathComponent(name)
+        return [
+            "filename": name,
+            "path": url.path,
+            "exists": fileExists(url),
+        ]
+    }
+}

--- a/Tests/MeetingSourcePayloadTests.swift
+++ b/Tests/MeetingSourcePayloadTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+@main
+struct MeetingSourcePayloadTests {
+    static func main() {
+        testResolvedTitlePrefersCustomThenCalendar()
+        testCalendarIsNullWhenNoMatch()
+        testAudioPathAndExistsAreResolved()
+        testAudioIsNullWhenNoFilename()
+        testResourceAttendeeFlagFromEmail()
+        testTimestampsUseProvidedFormatter()
+        print("MeetingSourcePayloadTests passed")
+    }
+
+    private static func seoulFormatter() -> ISO8601DateFormatter {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        f.timeZone = TimeZone(identifier: "Asia/Seoul")!
+        return f
+    }
+
+    private static func makeItem(
+        customTitle: String? = nil,
+        calendarMatch: CalendarEventMatch? = nil,
+        recordingStartedAt: Date? = nil,
+        audioFileName: String? = nil
+    ) -> PipelineHistoryItem {
+        PipelineHistoryItem(
+            id: UUID(uuidString: "00000000-0000-0000-0000-0000000000AA")!,
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+            recordingStartedAt: recordingStartedAt,
+            calendarMatch: calendarMatch,
+            rawTranscript: "raw text",
+            postProcessedTranscript: "clean text",
+            postProcessingPrompt: nil,
+            contextSummary: "ctx",
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "none",
+            postProcessingStatus: "done",
+            debugStatus: "",
+            customVocabulary: "",
+            audioFileName: audioFileName,
+            customTitle: customTitle
+        )
+    }
+
+    private static func sampleCalendar(attendees: [CalendarEventAttendee]) -> CalendarEventMatch {
+        CalendarEventMatch(
+            calendarID: "cal", eventID: "evt", title: "Weekly Sync",
+            start: Date(timeIntervalSince1970: 1_700_000_000),
+            end: Date(timeIntervalSince1970: 1_700_003_600),
+            attendees: attendees,
+            matchSource: .overlapSuggestion, titleState: .applied
+        )
+    }
+
+    private static func testResolvedTitlePrefersCustomThenCalendar() {
+        let withCustom = MeetingSourcePayload.make(
+            item: makeItem(customTitle: "내 제목", calendarMatch: sampleCalendar(attendees: [])),
+            audioDirectory: URL(fileURLWithPath: "/tmp"),
+            fileExists: { _ in false }, formatter: seoulFormatter())
+        let title = withCustom["title"] as! [String: Any]
+        assert(title["resolved"] as? String == "내 제목")
+        assert(title["custom"] as? String == "내 제목")
+        assert(title["calendar"] as? String == "Weekly Sync")
+
+        let calendarOnly = MeetingSourcePayload.make(
+            item: makeItem(customTitle: "  ", calendarMatch: sampleCalendar(attendees: [])),
+            audioDirectory: URL(fileURLWithPath: "/tmp"),
+            fileExists: { _ in false }, formatter: seoulFormatter())
+        let title2 = calendarOnly["title"] as! [String: Any]
+        assert(title2["resolved"] as? String == "Weekly Sync")
+        assert(title2["custom"] is NSNull)
+    }
+
+    private static func testCalendarIsNullWhenNoMatch() {
+        let payload = MeetingSourcePayload.make(
+            item: makeItem(), audioDirectory: URL(fileURLWithPath: "/tmp"),
+            fileExists: { _ in false }, formatter: seoulFormatter())
+        assert(payload["calendar"] is NSNull)
+    }
+
+    private static func testAudioPathAndExistsAreResolved() {
+        let payload = MeetingSourcePayload.make(
+            item: makeItem(audioFileName: "abc.wav"),
+            audioDirectory: URL(fileURLWithPath: "/audio"),
+            fileExists: { $0.path == "/audio/abc.wav" }, formatter: seoulFormatter())
+        let audio = payload["audio"] as! [String: Any]
+        assert(audio["filename"] as? String == "abc.wav")
+        assert(audio["path"] as? String == "/audio/abc.wav")
+        assert(audio["exists"] as? Bool == true)
+    }
+
+    private static func testAudioIsNullWhenNoFilename() {
+        let payload = MeetingSourcePayload.make(
+            item: makeItem(), audioDirectory: URL(fileURLWithPath: "/audio"),
+            fileExists: { _ in true }, formatter: seoulFormatter())
+        assert(payload["audio"] is NSNull)
+    }
+
+    private static func testResourceAttendeeFlagFromEmail() {
+        let attendees = [
+            CalendarEventAttendee(displayName: "우섭", email: "woosub@classting.com", responseStatus: "accepted"),
+            CalendarEventAttendee(displayName: "회의실 A", email: "c_x@resource.calendar.google.com", responseStatus: "accepted"),
+        ]
+        let payload = MeetingSourcePayload.make(
+            item: makeItem(calendarMatch: sampleCalendar(attendees: attendees)),
+            audioDirectory: URL(fileURLWithPath: "/tmp"),
+            fileExists: { _ in false }, formatter: seoulFormatter())
+        let cal = payload["calendar"] as! [String: Any]
+        let list = cal["attendees"] as! [[String: Any]]
+        assert(list[0]["is_resource"] as? Bool == false)
+        assert(list[0]["email"] as? String == "woosub@classting.com")
+        assert(list[1]["is_resource"] as? Bool == true)
+    }
+
+    private static func testTimestampsUseProvidedFormatter() {
+        let payload = MeetingSourcePayload.make(
+            item: makeItem(recordingStartedAt: Date(timeIntervalSince1970: 1_700_000_000)),
+            audioDirectory: URL(fileURLWithPath: "/tmp"),
+            fileExists: { _ in false }, formatter: seoulFormatter())
+        let ts = payload["timestamps"] as! [String: Any]
+        // 1_700_000_000 == 2023-11-15T06:13:20Z == +09:00 14:13:20
+        assert((ts["recording_started_at"] as? String)?.hasSuffix("+09:00") == true)
+        assert((ts["transcript_created_at"] as? String) != nil)
+        assert(ts["recording_ended_at"] is NSNull)
+    }
+}

--- a/Tests/MeetingSourcePayloadTests.swift
+++ b/Tests/MeetingSourcePayloadTests.swift
@@ -102,6 +102,8 @@ struct MeetingSourcePayloadTests {
         let attendees = [
             CalendarEventAttendee(displayName: "우섭", email: "woosub@classting.com", responseStatus: "accepted"),
             CalendarEventAttendee(displayName: "회의실 A", email: "c_x@resource.calendar.google.com", responseStatus: "accepted"),
+            // The resource domain appears in the local part / a different domain — must NOT be flagged.
+            CalendarEventAttendee(displayName: "사칭", email: "user.resource.calendar.google.com@example.com", responseStatus: "accepted"),
         ]
         let payload = MeetingSourcePayload.make(
             item: makeItem(calendarMatch: sampleCalendar(attendees: attendees)),
@@ -112,6 +114,7 @@ struct MeetingSourcePayloadTests {
         assert(list[0]["is_resource"] as? Bool == false)
         assert(list[0]["email"] as? String == "woosub@classting.com")
         assert(list[1]["is_resource"] as? Bool == true)
+        assert(list[2]["is_resource"] as? Bool == false)
     }
 
     private static func testTimestampsUseProvidedFormatter() {

--- a/docs/superpowers/specs/2026-06-16-mcp-get-meeting-source-design.md
+++ b/docs/superpowers/specs/2026-06-16-mcp-get-meeting-source-design.md
@@ -1,0 +1,150 @@
+# MCP `get_meeting_source` + `/mn` deterministic 전환 설계
+
+- 날짜: 2026-06-16
+- 브랜치: `feat/mcp-get-meeting-source`
+- 관련 코드: `Sources/MCPServer.swift`, `Sources/PipelineHistoryItem.swift`, `Sources/CalendarIntegrationModels.swift`, `/mn` 스킬(`~/Library/Mobile Documents/.../claude/.agents/skills/mn/SKILL.md`)
+
+## 배경 / 문제
+
+`/mn` 스킬로 Quill 전사문 기반 회의록을 만들 때 느리고 결과가 불안정하다. 원인은 Claude의 능력 부족이 아니라 **MCP가 회의록 생성에 필요한 구조화된 원천 데이터를 충분히 주지 않고, 그 공백을 `/mn`이 SQLite 직접 조회 + 추론으로 메우는** 구조다.
+
+현재 상태:
+
+- Swift 모델 `PipelineHistoryItem`은 이미 필요한 필드를 모두 갖고 있다: `customTitle`, `calendarMatch`(title/start/end/attendees, attendee별 email·displayName·responseStatus·isSelf·isOptional), `recordingStartedAt`/`recordingEndedAt`, `audioFileName`, `transcriptFileName`, `contextSummary`. 앱은 `AppState.audioStorageDirectory()`로 오디오 절대경로도 안다.
+- 그러나 MCP `get_transcript`는 **텍스트 blob**로 일부만 노출한다: `id, timestamp, transcript, raw_transcript, context`. title/calendar/attendees/audio/recordingStartedAt가 전부 빠져 있다.
+- 그래서 `/mn`은 `PipelineHistory.sqlite`를 직접 2회 조회하고, Apple epoch 변환 산수(`+978307200`)를 하고, `ZCALENDARMATCHJSON`을 수동 파싱하고, 오디오는 파일 mtime 기반으로 추론한다.
+
+## 목표
+
+MCP가 구조화된 원천 데이터를 deterministic하게 제공하고, `/mn`은 요약·Action Items·민감도 정제·People/Obsidian 컨벤션 매칭 같은 판단 영역만 담당하도록 역할을 분리한다.
+
+비목표(이번 범위 아님):
+
+- `PipelineHistoryItem` 모델 스키마 변경 (모든 필드가 이미 존재)
+- 기존 `get_transcript`의 출력 형식 변경 (사람이 읽는 텍스트로 유지)
+- People 매칭/회의록 포맷 등 Obsidian 측 로직 변경
+
+## 설계 결정 (확정)
+
+1. **새 도구 `get_meeting_source` 추가, JSON 반환.** `get_transcript`는 사람이 읽는 텍스트로 그대로 둔다. 하위호환 안전.
+2. **참석자는 구조화 원본 + `is_resource` 플래그까지만 앱이 가공.** People 폴더 매칭과 최종 필터는 `/mn`이 담당.
+3. **`/mn`의 SQLite 직접 조회는 완전 제거하지 않고 fallback으로 격하.** 주 경로는 MCP, SQLite는 구버전 Quill·필드 누락 대비.
+
+## 컴포넌트 1 — MCP 도구 `get_meeting_source(id)`
+
+### 인터페이스
+
+- 입력: `{ "id": "<UUID>" }` (필수, `list_transcripts`에서 얻은 id)
+- 출력: MCP content는 텍스트 타입이므로 **JSON 문자열** 1개를 text content로 반환
+- id 미존재/유효하지 않으면 `isError: true` 텍스트 반환 (기존 `get_transcript`와 동일 패턴)
+
+### JSON 스키마
+
+```json
+{
+  "id": "UUID",
+  "title": {
+    "custom": "사용자가 Quill에서 지정한 제목 | null",
+    "calendar": "캘린더 매칭 title | null",
+    "resolved": "custom → calendar 순으로 결정된 값 | null"
+  },
+  "timestamps": {
+    "recording_started_at": "2026-05-15T14:00:00+09:00 | null",
+    "recording_ended_at": "ISO8601(+offset) | null",
+    "transcript_created_at": "ISO8601(+offset)"
+  },
+  "calendar": {
+    "title": "...",
+    "start": "ISO8601(+offset)",
+    "end": "ISO8601(+offset)",
+    "attendees": [
+      {
+        "display_name": "... | null",
+        "email": "... | null",
+        "response_status": "accepted | declined | tentative | needsAction | null",
+        "is_self": false,
+        "is_optional": false,
+        "is_resource": true
+      }
+    ]
+  },
+  "audio": {
+    "filename": "uuid.wav",
+    "path": "/Users/.../Library/Application Support/Quill/audio/uuid.wav",
+    "exists": true
+  },
+  "transcript": "post-processed transcript",
+  "raw_transcript": "raw transcript",
+  "context": "context summary"
+}
+```
+
+규칙:
+
+- **시각은 앱이 ISO8601(timezone offset 포함)로 변환해서 준다.** `/mn`에서 Apple epoch 변환(`+978307200`) 완전 제거.
+- **`audio.path`는 앱이 `audioStorageDirectory()`로 해결한 절대경로.** `exists`는 `FileManager`로 실제 파일 존재 여부 검증.
+- **`is_resource`는 앱이 계산.** 판정 규칙: attendee email에 `resource.calendar.google.com` 포함 시 `true`. (displayName 기반 회의실 휴리스틱은 모호하므로 앱에 넣지 않고 `/mn`이 보조 판단으로 유지.)
+- 매칭/데이터 없는 상위 객체는 `null`: `calendar` 미매칭 시 `"calendar": null`, 오디오 없음 시 `"audio": null`. 개별 스칼라 누락은 해당 키 `null`.
+- `title.resolved`는 `custom`(비어있지 않으면) → `calendar` 순. 둘 다 없으면 `null` (전사문 추론은 `/mn` 몫).
+
+### 구현 노트 (`Sources/MCPServer.swift`)
+
+- `toolDefinitions()`에 `get_meeting_source` 항목 추가 (input schema: `id` required string).
+- `callTool`에 `case "get_meeting_source"` 추가:
+  - `args["id"]` → `UUID` 파싱, 실패 시 `isError`.
+  - `appState.pipelineHistory.first(where: { $0.id == uuid })`로 항목 조회, 없으면 `isError`.
+  - `ISO8601DateFormatter`(`formatOptions = [.withInternetDateTime]`, `timeZone = .current`)로 Date 직렬화.
+  - `audioFileName`이 있으면 `AppState.audioStorageDirectory().appendingPathComponent(name)`로 절대경로 + `FileManager.default.fileExists`로 `exists`.
+  - `calendarMatch`의 attendee를 순회하며 `is_resource = email?.contains("resource.calendar.google.com") ?? false`.
+  - `[String: Any]` 딕셔너리 구성 후 `JSONSerialization.data` → 문자열 → `textContent(jsonString)`.
+- 모델 변경 없음.
+
+## 컴포넌트 2 — `/mn` 스킬 변경
+
+대상 파일: `~/Library/Mobile Documents/com~apple~CloudDocs/claude/.agents/skills/mn/SKILL.md` (iCloud 동기화 본; `.claude/skills/mn`은 심링크/사본).
+
+변경 지점:
+
+- **st/mk 4단계(Quill 메타데이터 조회):** SQLite 1차 조회 블록 → `mcp__quill__get_meeting_source(id)` 호출로 교체.
+  - 제목: `title.resolved` → (null이면) 전사문/context 추론. 정규화 규칙은 유지.
+  - 회의일시: `calendar.start` → `timestamps.recording_started_at` → `timestamps.transcript_created_at`. **epoch 변환 산수 삭제** (이미 ISO8601).
+  - 참석자: `calendar.attendees`에서 `is_resource == true || response_status == "declined" || is_self == true` 제외 → 남은 참석자를 `$VAULT/People/`와 email/displayName 매칭(유지). displayName 회의실 휴리스틱은 보조로 유지.
+- **st/mk 5단계(오디오 복사):** SQLite 조회 + mtime fallback → `audio.path`를 그대로 `cp`.
+  - `audio`가 `null`이거나 `audio.exists == false`면 오디오 없이 진행.
+- **SQLite 블록 + mtime fallback:** 삭제하지 않고 "MCP `get_meeting_source`가 없거나 필드를 비워 주는 구버전 Quill 대비 fallback"으로 명시 격하. 주 경로는 항상 MCP.
+- "처리 전 필수 사항"/"실행 흐름" 섹션의 SQLite 우선 표현을 MCP 우선으로 갱신.
+
+## 역할 분리 결과
+
+- **MCP/앱 (deterministic):** 제목 후보, 시각(ISO8601), 오디오 절대경로+존재검증, 구조화 attendees + is_resource.
+- **Claude/`/mn` (판단):** 요약, Action Items, 민감도 정제, People/Obsidian 컨벤션 매칭, 전사문 기반 제목 추론(메타데이터 없을 때).
+
+## 데이터 플로우
+
+```
+list_transcripts → id
+  → get_meeting_source(id)  ── JSON ──▶  /mn
+       (title/timestamps/calendar/audio/transcript)
+  → /mn: 참석자 People 매칭 + 요약/Action Items 생성
+  → Obsidian 회의록 파일 작성 (+ audio.path cp)
+```
+
+## 오류 처리 / 엣지 케이스
+
+- id 미존재 → MCP `isError`; `/mn`은 안내 후 종료.
+- `calendar == null` → 제목·시각·참석자는 transcript/recording 기반으로 진행.
+- `audio == null` 또는 `exists == false` → 오디오 첨부 생략.
+- MCP에 `get_meeting_source`가 없는 구버전(tools/list에 미존재) → `/mn`이 기존 SQLite fallback 경로 사용.
+- 전사 둘 다 빈 값 → 기존과 동일하게 "전사 내용 없음" 안내.
+
+## 테스트
+
+- `Tests/`에 MCP 서버 테스트가 있으면 동일 패턴으로 `get_meeting_source`의 JSON 직렬화 케이스 추가(calendar 있음/없음, audio 있음/없음, id 미존재).
+- 빌드 후 실제 transcript id로 `get_meeting_source` 호출해 JSON 구조·ISO8601·절대경로·is_resource 확인.
+- `/mn st`(또는 `mk`) end-to-end로 epoch 산수/SQLite 없이 회의록이 동일 품질로 생성되는지 검증.
+
+## 마이그레이션 / 호환성
+
+- 기존 `get_transcript`·`list_transcripts` 등 다른 도구는 변경 없음.
+- `/mn`의 SQLite fallback 유지로 구버전 Quill에서도 동작.
+- 모델·DB 스키마 변경 없음.


### PR DESCRIPTION
## 배경

`/mn` 같은 회의록 생성 워크플로가 Quill 전사문으로 회의록을 만들 때, MCP는 전사문 텍스트만 제공하고 제목·시각·참석자·오디오 같은 구조화 메타데이터는 노출하지 않았다. 그 공백을 소비자 쪽에서 SQLite 직접 조회 + Apple epoch 변환 + 오디오 파일 mtime 추론으로 메우고 있어 느리고 불안정했다.

`PipelineHistoryItem` 모델은 이미 필요한 필드를 모두 갖고 있으므로, MCP가 이를 구조화해서 그대로 노출하면 소비자는 추론 없이 deterministic하게 사용할 수 있다.

## 변경 내용

- **`get_meeting_source(id)` MCP 도구 추가** — transcript id로 구조화된 회의 데이터를 JSON으로 반환:
  - `title` (custom / calendar / resolved)
  - `timestamps` (recording_started_at / recording_ended_at / transcript_created_at, 모두 ISO 8601 + timezone offset)
  - `calendar` (title / start / end / attendees[], attendee별 `is_resource` 플래그 포함) 또는 null
  - `audio` (filename / 절대 path / exists) 또는 null
  - `transcript`, `raw_transcript`, `context`
- **`MeetingSourcePayload`** — 모델 → JSON 변환을 파일시스템 의존성 주입으로 분리한 순수 함수. 단위 테스트 포함.
- `make test`에 `MeetingSourcePayloadTests` 등록.
- README의 MCP 도구 목록에 `get_meeting_source` 문서화.

## 설계 원칙

- 시각은 앱이 ISO 8601(+offset)로 변환해 제공 → 소비자의 Apple epoch 산수 제거.
- 오디오는 앱이 해결한 절대경로 + 존재 검증 제공 → mtime 추론 제거.
- `is_resource`는 앱이 계산(attendee email의 `resource.calendar.google.com` 포함 여부).
- 기존 `get_transcript`(사람이 읽는 텍스트)는 변경 없음. 모델/DB 스키마 변경 없음. 순수 추가 변경이라 구버전과 호환.

## 테스트

- `make test` 통과 (`MeetingSourcePayloadTests passed` 포함): resolved title, calendar/audio null 케이스, audio path+exists, is_resource 판정, ISO 8601 타임스탬프.
- `make all` 빌드 성공.

설계 spec: `docs/superpowers/specs/2026-06-16-mcp-get-meeting-source-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)