### PR TITLE
Add overlay waveform display mode setting (waveform / hover time / time)

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -289,6 +289,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let realtimeStreamingModelStorageKey = "realtime_streaming_model"
     private let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
     private let recordingOverlayLayoutStorageKey = "recording_overlay_layout"
+    private let overlayWaveformDisplayModeStorageKey = "overlay_waveform_display_mode"
     private let googleCalendarSelectedIDsStorageKey = "google_calendar_selected_ids"
     private let calendarRecordingRemindersEnabledStorageKey = "calendar_recording_reminders_enabled"
     private let legacyCalendarRecordingReminderLeadMinutesStorageKey = "calendar_recording_reminder_lead_minutes"
@@ -543,6 +544,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         didSet {
             UserDefaults.standard.set(recordingOverlayLayout.rawValue, forKey: recordingOverlayLayoutStorageKey)
             overlayManager.setRecordingOverlayLayout(recordingOverlayLayout)
+        }
+    }
+
+    @Published var overlayWaveformDisplayMode: OverlayWaveformDisplayMode {
+        didSet {
+            UserDefaults.standard.set(overlayWaveformDisplayMode.rawValue, forKey: overlayWaveformDisplayModeStorageKey)
+            overlayManager.setWaveformDisplayMode(overlayWaveformDisplayMode)
         }
     }
 
@@ -1165,6 +1173,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let recordingOverlayLayout = RecordingOverlayLayout.find(
             rawValue: UserDefaults.standard.string(forKey: recordingOverlayLayoutStorageKey)
         )
+        let overlayWaveformDisplayMode = OverlayWaveformDisplayMode.find(
+            rawValue: UserDefaults.standard.string(forKey: overlayWaveformDisplayModeStorageKey)
+        )
         let selectedGoogleCalendarIDs = Self.loadStringSet(forKey: googleCalendarSelectedIDsStorageKey)
         let storedGoogleCalendarConnectionMetadata = Self.loadGoogleCalendarConnectionMetadata()
         let calendarRecordingRemindersEnabled = UserDefaults.standard.bool(forKey: calendarRecordingRemindersEnabledStorageKey)
@@ -1303,6 +1314,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.realtimeStreamingModel = realtimeStreamingModel
         self.dictationAudioInterruptionEnabled = dictationAudioInterruptionEnabled
         self.recordingOverlayLayout = recordingOverlayLayout
+        self.overlayWaveformDisplayMode = overlayWaveformDisplayMode
         self.googleCalendarConnection = storedGoogleCalendarConnectionMetadata?.connectionState(
             selectedCalendarIDs: selectedGoogleCalendarIDs
         ) ?? .disconnected
@@ -1310,6 +1322,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.calendarRecordingReminderLeadMinutes = calendarRecordingReminderLeadMinutes
         self.calendarRecordingReminderRefreshIntervalMinutes = calendarRecordingReminderRefreshIntervalMinutes
         self.overlayManager.setRecordingOverlayLayout(recordingOverlayLayout)
