### PR TITLE
Add pause, scrubbing, and volume to the note audio player

### DIFF
--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -1368,12 +1368,21 @@ struct NoteAudioPlayerView: View {
     @State private var duration: TimeInterval = 0
     @State private var elapsed: TimeInterval = 0
     @State private var progressTimer: Timer?
+    @State private var volume: Double = 1
+    @State private var showVolumePopover = false
 
     @State private var barHeights: [CGFloat] = Array(repeating: 0.15, count: 80)
 
     private var progress: Double {
         guard duration > 0 else { return 0 }
         return min(elapsed / duration, 1.0)
+    }
+
+    private var volumeIcon: String {
+        if volume <= 0.001 { return "speaker.slash.fill" }
+        if volume < 0.34 { return "speaker.fill" }
+        if volume < 0.67 { return "speaker.wave.1.fill" }
+        return "speaker.wave.2.fill"
     }
 
     private var toolbarStrokeColor: Color {
@@ -1390,7 +1399,7 @@ struct NoteAudioPlayerView: View {
                         .overlay(GlassView(material: .popover).clipShape(Circle()))
                         .overlay(Circle().strokeBorder(toolbarStrokeColor, lineWidth: 0.7))
                         .frame(width: 36, height: 36)
-                    Image(systemName: isPlaying ? "stop.fill" : "play.fill")
+                    Image(systemName: isPlaying ? "pause.fill" : "play.fill")
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundStyle(Color.primary)
                         .offset(x: isPlaying ? 0 : 1.5)
@@ -1415,7 +1424,16 @@ struct NoteAudioPlayerView: View {
                             .frame(width: barWidth, height: geo.size.height * barHeights[i])
                     }
                 }
-                .frame(maxHeight: .infinity, alignment: .center)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                // Tap to jump, drag to scrub. minimumDistance 0 makes a plain
+                // tap report through onChanged as well as a drag.
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { value in
+                            seek(toFraction: Double(value.location.x / geo.size.width))
+                        }
+                )
             }
             .frame(height: 44)
 
