### PR TITLE
Move audio import copying off the main thread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,6 +258,8 @@ test: $(SPARKLE_STAMP)
 	@/tmp/InstructionExecutionDetectorTests
 	@swiftc -parse-as-library Tests/ReleaseSDKCompatibilityTests.swift -o /tmp/ReleaseSDKCompatibilityTests
 	@/tmp/ReleaseSDKCompatibilityTests
+	@framework="$$(cat "$(SPARKLE_STAMP)")"; framework_parent="$$(dirname "$$framework")"; swiftc -parse-as-library -F "$$framework_parent" -framework Sparkle -Xlinker -rpath -Xlinker "$$framework_parent" -target $(shell uname -m)-apple-macosx13.0 $(filter-out Sources/App.swift,$(SOURCES)) Tests/AudioImportFileCopyTests.swift -o /tmp/AudioImportFileCopyTests
+	@/tmp/AudioImportFileCopyTests
 	@swiftc -parse-as-library Sources/AudioInputDevice.swift Tests/SystemAudioInputSelectionTests.swift -o /tmp/SystemAudioInputSelectionTests
 	@/tmp/SystemAudioInputSelectionTests
 	@swiftc -parse-as-library Tests/SystemAudioRecorderSourceTests.swift -o /tmp/SystemAudioRecorderSourceTests

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1888,7 +1888,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         persistShortcut(binding, key: key)
     }
 
-    struct SavedAudioFile {
+    struct SavedAudioFile: Sendable {
         let fileName: String
         let fileURL: URL
     }
@@ -1976,6 +1976,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
         } catch {
             return nil
         }
