### PR TITLE
Reflect recent features in README and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It is built for everyday writing and work notes: replying to messages, drafting 
 ## What Quill helps with
 
 - **Capture thoughts before they disappear:** Speak rough ideas, meeting notes, follow-ups, or drafts without switching away from the app you are using.
-- **Record the right audio source:** Capture from the system default input, system audio, or System Default + System Audio (plus any connected microphone), and switch the source mid-recording without ending the session.
+- **Record the right audio source:** Capture from the System Default input, System Audio, or System Default + System Audio (plus any connected microphone), and switch the source mid-recording without ending the session.
 - **Write into any Mac app:** Dictate into text fields, documents, chat apps, browsers, terminals, and other focused inputs.
 - **Turn speech into finished text:** Clean up filler words, punctuation, phrasing, names, and project-specific vocabulary before the text is pasted.
 - **Edit by voice:** Highlight existing text and say what to change, such as “make this shorter” or “turn this into bullets.”

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It is built for everyday writing and work notes: replying to messages, drafting 
 ## What Quill helps with
 
 - **Capture thoughts before they disappear:** Speak rough ideas, meeting notes, follow-ups, or drafts without switching away from the app you are using.
+- **Record the right audio source:** Capture from the system default input, system audio, or System Default + System Audio (plus any connected microphone), and switch the source mid-recording without ending the session.
 - **Write into any Mac app:** Dictate into text fields, documents, chat apps, browsers, terminals, and other focused inputs.
 - **Turn speech into finished text:** Clean up filler words, punctuation, phrasing, names, and project-specific vocabulary before the text is pasted.
 - **Edit by voice:** Highlight existing text and say what to change, such as “make this shorter” or “turn this into bullets.”
@@ -37,7 +38,7 @@ It is built for everyday writing and work notes: replying to messages, drafting 
 
 ## How it works
 
-1. Quill records audio when you press your dictation shortcut.
+1. Quill records audio when you press your dictation shortcut and shows a compact overlay near the notch with a live waveform (and optional elapsed time).
 2. It transcribes the audio using your configured local or provider-based transcription option.
 3. It can clean up the transcript with app context, custom vocabulary, and output preferences.
 4. It pastes the final text into the focused app and keeps a local history entry for review or retry.

--- a/website/index.html
+++ b/website/index.html
@@ -73,7 +73,10 @@
               "AI transcript cleanup",
               "voice-driven text editing",
               "custom vocabulary",
-              "optional read-only Google Calendar note title suggestions"
+              "system audio capture with selectable audio source",
+              "recording overlay with waveform and elapsed time",
+              "local MCP server for Claude Code",
+              "optional read-only Google Calendar note title suggestions and recording reminders"
             ],
             "sameAs": ["https://github.com/woosublee/quill"]
           }
@@ -141,6 +144,18 @@
               <p>Add names, jargon, and project-specific terms so transcript cleanup can preserve important spellings.</p>
             </article>
             <article class="card">
+              <h3>System audio capture</h3>
+              <p>Record from System Default, System Audio, or System Default + System Audio, plus any connected microphone — and switch the source mid-recording without ending the session.</p>
+            </article>
+            <article class="card">
+              <h3>Recording overlay</h3>
+              <p>A compact overlay by the notch shows a live waveform while you record, with options to surface the elapsed time on hover or in place of the waveform.</p>
+            </article>
+            <article class="card">
+              <h3>Claude Code MCP server</h3>
+              <p>Quill exposes a local MCP server so Claude Code can start and stop recordings, add context, and read structured meeting data for note generation.</p>
+            </article>
+            <article class="card">
               <h3>Local history</h3>
               <p>Review, retry, and manage dictation results from local run history stored on your Mac.</p>
             </article>
@@ -161,7 +176,7 @@
           <div class="grid two">
             <article class="card">
               <h3>Optional Calendar access</h3>
-              <p>Quill can use read-only Google Calendar access to suggest note titles from selected calendars when an event overlaps a live recording.</p>
+              <p>Quill can use read-only Google Calendar access to suggest note titles from selected calendars when an event overlaps a live recording, and to show in-app reminders before a meeting starts.</p>
               <ul>
                 <li>No calendars are selected by default.</li>
                 <li>Quill does not create, edit, or delete calendar events.</li>

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -12,7 +12,11 @@ Platform: macOS 13 or later on Apple Silicon and Intel Macs
 
 Quill lets users dictate into the currently focused text field on macOS. It supports configurable dictation shortcuts, local or API-based transcription, AI-powered transcript cleanup, custom vocabulary, voice macros, local run history, and Edit Mode for transforming selected text with spoken instructions.
 
