### PR TITLE
Mid-recording audio input switching + notch-less overlay height fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,11 +280,11 @@ test: $(SPARKLE_STAMP)
 	@/tmp/TranscriptionModelCacheTests
 	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Tests/OverlayScreenGeometryTests.swift -o /tmp/OverlayScreenGeometryTests
 	@/tmp/OverlayScreenGeometryTests
-	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/RecordingOverlay.swift Tests/RecordingOverlayGeometryTests.swift -o /tmp/RecordingOverlayGeometryTests
+	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/AudioInputDevice.swift Sources/RecordingOverlay.swift Tests/RecordingOverlayGeometryTests.swift -o /tmp/RecordingOverlayGeometryTests
 	@/tmp/RecordingOverlayGeometryTests
 	@swiftc -parse-as-library Tests/UpstreamMergeBehaviorTests.swift -o /tmp/UpstreamMergeBehaviorTests
 	@/tmp/UpstreamMergeBehaviorTests
-	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/RecordingOverlay.swift Sources/CalendarIntegrationModels.swift Sources/AppNotificationManager.swift Sources/CalendarRecordingReminderScheduler.swift Sources/MeetingReminderOverlay.swift Tests/MeetingReminderOverlayGeometryTests.swift -o /tmp/MeetingReminderOverlayGeometryTests
+	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/AudioInputDevice.swift Sources/RecordingOverlay.swift Sources/CalendarIntegrationModels.swift Sources/AppNotificationManager.swift Sources/CalendarRecordingReminderScheduler.swift Sources/MeetingReminderOverlay.swift Tests/MeetingReminderOverlayGeometryTests.swift -o /tmp/MeetingReminderOverlayGeometryTests
 	@/tmp/MeetingReminderOverlayGeometryTests
 	@framework="$$(cat "$(SPARKLE_STAMP)")"; framework_parent="$$(dirname "$$framework")"; swiftc -parse-as-library -F "$$framework_parent" -framework Sparkle -Xlinker -rpath -Xlinker "$$framework_parent" -target $(shell uname -m)-apple-macosx13.0 $(filter-out Sources/App.swift,$(SOURCES)) Tests/AppStateTranscriptionConfigurationTests.swift -o /tmp/AppStateTranscriptionConfigurationTests
 	@/tmp/AppStateTranscriptionConfigurationTests

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2180,6 +2180,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
             self.didSwitchInputDuringRecording = true
             self.selectedMicrophoneID = newInputID
             self.activeAudioInputID = newInputID
