### PR TITLE
Keep instruction guard active for translated output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,8 @@ test: $(SPARKLE_STAMP)
 	@/tmp/UpdateManagerSafetyTests
 	@swiftc -parse-as-library Tests/BuildMetadataTests.swift -o /tmp/BuildMetadataTests
 	@/tmp/BuildMetadataTests
+	@swiftc -parse-as-library Sources/InstructionExecutionDetector.swift Tests/InstructionExecutionDetectorTests.swift -o /tmp/InstructionExecutionDetectorTests
+	@/tmp/InstructionExecutionDetectorTests
 	@swiftc -parse-as-library Tests/ReleaseSDKCompatibilityTests.swift -o /tmp/ReleaseSDKCompatibilityTests
 	@/tmp/ReleaseSDKCompatibilityTests
 	@swiftc -parse-as-library Sources/AudioInputDevice.swift Tests/SystemAudioInputSelectionTests.swift -o /tmp/SystemAudioInputSelectionTests

--- a/Sources/InstructionExecutionDetector.swift
+++ b/Sources/InstructionExecutionDetector.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+enum InstructionExecutionDetector {
+    private static let instructionMarkers: Set<String> = [
+        "ask", "answer", "compose", "create", "draft", "email", "generate", "make",
+        "message", "prompt", "reply", "respond", "response", "summarize", "tell",
+        "translate", "write", "claude", "chatgpt", "ai", "llm"
+    ]
+
+    private static let stopWords: Set<String> = [
+        "a", "an", "and", "are", "as", "at", "be", "but", "by", "can", "could",
+        "for", "from", "had", "has", "have", "he", "her", "him", "his", "i", "if",
+        "in", "into", "is", "it", "its", "just", "me", "my", "of", "on", "or", "our",
+        "please", "she", "so", "that", "the", "their", "them", "then", "there", "this",
+        "to", "um", "uh", "was", "we", "were", "what", "when", "where", "who", "with",
+        "would", "you", "your"
+    ]
+
+    private static let assistantPreamblePattern = #"(?i)^\s*(sure|certainly|absolutely|here(?:'s| is)|i(?:'d| would) be happy to|i can)\b"#
+
+    static func appearsToHaveExecutedInstruction(
+        rawTranscript: String,
+        cleanedTranscript: String,
+        outputLanguage: String
+    ) -> Bool {
+        let cleanedHasAssistantPreamble = cleanedTranscript.range(
+            of: assistantPreamblePattern,
+            options: .regularExpression
+        ) != nil
+        let rawHasSamePreamble = rawTranscript.range(
+            of: assistantPreamblePattern,
+            options: .regularExpression
+        ) != nil
+
+        if cleanedHasAssistantPreamble && !rawHasSamePreamble {
+            return true
+        }
+
+        guard outputLanguage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return false
+        }
+
+        let rawTokens = significantTokens(in: rawTranscript)
+        let cleanedTokens = significantTokens(in: cleanedTranscript)
+        guard !rawTokens.isEmpty, !cleanedTokens.isEmpty else { return false }
+
+        let rawMarkers = rawTokens.intersection(instructionMarkers)
+        guard !rawMarkers.isEmpty else { return false }
+
+        let preservedMarkers = rawMarkers.intersection(cleanedTokens)
+        let overlap = rawTokens.intersection(cleanedTokens)
+        let overlapRatio = Double(overlap.count) / Double(max(rawTokens.count, 1))
+
+        return preservedMarkers.isEmpty && overlapRatio < 0.35
+    }
+
+    private static func significantTokens(in text: String) -> Set<String> {
+        let normalized = text.lowercased()
+        let parts = normalized.split { character in
+            !character.isLetter && !character.isNumber
+        }
+
+        return Set(parts.map(String.init).filter { token in
+            token.count > 1 && !stopWords.contains(token)
+        })
+    }
+}

--- a/Sources/InstructionExecutionDetector.swift
+++ b/Sources/InstructionExecutionDetector.swift
@@ -16,21 +16,17 @@ enum InstructionExecutionDetector {
         "would", "you", "your"
     ]
 
