### PR TITLE
Show a toast when a mid-recording input switch is blocked

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2159,7 +2159,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
         // recording. Use non-prompting checks so we don't trigger the
         // recording-start permission UI / state resets mid-session.
         guard canAccessRecordingInput(newInputID) else {
+            // Detailed guidance in the menu bar; a short notice on the overlay
+            // (which the user is actually looking at) that auto-dismisses without
+            // ending the session. Pass the reminder card's frame so the overlay
+            // can anchor a toast below it instead of overlapping.
             errorMessage = recordingInputAccessErrorMessage(for: newInputID)
+            overlayManager.showRecordingNotice(
+                recordingInputAccessNotice(for: newInputID),
+                reminderFrame: meetingReminderOverlayManager.visibleOverlayFrame
+            )
             return
         }
 
@@ -2252,6 +2260,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return "Couldn't switch input: System Audio needs Screen & System Audio Recording access (System Settings > Privacy & Security). \(tail)"
         }
         return "Couldn't switch input: Microphone access is required (System Settings > Privacy & Security). \(tail)"
+    }
+
+    /// Short, single-line variant for the recording overlay pill, which only has
+    /// room for a brief notice. Full guidance lives in the menu-bar message.
+    private func recordingInputAccessNotice(for inputID: String) -> String {
+        if AudioInputDevice.isSystemDefaultAndSystemAudio(inputID) {
+            return "Mic + Screen Recording needed to switch"
+        }
+        if AudioInputDevice.isSystemAudio(inputID) {
+            return "Screen Recording needed to switch"
+        }
+        return "Microphone access needed to switch"
     }
 
     /// Removes any captured segment temp files and resets the switch state.

--- a/Sources/MeetingReminderOverlay.swift
+++ b/Sources/MeetingReminderOverlay.swift
@@ -205,6 +205,13 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
     var onStart: (@MainActor (CalendarRecordingReminderSchedule) -> Void)?
     var onDismiss: (@MainActor (CalendarRecordingReminderSchedule) -> Void)?
 
+    /// Frame of the reminder panel while a reminder is actually visible, else
+    /// nil. Lets the recording overlay anchor a notice toast below the card.
+    var visibleOverlayFrame: NSRect? {
+        guard visibleReminder != nil, let panel, panel.isVisible, panel.alphaValue > 0 else { return nil }
+        return panel.frame
+    }
+
     init(
         contextProvider: @escaping () -> MeetingReminderOverlayContext,
         screenProvider: @escaping () -> NSScreen? = { NSScreen.main }

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -681,6 +681,10 @@ final class RecordingOverlayManager {
             panel.orderOut(nil)
             overlayWindow = nil
         }
+        // Tear down any transient notice toast alongside the overlay so it
+        // doesn't linger after the session ends.
+        noticeToken = nil
+        noticeWindow?.orderOut(nil)
     }
 }
 

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -163,6 +163,13 @@ final class RecordingOverlayManager {
     private let overlayState = RecordingOverlayState()
     private var lockedOverlayWidth: CGFloat?
     private var screenParametersObserver: NSObjectProtocol?
+    /// Separate panel for transient recording notices (e.g. a rejected input
+    /// switch). Anchored just below the overlay stack so it never overlaps the
+    /// live waveform or a visible reminder card.
+    private var noticeWindow: NSPanel?
+    /// Identifies the in-flight notice so its scheduled dismissal only fires if
+    /// that same notice is still showing.
+    private var noticeToken: UUID?
     private let notchSideRegionWidth: CGFloat = 92
     private let notchSidePanelHeight: CGFloat = 38
     private let notchSideHorizontalInset: CGFloat = 8
@@ -330,14 +337,16 @@ final class RecordingOverlayManager {
         }
     }
 