+            // Keep the output-mute interruption in sync with the new input: mic-only
+            // mutes output to avoid echo, but System Audio must stay unmuted or it
+            // would be captured silent.
+            if AudioInputDevice.isMicrophoneOnly(newInputID) {
+                self.applyAudioInterruptionIfNeeded()
+            } else {
+                self.restoreAudioInterruptionIfNeeded()
+            }
             self.refreshOverlayInputOptions()
             self.configureSelectedAudioRecorderCallbacks(
                 inputID: newInputID,
@@ -4944,6 +4952,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
             let recordingFileURL = self.stitchedRecordingURL(finalSegmentURL: fileURL)
             let savedAudioFile = Self.saveAudioFile(from: recordingFileURL)
             let transcriptionFileURL = savedAudioFile?.fileURL ?? recordingFileURL
+            // Remove the stitched temp file once it has been copied to permanent
+            // storage (only created when segments were stitched, i.e. a new path).
+            if savedAudioFile != nil, recordingFileURL.path != fileURL.path {
+                try? FileManager.default.removeItem(at: recordingFileURL)
+            }
             if let savedAudioFile {
                 let recoveryContext = sessionContext ?? self.fallbackContextAtStop()
                 let activeJob = self.activeTranscriptionJobs[jobID]

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2159,8 +2159,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
         audioLevelCancellable?.cancel()
         audioLevelCancellable = nil
 
+        // All recorders deliver stopRecording's completion on the main thread
+        // (AudioRecorder, SystemAudioRecorder, SystemDefaultAndSystemAudioRecorder),
+        // matching the existing stopAndTranscribe path, so it is safe to touch
+        // main-actor state here.
         stopActiveAudioRecorder { [weak self] segmentURL in
             guard let self else { return }
+            // The session may have been stopped/cancelled while the old recorder
+            // was finishing. Don't start a new recorder in that case — it would
+            // leak a recording the app thinks has ended.
+            guard self.isRecording else {
+                if let segmentURL {
+                    try? FileManager.default.removeItem(at: segmentURL)
+                }
+                return
+            }
             if let segmentURL {
                 self.recordingSegmentURLs.append(segmentURL)
             }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1041,6 +1041,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var currentRecordingLiveNoteID: UUID?
     private var activeRecordingStartedAt: Date?
     private var activeAudioInputID: String?
+    /// Audio files of recording segments captured before a mid-recording input
+    /// switch. Stitched with the final segment at finish to keep one note.
+    private var recordingSegmentURLs: [URL] = []
+    /// True once the active recording has switched inputs at least once. Such a
+    /// session is finalized via file-based transcription of the stitched audio.
+    private var didSwitchInputDuringRecording = false
     private var isCancelConfirmationShowing = false
     private var overlayTranscriptionID: UUID = UUID()
     private var foregroundTranscriptionJobID: UUID?
@@ -2040,6 +2046,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         systemAudioRecorder.cleanup()
         systemDefaultAndSystemAudioRecorder.cleanup()
         activeAudioInputID = nil
+        discardRecordingSegments()
         refreshAvailableMicrophonesIfNeeded()
     }
 
@@ -2127,6 +2134,87 @@ final class AppState: ObservableObject, @unchecked Sendable {
             systemAudioRecorder.cancelRecording()
         } else {
             audioRecorder.cancelRecording()
+        }
+    }
+
+    /// Switches the audio input of an in-progress recording without ending the
+    /// session. The current recorder's audio is kept as a segment and stitched
+    /// with later segments at finish, so the result stays a single note. Live
+    /// transcription is torn down (plan A): a switched session is transcribed
+    /// from the stitched file at the end.
+    @MainActor
+    func switchActiveRecordingInput(to newInputID: String) {
+        guard isRecording else { return }
+        let currentInputID = activeAudioInputID ?? selectedMicrophoneID
+        guard !AudioInputDevice.isSameInput(newInputID, currentInputID) else { return }
+
+        liveTranscriber = nil
+        tearDownRealtimeService()
+        setActiveRecorderPCMHandler(nil)
+        audioLevelCancellable?.cancel()
+        audioLevelCancellable = nil
+
+        stopActiveAudioRecorder { [weak self] segmentURL in
+            guard let self else { return }
+            if let segmentURL {
+                self.recordingSegmentURLs.append(segmentURL)
+            }
+            self.didSwitchInputDuringRecording = true
+            self.selectedMicrophoneID = newInputID
+            self.activeAudioInputID = newInputID
+            self.configureSelectedAudioRecorderCallbacks(
+                inputID: newInputID,
+                onReady: {},
+                onFailure: { [weak self] error in
+                    DispatchQueue.main.async {
+                        self?.handleRecordingFailure(error)
+                    }
+                }
+            )
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    try await self.startSelectedAudioRecorder(inputID: newInputID)
+                    await MainActor.run {
+                        guard self.isRecording else { return }
+                        self.audioLevelCancellable = self.activeRecorderAudioLevelPublisher(inputID: newInputID)
+                            .receive(on: DispatchQueue.main)
+                            .sink { [weak self] level in
+                                self?.overlayManager.updateAudioLevel(level)
+                            }
+                    }
+                } catch {
+                    await MainActor.run {
+                        self.handleRecordingFailure(error)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Removes any captured segment temp files and resets the switch state.
+    private func discardRecordingSegments() {
+        for url in recordingSegmentURLs {
+            try? FileManager.default.removeItem(at: url)
+        }
+        recordingSegmentURLs = []
+        didSwitchInputDuringRecording = false
+    }
+
+    /// The audio file to finalize. When the session switched inputs, stitches the
+    /// captured segments and the final segment into one continuous file;
+    /// otherwise returns the final segment unchanged.
+    private func stitchedRecordingURL(finalSegmentURL: URL) -> URL {
+        guard didSwitchInputDuringRecording, !recordingSegmentURLs.isEmpty else {
+            return finalSegmentURL
+        }
+        let segments = recordingSegmentURLs + [finalSegmentURL]
+        defer { discardRecordingSegments() }
+        do {
+            return try AudioMixdownService().concatenate(segments)
+        } catch {
+            os_log(.error, log: recordingLog, "failed to stitch recording segments: %{public}@", String(describing: error))
+            return finalSegmentURL
         }
     }
 
@@ -3354,6 +3442,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         dismissTranscribingOverlay()
         tearDownRealtimeService()
         cancelActiveAudioRecorder()
+        discardRecordingSegments()
         restoreAudioInterruptionIfNeeded()
         syncCriticalDictationActivity()
         refreshAvailableMicrophonesIfNeeded()
@@ -4005,6 +4094,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         initTimer.resume()
 
         activeAudioInputID = audioInputID
+        discardRecordingSegments()
         configureSelectedAudioRecorderCallbacks(
             inputID: audioInputID,
             onReady: { [weak self] in
@@ -4813,8 +4903,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 return
             }
 
-            let savedAudioFile = Self.saveAudioFile(from: fileURL)
-            let transcriptionFileURL = savedAudioFile?.fileURL ?? fileURL
+            let recordingFileURL = self.stitchedRecordingURL(finalSegmentURL: fileURL)
+            let savedAudioFile = Self.saveAudioFile(from: recordingFileURL)
+            let transcriptionFileURL = savedAudioFile?.fileURL ?? recordingFileURL
             if let savedAudioFile {
                 let recoveryContext = sessionContext ?? self.fallbackContextAtStop()
                 let activeJob = self.activeTranscriptionJobs[jobID]

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1370,6 +1370,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 self?.handleOverlayStopButtonPressed()
             }
         }
+        overlayManager.onSelectInput = { [weak self] inputID in
+            DispatchQueue.main.async {
+                self?.switchActiveRecordingInput(to: inputID)
+            }
+        }
         Task { @MainActor [weak self] in
             self?.meetingReminderOverlayManager.onStart = { [weak self] _ in
                 self?.startRecordingFromCalendarReminder()
@@ -2162,6 +2167,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             self.didSwitchInputDuringRecording = true
             self.selectedMicrophoneID = newInputID
             self.activeAudioInputID = newInputID
+            self.refreshOverlayInputOptions()
             self.configureSelectedAudioRecorderCallbacks(
                 inputID: newInputID,
                 onReady: {},
@@ -2216,6 +2222,24 @@ final class AppState: ObservableObject, @unchecked Sendable {
             os_log(.error, log: recordingLog, "failed to stitch recording segments: %{public}@", String(describing: error))
             return finalSegmentURL
         }
+    }
+
+    /// Audio source choices shown in the recording overlay's input switcher.
+    /// Limited to the source modes — the meaningful mid-recording choice — rather
+    /// than the full hardware microphone list.
+    private func recordingOverlayInputOptions() -> [RecordingOverlayInputOption] {
+        [
+            RecordingOverlayInputOption(id: AudioInputDevice.defaultMicrophoneID, name: "System Default"),
+            RecordingOverlayInputOption(id: AudioInputDevice.systemAudioID, name: "System Audio"),
+            RecordingOverlayInputOption(id: AudioInputDevice.systemDefaultAndSystemAudioID, name: "System Default + System Audio")
+        ]
+    }
+
+    private func refreshOverlayInputOptions() {
+        overlayManager.updateInputOptions(
+            recordingOverlayInputOptions(),
+            selectedID: activeAudioInputID ?? selectedMicrophoneID
+        )
     }
 
     func clearPipelineHistory() {
@@ -4095,6 +4119,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         activeAudioInputID = audioInputID
         discardRecordingSegments()
+        refreshOverlayInputOptions()
         configureSelectedAudioRecorderCallbacks(
             inputID: audioInputID,
             onReady: { [weak self] in

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2153,6 +2153,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let currentInputID = activeAudioInputID ?? selectedMicrophoneID
         guard !AudioInputDevice.isSameInput(newInputID, currentInputID) else { return }
 
+        // Verify access to the new input BEFORE stopping the current recorder.
+        // A failed start (e.g. System Audio without Screen Recording permission)
+        // runs handleRecordingFailure, which would discard the whole in-progress
+        // recording. Use non-prompting checks so we don't trigger the
+        // recording-start permission UI / state resets mid-session.
+        guard canAccessRecordingInput(newInputID) else {
+            errorMessage = recordingInputAccessErrorMessage(for: newInputID)
+            return
+        }
+
         liveTranscriber = nil
         tearDownRealtimeService()
         setActiveRecorderPCMHandler(nil)
@@ -2217,6 +2227,31 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 }
             }
         }
+    }
+
+    /// Non-prompting permission check for switching to an input mid-recording.
+    /// Unlike ensureRecordingInputAccess(for:) this has no side effects (no
+    /// prompts, no error UI, no session-state resets).
+    private func canAccessRecordingInput(_ inputID: String) -> Bool {
+        let microphoneGranted = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+        if AudioInputDevice.isSystemDefaultAndSystemAudio(inputID) {
+            return microphoneGranted && hasScreenCapturePermission()
+        }
+        if AudioInputDevice.isSystemAudio(inputID) {
+            return hasScreenCapturePermission()
+        }
+        return microphoneGranted
+    }
+
+    private func recordingInputAccessErrorMessage(for inputID: String) -> String {
+        let tail = "Recording continues on the current input."
+        if AudioInputDevice.isSystemDefaultAndSystemAudio(inputID) {
+            return "Couldn't switch input: System Default + System Audio needs Microphone and Screen & System Audio Recording access (System Settings > Privacy & Security). \(tail)"
+        }
+        if AudioInputDevice.isSystemAudio(inputID) {
+            return "Couldn't switch input: System Audio needs Screen & System Audio Recording access (System Settings > Privacy & Security). \(tail)"
+        }
+        return "Couldn't switch input: Microphone access is required (System Settings > Privacy & Security). \(tail)"
     }
 
     /// Removes any captured segment temp files and resets the switch state.

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1020,7 +1020,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         guard let self else {
             return MeetingReminderOverlayContext(phase: .idle, layout: .centerDropdownFill)
         }
-        let phase: MeetingReminderOverlayContext.Phase = if self.isRecording {
+        let phase: MeetingReminderOverlayContext.Phase = if self.isRecording || self.isDebugOverlayActive {
+            // Treat the debug overlay as recording so the reminder shows its
+            // recording (wrapping) variant for visual testing in dev builds.
             .recording
         } else if self.isTranscribing {
             .processing
@@ -5649,6 +5651,29 @@ final class AppState: ObservableObject, @unchecked Sendable {
             guard let self, self.pendingOverlayDismissToken == dismissToken else { return }
             self.pendingOverlayDismissToken = nil
             self.overlayManager.dismiss()
+        }
+    }
+
+    @MainActor
+    func showDebugMeetingReminderOverlay() {
+        let now = Date()
+        let event = GoogleCalendarEvent(
+            id: "debug-meeting-reminder-\(UUID().uuidString)",
+            calendarID: "primary",
+            title: "Team Standup",
+            start: now.addingTimeInterval(600),
+            end: now.addingTimeInterval(1_800),
+            isAllDay: false,
+            attendees: []
+        )
+        let schedule = CalendarRecordingReminderSchedule(
+            identifier: "debug-meeting-reminder:\(UUID().uuidString)",
+            fireDate: now,
+            event: event,
+            delivery: .immediate
+        )
+        Task { [weak self] in
+            _ = await self?.meetingReminderOverlayManager.presentCalendarRecordingReminder(schedule) { _ in }
         }
     }
 

--- a/Sources/AudioInputDevice.swift
+++ b/Sources/AudioInputDevice.swift
@@ -18,4 +18,14 @@ enum AudioInputDevice {
     static func isMicrophoneOnly(_ id: String) -> Bool {
         !isSpecialInput(id)
     }
+
+    /// Treats an empty id as the system default microphone so the two spellings
+    /// compare equal.
+    static func normalized(_ id: String) -> String {
+        id.isEmpty ? defaultMicrophoneID : id
+    }
+
+    static func isSameInput(_ lhs: String, _ rhs: String) -> Bool {
+        normalized(lhs) == normalized(rhs)
+    }
 }

--- a/Sources/AudioMixdownService.swift
+++ b/Sources/AudioMixdownService.swift
@@ -36,6 +36,26 @@ public struct AudioMixdownService {
         return outputURL
     }
 
+    /// Concatenates 16 kHz mono 16-bit PCM WAV segments end to end into a single
+    /// WAV file, preserving order. Used to stitch recording segments captured
+    /// across a mid-recording input switch into one continuous file.
+    public func concatenate(_ segmentURLs: [URL]) throws -> URL {
+        guard !segmentURLs.isEmpty else {
+            throw AudioMixdownServiceError.noSegmentsToConcatenate
+        }
+
+        var combinedSamples: [Int16] = []
+        for url in segmentURLs {
+            combinedSamples.append(contentsOf: try readSamples(from: url))
+        }
+
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("wav")
+        try writeWAV(samples: combinedSamples, to: outputURL)
+        return outputURL
+    }
+
     private func systemAudioGain(microphoneSamples: [Int16], systemAudioSamples: [Int16]) -> Float {
         let systemRMS = activeRMS(systemAudioSamples)
         guard systemRMS > 0 else { return 1 }
@@ -195,6 +215,7 @@ public struct AudioMixdownService {
 enum AudioMixdownServiceError: Error {
     case invalidWAVFile
     case unsupportedWAVFormat
+    case noSegmentsToConcatenate
 }
 
 private extension Data {

--- a/Sources/MeetingReminderOverlay.swift
+++ b/Sources/MeetingReminderOverlay.swift
@@ -45,6 +45,21 @@ struct MeetingReminderOverlayGeometry {
     private static let notchSideHorizontalInset: CGFloat = 8
     private static let centerRecordingBaseWidth: CGFloat = 150
 
+    /// Shared height for the centered reminder card. The idle (default) reminder
+    /// and the recording/processing banner use the same height so the card morphs
+    /// smoothly between them when recording starts from a visible reminder.
+    static let centerReminderCardHeight: CGFloat = 80
+    /// Approximate height of the single-line meeting-info row, used to vertically
+    /// center it in the content area below the top strip.
+    private static let centerRecordingRowHeight: CGFloat = 20
+
+    /// Top inset that vertically centers the single-line meeting-info row in the
+    /// content area below the top strip (which tracks the recording pill height).
+    static func centerRecordingRowTop(stripHeight: CGFloat) -> CGFloat {
+        let contentArea = centerReminderCardHeight - stripHeight
+        return stripHeight + max(0, (contentArea - centerRecordingRowHeight) / 2)
+    }
+
     static func size(forScreenWidth screenWidth: CGFloat) -> CGSize {
         CGSize(
             width: min(defaultSize.width, max(280, screenWidth - horizontalScreenMargin * 2)),
@@ -79,9 +94,9 @@ struct MeetingReminderOverlayGeometry {
     ) -> CGSize {
         switch variant {
         case .defaultReminder:
-            let defaultSize = size(forScreenWidth: screenWidth)
-            guard let notchSideWidth else { return defaultSize }
-            return CGSize(width: max(defaultSize.width, notchSideWidth), height: defaultSize.height)
+            let width = size(forScreenWidth: screenWidth).width
+            let resolvedWidth = notchSideWidth.map { max(width, $0) } ?? width
+            return CGSize(width: resolvedWidth, height: centerReminderCardHeight)
         case .notchSidesRecording, .notchSidesProcessing:
             return CGSize(width: max(280, notchSideWidth ?? defaultSize.width), height: defaultSize.height)
         case .notchCenterRecording, .notchCenterProcessing:
@@ -91,7 +106,13 @@ struct MeetingReminderOverlayGeometry {
                 height: notchCenterSize.height
             )
         case .centerRecording, .centerProcessing:
-            return size(forScreenWidth: screenWidth)
+            // Matches the idle reminder height so the two morph smoothly; the top
+            // strip aligns with the recording pill and the meeting row is centered
+            // in the area below it.
+            return CGSize(
+                width: size(forScreenWidth: screenWidth).width,
+                height: centerReminderCardHeight
+            )
         }
     }
 
@@ -155,6 +176,9 @@ struct MeetingReminderOverlayDisplayData: Equatable {
     let context: MeetingReminderOverlayContext
     let variant: MeetingReminderOverlayVariant
     let centerOverlayWidth: CGFloat
+    /// Height of the top strip in the center recording/processing variants,
+    /// matched to the recording pill height so the two align.
+    let topStripHeight: CGFloat
 
     var showsStartButton: Bool { variant == .defaultReminder }
 }
@@ -264,7 +288,8 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
             for: schedule,
             context: context,
             variant: variant,
-            centerOverlayWidth: MeetingReminderOverlayGeometry.centerRecordingOverlayWidth(for: geometry)
+            centerOverlayWidth: MeetingReminderOverlayGeometry.centerRecordingOverlayWidth(for: geometry),
+            topStripHeight: geometry.menuBarStripHeight
         )
 
         if let panel, let viewModel, let contentContainer {
@@ -456,7 +481,8 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
         for schedule: CalendarRecordingReminderSchedule,
         context: MeetingReminderOverlayContext,
         variant: MeetingReminderOverlayVariant,
-        centerOverlayWidth: CGFloat
+        centerOverlayWidth: CGFloat,
+        topStripHeight: CGFloat
     ) -> MeetingReminderOverlayDisplayData {
         MeetingReminderOverlayDisplayData(
             identifier: schedule.identifier,
@@ -465,7 +491,8 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
             startTimeText: Self.startTimeText(for: schedule.event.start),
             context: context,
             variant: variant,
-            centerOverlayWidth: centerOverlayWidth
+            centerOverlayWidth: centerOverlayWidth,
+            topStripHeight: topStripHeight
         )
     }
 
@@ -556,8 +583,8 @@ private struct MeetingReminderOverlayView: View {
             CenterMeetingReminderOverlayView(
                 displayData: displayData,
                 animationNamespace: animationNamespace,
-                topContentHeight: 38,
-                rowTop: 58,
+                topContentHeight: displayData.topStripHeight,
+                rowTop: MeetingReminderOverlayGeometry.centerRecordingRowTop(stripHeight: displayData.topStripHeight),
                 onDismiss: onDismiss
             )
         }

--- a/Sources/OverlayScreenGeometry.swift
+++ b/Sources/OverlayScreenGeometry.swift
@@ -60,6 +60,17 @@ struct OverlayScreenGeometry {
         max(0, screenFrame.maxY - visibleFrame.maxY)
     }
 
+    /// Floor for the top overlay strip on a display that has no menu bar
+    /// (e.g. a secondary display). Keeps the strip tall enough for its content.
+    static let minMenuBarStripHeight: CGFloat = 24
+
+    /// Height of the menu-bar strip on a display without a notch. The recording
+    /// pill and the meeting-reminder overlay's top strip both use this value so
+    /// they stay vertically aligned when shown together.
+    var menuBarStripHeight: CGFloat {
+        notchOverlap > 0 ? notchOverlap : Self.minMenuBarStripHeight
+    }
+
     func centeredTopFrame(width: CGFloat, height: CGFloat) -> NSRect {
         NSRect(
             x: screenFrame.midX - width / 2,

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -1060,7 +1060,9 @@ private struct InputMenuClickCatcher: NSViewRepresentable {
                 item.state = AudioInputDevice.isSameInput(option.id, selectedID) ? .on : .off
                 menu.addItem(item)
             }
-            menu.popUp(positioning: nil, at: NSPoint(x: 0, y: bounds.height + 4), in: self)
+            // Anchor just below the view's bottom-left so the menu drops downward
+            // consistently (NSView is not flipped, so y grows upward).
+            menu.popUp(positioning: nil, at: NSPoint(x: 0, y: -4), in: self)
         }
 
         @objc private func selectOption(_ sender: NSMenuItem) {

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -159,6 +159,8 @@ final class RecordingOverlayManager {
 
     private typealias NotchSideGeometry = OverlayScreenGeometry.NotchSideGeometry
     private static let maxToastMessageLength = 90
+    /// Fixed height of the centered pill on notched displays (sits below the notch).
+    private static let overlayPillHeight: CGFloat = 38
 
     var onStopButtonPressed: (() -> Void)?
     var onUpdateOverlayPressed: (() -> Void)?
@@ -469,8 +471,19 @@ final class RecordingOverlayManager {
         }
 
         let width = overlayWidth
-        let overlap = screenHasTopSafeArea ? notchOverlap : 0
-        let height: CGFloat = 38 + overlap
+        let height: CGFloat
+        if screenHasTopSafeArea {
+            // Notched displays: the pill sits below the notch/menu bar, so add
+            // the menu bar gap on top of the fixed pill height.
+            height = Self.overlayPillHeight + notchOverlap
+        } else {
+            // No notch: match the menu bar height so the overlay occupies exactly
+            // the menu bar area instead of overflowing below it. This is shared
+            // with the reminder overlay's top strip so the two stay aligned when
+            // shown together. The overlay content is <=20pt tall, so the floor
+            // keeps it from clipping.
+            height = screenGeometry.menuBarStripHeight
+        }
         return screenGeometry.centeredTopFrame(width: width, height: height)
     }
 

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -3,6 +3,11 @@ import AppKit
 
 // MARK: - State
 
+struct RecordingOverlayInputOption: Identifiable, Equatable {
+    let id: String
+    let name: String
+}
+
 final class RecordingOverlayState: ObservableObject {
     @Published var phase: OverlayPhase = .recording
     @Published var audioLevel: Float = 0.0
@@ -12,6 +17,8 @@ final class RecordingOverlayState: ObservableObject {
     @Published var updateVersion: String = ""
     @Published var errorMessage: String?
     @Published var toastID: UUID?
+    @Published var inputOptions: [RecordingOverlayInputOption] = []
+    @Published var selectedInputID: String = ""
 }
 
 enum OverlayPhase {
@@ -164,6 +171,12 @@ final class RecordingOverlayManager {
 
     var onStopButtonPressed: (() -> Void)?
     var onUpdateOverlayPressed: (() -> Void)?
+    var onSelectInput: ((String) -> Void)?
+
+    func updateInputOptions(_ options: [RecordingOverlayInputOption], selectedID: String) {
+        overlayState.inputOptions = options
+        overlayState.selectedInputID = selectedID
+    }
 
     init() {
         screenParametersObserver = NotificationCenter.default.addObserver(
@@ -429,6 +442,9 @@ final class RecordingOverlayManager {
                 },
                 onUpdateOverlayPressed: { [weak self] in
                     self?.onUpdateOverlayPressed?()
+                },
+                onSelectInput: { [weak self] id in
+                    self?.onSelectInput?(id)
                 }
             )
             .padding(.top, screenHasTopSafeArea ? notchOverlap : 0)
@@ -445,6 +461,9 @@ final class RecordingOverlayManager {
                 rightContentFrame: geometry.rightContentFrame,
                 onStopButtonPressed: { [weak self] in
                     self?.onStopButtonPressed?()
+                },
+                onSelectInput: { [weak self] id in
+                    self?.onSelectInput?(id)
                 }
             )
         )
@@ -790,6 +809,7 @@ private struct NotchSideOverlayView: View {
     let leftContentFrame: CGRect
     let rightContentFrame: CGRect
     let onStopButtonPressed: () -> Void
+    let onSelectInput: (String) -> Void
 
     private var showsLiveRecordingContent: Bool {
         state.phase == .recording
@@ -797,6 +817,12 @@ private struct NotchSideOverlayView: View {
 
     private var showsStopButton: Bool {
         showsLiveRecordingContent && state.recordingTriggerMode == .toggle
+    }
+
+    private var showsInputSwitcher: Bool {
+        showsLiveRecordingContent
+            && state.recordingTriggerMode == .toggle
+            && !state.inputOptions.isEmpty
     }
 
     var body: some View {
@@ -832,7 +858,17 @@ private struct NotchSideOverlayView: View {
                             .foregroundStyle(.white.opacity(0.92))
                             .transition(.opacity.combined(with: .scale(scale: 0.96)))
                     }
-                    CompactWaveformView(audioLevel: state.audioLevel, showsActivityPulse: true)
+                    if showsInputSwitcher {
+                        InputSwitchMenu(
+                            options: state.inputOptions,
+                            selectedID: state.selectedInputID,
+                            onSelect: onSelectInput
+                        ) {
+                            CompactWaveformView(audioLevel: state.audioLevel, showsActivityPulse: true)
+                        }
+                    } else {
+                        CompactWaveformView(audioLevel: state.audioLevel, showsActivityPulse: true)
+                    }
                 }
                 .transition(.opacity.combined(with: .scale(scale: 0.96)))
             case .transcribing:
@@ -875,6 +911,7 @@ struct RecordingOverlayView: View {
     @ObservedObject var state: RecordingOverlayState
     let onStopButtonPressed: () -> Void
     let onUpdateOverlayPressed: () -> Void
+    let onSelectInput: (String) -> Void
 
     private let leadingAccessoryWidth: CGFloat = 24
     private let trailingAccessoryWidth: CGFloat = 32
@@ -885,6 +922,12 @@ struct RecordingOverlayView: View {
 
     private var showsStopButton: Bool {
         showsLiveRecordingContent && state.recordingTriggerMode == .toggle
+    }
+
+    private var showsInputSwitcher: Bool {
+        showsLiveRecordingContent
+            && state.recordingTriggerMode == .toggle
+            && !state.inputOptions.isEmpty
     }
 
     var body: some View {
@@ -902,11 +945,22 @@ struct RecordingOverlayView: View {
                             InitializingDotsView()
                                 .transition(.opacity)
                         } else if showsLiveRecordingContent {
-                            WaveformView(
-                                audioLevel: state.audioLevel,
-                                showsActivityPulse: state.phase == .recording
-                            )
+                            if showsInputSwitcher {
+                                InputSwitchMenu(
+                                    options: state.inputOptions,
+                                    selectedID: state.selectedInputID,
+                                    onSelect: onSelectInput
+                                ) {
+                                    WaveformView(audioLevel: state.audioLevel, showsActivityPulse: true)
+                                }
                                 .transition(.opacity)
+                            } else {
+                                WaveformView(
+                                    audioLevel: state.audioLevel,
+                                    showsActivityPulse: state.phase == .recording
+                                )
+                                .transition(.opacity)
+                            }
                         } else {
                             ProcessingIndicatorView()
                                 .transition(.opacity.combined(with: .scale(scale: 0.96)))
@@ -948,6 +1002,71 @@ struct RecordingOverlayView: View {
         .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.phase)
         .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.recordingTriggerMode)
         .animation(.spring(response: 0.28, dampingFraction: 0.8), value: state.isCommandMode)
+    }
+}
+
+/// Wraps overlay content (the waveform) so clicking it opens a menu to switch
+/// the audio input mid-recording. Uses an AppKit NSMenu (via a transparent click
+/// catcher) because SwiftUI's `Menu` does not reliably open/reopen inside the
+/// borderless, non-activating overlay panel.
+struct InputSwitchMenu<Content: View>: View {
+    let options: [RecordingOverlayInputOption]
+    let selectedID: String
+    let onSelect: (String) -> Void
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        content()
+            .overlay(
+                InputMenuClickCatcher(options: options, selectedID: selectedID, onSelect: onSelect)
+            )
+            .help("Switch audio input")
+    }
+}
+
+private struct InputMenuClickCatcher: NSViewRepresentable {
+    let options: [RecordingOverlayInputOption]
+    let selectedID: String
+    let onSelect: (String) -> Void
+
+    func makeNSView(context: Context) -> ClickCatcherView {
+        let view = ClickCatcherView()
+        view.apply(options: options, selectedID: selectedID, onSelect: onSelect)
+        return view
+    }
+
+    func updateNSView(_ nsView: ClickCatcherView, context: Context) {
+        nsView.apply(options: options, selectedID: selectedID, onSelect: onSelect)
+    }
+
+    final class ClickCatcherView: NSView {
+        private var options: [RecordingOverlayInputOption] = []
+        private var selectedID: String = ""
+        private var onSelect: ((String) -> Void)?
+
+        func apply(options: [RecordingOverlayInputOption], selectedID: String, onSelect: @escaping (String) -> Void) {
+            self.options = options
+            self.selectedID = selectedID
+            self.onSelect = onSelect
+        }
+
+        override func mouseDown(with event: NSEvent) {
+            guard !options.isEmpty else { return }
+            let menu = NSMenu()
+            for option in options {
+                let item = NSMenuItem(title: option.name, action: #selector(selectOption(_:)), keyEquivalent: "")
+                item.target = self
+                item.representedObject = option.id
+                item.state = AudioInputDevice.isSameInput(option.id, selectedID) ? .on : .off
+                menu.addItem(item)
+            }
+            menu.popUp(positioning: nil, at: NSPoint(x: 0, y: bounds.height + 4), in: self)
+        }
+
+        @objc private func selectOption(_ sender: NSMenuItem) {
+            guard let id = sender.representedObject as? String else { return }
+            onSelect?(id)
+        }
     }
 }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -470,6 +470,18 @@ struct DebugSettingsView: View {
                         }
                     }
                 }
+
+                SettingsCard("Meeting Reminder", icon: "calendar") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Show a sample calendar reminder overlay. Turn on Debug Overlay first to preview the recording (wrapping) variant.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        Button("Show Meeting Reminder") {
+                            appState.showDebugMeetingReminderOverlay()
+                        }
+                    }
+                }
             }
             .padding(24)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Tests/AudioMixdownServiceTests.swift
+++ b/Tests/AudioMixdownServiceTests.swift
@@ -11,6 +11,10 @@ struct AudioMixdownServiceTests {
             try doesNotClipLoudSystemAudio()
             try outputFormatIs16kHzMonoInt16AndFrameCountIsMaxInputFrameCount()
             try activeRMSAvoidsIntermediateArrays()
+            try concatenatesSegmentsInOrder()
+            try concatenateWithSingleSegmentReturnsSameSamples()
+            try concatenateOutputIs16kHzMonoInt16InTempDir()
+            try concatenateThrowsOnEmptyInput()
             print("AudioMixdownServiceTests passed")
         } catch {
             fputs("AudioMixdownServiceTests failed: \(error)\n", stderr)
@@ -102,6 +106,67 @@ struct AudioMixdownServiceTests {
 
         let samples = try readSamples(from: outputURL)
         try expectEqual(samples, [250, 400, 800, 1000, 1200], "mixed samples should silence-pad shorter input")
+    }
+
+    private static func concatenatesSegmentsInOrder() throws {
+        let first = try writeTinyWAV(samples: [1, 2, 3])
+        let second = try writeTinyWAV(samples: [4, 5])
+        let third = try writeTinyWAV(samples: [6])
+        defer { try? FileManager.default.removeItem(at: first) }
+        defer { try? FileManager.default.removeItem(at: second) }
+        defer { try? FileManager.default.removeItem(at: third) }
+
+        let outputURL = try AudioMixdownService().concatenate([first, second, third])
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        let samples = try readSamples(from: outputURL)
+        try expectEqual(samples, [1, 2, 3, 4, 5, 6], "segments should be joined end to end in order")
+    }
+
+    private static func concatenateWithSingleSegmentReturnsSameSamples() throws {
+        let only = try writeTinyWAV(samples: [7, 8, 9])
+        defer { try? FileManager.default.removeItem(at: only) }
+
+        let outputURL = try AudioMixdownService().concatenate([only])
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        let samples = try readSamples(from: outputURL)
+        try expectEqual(samples, [7, 8, 9], "single segment should be copied unchanged")
+    }
+
+    private static func concatenateOutputIs16kHzMonoInt16InTempDir() throws {
+        let first = try writeTinyWAV(samples: [100, 200])
+        let second = try writeTinyWAV(samples: [300, 400, 500])
+        defer { try? FileManager.default.removeItem(at: first) }
+        defer { try? FileManager.default.removeItem(at: second) }
+
+        let outputURL = try AudioMixdownService().concatenate([first, second])
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        guard outputURL.pathExtension == "wav" else {
+            throw TestFailure("expected .wav output, got \(outputURL.lastPathComponent)")
+        }
+        guard outputURL.deletingLastPathComponent().standardizedFileURL == FileManager.default.temporaryDirectory.standardizedFileURL else {
+            throw TestFailure("expected output in temporaryDirectory, got \(outputURL.path)")
+        }
+
+        let file = try AVAudioFile(forReading: outputURL)
+        let format = file.fileFormat
+        try expectEqual(format.sampleRate, 16_000, "sample rate")
+        try expectEqual(format.channelCount, 1, "channel count")
+        guard format.commonFormat == .pcmFormatInt16 else {
+            throw TestFailure("expected pcmFormatInt16, got \(format.commonFormat)")
+        }
+        try expectEqual(file.length, 5, "output frame count should be the sum of segment frame counts")
+    }
+
+    private static func concatenateThrowsOnEmptyInput() throws {
+        do {
+            _ = try AudioMixdownService().concatenate([])
+            throw TestFailure("concatenate([]) should throw")
+        } catch AudioMixdownServiceError.noSegmentsToConcatenate {
+            // expected
+        }
     }
 
     private static func activeRMSAvoidsIntermediateArrays() throws {

--- a/Tests/MeetingReminderOverlayGeometryTests.swift
+++ b/Tests/MeetingReminderOverlayGeometryTests.swift
@@ -15,6 +15,7 @@ struct MeetingReminderOverlayGeometryTests {
         testRecordingCenterWithoutNotchUsesCenterVariant()
         testNotchSideWidthMatchesRecordingOverlayGeometry()
         testContextualSizesMatchFinalDesign()
+        testCenterRecordingMatchesIdleHeight()
         testFrameUsesSharedScreenGeometryForUpdatedFrames()
         testFrameUsesSharedNotchSideGeometryWidth()
         try testMeetingReminderUsesSharedScreenGeometry()
@@ -103,16 +104,50 @@ struct MeetingReminderOverlayGeometryTests {
     }
 
     private static func testContextualSizesMatchFinalDesign() {
-        assert(MeetingReminderOverlayGeometry.size(for: .defaultReminder, screenWidth: 1_440, notchSideWidth: nil) == CGSize(width: 336, height: 92))
-        assert(MeetingReminderOverlayGeometry.size(for: .defaultReminder, screenWidth: 1_440, notchSideWidth: 404) == CGSize(width: 404, height: 92))
+        assert(MeetingReminderOverlayGeometry.size(for: .defaultReminder, screenWidth: 1_440, notchSideWidth: nil) == CGSize(width: 336, height: 80))
+        assert(MeetingReminderOverlayGeometry.size(for: .defaultReminder, screenWidth: 1_440, notchSideWidth: 404) == CGSize(width: 404, height: 80))
         assert(MeetingReminderOverlayGeometry.size(for: .notchSidesRecording, screenWidth: 1_440, notchSideWidth: 330) == CGSize(width: 330, height: 92))
         assert(MeetingReminderOverlayGeometry.size(for: .notchSidesProcessing, screenWidth: 1_440, notchSideWidth: 330) == CGSize(width: 330, height: 92))
         assert(MeetingReminderOverlayGeometry.size(for: .notchCenterRecording, screenWidth: 1_440, notchSideWidth: nil) == CGSize(width: 360, height: 112))
         assert(MeetingReminderOverlayGeometry.size(for: .notchCenterProcessing, screenWidth: 1_440, notchSideWidth: nil) == CGSize(width: 360, height: 112))
         assert(MeetingReminderOverlayGeometry.size(for: .notchCenterRecording, screenWidth: 2_056, notchSideWidth: 404) == CGSize(width: 404, height: 112))
         assert(MeetingReminderOverlayGeometry.size(for: .notchCenterProcessing, screenWidth: 2_056, notchSideWidth: 404) == CGSize(width: 404, height: 112))
-        assert(MeetingReminderOverlayGeometry.size(for: .centerRecording, screenWidth: 1_440, notchSideWidth: nil) == CGSize(width: 336, height: 92))
-        assert(MeetingReminderOverlayGeometry.size(for: .centerProcessing, screenWidth: 1_440, notchSideWidth: nil) == CGSize(width: 336, height: 92))
+        assert(MeetingReminderOverlayGeometry.size(for: .centerRecording, screenWidth: 1_440, notchSideWidth: nil) == CGSize(width: 336, height: 80))
+        assert(MeetingReminderOverlayGeometry.size(for: .centerProcessing, screenWidth: 1_440, notchSideWidth: nil) == CGSize(width: 336, height: 80))
+    }
+
+    private static func testCenterRecordingMatchesIdleHeight() {
+        // No-notch display with a 24pt menu bar. The pill and the reminder's top
+        // strip both derive from menuBarStripHeight so they align.
+        let geometry = OverlayScreenGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1_440, height: 900),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_440, height: 876)
+        )
+        assert(geometry.menuBarStripHeight == 24)
+
+        // Idle reminder and recording banner share one height so the card morphs
+        // smoothly when recording starts from a visible reminder.
+        let idle = MeetingReminderOverlayGeometry.frame(
+            for: geometry,
+            context: MeetingReminderOverlayContext(phase: .idle, layout: .centerDropdownFill)
+        )
+        let recording = MeetingReminderOverlayGeometry.frame(
+            for: geometry,
+            context: MeetingReminderOverlayContext(phase: .recording, layout: .centerDropdownFill)
+        )
+        assert(idle.height == MeetingReminderOverlayGeometry.centerReminderCardHeight)
+        assert(recording.height == MeetingReminderOverlayGeometry.centerReminderCardHeight)
+        assert(idle.height == recording.height)
+
+        // The single-line meeting row is centered in the area below the 24pt strip.
+        assert(MeetingReminderOverlayGeometry.centerRecordingRowTop(stripHeight: 24) == 42)
+
+        // Falls back to the floor when the display reports no menu bar.
+        let noMenuBar = OverlayScreenGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1_440, height: 900),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        )
+        assert(noMenuBar.menuBarStripHeight == OverlayScreenGeometry.minMenuBarStripHeight)
     }
 
     private static func testFrameUsesSharedScreenGeometryForUpdatedFrames() {
@@ -130,9 +165,9 @@ struct MeetingReminderOverlayGeometryTests {
         let updatedFrame = MeetingReminderOverlayGeometry.frame(for: updatedGeometry, context: context)
 
         assert(oldFrame.origin.x == 588)
-        assert(oldFrame.origin.y == 890)
+        assert(oldFrame.origin.y == 902)
         assert(updatedFrame.origin.x == 696)
-        assert(updatedFrame.origin.y == 1025)
+        assert(updatedFrame.origin.y == 1037)
     }
 
     private static func testFrameUsesSharedNotchSideGeometryWidth() {


### PR DESCRIPTION
## Summary

Lets you change the audio input **during** a recording without ending the session — useful when an online meeting starts mid-dictation — and fixes the recording overlay height on displays without a notch. Built as small, reviewable steps.

## What's included

**Overlay height (notch-less displays)**
- The centered recording overlay used a fixed 38pt height and overflowed the (shorter) menu bar on notch-less displays. It now uses the actual menu bar height, shared with the meeting-reminder overlay so the reminder's top strip stays aligned with the recording pill when a reminder wraps an active recording.
- The idle reminder and the recording-banner reminder share one height (80pt) so they morph smoothly between states. Notched displays are unchanged.

**Mid-recording input switching**
- `AudioMixdownService.concatenate(_:)` — stitches 16 kHz mono WAV segments end to end (with unit tests).
- `AppState.switchActiveRecordingInput(to:)` — swaps the input mid-recording without ending the session: the current recorder's audio is kept as a segment, a new recorder starts, and the overlay audio level re-subscribes. Segments are stitched into one note at finish. Per plan, a switched session is transcribed from the stitched file (live transcription is torn down on switch). Sessions that never switch are byte-for-byte unchanged.
- In-overlay switcher: clicking the recording overlay waveform during a toggle recording opens a source menu (System Default / System Audio / System Default + System Audio); works in both centered and notch-sides layouts. Uses an AppKit `NSMenu` via a transparent click catcher because SwiftUI's `Menu` does not reliably open/reopen inside the borderless, non-activating overlay panel.

**Dev tooling**
- A dev-only Debug settings button to preview the meeting-reminder overlay (and its recording/wrapping variant).

## Verification

- Full app type-checks; overlay geometry tests and `AudioMixdownService` tests pass (incl. new concatenation tests).
- Manually verified in a dev build: notch-less overlay height, reminder wrapping alignment, and live input switching (waveform-click menu, segment stitching into one note).

## Known limitations / follow-ups

Tracked in #136:
- A global hotkey to switch the input **before** recording (quick route) — deferred due to the large surface area of adding a new shortcut action.
- `System Audio`-only recordings come out shorter than wall-clock during silence, because ScreenCaptureKit doesn't deliver buffers while silent and we don't pad the gaps. Meeting mode (`System Default + System Audio`) is unaffected (mic is continuous) and transcription is unaffected; deferred as it's cosmetic duration vs. risk in a sensitive recorder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 녹음 중 오디오 입력 소스 전환 기능 추가(선택 메뉴 포함)
  * 여러 오디오 세그먼트를 자동 병합해 최종 녹음 파일을 생성
  * 디버그 설정에서 미팅 리마인더 즉시 미리보기 제공

* **개선 사항**
  * 미팅 리마인더 오버레이 레이아웃 높이/메뉴바 스트립 영역이 기기 환경에 맞게 더 정확히 조정
  * 녹음 중 입력 전환 시 세션 누적/정리 흐름과 이어붙이기 결과 처리가 개선
  * 입력 기본값 처리와 입력 비교가 더 일관되게 동작
<!-- end of auto-generated comment: release notes by coderabbit.ai -->