+    }
+
+    static func saveSecurityScopedAudioFileOffMain(from fileURL: URL) async -> SavedAudioFile? {
+        await Task.detached(priority: .userInitiated) {
+            let accessGranted = fileURL.startAccessingSecurityScopedResource()
+            defer {
+                if accessGranted {
+                    fileURL.stopAccessingSecurityScopedResource()
+                }
+            }
+            return Self.saveAudioFile(from: fileURL)
+        }.value
     }
 
     private static func deleteAudioFile(_ fileName: String) {
@@ -2450,72 +2462,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let jobID = UUID()
         let noteID = UUID()
         let startedAt = Date()
-        let accessGranted = fileURL.startAccessingSecurityScopedResource()
-        defer {
-            if accessGranted {
-                fileURL.stopAccessingSecurityScopedResource()
-            }
-        }
-        guard let savedAudioFile = Self.saveAudioFile(from: fileURL) else {
-            errorMessage = "Unable to save the audio file. Check disk space or file permissions and try again."
-            return
-        }
         let importContextSummary = AudioImportOptions.importContextSummary(for: fileURL.lastPathComponent)
-        let placeholder = PipelineHistoryItem(
-            id: noteID,
-            timestamp: startedAt,
-            recordingStartedAt: nil,
-            recordingEndedAt: nil,
-            calendarMatch: nil,
-            rawTranscript: "",
-            postProcessedTranscript: "",
-            postProcessingPrompt: nil,
-            systemPrompt: Self.resolvedSystemPrompt(customSystemPrompt),
-            contextSummary: importContextSummary,
-            contextPrompt: nil,
-            contextScreenshotDataURL: nil,
-            contextScreenshotStatus: "No screenshot",
-            postProcessingStatus: "importing",
-            debugStatus: "Importing audio",
-            customVocabulary: customVocabulary,
-            customSystemPrompt: customSystemPrompt,
-            audioFileName: savedAudioFile.fileName,
-            usedLocalTranscription: configuration.useLocalTranscription,
-            usedContextCapture: false,
-            usedPostProcessing: !disablePostProcessing,
-            transcriptionLanguageCode: transcriptionLanguage.code,
-            localTranscriptionModelID: configuration.localTranscriptionModel.id,
-            contextAppName: nil,
-            contextBundleIdentifier: nil,
-            contextWindowTitle: nil
-        )
-
-        do {
-            let removedStoredFiles = try appendPipelineHistoryItem(placeholder)
-            for removedAssets in removedStoredFiles {
-                Self.deleteStoredFiles(removedAssets)
-            }
-        } catch {
-            Self.deleteAudioFile(savedAudioFile.fileName)
-            errorMessage = "Unable to save imported audio note: \(error.localizedDescription)"
-            return
-        }
-
-        registerTranscriptionJob(
-            id: jobID,
-            startedAt: startedAt,
-            sessionIntent: .dictation,
-            sessionContext: nil,
-            contextTask: nil,
-            recordingStartedAt: nil,
-            recordingEndedAt: nil,
-            isImportedAudio: true
-        )
-        updateTranscriptionJob(jobID) {
-            $0.liveNoteID = noteID
-            $0.audioFileName = savedAudioFile.fileName
-        }
-
         let postProcessingService = PostProcessingService(
             apiKey: apiKey,
             baseURL: apiBaseURL,
@@ -2534,95 +2481,161 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let capturedPostProcessingEnabled = !disablePostProcessing
         let capturedPressEnterCommandEnabled = isPressEnterVoiceCommandEnabled
 
-        let task = Task { [weak self] in
-            guard let self else { return }
-            let importedContext = AppContext(
-                appName: nil,
-                bundleIdentifier: nil,
-                windowTitle: nil,
-                selectedText: nil,
-                currentActivity: importContextSummary,
-                contextSystemPrompt: nil,
+        Task { [weak self] in
+            guard let savedAudioFile = await Self.saveSecurityScopedAudioFileOffMain(from: fileURL) else {
+                self?.errorMessage = "Unable to save the audio file. Check disk space or file permissions and try again."
+                return
+            }
+            guard let self else {
+                Self.deleteAudioFile(savedAudioFile.fileName)
+                return
+            }
+
+            let placeholder = PipelineHistoryItem(
+                id: noteID,
+                timestamp: startedAt,
+                recordingStartedAt: nil,
+                recordingEndedAt: nil,
+                calendarMatch: nil,
+                rawTranscript: "",
+                postProcessedTranscript: "",
+                postProcessingPrompt: nil,
+                systemPrompt: Self.resolvedSystemPrompt(capturedCustomSystemPrompt),
+                contextSummary: importContextSummary,
                 contextPrompt: nil,
-                screenshotDataURL: nil,
-                screenshotMimeType: nil,
-                screenshotError: "No screenshot"
+                contextScreenshotDataURL: nil,
+                contextScreenshotStatus: "No screenshot",
+                postProcessingStatus: "importing",
+                debugStatus: "Importing audio",
+                customVocabulary: capturedCustomVocabulary,
+                customSystemPrompt: capturedCustomSystemPrompt,
+                audioFileName: savedAudioFile.fileName,
+                usedLocalTranscription: configuration.useLocalTranscription,
+                usedContextCapture: false,
+                usedPostProcessing: capturedPostProcessingEnabled,
+                transcriptionLanguageCode: capturedTranscriptionLanguage.code,
+                localTranscriptionModelID: configuration.localTranscriptionModel.id,
+                contextAppName: nil,
+                contextBundleIdentifier: nil,
+                contextWindowTitle: nil
             )
+
             do {
-                let transcriptionService = try TranscriptionService(
-                    apiKey: capturedApiKey,
-                    baseURL: capturedApiBaseURL,
-                    useLocalTranscription: configuration.useLocalTranscription,
-                    localWhisperPath: capturedLocalWhisperPath.isEmpty ? nil : capturedLocalWhisperPath,
-                    transcriptionLanguage: capturedTranscriptionLanguage,
-                    localTranscriptionModel: configuration.localTranscriptionModel,
-                    transcriptionModel: capturedTranscriptionModel
-                )
-                let rawTranscript = try await transcriptionService.transcribe(fileURL: savedAudioFile.fileURL)
-                let parsedTranscript = Self.parseTranscriptCommands(
-                    from: rawTranscript,
-                    pressEnterCommandEnabled: capturedPressEnterCommandEnabled
-                )
-                let result = await self.processTranscript(
-                    parsedTranscript.transcript,
-                    intent: .dictation,
-                    context: importedContext,
-                    postProcessingService: postProcessingService,
-                    customVocabulary: capturedCustomVocabulary,
-                    customSystemPrompt: capturedCustomSystemPrompt,
-                    outputLanguage: capturedOutputLanguage,
-                    postProcessingEnabled: capturedPostProcessingEnabled
-                )
-                let processingStatus = Self.statusMessage(
-                    for: result.outcome,
-                    parsedTranscript: parsedTranscript
-                )
-                await MainActor.run {
-                    self.recordPipelineHistoryEntry(
-                        jobID: jobID,
-                        rawTranscript: parsedTranscript.transcript,
-                        postProcessedTranscript: result.finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
-                        postProcessingPrompt: result.prompt,
-                        systemPrompt: Self.resolvedSystemPrompt(capturedCustomSystemPrompt),
-                        context: importedContext,
-                        processingStatus: processingStatus,
-                        intent: .dictation,
-                        audioFileName: savedAudioFile.fileName,
-                        useLocalTranscriptionOverride: configuration.useLocalTranscription,
-                        localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id,
-                        usedContextCaptureOverride: false,
-                        usedPostProcessingOverride: capturedPostProcessingEnabled,
-                        transcriptionLanguageCodeOverride: capturedTranscriptionLanguage.code,
-                        customVocabularyOverride: capturedCustomVocabulary,
-                        customSystemPromptOverride: capturedCustomSystemPrompt
-                    )
-                    self.finishTranscriptionJob(jobID)
+                let removedStoredFiles = try self.appendPipelineHistoryItem(placeholder)
+                for removedAssets in removedStoredFiles {
+                    Self.deleteStoredFiles(removedAssets)
                 }
             } catch {
-                await MainActor.run {
-                    self.recordPipelineHistoryEntry(
-                        jobID: jobID,
-                        rawTranscript: "",
-                        postProcessedTranscript: "",
-                        postProcessingPrompt: "",
-                        systemPrompt: Self.resolvedSystemPrompt(capturedCustomSystemPrompt),
-                        context: importedContext,
-                        processingStatus: "Error: \(error.localizedDescription)",
-                        intent: .dictation,
-                        audioFileName: savedAudioFile.fileName,
-                        useLocalTranscriptionOverride: configuration.useLocalTranscription,
-                        localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id,
-                        usedContextCaptureOverride: false,
-                        usedPostProcessingOverride: capturedPostProcessingEnabled,
-                        transcriptionLanguageCodeOverride: capturedTranscriptionLanguage.code,
-                        customVocabularyOverride: capturedCustomVocabulary,
-                        customSystemPromptOverride: capturedCustomSystemPrompt
+                Self.deleteAudioFile(savedAudioFile.fileName)
+                self.errorMessage = "Unable to save imported audio note: \(error.localizedDescription)"
+                return
+            }
+
+            self.registerTranscriptionJob(
+                id: jobID,
+                startedAt: startedAt,
+                sessionIntent: .dictation,
+                sessionContext: nil,
+                contextTask: nil,
+                recordingStartedAt: nil,
+                recordingEndedAt: nil,
+                isImportedAudio: true
+            )
+            self.updateTranscriptionJob(jobID) {
+                $0.liveNoteID = noteID
+                $0.audioFileName = savedAudioFile.fileName
+            }
+
+            let task = Task { [weak self] in
+                guard let self else { return }
+                let importedContext = AppContext(
+                    appName: nil,
+                    bundleIdentifier: nil,
+                    windowTitle: nil,
+                    selectedText: nil,
+                    currentActivity: importContextSummary,
+                    contextSystemPrompt: nil,
+                    contextPrompt: nil,
+                    screenshotDataURL: nil,
+                    screenshotMimeType: nil,
+                    screenshotError: "No screenshot"
+                )
+                do {
+                    let transcriptionService = try TranscriptionService(
+                        apiKey: capturedApiKey,
+                        baseURL: capturedApiBaseURL,
+                        useLocalTranscription: configuration.useLocalTranscription,
+                        localWhisperPath: capturedLocalWhisperPath.isEmpty ? nil : capturedLocalWhisperPath,
+                        transcriptionLanguage: capturedTranscriptionLanguage,
+                        localTranscriptionModel: configuration.localTranscriptionModel,
+                        transcriptionModel: capturedTranscriptionModel
                     )
-                    self.finishTranscriptionJob(jobID)
+                    let rawTranscript = try await transcriptionService.transcribe(fileURL: savedAudioFile.fileURL)
+                    let parsedTranscript = Self.parseTranscriptCommands(
+                        from: rawTranscript,
+                        pressEnterCommandEnabled: capturedPressEnterCommandEnabled
+                    )
+                    let result = await self.processTranscript(
+                        parsedTranscript.transcript,
+                        intent: .dictation,
+                        context: importedContext,
+                        postProcessingService: postProcessingService,
+                        customVocabulary: capturedCustomVocabulary,
+                        customSystemPrompt: capturedCustomSystemPrompt,
+                        outputLanguage: capturedOutputLanguage,
+                        postProcessingEnabled: capturedPostProcessingEnabled
+                    )
+                    let processingStatus = Self.statusMessage(
+                        for: result.outcome,
+                        parsedTranscript: parsedTranscript
+                    )
+                    await MainActor.run {
+                        self.recordPipelineHistoryEntry(
+                            jobID: jobID,
+                            rawTranscript: parsedTranscript.transcript,
+                            postProcessedTranscript: result.finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
+                            postProcessingPrompt: result.prompt,
+                            systemPrompt: Self.resolvedSystemPrompt(capturedCustomSystemPrompt),
+                            context: importedContext,
+                            processingStatus: processingStatus,
+                            intent: .dictation,
+                            audioFileName: savedAudioFile.fileName,
+                            useLocalTranscriptionOverride: configuration.useLocalTranscription,
+                            localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id,
+                            usedContextCaptureOverride: false,
+                            usedPostProcessingOverride: capturedPostProcessingEnabled,
+                            transcriptionLanguageCodeOverride: capturedTranscriptionLanguage.code,
+                            customVocabularyOverride: capturedCustomVocabulary,
+                            customSystemPromptOverride: capturedCustomSystemPrompt
+                        )
+                        self.finishTranscriptionJob(jobID)
+                    }
+                } catch {
+                    await MainActor.run {
+                        self.recordPipelineHistoryEntry(
+                            jobID: jobID,
+                            rawTranscript: "",
+                            postProcessedTranscript: "",
+                            postProcessingPrompt: "",
+                            systemPrompt: Self.resolvedSystemPrompt(capturedCustomSystemPrompt),
+                            context: importedContext,
+                            processingStatus: "Error: \(error.localizedDescription)",
+                            intent: .dictation,
+                            audioFileName: savedAudioFile.fileName,
+                            useLocalTranscriptionOverride: configuration.useLocalTranscription,
+                            localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id,
+                            usedContextCaptureOverride: false,
+                            usedPostProcessingOverride: capturedPostProcessingEnabled,
+                            transcriptionLanguageCodeOverride: capturedTranscriptionLanguage.code,
+                            customVocabularyOverride: capturedCustomVocabulary,
+                            customSystemPromptOverride: capturedCustomSystemPrompt
+                        )
+                        self.finishTranscriptionJob(jobID)
+                    }
                 }
             }
+            self.updateTranscriptionJob(jobID) { $0.task = task }
         }
-        updateTranscriptionJob(jobID) { $0.task = task }
     }
 
     @MainActor

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2571,6 +2571,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         transcriptionModel: capturedTranscriptionModel
                     )
                     let rawTranscript = try await transcriptionService.transcribe(fileURL: savedAudioFile.fileURL)
+                    try Task.checkCancellation()
                     let parsedTranscript = Self.parseTranscriptCommands(
                         from: rawTranscript,
                         pressEnterCommandEnabled: capturedPressEnterCommandEnabled
@@ -2585,53 +2586,56 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         outputLanguage: capturedOutputLanguage,
                         postProcessingEnabled: capturedPostProcessingEnabled
                     )
+                    try Task.checkCancellation()
                     let processingStatus = Self.statusMessage(
                         for: result.outcome,
                         parsedTranscript: parsedTranscript
                     )
-                    await MainActor.run {
-                        self.recordPipelineHistoryEntry(
-                            jobID: jobID,
-                            rawTranscript: parsedTranscript.transcript,
-                            postProcessedTranscript: result.finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
-                            postProcessingPrompt: result.prompt,
-                            systemPrompt: Self.resolvedSystemPrompt(capturedCustomSystemPrompt),
-                            context: importedContext,
-                            processingStatus: processingStatus,
-                            intent: .dictation,
-                            audioFileName: savedAudioFile.fileName,
-                            useLocalTranscriptionOverride: configuration.useLocalTranscription,
-                            localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id,
-                            usedContextCaptureOverride: false,
-                            usedPostProcessingOverride: capturedPostProcessingEnabled,
-                            transcriptionLanguageCodeOverride: capturedTranscriptionLanguage.code,
-                            customVocabularyOverride: capturedCustomVocabulary,
-                            customSystemPromptOverride: capturedCustomSystemPrompt
-                        )
-                        self.finishTranscriptionJob(jobID)
-                    }
+                    self.recordPipelineHistoryEntry(
+                        jobID: jobID,
+                        rawTranscript: parsedTranscript.transcript,
+                        postProcessedTranscript: result.finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
+                        postProcessingPrompt: result.prompt,
+                        systemPrompt: Self.resolvedSystemPrompt(capturedCustomSystemPrompt),
+                        context: importedContext,
+                        processingStatus: processingStatus,
+                        intent: .dictation,
+                        audioFileName: savedAudioFile.fileName,
+                        useLocalTranscriptionOverride: configuration.useLocalTranscription,
+                        localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id,
+                        usedContextCaptureOverride: false,
+                        usedPostProcessingOverride: capturedPostProcessingEnabled,
+                        transcriptionLanguageCodeOverride: capturedTranscriptionLanguage.code,
+                        customVocabularyOverride: capturedCustomVocabulary,
+                        customSystemPromptOverride: capturedCustomSystemPrompt
+                    )
+                    self.finishTranscriptionJob(jobID)
+                } catch is CancellationError {
+                    self.finishTranscriptionJob(jobID)
                 } catch {
-                    await MainActor.run {
-                        self.recordPipelineHistoryEntry(
-                            jobID: jobID,
-                            rawTranscript: "",
-                            postProcessedTranscript: "",
-                            postProcessingPrompt: "",
-                            systemPrompt: Self.resolvedSystemPrompt(capturedCustomSystemPrompt),
-                            context: importedContext,
-                            processingStatus: "Error: \(error.localizedDescription)",
-                            intent: .dictation,
-                            audioFileName: savedAudioFile.fileName,
-                            useLocalTranscriptionOverride: configuration.useLocalTranscription,
-                            localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id,
-                            usedContextCaptureOverride: false,
-                            usedPostProcessingOverride: capturedPostProcessingEnabled,
-                            transcriptionLanguageCodeOverride: capturedTranscriptionLanguage.code,
-                            customVocabularyOverride: capturedCustomVocabulary,
-                            customSystemPromptOverride: capturedCustomSystemPrompt
-                        )
+                    guard !Task.isCancelled else {
                         self.finishTranscriptionJob(jobID)
+                        return
                     }
+                    self.recordPipelineHistoryEntry(
+                        jobID: jobID,
+                        rawTranscript: "",
+                        postProcessedTranscript: "",
+                        postProcessingPrompt: "",
+                        systemPrompt: Self.resolvedSystemPrompt(capturedCustomSystemPrompt),
+                        context: importedContext,
+                        processingStatus: "Error: \(error.localizedDescription)",
+                        intent: .dictation,
+                        audioFileName: savedAudioFile.fileName,
+                        useLocalTranscriptionOverride: configuration.useLocalTranscription,
+                        localTranscriptionModelIDOverride: configuration.localTranscriptionModel.id,
+                        usedContextCaptureOverride: false,
+                        usedPostProcessingOverride: capturedPostProcessingEnabled,
+                        transcriptionLanguageCodeOverride: capturedTranscriptionLanguage.code,
+                        customVocabularyOverride: capturedCustomVocabulary,
+                        customSystemPromptOverride: capturedCustomSystemPrompt
+                    )
+                    self.finishTranscriptionJob(jobID)
                 }
             }
             self.updateTranscriptionJob(jobID) { $0.task = task }

--- a/Tests/AudioImportFileCopyTests.swift
+++ b/Tests/AudioImportFileCopyTests.swift
@@ -29,7 +29,7 @@ struct AudioImportFileCopyTests {
 
     private static func testOffMainCopyReturnsNilForMissingFile() async {
         let missingURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("quill-missing-audio-import-")
+            .appendingPathComponent("quill-missing-audio-import-\(ProcessInfo.processInfo.globallyUniqueString)")
             .appendingPathExtension("mp3")
 
         let saved = await AppState.saveSecurityScopedAudioFileOffMain(from: missingURL)

--- a/Tests/AudioImportFileCopyTests.swift
+++ b/Tests/AudioImportFileCopyTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+@main
+struct AudioImportFileCopyTests {
+    static func main() async throws {
+        try await testOffMainCopyPreservesExtensionAndContents()
+        await testOffMainCopyReturnsNilForMissingFile()
+        try testImportAudioFileUsesOffMainSecurityScopedCopy()
+        print("AudioImportFileCopyTests passed")
+    }
+
+    private static func testOffMainCopyPreservesExtensionAndContents() async throws {
+        let sourceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-audio-import-copy-source-\(ProcessInfo.processInfo.globallyUniqueString)")
+            .appendingPathExtension("m4a")
+        let contents = Data("audio import copy test".utf8)
+        try contents.write(to: sourceURL)
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        guard let saved = await AppState.saveSecurityScopedAudioFileOffMain(from: sourceURL) else {
+            preconditionFailure("Expected off-main audio copy to succeed")
+        }
+        defer { try? FileManager.default.removeItem(at: saved.fileURL) }
+
+        precondition(saved.fileName.hasSuffix(".m4a"), "Expected copied file to preserve supported extension")
+        let copied = try Data(contentsOf: saved.fileURL)
+        precondition(copied == contents, "Expected copied file contents to match source")
+    }
+
+    private static func testOffMainCopyReturnsNilForMissingFile() async {
+        let missingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-missing-audio-import-")
+            .appendingPathExtension("mp3")
+
+        let saved = await AppState.saveSecurityScopedAudioFileOffMain(from: missingURL)
+
+        precondition(saved == nil, "Expected missing source file to fail off-main copy")
+    }
+
+    private static func testImportAudioFileUsesOffMainSecurityScopedCopy() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+
+        assertContains(source, "static func saveSecurityScopedAudioFileOffMain(from fileURL: URL) async -> SavedAudioFile?")
+        assertContains(source, "await Task.detached(priority: .userInitiated)")
+        assertContains(source, "let accessGranted = fileURL.startAccessingSecurityScopedResource()")
+        assertContains(source, "fileURL.stopAccessingSecurityScopedResource()")
+        assertContains(source, "guard let savedAudioFile = await Self.saveSecurityScopedAudioFileOffMain(from: fileURL)")
+        assertDoesNotContain(importAudioFileBody(in: source), "Self.saveAudioFile(from: fileURL)")
+        assertDoesNotContain(importAudioFileBody(in: source), "startAccessingSecurityScopedResource()")
+    }
+
+    private static func importAudioFileBody(in source: String) -> String {
+        guard let start = source.range(of: "func importAudioFile(_ fileURL: URL, mode: NoteBrowserTranscriptionMode)"),
+              let end = source.range(of: "\n    @MainActor\n    func retryTranscription", range: start.upperBound..<source.endIndex) else {
+            preconditionFailure("Could not find importAudioFile body")
+        }
+        return String(source[start.lowerBound..<end.lowerBound])
+    }
+
+    private static func assertContains(_ text: String, _ expected: String) {
+        precondition(text.contains(expected), "Expected content to contain \(expected)")
+    }
+
+    private static func assertDoesNotContain(_ text: String, _ unexpected: String) {
+        precondition(!text.contains(unexpected), "Expected content not to contain \(unexpected)")
+    }
+}


### PR DESCRIPTION
## Summary
- copy imported audio files through a security-scoped off-main helper
- keep imported-audio placeholder creation after a successful copy and preserve existing cleanup semantics
- add coverage for off-main copy behavior and the import threading structure

Fixes #47

## Tests
- `swiftc -parse-as-library -F "$framework_parent" -framework Sparkle -Xlinker -rpath -Xlinker "$framework_parent" -target "$(uname -m)-apple-macosx13.0" $(find Sources -name "*.swift" -type f | LC_ALL=C sort | grep -v "Sources/App.swift") Tests/AudioImportFileCopyTests.swift -o /tmp/AudioImportFileCopyTests && /tmp/AudioImportFileCopyTests`
- `make test`
- `make all CODESIGN_IDENTITY=Quill`
- `codesign --verify --deep --strict --verbose=2 build/Quill.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 오디오 파일 가져오기 시 보안 스코프 파일 접근이 더 안정적으로 처리되도록 개선했습니다.
  * 가져온 파일 저장, 전사 작업 등록, 결과 기록 흐름이 비동기적으로 이어져 처리 중 끊김과 실패 가능성을 줄였습니다.
  * 파일이 없거나 복사에 실패한 경우 더 일관되게 중단하도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->