### PR TITLE
Fix crackle when mixing microphone with system audio

### DIFF
--- a/Sources/AudioMixdownService.swift
+++ b/Sources/AudioMixdownService.swift
@@ -2,6 +2,13 @@ import AVFoundation
 import Foundation
 
 public struct AudioMixdownService {
+    /// Per-source headroom applied before summing the two streams. Summing two
+    /// full-scale signals would overflow, so each is attenuated to leave room.
+    /// Mixing the streams continuously (rather than gating sample-by-sample on
+    /// activity) avoids the per-sample amplitude jumps that produced audible
+    /// crackle when the microphone was recorded alongside system audio.
+    private static let mixHeadroom: Float = 0.8
+
     public init() {}
 
     public func mix(microphoneURL: URL, systemAudioURL: URL) throws -> URL {
@@ -14,19 +21,12 @@ public struct AudioMixdownService {
         mixedSamples.reserveCapacity(outputFrameCount)
 
         for index in 0..<outputFrameCount {
-            let hasMicrophoneSample = index < microphoneSamples.count
-            let hasSystemAudioSample = index < systemAudioSamples.count
-
-            switch (hasMicrophoneSample, hasSystemAudioSample) {
-            case (true, true):
-                mixedSamples.append(mix(microphoneSample: microphoneSamples[index], systemAudioSample: systemAudioSamples[index], systemGain: systemGain))
-            case (true, false):
-                mixedSamples.append(microphoneSamples[index])
-            case (false, true):
-                mixedSamples.append(applyGain(systemAudioSamples[index], gain: systemGain))
-            case (false, false):
-                mixedSamples.append(0)
-            }
+            // A source that has run out (the shorter recording) contributes
+            // silence, so the same continuous mix runs across the whole file
+            // without an amplitude step at the boundary.
+            let microphoneSample = index < microphoneSamples.count ? microphoneSamples[index] : 0
+            let systemAudioSample = index < systemAudioSamples.count ? systemAudioSamples[index] : 0
+            mixedSamples.append(mix(microphoneSample: microphoneSample, systemAudioSample: systemAudioSample, systemGain: systemGain))
         }
 
         let outputURL = FileManager.default.temporaryDirectory
@@ -109,24 +109,9 @@ public struct AudioMixdownService {
     }
 
     private func mix(microphoneSample: Int16, systemAudioSample: Int16, systemGain: Float) -> Int16 {
-        let adjustedSystemSample = applyGain(systemAudioSample, gain: systemGain)
-        let microphoneActive = abs(Int(microphoneSample)) > 32
-        let systemActive = abs(Int(adjustedSystemSample)) > 32
-
-        switch (microphoneActive, systemActive) {
-        case (true, true):
-            return clampedInt16((Int(microphoneSample) + Int(adjustedSystemSample)) / 2)
-        case (true, false):
-            return microphoneSample
-        case (false, true):
-            return adjustedSystemSample
-        case (false, false):
-            return 0
-        }
-    }
-
-    private func applyGain(_ sample: Int16, gain: Float) -> Int16 {
-        clampedInt16(Int((Float(sample) * gain).rounded()))
+        let microphone = Float(microphoneSample) * Self.mixHeadroom
+        let systemAudio = Float(systemAudioSample) * systemGain * Self.mixHeadroom
+        return clampedInt16(Int((microphone + systemAudio).rounded()))
     }
 
     private func clampedInt16(_ sample: Int) -> Int16 {

--- a/Tests/AudioMixdownServiceTests.swift
+++ b/Tests/AudioMixdownServiceTests.swift
@@ -5,7 +5,7 @@ import Foundation
 struct AudioMixdownServiceTests {
     static func main() {
         do {
-            try averagesOverlappingSamplesAndPreservesLongerTail()
+            try sumsOverlappingSamplesWithHeadroomAndPreservesLongerTail()
             try boostsQuietSystemAudioBeforeMixing()
             try preservesSystemAudioWhenMicrophoneIsSilent()
             try doesNotClipLoudSystemAudio()
@@ -22,7 +22,7 @@ struct AudioMixdownServiceTests {
         }
     }
 
-    private static func averagesOverlappingSamplesAndPreservesLongerTail() throws {
+    private static func sumsOverlappingSamplesWithHeadroomAndPreservesLongerTail() throws {
         let microphoneURL = try writeTinyWAV(samples: [1000, 1000, 1000, 1000])
         let systemAudioURL = try writeTinyWAV(samples: [3000, 3000])
         defer { try? FileManager.default.removeItem(at: microphoneURL) }
@@ -31,8 +31,11 @@ struct AudioMixdownServiceTests {
         let outputURL = try AudioMixdownService().mix(microphoneURL: microphoneURL, systemAudioURL: systemAudioURL)
         defer { try? FileManager.default.removeItem(at: outputURL) }
 
+        // systemGain stays at 1 (system already louder than the microphone), and
+        // each source is attenuated by the 0.8 headroom: overlap is
+        // 1000*0.8 + 3000*0.8 = 3200; the microphone-only tail is 1000*0.8 = 800.
         let samples = try readSamples(from: outputURL)
-        try expectEqual(samples, [2000, 2000, 1000, 1000], "mixed samples should average overlap and preserve tail")
+        try expectEqual(samples, [3200, 3200, 800, 800], "mixed samples should sum overlap with headroom and preserve tail")
     }
 
     private static func boostsQuietSystemAudioBeforeMixing() throws {
@@ -44,8 +47,10 @@ struct AudioMixdownServiceTests {
         let outputURL = try AudioMixdownService().mix(microphoneURL: microphoneURL, systemAudioURL: systemAudioURL)
         defer { try? FileManager.default.removeItem(at: outputURL) }
 
+        // systemGain is capped at 2 (100 -> 200), then both sources take the 0.8
+        // headroom: 1000*0.8 + 100*2*0.8 = 800 + 160 = 960.
         let samples = try readSamples(from: outputURL)
-        try expectEqual(samples, [600, 600], "quiet system audio should be boosted conservatively before averaging with microphone")
+        try expectEqual(samples, [960, 960], "quiet system audio should be boosted conservatively before summing with microphone")
     }
 
     private static func preservesSystemAudioWhenMicrophoneIsSilent() throws {
@@ -57,8 +62,10 @@ struct AudioMixdownServiceTests {
         let outputURL = try AudioMixdownService().mix(microphoneURL: microphoneURL, systemAudioURL: systemAudioURL)
         defer { try? FileManager.default.removeItem(at: outputURL) }
 
+        // A silent microphone contributes nothing; system audio passes through at
+        // the 0.8 headroom (100*0.8 = 80) with no activity-gated halving.
         let samples = try readSamples(from: outputURL)
-        try expectEqual(samples, [100, 100], "system audio should not be halved by silent microphone samples")
+        try expectEqual(samples, [80, 80], "system audio should not be halved by silent microphone samples")
     }
 
     private static func doesNotClipLoudSystemAudio() throws {
@@ -104,8 +111,11 @@ struct AudioMixdownServiceTests {
         }
         try expectEqual(file.length, 5, "output frame count should be max input frame count")
 
+        // systemGain stays at 1; every sample takes the 0.8 headroom. Overlap:
+        // 100*0.8 + 400*0.8 = 400 and 200*0.8 + 600*0.8 = 640. The system-only
+        // tail is 800*0.8, 1000*0.8, 1200*0.8.
         let samples = try readSamples(from: outputURL)
-        try expectEqual(samples, [250, 400, 800, 1000, 1200], "mixed samples should silence-pad shorter input")
+        try expectEqual(samples, [400, 640, 640, 800, 960], "mixed samples should silence-pad shorter input")
     }
 
     private static func concatenatesSegmentsInOrder() throws {


### PR DESCRIPTION
## 문제

마이크와 시스템 오디오를 함께 녹음하면 지직거리는 잡음(crackle)이 섞여 들어갔습니다. 시스템 오디오만 녹음할 때는 깨끗했습니다.

## 원인

`AudioMixdownService`의 믹싱이 **샘플마다 소스별 활성도(`|값| > 32`)로 분기**하고 있었습니다. 시스템 오디오가 재생되는 동안 마이크의 미세한 노이즈가 임계값을 넘나들 때마다, 시스템 기여분이 ×1.0 ↔ ×0.5(평균) 사이로 샘플 단위로 튀었습니다. 이 급격한 진폭 불연속이 가청 클릭/지직음을 만들었습니다. 시스템 오디오만 녹음할 때는 믹서를 거치지 않아(원본 그대로 반환) 깨끗했던 것이 이를 뒷받침합니다.

## 해결

활성도 게이트를 제거하고 두 스트림을 **연속적으로 합산**합니다.

- 각 소스에 고정 헤드룸(0.8)을 적용한 뒤 합산하고 Int16으로 클램프 — 합산 오버플로우 방지.
- 길이가 짧은 녹음의 끝부분은 무음과 섞이게 해서 경계에서 음량 점프가 없습니다.
- 시스템 게인 정규화(마이크 대비 RMS 매칭 + 피크 세이프 클램프)는 그대로 유지.

## 테스트

`Tests/AudioMixdownServiceTests.swift`의 기대값을 새 헤드룸 합산 동작에 맞게 갱신했습니다(각 케이스에 계산 근거 주석 포함). 전체 통과.

개발 빌드(`make run`)로 실제 마이크+시스템 동시 녹음을 확인했고, 지직거림이 눈에 띄게 개선되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 마이크와 시스템 오디오 믹싱 알고리즘을 개선하여 일관성 있는 음질로 두 오디오 소스를 합성하도록 변경했습니다.
  * 길이가 다른 오디오 소스를 처리할 때 더 안정적이고 예측 가능한 결과를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->