-    private static let assistantPreamblePattern = #"(?i)^\s*(sure|certainly|absolutely|here(?:'s| is)|i(?:'d| would) be happy to|i can)\b"#
+    private static let assistantPreamblePattern = #"(?i)^\s*(?:(?:sure|certainly|absolutely)\b|here(?:'s| is)\b|i(?:'d| would) be happy to\b|i can\b|(?:claro|por supuesto|con gusto|aquí tienes|aqui tienes)\b|(?:물론입니다|물론이죠|알겠습니다|아래는|다음은|도와드리겠습니다|작성해 드리겠습니다))"#
+    private static let leadingPunctuationPattern = #"^[\s,.:;!?\"'“”‘’()\[\]{}—–-]+"#
+    private static let leadingFillerPattern = #"(?i)^\s*(?:(?:(?:um+|uh+|erm|er|ah+|eh+|yeah|yep|well|okay|ok|so)\b|음+|어+|저기)[\s,.:;!?—–-]*)+"#
 
     static func appearsToHaveExecutedInstruction(
         rawTranscript: String,
         cleanedTranscript: String,
         outputLanguage: String
     ) -> Bool {
-        let cleanedHasAssistantPreamble = cleanedTranscript.range(
-            of: assistantPreamblePattern,
-            options: .regularExpression
-        ) != nil
-        let rawHasSamePreamble = rawTranscript.range(
-            of: assistantPreamblePattern,
-            options: .regularExpression
-        ) != nil
+        let cleanedHasAssistantPreamble = hasAssistantPreamble(in: cleanedTranscript)
+        let rawHasSamePreamble = hasAssistantPreamble(in: rawTranscript)
 
         if cleanedHasAssistantPreamble && !rawHasSamePreamble {
             return true
@@ -52,6 +48,14 @@ enum InstructionExecutionDetector {
         let overlapRatio = Double(overlap.count) / Double(max(rawTokens.count, 1))
 
         return preservedMarkers.isEmpty && overlapRatio < 0.35
+    }
+
+    private static func hasAssistantPreamble(in text: String) -> Bool {
+        let normalized = text
+            .replacingOccurrences(of: leadingPunctuationPattern, with: "", options: .regularExpression)
+            .replacingOccurrences(of: leadingFillerPattern, with: "", options: .regularExpression)
+
+        return normalized.range(of: assistantPreamblePattern, options: .regularExpression) != nil
     }
 
     private static func significantTokens(in text: String) -> Set<String> {

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -657,61 +657,16 @@ Model: \(model)
         value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private static let instructionMarkers: Set<String> = [
-        "ask", "answer", "compose", "create", "draft", "email", "generate", "make",
-        "message", "prompt", "reply", "respond", "response", "summarize", "tell",
-        "translate", "write", "claude", "chatgpt", "ai", "llm"
-    ]
-
     private func appearsToHaveExecutedInstruction(
         rawTranscript: String,
         cleanedTranscript: String,
         outputLanguage: String
     ) -> Bool {
-        guard outputLanguage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
-
-        let rawTokens = significantTokens(in: rawTranscript)
-        let cleanedTokens = significantTokens(in: cleanedTranscript)
-        guard !rawTokens.isEmpty, !cleanedTokens.isEmpty else { return false }
-
-        let rawMarkers = rawTokens.intersection(Self.instructionMarkers)
-        guard !rawMarkers.isEmpty else { return false }
-
-        let preservedMarkers = rawMarkers.intersection(cleanedTokens)
-        let overlap = rawTokens.intersection(cleanedTokens)
-        let overlapRatio = Double(overlap.count) / Double(max(rawTokens.count, 1))
-        let assistantPreamblePattern = #"(?i)^\s*(sure|certainly|absolutely|here(?:'s| is)|i(?:'d| would) be happy to|i can)\b"#
-        let cleanedHasAssistantPreamble = cleanedTranscript.range(
-            of: assistantPreamblePattern,
-            options: .regularExpression
-        ) != nil
-        let rawHasSamePreamble = rawTranscript.range(
-            of: assistantPreamblePattern,
-            options: .regularExpression
-        ) != nil
-
-        return (cleanedHasAssistantPreamble && !rawHasSamePreamble)
-            || (preservedMarkers.isEmpty && overlapRatio < 0.35)
-    }
-
-    private static let stopWords: Set<String> = [
-        "a", "an", "and", "are", "as", "at", "be", "but", "by", "can", "could",
-        "for", "from", "had", "has", "have", "he", "her", "him", "his", "i", "if",
-        "in", "into", "is", "it", "its", "just", "me", "my", "of", "on", "or", "our",
-        "please", "she", "so", "that", "the", "their", "them", "then", "there", "this",
-        "to", "um", "uh", "was", "we", "were", "what", "when", "where", "who", "with",
-        "would", "you", "your"
-    ]
-
-    private func significantTokens(in text: String) -> Set<String> {
-        let normalized = text.lowercased()
-        let parts = normalized.split { character in
-            !character.isLetter && !character.isNumber
-        }
-
-        return Set(parts.map(String.init).filter { token in
-            token.count > 1 && !Self.stopWords.contains(token)
-        })
+        InstructionExecutionDetector.appearsToHaveExecutedInstruction(
+            rawTranscript: rawTranscript,
+            cleanedTranscript: cleanedTranscript,
+            outputLanguage: outputLanguage
+        )
     }
 
     private func mergedVocabularyTerms(rawVocabulary: String) -> [String] {

--- a/Tests/BuildMetadataTests.swift
+++ b/Tests/BuildMetadataTests.swift
@@ -141,7 +141,7 @@ struct BuildMetadataTests {
         assertContains(infoPlist, "<key>SUEnableAutomaticChecks</key>")
         assertContains(infoPlist, "<key>SUAutomaticallyUpdate</key>")
         assertContains(infoPlist, "<key>SUUpdateCheckInterval</key>")
-        assertContains(infoPlist, "<integer>604800</integer>")
+        assertContains(infoPlist, "<integer>86400</integer>")
 
         assertContains(makefile, "SPARKLE_VERSION ?= 2.9.2")
         assertContains(makefile, "swift build --product SparkleResolver")

--- a/Tests/InstructionExecutionDetectorTests.swift
+++ b/Tests/InstructionExecutionDetectorTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+@main
+struct InstructionExecutionDetectorTests {
+    static func main() {
+        testAssistantPreambleIsDetectedWithOutputLanguage()
+        testTokenOverlapHeuristicIsSkippedWithOutputLanguage()
+        testRawAssistantPreambleDoesNotTriggerDetection()
+        testTokenOverlapHeuristicStillRunsWithoutOutputLanguage()
+        print("InstructionExecutionDetectorTests passed")
+    }
+
+    private static func testAssistantPreambleIsDetectedWithOutputLanguage() {
+        let detected = InstructionExecutionDetector.appearsToHaveExecutedInstruction(
+            rawTranscript: "write a reply to Sarah saying sorry for the delay",
+            cleanedTranscript: "Sure, here's a reply you can send to Sarah: Sorry for the delay.",
+            outputLanguage: "Korean"
+        )
+
+        assert(detected, "Expected assistant preamble detection to stay active with an output language")
+    }
+
+    private static func testTokenOverlapHeuristicIsSkippedWithOutputLanguage() {
+        let detected = InstructionExecutionDetector.appearsToHaveExecutedInstruction(
+            rawTranscript: "write a reply to Sarah saying sorry for the delay",
+            cleanedTranscript: "Sarah에게 지연에 대해 사과하는 답장을 작성해 주세요.",
+            outputLanguage: "Korean"
+        )
+
+        assert(!detected, "Expected token-overlap detection to be skipped with an output language")
+    }
+
+    private static func testRawAssistantPreambleDoesNotTriggerDetection() {
+        let detected = InstructionExecutionDetector.appearsToHaveExecutedInstruction(
+            rawTranscript: "Sure, here's what I want to say",
+            cleanedTranscript: "Sure, here's what I want to say.",
+            outputLanguage: "Korean"
+        )
+
+        assert(!detected, "Expected spoken assistant preamble to avoid false positives")
+    }
+
+    private static func testTokenOverlapHeuristicStillRunsWithoutOutputLanguage() {
+        let detected = InstructionExecutionDetector.appearsToHaveExecutedInstruction(
+            rawTranscript: "write an email to Sarah saying sorry for the delay",
+            cleanedTranscript: "I apologize for the delayed response and appreciate your patience.",
+            outputLanguage: ""
+        )
+
+        assert(detected, "Expected token-overlap detection to keep running without an output language")
+    }
+}

--- a/Tests/InstructionExecutionDetectorTests.swift
+++ b/Tests/InstructionExecutionDetectorTests.swift
@@ -4,8 +4,11 @@ import Foundation
 struct InstructionExecutionDetectorTests {
     static func main() {
         testAssistantPreambleIsDetectedWithOutputLanguage()
+        testKoreanAssistantPreambleIsDetectedWithOutputLanguage()
+        testSpanishAssistantPreambleIsDetectedWithOutputLanguage()
         testTokenOverlapHeuristicIsSkippedWithOutputLanguage()
         testRawAssistantPreambleDoesNotTriggerDetection()
+        testRawAssistantPreambleWithLeadingFillerDoesNotTriggerDetection()
         testTokenOverlapHeuristicStillRunsWithoutOutputLanguage()
         print("InstructionExecutionDetectorTests passed")
     }
@@ -18,6 +21,26 @@ struct InstructionExecutionDetectorTests {
         )
 
         assert(detected, "Expected assistant preamble detection to stay active with an output language")
+    }
+
+    private static func testKoreanAssistantPreambleIsDetectedWithOutputLanguage() {
+        let detected = InstructionExecutionDetector.appearsToHaveExecutedInstruction(
+            rawTranscript: "write a reply to Sarah saying sorry for the delay",
+            cleanedTranscript: "물론입니다. Sarah에게 보낼 답장은 다음과 같습니다: 지연되어 죄송합니다.",
+            outputLanguage: "Korean"
+        )
+
+        assert(detected, "Expected Korean assistant preamble detection to stay active with an output language")
+    }
+
+    private static func testSpanishAssistantPreambleIsDetectedWithOutputLanguage() {
+        let detected = InstructionExecutionDetector.appearsToHaveExecutedInstruction(
+            rawTranscript: "write a reply to Sarah saying sorry for the delay",
+            cleanedTranscript: "Claro, aquí tienes una respuesta para Sarah: Perdón por la demora.",
+            outputLanguage: "Spanish"
+        )
+
+        assert(detected, "Expected Spanish assistant preamble detection to stay active with an output language")
     }
 
     private static func testTokenOverlapHeuristicIsSkippedWithOutputLanguage() {
@@ -38,6 +61,16 @@ struct InstructionExecutionDetectorTests {
         )
 
         assert(!detected, "Expected spoken assistant preamble to avoid false positives")
+    }
+
+    private static func testRawAssistantPreambleWithLeadingFillerDoesNotTriggerDetection() {
+        let detected = InstructionExecutionDetector.appearsToHaveExecutedInstruction(
+            rawTranscript: "uh, sure, here's what I want to say",
+            cleanedTranscript: "Sure, here's what I want to say.",
+            outputLanguage: "Korean"
+        )
+
+        assert(!detected, "Expected spoken assistant preamble with leading filler to avoid false positives")
     }
 
     private static func testTokenOverlapHeuristicStillRunsWithoutOutputLanguage() {


### PR DESCRIPTION
## Summary
- split instruction-execution detection into a small testable detector
- keep assistant-preamble detection active even when an output language is configured
- skip only token-overlap detection for translated output, where cross-language overlap is unreliable
- update the stale Sparkle update interval metadata test expectation to match the current daily check interval

Fixes #158

## Tests
- `swiftc -parse-as-library Sources/InstructionExecutionDetector.swift Tests/InstructionExecutionDetectorTests.swift -o /tmp/InstructionExecutionDetectorTests && /tmp/InstructionExecutionDetectorTests`
- `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 음성/전사 결과에서 지시 실행 여부를 더 정교하게 판별하는 감지 기능이 추가되었습니다.
  * 출력 언어가 설정된 경우와 비어 있는 경우에 따라 판단 방식이 달라집니다.

* **Bug Fixes**
  * 명령 수행 여부 판단 로직이 더 일관되게 동작하도록 개선되었습니다.
  * 자동 업데이트 점검 주기 검증값이 최신 설정에 맞게 조정되었습니다.

* **Tests**
  * 새 감지 로직에 대한 검증이 추가되어 주요 동작 시나리오를 확인합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->