-Quill can optionally connect to Google Calendar to suggest note titles from events that overlap a live recording.
+Quill can capture from the system default input, system audio, or both combined, and the audio source can be switched mid-recording. A recording overlay near the notch shows a live waveform with optional elapsed-time display.
+
+Quill can optionally connect to Google Calendar to suggest note titles from events that overlap a live recording and to show in-app reminders before a meeting starts.
+
+Quill also runs a local MCP server so Claude Code can drive recordings and read meeting data (see the MCP section below).
 
 ## Google Calendar Access
 
@@ -26,6 +30,20 @@ Quill uses calendar list access so users can choose which calendars Quill may us
 For selected calendars, Quill reads event metadata around the time of a live recording so it can suggest note titles from overlapping events. Quill does not create, edit, or delete Google Calendar events.
 
 Google Calendar OAuth tokens are stored locally in macOS Keychain. Disconnecting Google Calendar in Quill Settings removes the stored Google Calendar token and clears selected calendars.
+
+## Claude Code MCP Server
+
+While Quill is running, it exposes a local MCP server at http://localhost:3457 that Claude Code can register with `claude mcp add -s user -t http quill http://localhost:3457`. The server is local to the user's Mac, is only available while Quill is running, and does not require a separate MCP API key.
+
+Available MCP tools:
+
+- start_recording — start a recording session, optionally with initial context such as meeting name, participants, topic, or a Notion URL.
+- add_context — append more context while a recording is in progress.
+- stop_recording — stop the recording and trigger transcription.
+- get_status — check whether Quill is idle, recording, or transcribing.
+- list_transcripts — list recent transcript history entries.
+- get_transcript — fetch a specific transcript by id.
+- get_meeting_source — fetch structured meeting data for a transcript id as JSON (resolved title, ISO 8601 timestamps, calendar match, attendees, audio file path, transcript, and context) for meeting-note generation.
 
 ## Privacy
 
@@ -41,7 +59,10 @@ When configured by the user, Quill may send necessary audio, transcript, selecte
 - AI-powered transcript cleanup and output language selection.
 - Edit Mode for voice-driven transformations of selected text.
 - Custom vocabulary and custom prompts.
-- Optional read-only Google Calendar note title suggestions.
+- System audio capture with a selectable audio source (system default, system audio, or both) that can be switched mid-recording.
+- Recording overlay with a live waveform and optional elapsed-time display.
+- Local MCP server for driving recordings and reading meeting data from Claude Code.
+- Optional read-only Google Calendar note title suggestions and in-app meeting reminders.
 - Local run history for reviewing and retrying dictation results.
 - Open source under the MIT license.
 


### PR DESCRIPTION
## Summary

Brings the README, website landing page, and `llms.txt` up to date with user-visible features shipped in 0.1.7–0.1.11.

### README.md
- Added an audio-source bullet (System Default / System Audio / both, switchable mid-recording).
- Mentioned the recording overlay (notch-side live waveform, optional elapsed time) in "How it works".

### website/index.html
- Added three feature cards: **System audio capture**, **Recording overlay**, **Claude Code MCP server**.
- Noted in-app meeting reminders on the Calendar card.
- Extended the JSON-LD `featureList` for SEO.

### website/llms.txt
- Added system-audio / overlay / MCP context to "What Quill Does" and Key Features.
- Added a **Claude Code MCP Server** section mirroring the README tool list.

Self-signed update infrastructure (Sparkle) was intentionally left out as it isn't a user-facing feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 녹음 중 오디오 소스(시스템 기본 입력/시스템 오디오/마이크) 전환 기능 추가
  * 녹음 오버레이에 실시간 웨이브폼 및 경과 시간 표시 기능 추가
  * Claude Code를 위한 로컬 MCP 서버 지원 추가
  * Google Calendar 연동을 통한 메모 제목 제안 및 녹화 리마인더 기능 강화

* **문서**
  * 새로운 기능들에 대한 설명 및 사용 가이드 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->