### PR TITLE
Polish Note Browser audio and toolbar layout

### DIFF
--- a/Sources/AudioWaveformHeights.swift
+++ b/Sources/AudioWaveformHeights.swift
@@ -1,6 +1,28 @@
 import Foundation
 
 enum AudioWaveformHeights {
+    struct Layout {
+        let barCount: Int
+        let barWidth: CGFloat
+        let gap: CGFloat
+    }
+
+    static func layout(width: CGFloat, barCount: Int = 80, preferredGap: CGFloat = 2) -> Layout {
+        guard width > 0, barCount > 0 else {
+            return Layout(barCount: 0, barWidth: 0, gap: 0)
+        }
+
+        let minimumBarWidth: CGFloat = 1
+        let maxGap = barCount > 1
+            ? max(0, (width - CGFloat(barCount) * minimumBarWidth) / CGFloat(barCount - 1))
+            : 0
+        let gap = min(preferredGap, maxGap)
+        let totalGap = gap * CGFloat(max(0, barCount - 1))
+        let barWidth = max(0, (width - totalGap) / CGFloat(barCount))
+
+        return Layout(barCount: barCount, barWidth: barWidth, gap: gap)
+    }
+
     static func heights(from samples: [Float], barCount: Int = 80) -> [Float] {
         guard !samples.isEmpty, barCount > 0 else { return [] }
 

--- a/Sources/AudioWaveformHeights.swift
+++ b/Sources/AudioWaveformHeights.swift
@@ -16,7 +16,8 @@ enum AudioWaveformHeights {
         let maxGap = barCount > 1
             ? max(0, (width - CGFloat(barCount) * minimumBarWidth) / CGFloat(barCount - 1))
             : 0
-        let gap = min(preferredGap, maxGap)
+        let safePreferredGap = max(0, preferredGap)
+        let gap = min(safePreferredGap, maxGap)
         let totalGap = gap * CGFloat(max(0, barCount - 1))
         let barWidth = max(0, (width - totalGap) / CGFloat(barCount))
 

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -1409,19 +1409,20 @@ struct NoteAudioPlayerView: View {
 
             // Waveform — border-radius:1px, opacity:0.45 unplayed, accent played
             GeometryReader { geo in
-                let barCount = barHeights.count
-                let gap: CGFloat = 2
-                let totalGap = gap * CGFloat(barCount - 1)
-                let barWidth = max(1, (geo.size.width - totalGap) / CGFloat(barCount))
-                let playedCount = Int(Double(barCount) * progress)
+                let layout = AudioWaveformHeights.layout(
+                    width: geo.size.width,
+                    barCount: barHeights.count,
+                    preferredGap: 2
+                )
+                let playedCount = Int(Double(layout.barCount) * progress)
 
-                HStack(alignment: .center, spacing: gap) {
-                    ForEach(0..<barCount, id: \.self) { i in
+                HStack(alignment: .center, spacing: layout.gap) {
+                    ForEach(0..<layout.barCount, id: \.self) { i in
                         RoundedRectangle(cornerRadius: 1)
                             .fill(i < playedCount
                                   ? Color.accentColor
                                   : Color.primary.opacity(0.45))
-                            .frame(width: barWidth, height: geo.size.height * barHeights[i])
+                            .frame(width: layout.barWidth, height: geo.size.height * barHeights[i])
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
@@ -1437,12 +1438,13 @@ struct NoteAudioPlayerView: View {
             }
             .frame(height: 44)
 
-            // Time — monospaced, tabular, var(--ink-2) ≈ secondary, min-width 80
+            // Time — monospaced, tabular, intrinsic width so the waveform flexes with label length.
             Text("\(formatDuration(elapsed)) / \(formatDuration(duration))")
                 .font(.system(size: 11, design: .monospaced))
                 .foregroundStyle(.secondary)
                 .monospacedDigit()
-                .frame(minWidth: 80, alignment: .center)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
 
             // Volume — tap the speaker for a slider popover
             Button { showVolumePopover.toggle() } label: {

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -504,58 +504,71 @@ struct NoteBrowserView: View {
         VStack(spacing: 0) {
             // Title row
             HStack(spacing: 8) {
-                Text("Recordings")
-                    .font(.system(size: 15, weight: .bold))
-                    .foregroundStyle(.primary)
-                if !appState.pipelineHistory.isEmpty {
-                    Text("\(appState.pipelineHistory.count)")
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(.tertiary)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(Color.primary.opacity(0.08), in: Capsule())
-                }
-                Spacer()
-                Button {
-                    showAudioImportPicker()
-                } label: {
-                    Image(systemName: "plus")
-                        .font(.system(size: 12, weight: .bold))
-                        .frame(width: 24, height: 24)
-                        .background(Color.primary.opacity(0.06), in: Circle())
-                }
-                .buttonStyle(.plain)
-                .help("Import audio file")
-                .disabled(appState.isRecording)
-                .overrideCursor(.arrow)
-
-                // Record button
-                Button {
-                    appState.toggleRecording()
-                } label: {
-                    HStack(spacing: 5) {
-                        Circle()
-                            .fill(.white)
-                            .frame(width: 6, height: 6)
-                            // Pulse opacity only (via recordingPulse) so the dot blinks
-                            // in place and isn't dragged by the Rec/Stop layout change.
-                            .opacity(appState.isRecording ? (recordingPulse ? 0.35 : 1.0) : 1.0)
-                        Text(appState.isRecording ? "Stop" : "Rec")
-                            .font(.system(size: 11, weight: .semibold))
+                HStack(spacing: 6) {
+                    Text("Recordings")
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
+                    if !appState.pipelineHistory.isEmpty {
+                        Text("\(appState.pipelineHistory.count)")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                            .fixedSize(horizontal: true, vertical: false)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.primary.opacity(0.08), in: Capsule())
                     }
-                    .onChange(of: appState.isRecording) { isRecording in
-                        updateRecordingPulse(isRecording)
-                    }
-                    .onAppear { updateRecordingPulse(appState.isRecording) }
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
-                    .background(appState.isRecording ? Color.orange : Color.red, in: Capsule())
-                    .foregroundStyle(.white)
                 }
-                .buttonStyle(.plain)
-                .overrideCursor(.arrow)
+                .layoutPriority(1)
 
-                inputPickerMenu
+                Spacer(minLength: 8)
+
+                HStack(spacing: 8) {
+                    Button {
+                        showAudioImportPicker()
+                    } label: {
+                        Image(systemName: "plus")
+                            .font(.system(size: 12, weight: .bold))
+                            .frame(width: 24, height: 24)
+                            .background(Color.primary.opacity(0.06), in: Circle())
+                    }
+                    .buttonStyle(.plain)
+                    .help("Import audio file")
+                    .disabled(appState.isRecording)
+                    .overrideCursor(.arrow)
+
+                    // Record button
+                    Button {
+                        appState.toggleRecording()
+                    } label: {
+                        HStack(spacing: 5) {
+                            Circle()
+                                .fill(.white)
+                                .frame(width: 6, height: 6)
+                                // Pulse opacity only (via recordingPulse) so the dot blinks
+                                // in place and isn't dragged by the Rec/Stop layout change.
+                                .opacity(appState.isRecording ? (recordingPulse ? 0.35 : 1.0) : 1.0)
+                            Text(appState.isRecording ? "Stop" : "Rec")
+                                .font(.system(size: 11, weight: .semibold))
+                                .lineLimit(1)
+                        }
+                        .onChange(of: appState.isRecording) { isRecording in
+                            updateRecordingPulse(isRecording)
+                        }
+                        .onAppear { updateRecordingPulse(appState.isRecording) }
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(appState.isRecording ? Color.orange : Color.red, in: Capsule())
+                        .foregroundStyle(.white)
+                    }
+                    .buttonStyle(.plain)
+                    .overrideCursor(.arrow)
+
+                    inputPickerMenu
+                }
+                .fixedSize(horizontal: true, vertical: false)
             }
             .padding(.horizontal, 14)
             .padding(.top, 14)

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -1296,10 +1296,13 @@ private struct NoteDetailView: View {
         .padding(.horizontal, 8)
         .frame(height: 48)
         .background {
-            GlassView(material: .underWindowBackground)
-                .clipShape(Capsule())
-                .overlay(Capsule().strokeBorder(toolbarStrokeColor, lineWidth: 0.6))
+            if #available(macOS 26.0, *) {
+                Color.clear.glassEffect(.regular, in: Capsule())
+            } else {
+                Capsule().fill(.ultraThinMaterial)
+            }
         }
+        .overlay(Capsule().strokeBorder(toolbarStrokeColor, lineWidth: 0.6))
         .compositingGroup()
         .shadow(color: .black.opacity(0.085), radius: 14, x: 0, y: 4)
         .shadow(color: .white.opacity(0.05), radius: 4, x: 0, y: -1)

--- a/Tests/AudioWaveformHeightsTests.swift
+++ b/Tests/AudioWaveformHeightsTests.swift
@@ -7,6 +7,7 @@ struct AudioWaveformHeightsTests {
             try mildlyBoostsQuietWaveform()
             try preservesAlreadyVisibleWaveformScale()
             try returnsNoHeightsForEmptySamples()
+            try fitsBarsInsideAvailableWidth()
             print("AudioWaveformHeightsTests passed")
         } catch {
             fputs("AudioWaveformHeightsTests failed: \(error)\n", stderr)
@@ -30,6 +31,26 @@ struct AudioWaveformHeightsTests {
         let heights = AudioWaveformHeights.heights(from: [], barCount: 4)
 
         try expectEqual(heights, [], "empty samples should not produce waveform bars")
+    }
+
+    private static func fitsBarsInsideAvailableWidth() throws {
+        let layout = AudioWaveformHeights.layout(width: 210, barCount: 80, preferredGap: 2)
+        let totalWidth = CGFloat(layout.barCount) * layout.barWidth
+            + CGFloat(layout.barCount - 1) * layout.gap
+
+        try expect(layout.barCount == 80, "wide-enough waveform should preserve all bars")
+        try expect(totalWidth <= 210.0001, "wide-enough waveform should fit inside available width")
+
+        let narrowLayout = AudioWaveformHeights.layout(width: 96, barCount: 80, preferredGap: 2)
+        let narrowTotalWidth = CGFloat(narrowLayout.barCount) * narrowLayout.barWidth
+            + CGFloat(narrowLayout.barCount - 1) * narrowLayout.gap
+
+        try expect(narrowLayout.barCount == 80, "narrow waveform should preserve all bars")
+        try expect(narrowTotalWidth <= 96.0001, "narrow waveform should fit inside available width")
+    }
+
+    private static func expect(_ condition: Bool, _ label: String) throws {
+        guard condition else { throw TestFailure(label) }
     }
 
     private static func expectEqual(_ actual: [Float], _ expected: [Float], _ label: String) throws {

--- a/Tests/AudioWaveformHeightsTests.swift
+++ b/Tests/AudioWaveformHeightsTests.swift
@@ -8,6 +8,7 @@ struct AudioWaveformHeightsTests {
             try preservesAlreadyVisibleWaveformScale()
             try returnsNoHeightsForEmptySamples()
             try fitsBarsInsideAvailableWidth()
+            try clampsNegativePreferredGap()
             print("AudioWaveformHeightsTests passed")
         } catch {
             fputs("AudioWaveformHeightsTests failed: \(error)\n", stderr)
@@ -47,6 +48,15 @@ struct AudioWaveformHeightsTests {
 
         try expect(narrowLayout.barCount == 80, "narrow waveform should preserve all bars")
         try expect(narrowTotalWidth <= 96.0001, "narrow waveform should fit inside available width")
+    }
+
+    private static func clampsNegativePreferredGap() throws {
+        let layout = AudioWaveformHeights.layout(width: 96, barCount: 80, preferredGap: -2)
+        let totalWidth = CGFloat(layout.barCount) * layout.barWidth
+            + CGFloat(layout.barCount - 1) * layout.gap
+
+        try expect(layout.gap >= 0, "negative preferred gap should be clamped to non-negative spacing")
+        try expect(totalWidth <= 96.0001, "negative preferred gap layout should still fit inside available width")
     }
 
     private static func expect(_ condition: Bool, _ label: String) throws {


### PR DESCRIPTION
## Summary
- Prevent long Note Browser audio-player time labels from overlapping the waveform by letting the label use intrinsic width and keeping waveform bars inside their available width
- Keep the Recordings sidebar header on one line when the count grows and the recording button changes to Stop
- Restore the floating toolbar pill with Liquid Glass on macOS 26+, with an ultra-thin material fallback on older macOS versions

## Test
- make test CODESIGN_IDENTITY=Quill

Closes #164
Closes #165
Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 오디오 웨이브폼이 화면 너비에 맞게 더 안정적으로 배치되도록 개선되었습니다.
  * 플레이어 시간 표시가 더 자연스럽게 정렬되어, 길이가 달라도 레이아웃이 덜 흔들립니다.

* **개선**
  * 사이드바의 Recordings 영역과 녹음 버튼 배치가 더 간결하게 정리되었습니다.
  * macOS 버전에 따라 툴바 배경 효과가 더 잘 맞도록 조정되었습니다.

* **버그 수정**
  * 웨이브폼 막대가 उपलब्ध 공간을 넘지 않도록 계산 방식이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->