### PR TITLE
Check for updates daily instead of weekly

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -31,7 +31,7 @@
     <key>SUAutomaticallyUpdate</key>
     <false/>
     <key>SUUpdateCheckInterval</key>
-    <integer>604800</integer>
+    <integer>86400</integer>
     <key>GoogleCalendarOAuthClientID</key>
     <string></string>
     <key>GoogleCalendarOAuthClientSecret</key>


### PR DESCRIPTION
## 변경

Sparkle 자동 업데이트 확인 주기를 **7일 → 하루(86400초)**로 변경합니다 (`Info.plist`의 `SUUpdateCheckInterval`).

## 배경

기존 7일 주기에서는 릴리스된 수정이 사용자에게 도달하기까지 최대 일주일이 걸릴 수 있었습니다. 하루 주기로 좁혀 업데이트 전달을 빠르게 합니다.

- `SUEnableAutomaticChecks`는 그대로 `true` (자동 확인 유지)
- `SUAutomaticallyUpdate`는 그대로 `false` — 새 버전을 발견해도 자동 설치하지 않고 사용자 동의 후 설치하는 동작은 유지

## 검증

개발 빌드 후 번들에 반영된 값 확인: `SUUpdateCheckInterval = 86400`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)