+    private static func truncatedToastMessage(_ message: String) -> String {
+        guard message.count > maxToastMessageLength else { return message }
+        let cutoff = message.index(message.startIndex, offsetBy: maxToastMessageLength - 1)
+        return String(message[..<cutoff]) + "…"
+    }
+
     /// Surface a transient error in the menu-bar pill. The pill resizes to fit
     /// the message, holds briefly, then dismisses.
     func showError(_ message: String) {
-        let truncated: String = {
-            guard message.count > Self.maxToastMessageLength else { return message }
-            let cutoff = message.index(message.startIndex, offsetBy: Self.maxToastMessageLength - 1)
-            return String(message[..<cutoff]) + "…"
-        }()
+        let truncated = Self.truncatedToastMessage(message)
         DispatchQueue.main.async {
             let toastID = UUID()
             self.overlayState.errorMessage = truncated
@@ -357,6 +366,95 @@ final class RecordingOverlayManager {
                 self.dismissAll()
             }
         }
+    }
+
+    /// Frame of the recording overlay panel while it's on screen, else nil.
+    /// Used to anchor the transient notice toast below the overlay stack.
+    var visibleOverlayFrame: NSRect? {
+        guard let overlayWindow, overlayWindow.isVisible, overlayWindow.alphaValue > 0 else { return nil }
+        return overlayWindow.frame
+    }
+
+    /// Surface a transient notice for a non-fatal mid-recording event (e.g. a
+    /// rejected input switch) WITHOUT ending the session: a separate toast
+    /// anchored just under the lowest visible overlay (the recording pill, or
+    /// the taller reminder card when `reminderFrame` is set) so it never covers
+    /// the live waveform or overlaps the reminder.
+    func showRecordingNotice(_ message: String, reminderFrame: NSRect?) {
+        let truncated = Self.truncatedToastMessage(message)
+        DispatchQueue.main.async {
+            guard self.overlayState.phase == .recording,
+                  let anchor = self.noticeAnchorFrame(reminderFrame: reminderFrame) else {
+                // No recording overlay on screen — fall back to the standard toast.
+                self.showError(message)
+                return
+            }
+            self.showAnchoredRecordingNotice(truncated, anchor: anchor)
+        }
+    }
+
+    /// Bottom-most visible overlay frame (recording pill vs. the taller reminder
+    /// card), used as the anchor for the toast. Smaller minY = lower on screen.
+    private func noticeAnchorFrame(reminderFrame: NSRect?) -> NSRect? {
+        [overlayWindow?.frame, reminderFrame]
+            .compactMap { $0 }
+            .min(by: { $0.minY < $1.minY })
+    }
+
+    /// Show a standalone toast panel just below `anchor`, matching its width but
+    /// never narrower than the message needs.
+    private func showAnchoredRecordingNotice(_ truncated: String, anchor: NSRect) {
+        let token = UUID()
+        noticeToken = token
+
+        let height: CGFloat = 30
+        let gap: CGFloat = 6
+        let estimatedFit = CGFloat(truncated.count) * 6.8 + 44
+        let minFit = min(420, max(220, estimatedFit))
+        var width = max(anchor.width, minFit)
+        if let screenWidth = screenGeometry?.screenFrame.width {
+            width = min(width, screenWidth - 32)
+        }
+        let frame = NSRect(
+            x: anchor.midX - width / 2,
+            y: anchor.minY - gap - height,
+            width: width,
+            height: height
+        )
+
+        let panel = noticeWindow ?? makeOverlayPanel(width: frame.width, height: frame.height)
+        panel.hasShadow = true
+        panel.ignoresMouseEvents = true
+        panel.contentView = makeTransparentContent(
+            width: frame.width,
+            height: frame.height,
+            rootView: RecordingNoticeToastView(message: truncated)
+        )
+        panel.setFrame(frame, display: true)
+        panel.alphaValue = 0
+        panel.orderFrontRegardless()
+        noticeWindow = panel
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.16
+            panel.animator().alphaValue = 1
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) { [weak self] in
+            guard let self, self.noticeToken == token else { return }
+            self.noticeToken = nil
+            self.dismissNoticeToast()
+        }
+    }
+
+    private func dismissNoticeToast() {
+        guard let panel = noticeWindow else { return }
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.16
+            panel.animator().alphaValue = 0
+        }, completionHandler: { [weak panel] in
+            panel?.orderOut(nil)
+        })
     }
 
     func showUpdateAvailable(version: String) {
@@ -1205,6 +1303,32 @@ struct ErrorOverlayView: View {
                 .truncationMode(.tail)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    }
+}
+
+/// Standalone transient toast for non-fatal mid-recording notices, shown in its
+/// own panel anchored below the overlay stack. Draws its own rounded background
+/// since the panel itself is transparent.
+struct RecordingNoticeToastView: View {
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.circle.fill")
+                .font(.system(size: 12, weight: .bold))
+                .foregroundStyle(Color.red.opacity(0.92))
+            Text(message)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .padding(.horizontal, 14)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.black)
+        )
     }
 }
 

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -396,7 +396,9 @@ final class RecordingOverlayManager {
     /// Bottom-most visible overlay frame (recording pill vs. the taller reminder
     /// card), used as the anchor for the toast. Smaller minY = lower on screen.
     private func noticeAnchorFrame(reminderFrame: NSRect?) -> NSRect? {
-        [overlayWindow?.frame, reminderFrame]
+        // Only anchor to actually-visible frames so the toast never attaches to
+        // a stale/hidden overlay position.
+        [visibleOverlayFrame, reminderFrame]
             .compactMap { $0 }
             .min(by: { $0.minY < $1.minY })
     }
@@ -430,8 +432,13 @@ final class RecordingOverlayManager {
             height: frame.height,
             rootView: RecordingNoticeToastView(message: truncated)
         )
+        // Reuse keeps the panel on screen; only reset alpha when it's actually
+        // hidden, otherwise replacing a still-visible notice flashes.
+        let isAlreadyVisible = panel.isVisible && panel.alphaValue > 0
         panel.setFrame(frame, display: true)
-        panel.alphaValue = 0
+        if !isAlreadyVisible {
+            panel.alphaValue = 0
+        }
         panel.orderFrontRegardless()
         noticeWindow = panel
 
@@ -452,7 +459,10 @@ final class RecordingOverlayManager {
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = 0.16
             panel.animator().alphaValue = 0
-        }, completionHandler: { [weak panel] in
+        }, completionHandler: { [weak self, weak panel] in
+            // A newer notice may have been scheduled mid-fade; only hide the
+            // panel if nothing is showing now.
+            guard let self, self.noticeToken == nil else { return }
             panel?.orderOut(nil)
         })
     }


