### PR TITLE
Pin codesign identity to Quill in self-signed release

### DIFF
--- a/.github/workflows/self-signed-release.yml
+++ b/.github/workflows/self-signed-release.yml
@@ -123,11 +123,16 @@ jobs:
             -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
           security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+          security default-keychain -s "$KEYCHAIN_PATH"
 
-          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          echo "CODESIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
+          # The Quill certificate is self-signed, so without trust settings it is
+          # not reported by `find-identity -v` (valid only) in this throwaway
+          # keychain — that returned nothing and poisoned CODESIGN_IDENTITY.
+          # codesign can still sign by name, so pin the identity to the cert's CN.
+          echo "Codesigning identities present in keychain:"
+          security find-identity -p codesigning "$KEYCHAIN_PATH" || true
+          echo "CODESIGN_IDENTITY=Quill" >> "$GITHUB_ENV"
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
-          echo "Found signing identity: $IDENTITY"
 
       - name: Build universal
         run: make ARCH=universal APP_NAME=Quill BUNDLE_ID=com.woosublee.quill CODESIGN_IDENTITY="$CODESIGN_IDENTITY" APP_VERSION="${{ steps.version.outputs.version }}" BUILD_NUMBER="${{ steps.version.outputs.build_number }}" BUILD_TAG="${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
## 문제

`self-signed-release.yml`의 첫 실행(v0.1.12)이 `Build universal` 단계에서 실패했습니다:

```
Found signing identity:      0 valid identities found
error: The specified item could not be found in the keychain.
```

## 원인

CI의 임시 키체인에는 trust 설정이 없어서, **self-signed `Quill` 인증서가 `security find-identity -v`(유효한 것만)에 잡히지 않습니다**(로컬에선 trust가 설정돼 있어 valid로 보였음). 그 결과 `CODESIGN_IDENTITY`에 `"0 valid identities found"`라는 문자열이 들어가 codesign이 실패했습니다.

## 수정

codesign은 trust 여부와 무관하게 **이름으로** 서명할 수 있으므로:
- `find-identity -v` 자동 탐색을 제거하고 `CODESIGN_IDENTITY`를 인증서 CN인 `Quill`로 고정
- import한 키체인을 default keychain으로 설정(안전장치)
- 진단용으로 키체인 내 codesigning identity 목록을 로그 출력

빌드 실패로 태그·릴리스는 생성되지 않았으므로, 머지 후 v0.1.12 워크플로를 재실행하면 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)