### PR TITLE
Require Accessibility only when the recording flow will use it

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -96,7 +96,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             if appState.requiresAccessibility, !AXIsProcessTrusted() {
-                appState.showAccessibilityAlert()
+                appState.promptForAccessibilityAccess()
             }
 
             startMCPServer()
@@ -318,7 +318,7 @@ private func showNoteBrowserWindow() {
 
         if appState.requiresAccessibility, !AXIsProcessTrusted() {
             Task { @MainActor in
-                appState.showAccessibilityAlert()
+                appState.promptForAccessibilityAccess()
             }
         }
     }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -95,7 +95,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 UpdateManager.shared.startPeriodicChecks()
             }
 
-            if !AXIsProcessTrusted() {
+            if appState.requiresAccessibility, !AXIsProcessTrusted() {
                 appState.showAccessibilityAlert()
             }
 
@@ -316,7 +316,7 @@ private func showNoteBrowserWindow() {
             UpdateManager.shared.startPeriodicChecks()
         }
 
-        if !AXIsProcessTrusted() {
+        if appState.requiresAccessibility, !AXIsProcessTrusted() {
             Task { @MainActor in
                 appState.showAccessibilityAlert()
             }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -3724,6 +3724,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    /// Whether the configured recording flow will actually exercise Accessibility.
+    /// Auto-paste synthesizes a Cmd+V keystroke and command mode reads the
+    /// frontmost app's selected text — both require AX. Pure dictation that only
+    /// copies to the clipboard (auto-paste off, command mode off) does not, so
+    /// MCP / Rec-button / calendar recordings can proceed without it.
+    ///
+    /// Note: the global hotkey's event tap also needs AX, but that is a separate
+    /// concern — we intentionally don't gate on whether a shortcut is bound here.
+    var requiresAccessibility: Bool {
+        !disableAutoPaste || isCommandModeEnabled
+    }
+
     @MainActor
     private func prepareRecordingStart(
         triggerMode: RecordingTriggerMode,
@@ -3735,7 +3747,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         activeRecordingTriggerMode = triggerMode
         let isAccessibilityTrusted = AXIsProcessTrusted()
         hasAccessibility = isAccessibilityTrusted
-        guard isAccessibilityTrusted else {
+        guard isAccessibilityTrusted || !requiresAccessibility else {
             errorMessage = "Accessibility permission required. Grant access in System Settings > Privacy & Security > Accessibility."
             statusText = "No Accessibility"
             activeRecordingTriggerMode = nil

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2801,6 +2801,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    /// Shows the native macOS Accessibility prompt directly (the system "wants to
+    /// control this computer" dialog) without our own explanatory alert and
+    /// without force-opening System Settings — the system dialog already has an
+    /// "Open System Settings" button. Used at launch so the user sees a single
+    /// native prompt. macOS only surfaces this dialog while the app is still
+    /// undetermined; once the user has decided it no-ops, and the menu-bar
+    /// "Accessibility Required" warning remains the path back.
+    func promptForAccessibilityAccess() {
+        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+        _ = AXIsProcessTrustedWithOptions(options)
+    }
+
     func openMicrophoneSettings() {
         openPrivacySettingsPane("Privacy_Microphone")
     }
@@ -3753,7 +3765,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             activeRecordingTriggerMode = nil
             currentSessionIntent = .dictation
             shortcutSessionController.reset()
-            showAccessibilityAlert()
+            openAccessibilitySettings()
             return false
         }
         if let startedAt {
@@ -4406,27 +4418,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    func showAccessibilityAlert() {
-        guard Thread.isMainThread else {
-            DispatchQueue.main.async { [weak self] in
-                self?.showAccessibilityAlert()
-            }
-            return
-        }
-
-        let alert = NSAlert()
-        alert.messageText = "Accessibility Permission Required"
-        alert.informativeText = "Quill cannot type transcriptions without Accessibility access.\n\nGo to System Settings > Privacy & Security > Accessibility and enable Quill."
-        alert.alertStyle = .critical
-        alert.addButton(withTitle: "Open System Settings")
-        alert.addButton(withTitle: "Dismiss")
-        alert.icon = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: nil)
-
-        let response = alert.runModal()
-        if response == .alertFirstButtonReturn {
-            openAccessibilitySettings()
-        }
-    }
 
     private func precomputeMacros() {
         precomputedMacros = voiceMacros.map { macro in

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -76,7 +76,7 @@ struct MenuBarView: View {
             // Accessibility warning
             if appState.requiresAccessibility, !appState.hasAccessibility {
                 Button {
-                    appState.showAccessibilityAlert()
+                    appState.openAccessibilitySettings()
                 } label: {
                     Label("Accessibility Required", systemImage: "exclamationmark.triangle.fill")
                 }

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -74,7 +74,7 @@ struct MenuBarView: View {
             }
 
             // Accessibility warning
-            if !appState.hasAccessibility {
+            if appState.requiresAccessibility, !appState.hasAccessibility {
                 Button {
                     appState.showAccessibilityAlert()
                 } label: {


### PR DESCRIPTION
Quill demanded Accessibility up front on every launch and blocked **every** recording start when it wasn't granted. But AX is only actually exercised by:

- **Auto-paste** — synthesizes a Cmd+V keystroke to insert the transcript at the cursor.
- **Command mode** — reads the frontmost app's selected text.

Pure dictation that just copies to the clipboard — and **MCP / Rec-button / calendar** recordings — never touch AX, so requiring it there was unnecessary friction.

## 1. Require AX only when the flow will use it
Gate the AX checks on a shared `AppState.requiresAccessibility` (`!disableAutoPaste || isCommandModeEnabled`):

- **AppDelegate** — only request Accessibility at launch when AX will be used (both launch paths).
- **prepareRecordingStart** — only hard-block a recording start when AX is required; otherwise proceed without it.
- **MenuBarView** — only show the "Accessibility Required" warning when it's actually relevant.

### Note on the global hotkey
The global shortcut's `CGEventTap` also needs AX, but this intentionally does **not** gate on whether a shortcut is bound — the AX requirement follows the recording *action's* needs (paste / command mode), not the presence of a hotkey. Trade-off: a user who relies on the keyboard shortcut but has turned auto-paste off won't be prompted at startup; the tap simply won't receive events until AX is granted.

## 2. Use the native prompt instead of a custom alert
Requesting AX previously showed our own NSAlert first, and only after clicking "Open System Settings" did the native macOS prompt appear — two dialogs for one grant. Now we rely on the system affordances:

- **Launch** — trigger the native prompt directly (`promptForAccessibilityAccess`); a single native dialog, no custom alert first.
- **Recording blocked / menu-bar warning** — use `openAccessibilitySettings()`, which shows the native prompt while the choice is undetermined and opens the Settings pane once the user has already decided (the native prompt only fires once, so this keeps a working path after a denial).
- Removes the now-unused `showAccessibilityAlert()`.

## Testing
- Built and ran the dev build. With auto-paste **on** (default), AX is requested at launch as before; with auto-paste **off** and command mode off (`requiresAccessibility == false`), relaunched with AX not granted and confirmed nothing is requested.
- Reset the dev bundle's Accessibility TCC and confirmed a single native prompt at launch, and that after denying, the menu-bar warning / a blocked recording opens System Settings (no dead-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)