### PR TITLE
Add self-signed CI release workflow

### DIFF
--- a/.github/workflows/self-signed-release.yml
+++ b/.github/workflows/self-signed-release.yml
@@ -1,0 +1,179 @@
+name: Self-signed Release
+
+# Builds the official auto-update release entirely in CI, signed with the
+# self-signed "Quill" certificate (the same identity used for local releases).
+# Keeping the identity identical means Sparkle's code-signing check still
+# matches for existing installs, so auto-updates are not interrupted. The
+# trade-off versus release.yml (Developer ID + notarization) is a Gatekeeper
+# warning on first launch for brand-new users — the same as today's local
+# releases. release.yml is kept for a future notarized transition.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag, for example v0.1.0"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release version
+        id: version
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          TAG="$INPUT_TAG"
+          APP_VERSION="$(make -s print-app-version)"
+          BUILD_NUMBER="$(make -s print-build-number)"
+          BUILD_TAG="$(make -s print-build-tag)"
+          VERSION="${TAG#v}"
+
+          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tags must use semantic versioning, for example v0.1.0." >&2
+            exit 1
+          fi
+
+          if [ "$TAG" != "$BUILD_TAG" ]; then
+            echo "Workflow tag $TAG must match BUILD_TAG $BUILD_TAG from version.mk." >&2
+            exit 1
+          fi
+
+          if [ "$VERSION" != "$APP_VERSION" ]; then
+            echo "Workflow version $VERSION must match APP_VERSION $APP_VERSION from version.mk." >&2
+            exit 1
+          fi
+
+          if ! [[ "$BUILD_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Build number must be a positive integer." >&2
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Release tag $TAG already exists on origin. Choose a new release tag." >&2
+            exit 1
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Stamp app version
+        run: |
+          plutil -replace CFBundleShortVersionString -string "${{ steps.version.outputs.version }}" Info.plist
+          plutil -replace CFBundleVersion -string "${{ steps.version.outputs.build_number }}" Info.plist
+          plutil -replace QuillBuildTag -string "${{ steps.version.outputs.tag }}" Info.plist
+
+      - name: Build release notes from changelog
+        id: release_notes
+        run: |
+          .github/scripts/changelog-section.sh "${{ steps.version.outputs.version }}" > "$RUNNER_TEMP/release-notes.md"
+          {
+            echo "body<<EOF"
+            cat "$RUNNER_TEMP/release-notes.md"
+            echo
+            echo "## Download"
+            echo
+            echo "**[Quill.dmg](https://github.com/woosublee/quill/releases/download/${{ steps.version.outputs.tag }}/Quill.dmg)** — Universal build for all Macs (Apple Silicon + Intel)."
+            echo
+            echo "macOS may show a first-launch security warning because this build is signed with Quill's own certificate rather than notarized. If that happens, open System Settings > Privacy & Security and choose Open Anyway."
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install build tools
+        run: brew install create-dmg fileicon
+
+      # Required GitHub secrets:
+      #   QUILL_CERTIFICATE_BASE64 — base64-encoded .p12 of the self-signed "Quill" certificate (with private key)
+      #   QUILL_CERTIFICATE_PASSWORD — password for the .p12
+      #   SPARKLE_PRIVATE_KEY — Sparkle EdDSA private key for appcast signing
+      - name: Import Quill signing certificate
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.QUILL_CERTIFICATE_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.QUILL_CERTIFICATE_PASSWORD }}
+        run: |
+          CERTIFICATE_PATH="$RUNNER_TEMP/quill_certificate.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 20)"
+
+          echo "$CERTIFICATE_BASE64" | base64 --decode > "$CERTIFICATE_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          security import "$CERTIFICATE_PATH" \
+            -P "$CERTIFICATE_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+          rm -f "$CERTIFICATE_PATH"
+
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "CODESIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          echo "Found signing identity: $IDENTITY"
+
+      - name: Build universal
+        run: make ARCH=universal APP_NAME=Quill BUNDLE_ID=com.woosublee.quill CODESIGN_IDENTITY="$CODESIGN_IDENTITY" APP_VERSION="${{ steps.version.outputs.version }}" BUILD_NUMBER="${{ steps.version.outputs.build_number }}" BUILD_TAG="${{ steps.version.outputs.tag }}"
+
+      - name: Create universal DMG
+        run: make dmg ARCH=universal APP_NAME=Quill BUNDLE_ID=com.woosublee.quill CODESIGN_IDENTITY="$CODESIGN_IDENTITY" APP_VERSION="${{ steps.version.outputs.version }}" BUILD_NUMBER="${{ steps.version.outputs.build_number }}" BUILD_TAG="${{ steps.version.outputs.tag }}"
+
+      - name: Sign universal DMG
+        run: codesign --force --sign "$CODESIGN_IDENTITY" build/Quill.dmg
+
+      - name: Save universal DMG
+        run: mv build/Quill.dmg Quill.dmg
+
+      - name: Generate Sparkle appcast
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+          BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
+          DMG_PATH: Quill.dmg
+          APPCAST_PATH: appcast.xml
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: scripts/generate-sparkle-appcast.sh
+
+      - name: Create tag
+        run: |
+          git tag "${{ steps.version.outputs.tag }}" "$GITHUB_SHA"
+          git push origin "refs/tags/${{ steps.version.outputs.tag }}"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          target_commitish: ${{ github.sha }}
+          name: Quill ${{ steps.version.outputs.version }}
+          body: ${{ steps.release_notes.outputs.body }}
+          generate_release_notes: false
+          make_latest: true
+          files: |
+            Quill.dmg
+            appcast.xml
+
+      - name: Cleanup signing artifacts
+        if: always()
+        run: |
+          rm -f "$RUNNER_TEMP/quill_certificate.p12"
+          KPATH="${KEYCHAIN_PATH:-$RUNNER_TEMP/signing.keychain-db}"
+          if [ -f "$KPATH" ]; then
+            security delete-keychain "$KPATH"
+          fi


### PR DESCRIPTION
## 배경

자동 업데이트가 흐르는 공식 릴리스가 지금까지 **로컬에서 수동으로** 빌드·서명되었습니다. 이를 GitHub Actions에서 재현해 릴리스를 자동화합니다.

이미 공증 기반 `release.yml`(Developer ID + notarytool)이 있지만, 이를 쓰려면 인증서 신원이 바뀌어 **기존 사용자의 자동 업데이트가 한 번 끊깁니다**(Sparkle 코드서명 일치 검증 때문에 1회 수동 재설치 필요). 이를 피하기 위해, 현재 로컬과 **동일한 self-signed `Quill` 인증서**를 그대로 CI로 옮깁니다. 같은 인증서라 designated requirement가 동일 → 기존 사용자 자동 업데이트가 끊기지 않습니다. 트레이드오프는 신규 사용자 첫 실행 시 Gatekeeper 경고(공증 안 됨)뿐이며, 이는 현재 로컬 릴리스와 동일한 조건입니다.

## 변경

`.github/workflows/self-signed-release.yml` 신규 추가 (`release.yml`을 베이스로, Developer ID/공증 부분만 self-signed로 치환):

- `workflow_dispatch`로 `tag` 입력받아 수동 실행
- `version.mk`의 `BUILD_TAG`/`APP_VERSION`/`BUILD_NUMBER`와 일치 검증, 기존 태그 중복 거부
- `Quill` 인증서(.p12)를 임시 키체인에 import 후 universal 빌드 + 앱/DMG 서명
- `scripts/generate-sparkle-appcast.sh`로 appcast EdDSA 서명
- `make_latest: true`로 Release 생성 (`Quill.dmg` + `appcast.xml`) — `SUFeedURL`이 `releases/latest/...`라 latest여야 업데이트가 흐름
- 종료 시 키체인/인증서 정리

`release.yml`(notarized)은 향후 공증 전환용으로 **그대로 보존**합니다. 워크플로 테스트(`ManualReleaseWorkflowTests`)는 `manual-release.yml`만 검사하므로 영향 없습니다(통과 확인).

## 필요한 저장소 Secret (3개)

워크플로 동작에는 아래 secret 등록이 필요합니다(값은 등록자가 로컬에서 직접 설정):

- `QUILL_CERTIFICATE_BASE64` — self-signed `Quill` 인증서 `.p12`(개인키 포함)의 base64
- `QUILL_CERTIFICATE_PASSWORD` — 위 `.p12` 비밀번호
- `SPARKLE_PRIVATE_KEY` — appcast 서명용 Sparkle EdDSA 개인키

## 사용법

1. `version.mk` 버전 범프 + `CHANGELOG.md`에 `## [버전]` 섹션 추가 → main 커밋
2. Actions에서 **Self-signed Release** 실행 (`tag=vX.Y.Z`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)