+        self.overlayManager.setWaveformDisplayMode(overlayWaveformDisplayMode)
         self.isPressEnterVoiceCommandEnabled = isPressEnterVoiceCommandEnabled
         self.alertSoundsEnabled = alertSoundsEnabled
         self.useLocalTranscription = useLocalTranscription

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -1085,8 +1085,14 @@ struct InputSwitchMenu<Content: View>: View {
         // resize as content swaps, making the mouse cross its edge and flicker
         // enter/exit (and sometimes get stuck "entered").
         ZStack {
-            content()
-                .opacity(showsTime ? 0 : 1)
+            // In .timeOnly the waveform never shows, so omit it entirely rather
+            // than keeping it at opacity 0 — otherwise its TimelineView keeps
+            // ticking (and redrawing) invisibly. The other modes keep it laid
+            // out so the hover-tracked area doesn't resize when time appears.
+            if displayMode != .timeOnly {
+                content()
+                    .opacity(showsTime ? 0 : 1)
+            }
             if let recordingStartedAt {
                 ElapsedTimeView(startedAt: recordingStartedAt)
                     .opacity(showsTime ? 1 : 0)

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -22,6 +22,8 @@ final class RecordingOverlayState: ObservableObject {
     /// When the active recording effectively started (first captured audio),
     /// preserved across mid-recording input switches. Used for the hover timer.
     @Published var recordingStartedAt: Date?
+    /// How the overlay presents the elapsed recording time relative to the waveform.
+    @Published var waveformDisplayMode: OverlayWaveformDisplayMode = .waveformOnly
 }
 
 enum OverlayPhase {
@@ -30,6 +32,26 @@ enum OverlayPhase {
     case transcribing
     case feedback
     case updateAvailable
+}
+
+/// Controls how the recording overlay presents elapsed time relative to the
+/// live audio waveform.
+enum OverlayWaveformDisplayMode: String, CaseIterable, Identifiable {
+    /// Show only the live waveform (default). No elapsed time.
+    case waveformOnly
+    /// Show the waveform; reveal elapsed time only while hovering it.
+    case hoverTime
+    /// Replace the waveform with a running elapsed-time counter.
+    case timeOnly
+
+    var id: String { rawValue }
+
+    static func find(rawValue: String?) -> OverlayWaveformDisplayMode {
+        guard let rawValue, let mode = OverlayWaveformDisplayMode(rawValue: rawValue) else {
+            return .waveformOnly
+        }
+        return mode
+    }
 }
 
 enum RecordingOverlayLayout: String, CaseIterable, Identifiable {
@@ -183,6 +205,12 @@ final class RecordingOverlayManager {
 
     func setRecordingStartedAt(_ date: Date?) {
         overlayState.recordingStartedAt = date
+    }
+
+    func setWaveformDisplayMode(_ mode: OverlayWaveformDisplayMode) {
+        DispatchQueue.main.async {
+            self.overlayState.waveformDisplayMode = mode
+        }
     }
 
     init() {
@@ -870,7 +898,8 @@ private struct NotchSideOverlayView: View {
                             options: state.inputOptions,
                             selectedID: state.selectedInputID,
                             onSelect: onSelectInput,
-                            recordingStartedAt: state.recordingStartedAt
+                            recordingStartedAt: state.recordingStartedAt,
+                            displayMode: state.waveformDisplayMode
                         ) {
                             CompactWaveformView(audioLevel: state.audioLevel, showsActivityPulse: true)
                         }
@@ -958,7 +987,8 @@ struct RecordingOverlayView: View {
                                     options: state.inputOptions,
                                     selectedID: state.selectedInputID,
                                     onSelect: onSelectInput,
-                                    recordingStartedAt: state.recordingStartedAt
+                                    recordingStartedAt: state.recordingStartedAt,
+                                    displayMode: state.waveformDisplayMode
                                 ) {
                                     WaveformView(audioLevel: state.audioLevel, showsActivityPulse: true)
                                 }
@@ -1024,11 +1054,29 @@ struct InputSwitchMenu<Content: View>: View {
     let selectedID: String
     let onSelect: (String) -> Void
     let recordingStartedAt: Date?
+    let displayMode: OverlayWaveformDisplayMode
     @ViewBuilder var content: () -> Content
     @State private var isHovering = false
 
+    /// Whether elapsed time is shown instead of the waveform right now.
+    /// - `.waveformOnly`: never.
+    /// - `.hoverTime`: only while hovering.
+    /// - `.timeOnly`: always (waveform hidden for the whole recording).
     private var showsTime: Bool {
-        isHovering && recordingStartedAt != nil
+        guard recordingStartedAt != nil else { return false }
+        switch displayMode {
+        case .waveformOnly: return false
+        case .hoverTime: return isHovering
+        case .timeOnly: return true
+        }
+    }
+
+    private var helpText: String {
+        switch displayMode {
+        case .timeOnly: return "Elapsed time · click to switch audio input"
+        case .hoverTime: return "Hover for elapsed time · click to switch audio input"
+        case .waveformOnly: return "Switch audio input"
+        }
     }
 
     var body: some View {
@@ -1053,7 +1101,7 @@ struct InputSwitchMenu<Content: View>: View {
                 onHoverChange: { hovering in isHovering = hovering }
             )
         )
-        .help("Hover for elapsed time · click to switch audio input")
+        .help(helpText)
     }
 }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -544,6 +544,33 @@ struct AppearanceSettingsView: View {
 
                         Divider()
 
+                        VStack(alignment: .leading, spacing: 10) {
+                            Text("Waveform display")
+                                .font(.system(size: 13, weight: .semibold))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+
+                            OverlayWaveformModeOptionRow(
+                                title: "Waveform only",
+                                subtitle: "Show the live audio waveform while recording.",
+                                mode: .waveformOnly,
+                                selection: $appState.overlayWaveformDisplayMode
+                            )
+                            OverlayWaveformModeOptionRow(
+                                title: "Show elapsed time on hover",
+                                subtitle: "Show the waveform; hover it to peek the elapsed recording time.",
+                                mode: .hoverTime,
+                                selection: $appState.overlayWaveformDisplayMode
+                            )
+                            OverlayWaveformModeOptionRow(
+                                title: "Show elapsed time instead of waveform",
+                                subtitle: "Replace the waveform with a running elapsed-time counter.",
+                                mode: .timeOnly,
+                                selection: $appState.overlayWaveformDisplayMode
+                            )
+                        }
+
+                        Divider()
+
                         overlayDisplaySection
                     }
                 }
@@ -612,6 +639,53 @@ struct OverlayLayoutOptionRow: View {
                     .foregroundStyle(isSelected ? Color.blue : Color.secondary)
 
                 OverlayLayoutPreview(layout: layout)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(isSelected ? Color.blue : Color.clear, lineWidth: 2)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+    }
+}
+
+struct OverlayWaveformModeOptionRow: View {
+    let title: String
+    let subtitle: String
+    let mode: OverlayWaveformDisplayMode
+    @Binding var selection: OverlayWaveformDisplayMode
+
+    private var isSelected: Bool {
+        selection == mode
+    }
+
+    var body: some View {
+        Button {
+            selection = mode
+        } label: {
+            HStack(alignment: .center, spacing: 14) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 20))
+                    .foregroundStyle(isSelected ? Color.blue : Color.secondary)
 
                 VStack(alignment: .leading, spacing: 4) {
                     Text(title)

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -663,7 +663,8 @@ struct OverlayLayoutOptionRow: View {
             )
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(title)
+        // Combine so VoiceOver reads the subtitle too, not just the title.
+        .accessibilityElement(children: .combine)
         .accessibilityValue(isSelected ? "Selected" : "Not selected")
     }
 }
@@ -710,7 +711,8 @@ struct OverlayWaveformModeOptionRow: View {
             )
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(title)
+        // Combine so VoiceOver reads the subtitle too, not just the title.
+        .accessibilityElement(children: .combine)
         .accessibilityValue(isSelected ? "Selected" : "Not selected")
     }
 }


### PR DESCRIPTION
The recording overlay previously always revealed elapsed recording time on hover. This makes that a user choice with three modes, **defaulting to waveform-only** (so the hover-time behavior shipped in #138 becomes opt-in).

## Modes
- **Waveform only** (new default) — live audio waveform, no elapsed time.
- **Show elapsed time on hover** — the previous behavior: hover the waveform to peek `MM:SS` (`H:MM:SS` past an hour).
- **Show elapsed time instead of waveform** — a running elapsed-time counter replaces the waveform for the whole recording.

Clicking the overlay still opens the audio-input switcher in every mode.

## Implementation
- New `OverlayWaveformDisplayMode` enum, persisted under `overlay_waveform_display_mode`.
- Wired through `AppState` into the overlay, mirroring the existing `recordingOverlayLayout` setting pattern (published property + UserDefaults + push to `RecordingOverlayManager`).
- `InputSwitchMenu` computes whether to show time per mode, reusing the existing hover ZStack/opacity + tracking-area logic from #138.
- Surfaced as radio options in the **Recording Overlay** settings card.

## Testing
- Built and ran the dev build; verified the three options appear in Settings → Recording Overlay and the overlay behaves per mode (waveform-only, hover-reveal, always-time), with the input switcher still opening on click in each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 녹음 오버레이의 파형 표시 방식을 설정할 수 있도록 개선되었습니다. 설정 화면에서 웨이브폼 전용, 호버 시 경과 시간 표시, 또는 경과 시간만 표시 중 원하는 방식을 선택할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->