### PR DESCRIPTION
Switching the audio input **mid-recording** silently failed when the new input lacked permission (e.g. switching to System Audio without Screen Recording). The code set `errorMessage`, which only renders in the menu-bar dropdown — so a user looking at the recording overlay saw nothing happen and didn't know why the switch was ignored.

## Change
Surface a short, auto-dismissing notice **on the overlay itself**, as a standalone toast anchored just below the lowest visible overlay — the recording pill, or the taller reminder card when one is showing — so it never covers the live waveform or overlaps the reminder.

- The toast width follows the overlay-stack width but is never narrower than the message needs (and clamps to the screen width).
- Icon/typography match the existing error styling (red `exclamationmark.circle.fill`).
- Recording is never interrupted; the toast fades out after ~4s.
- The full, detailed guidance still appears in the menu-bar message.

### Files
- **RecordingOverlay** — `showRecordingNotice(_:reminderFrame:)`, a separate notice panel + `RecordingNoticeToastView`, and `visibleOverlayFrame` for anchoring.
- **MeetingReminderOverlay** — expose `visibleOverlayFrame` so the toast can anchor below a visible reminder card.
- **AppState** — pass the reminder frame when a blocked input switch is reported, with a short per-source message for the toast.

## Testing
Built and ran the dev build. With Screen Recording not granted, started a toggle recording and attempted to switch to System Audio; verified the toast appears below the overlay (centered pill, notch-side, and with a reminder card present) without covering the waveform, and that recording continues uninterrupted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **새로운 기능**
  * 녹음 입력 전환 중 권한 거부 시 녹음 오버레이 위에 권한 안내 토스트 표시
  * 녹음 진행 중 비정상 종료 없는 알림을 토스트로 표시하도록 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->