@@ -1425,6 +1443,30 @@ struct NoteAudioPlayerView: View {
                 .foregroundStyle(.secondary)
                 .monospacedDigit()
                 .frame(minWidth: 80, alignment: .center)
+
+            // Volume — tap the speaker for a slider popover
+            Button { showVolumePopover.toggle() } label: {
+                Image(systemName: volumeIcon)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20, height: 20)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .popover(isPresented: $showVolumePopover, arrowEdge: .bottom) {
+                HStack(spacing: 8) {
+                    Image(systemName: "speaker.fill")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                    Slider(value: $volume, in: 0...1)
+                        .frame(width: 120)
+                    Image(systemName: "speaker.wave.3.fill")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+            }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
@@ -1448,6 +1490,9 @@ struct NoteAudioPlayerView: View {
         .onAppear {
             loadDuration()
             loadWaveform()
+        }
+        .onChange(of: volume) { newValue in
+            player?.volume = Float(newValue)
         }
         .onDisappear { stopPlayback() }
     }
@@ -1506,22 +1551,53 @@ struct NoteAudioPlayerView: View {
 
     private func togglePlayback() {
         if isPlaying {
-            stopPlayback()
+            pausePlayback()
         } else {
-            guard FileManager.default.fileExists(atPath: audioURL.path) else { return }
-            do {
-                let p = try AVAudioPlayer(contentsOf: audioURL)
-                delegate.onFinish = { stopPlayback() }
-                p.delegate = delegate
-                p.play()
-                player = p
-                isPlaying = true
-                elapsed = 0
-                startProgressTimer()
-            } catch {}
+            play()
         }
     }
 
+    /// Lazily creates the player (if needed) and resumes from the current
+    /// position so pause keeps its place and seeking before pressing play works.
+    @discardableResult
+    private func preparedPlayer() -> AVAudioPlayer? {
+        if let player { return player }
+        guard FileManager.default.fileExists(atPath: audioURL.path) else { return nil }
+        guard let p = try? AVAudioPlayer(contentsOf: audioURL) else { return nil }
+        delegate.onFinish = { handlePlaybackFinished() }
+        p.delegate = delegate
+        p.volume = Float(volume)
+        p.prepareToPlay()
+        player = p
+        return p
+    }
+
+    private func play() {
+        guard let p = preparedPlayer() else { return }
+        p.play()
+        isPlaying = true
+        startProgressTimer()
+    }
+
+    private func pausePlayback() {
+        player?.pause()
+        isPlaying = false
+        progressTimer?.invalidate()
+        progressTimer = nil
+        elapsed = player?.currentTime ?? elapsed
+    }
+
+    /// Playback reached the end: stop the ticker and rewind to the start so the
+    /// next press of play restarts from the beginning.
+    private func handlePlaybackFinished() {
+        isPlaying = false
+        progressTimer?.invalidate()
+        progressTimer = nil
+        player?.currentTime = 0
+        elapsed = 0
+    }
+
+    /// Tears the player down entirely. Used when the view goes away.
     private func stopPlayback() {
         player?.stop()
         player = nil
@@ -1529,6 +1605,16 @@ struct NoteAudioPlayerView: View {
         progressTimer?.invalidate()
         progressTimer = nil
         elapsed = 0
+    }
+
+    /// Moves the playhead to `fraction` (0...1) of the duration. Works whether or
+    /// not playback is currently running.
+    private func seek(toFraction fraction: Double) {
+        guard duration > 0, let p = preparedPlayer() else { return }
+        let clamped = min(max(fraction, 0), 1)
+        let target = clamped * duration
+        p.currentTime = target
+        elapsed = target
     }
 
     private func startProgressTimer() {

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -1610,7 +1610,9 @@ struct NoteAudioPlayerView: View {
     /// Moves the playhead to `fraction` (0...1) of the duration. Works whether or
     /// not playback is currently running.
     private func seek(toFraction fraction: Double) {
-        guard duration > 0, let p = preparedPlayer() else { return }
+        // `fraction` comes from location.x / width; guard against a 0-width
+        // layout (NaN/Infinity) so we never set a bad AVAudioPlayer.currentTime.
+        guard fraction.isFinite, duration > 0, let p = preparedPlayer() else { return }
         let clamped = min(max(fraction, 0), 1)
         let target = clamped * duration
         p.currentTime = target


### PR DESCRIPTION
## 배경

노트 브라우저의 오디오 플레이어(`NoteAudioPlayerView`)는 재생/정지만 지원했습니다. 정지하면 위치가 처음으로 되돌아가고, 파형·진행률은 표시 전용이라 클릭해도 반응이 없었으며, 음량을 조절할 방법이 없었습니다.

## 변경

- **재생/일시정지 토글**: 버튼이 play ↔ pause로 동작하며 일시정지해도 재생 위치를 유지합니다. 끝까지 재생되면 자동으로 멈추고 맨 앞으로 되감겨, 다음 재생 시 처음부터 시작합니다.
- **파형 탐색(seek)**: 파형을 클릭하면 그 지점으로 점프하고, 좌우로 드래그하면 스크럽합니다. 재생 중이 아니어도 동작하도록 플레이어를 지연 생성(`preparedPlayer()`)해, 재생 전에 위치를 잡아두고 재생할 수도 있습니다.
- **음량 조절**: 시간 텍스트 옆 스피커 아이콘을 누르면 슬라이더 팝오버가 떠서 이 플레이어 전용 음량을 0~100%로 조절합니다(1.0이 원본 음량). 아이콘은 현재 음량 수준을 반영합니다.

UI 레이아웃은 기존 구성(버튼·파형·시간)을 거의 그대로 두고, 파형에 제스처를 추가하고 우측에 스피커 아이콘 하나만 더했습니다.

## 검증

개발 빌드(`make run`)로 실제 노트 오디오에서 일시정지·이어재생, 파형 클릭/드래그 탐색, 음량 조절을 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)