### PR TITLE
Package native Local Whisper beta

### DIFF
--- a/BuildSupport/WhisperRuntime/build-whisper.cpp.sh
+++ b/BuildSupport/WhisperRuntime/build-whisper.cpp.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_url="${1:?repo url required}"
+version="${2:?version required}"
+checkout_dir="${3:?checkout dir required}"
+
+mkdir -p "$(dirname "$checkout_dir")"
+
+if [ ! -d "$checkout_dir/.git" ]; then
+  git clone --depth 1 --branch "$version" "$repo_url" "$checkout_dir"
+else
+  git -C "$checkout_dir" fetch --depth 1 origin "refs/tags/$version:refs/tags/$version"
+  git -C "$checkout_dir" checkout --force "$version"
+fi
+
+cmake -S "$checkout_dir" -B "$checkout_dir/build" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DWHISPER_BUILD_TESTS=OFF \
+  -DWHISPER_BUILD_EXAMPLES=ON
+cmake --build "$checkout_dir/build" --target whisper-cli --config Release -j "$(sysctl -n hw.ncpu)"
+
+test -x "$checkout_dir/build/bin/whisper-cli"

--- a/BuildSupport/WhisperRuntime/build-whisper.cpp.sh
+++ b/BuildSupport/WhisperRuntime/build-whisper.cpp.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 repo_url="${1:?repo url required}"
 version="${2:?version required}"
 checkout_dir="${3:?checkout dir required}"
+arch="${4:-$(uname -m)}"
 
 mkdir -p "$(dirname "$checkout_dir")"
 
@@ -14,10 +15,47 @@ else
   git -C "$checkout_dir" checkout --force "$version"
 fi
 
+cmake_arch_args=()
+if [ "$arch" = "universal" ]; then
+  cmake_arch_args=(-DCMAKE_OSX_ARCHITECTURES="arm64;x86_64")
+else
+  cmake_arch_args=(-DCMAKE_OSX_ARCHITECTURES="$arch")
+fi
+
 cmake -S "$checkout_dir" -B "$checkout_dir/build" \
+  "${cmake_arch_args[@]}" \
   -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=OFF \
   -DWHISPER_BUILD_TESTS=OFF \
   -DWHISPER_BUILD_EXAMPLES=ON
 cmake --build "$checkout_dir/build" --target whisper-cli --config Release -j "$(sysctl -n hw.ncpu)"
 
-test -x "$checkout_dir/build/bin/whisper-cli"
+helper="$checkout_dir/build/bin/whisper-cli"
+test -x "$helper"
+
+if otool -L "$helper" | grep -E '(@rpath/)?lib(whisper|ggml)' >/dev/null; then
+  echo "whisper-cli still links whisper.cpp/ggml dylibs; expected a self-contained helper." >&2
+  otool -L "$helper" >&2
+  exit 1
+fi
+
+helper_archs="$(lipo -archs "$helper")"
+if [ "$arch" = "universal" ]; then
+  for required_arch in arm64 x86_64; do
+    case " $helper_archs " in
+      *" $required_arch "*) ;;
+      *)
+        echo "whisper-cli is not universal; missing $required_arch; found architectures: $helper_archs" >&2
+        exit 1
+        ;;
+    esac
+  done
+else
+  case " $helper_archs " in
+    *" $arch "*) ;;
+    *)
+      echo "whisper-cli missing requested architecture $arch; found architectures: $helper_archs" >&2
+      exit 1
+      ;;
+  esac
+fi

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,11 @@ BUILD_SETTINGS = $(BUILD_DIR)/.build-settings
 SPARKLE_STAMP = $(BUILD_DIR)/.sparkle-framework
 SPARKLE_VERSION ?= 2.9.2
 SPARKLE_FRAMEWORK_FIND = find .build/artifacts -path '*/Sparkle.framework' -type d -print -quit
+WHISPER_CPP_VERSION ?= v1.9.1
+WHISPER_CPP_REPO ?= https://github.com/ggml-org/whisper.cpp.git
+WHISPER_CPP_DIR = .build/checkouts/whisper.cpp
+WHISPER_HELPER = $(WHISPER_CPP_DIR)/build/bin/whisper-cli
+WHISPER_STAMP = $(BUILD_DIR)/.whisper-helper
 empty :=
 space := $(empty) $(empty)
 APP_EXECUTABLE = $(MACOS_DIR)/$(APP_NAME)
@@ -63,7 +68,12 @@ $(SPARKLE_STAMP): Package.swift BuildSupport/SparkleResolver/main.swift
 		fi; \
 		printf '%s\n' "$$framework" > "$@"
 
-$(APP_EXECUTABLE_TARGET): $(SOURCES) Info.plist $(ICON_ICNS) $(BUILD_SETTINGS) $(SPARKLE_STAMP)
+$(WHISPER_STAMP): BuildSupport/WhisperRuntime/build-whisper.cpp.sh
+	@BuildSupport/WhisperRuntime/build-whisper.cpp.sh "$(WHISPER_CPP_REPO)" "$(WHISPER_CPP_VERSION)" "$(WHISPER_CPP_DIR)"
+	@mkdir -p "$(BUILD_DIR)"
+	@printf '%s\n' "$(WHISPER_HELPER)" > "$@"
+
+$(APP_EXECUTABLE_TARGET): $(SOURCES) Info.plist $(ICON_ICNS) $(BUILD_SETTINGS) $(SPARKLE_STAMP) $(WHISPER_STAMP)
 	@mkdir -p "$(MACOS_DIR)" "$(RESOURCES)" "$(FRAMEWORKS)"
 	@framework="$$(cat "$(SPARKLE_STAMP)" 2>/dev/null)"; \
 		if [ -z "$$framework" ] || [ ! -d "$$framework" ]; then \
@@ -120,6 +130,14 @@ endif
 	@plutil -replace GoogleCalendarOAuthClientID -string "$(GOOGLE_CALENDAR_OAUTH_CLIENT_ID)" "$(CONTENTS)/Info.plist"
 	@plutil -replace GoogleCalendarOAuthClientSecret -string "$(GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET)" "$(CONTENTS)/Info.plist"
 	@cp $(ICON_ICNS) "$(RESOURCES)/AppIcon.icns"
+	@mkdir -p "$(RESOURCES)/whisper"
+	@whisper_helper="$$(cat "$(WHISPER_STAMP)")"; \
+		if [ -z "$$whisper_helper" ] || [ ! -x "$$whisper_helper" ]; then \
+			echo "Missing whisper.cpp helper at $$whisper_helper" >&2; \
+			exit 1; \
+		fi; \
+		cp "$$whisper_helper" "$(RESOURCES)/whisper/whisper-cli"; \
+		chmod 755 "$(RESOURCES)/whisper/whisper-cli"
 	@xattr -cr "$(APP_BUNDLE)"
 	@rm -rf "$(BUILD_DIR)/codesign-staging"
 	@mkdir -p "$(BUILD_DIR)/codesign-staging"
@@ -136,6 +154,13 @@ endif
 			codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" "$$staged_framework/Versions/Current/Autoupdate"; \
 		fi; \
 		codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" "$$staged_framework"
+	@helper="$(BUILD_DIR)/codesign-staging/$(APP_NAME).app/Contents/Resources/whisper/whisper-cli"; \
+		if [ -x "$$helper" ]; then \
+			codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" "$$helper"; \
+		else \
+			echo "Missing bundled whisper helper in staging app." >&2; \
+			exit 1; \
+		fi
 	@codesign --force --options runtime --sign "$(CODESIGN_IDENTITY)" --entitlements Quill.entitlements "$(BUILD_DIR)/codesign-staging/$(APP_NAME).app"
 	@rm -rf "$(APP_BUNDLE)"
 	@ditto --norsrc --noextattr "$(BUILD_DIR)/codesign-staging/$(APP_NAME).app" "$(APP_BUNDLE)"

--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,8 @@ test: $(SPARKLE_STAMP)
 	@/tmp/NativeWhisperModelTests
 	@swiftc -parse-as-library Sources/NativeWhisperModel.swift Sources/NativeWhisperRuntime.swift Tests/NativeWhisperRuntimeTests.swift -o /tmp/NativeWhisperRuntimeTests
 	@/tmp/NativeWhisperRuntimeTests
+	@swiftc -parse-as-library Sources/NativeWhisperModel.swift Sources/NativeWhisperInstaller.swift Tests/NativeWhisperInstallerTests.swift -o /tmp/NativeWhisperInstallerTests
+	@/tmp/NativeWhisperInstallerTests
 	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Tests/OverlayScreenGeometryTests.swift -o /tmp/OverlayScreenGeometryTests
 	@/tmp/OverlayScreenGeometryTests
 	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/AudioInputDevice.swift Sources/RecordingOverlay.swift Tests/RecordingOverlayGeometryTests.swift -o /tmp/RecordingOverlayGeometryTests

--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,8 @@ test: $(SPARKLE_STAMP)
 	@/tmp/SetupFlowTests
 	@swiftc -parse-as-library Sources/TranscriptionModel.swift Tests/TranscriptionModelCacheTests.swift -o /tmp/TranscriptionModelCacheTests
 	@/tmp/TranscriptionModelCacheTests
+	@swiftc -parse-as-library Sources/NativeWhisperModel.swift Tests/NativeWhisperModelTests.swift -o /tmp/NativeWhisperModelTests
+	@/tmp/NativeWhisperModelTests
 	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Tests/OverlayScreenGeometryTests.swift -o /tmp/OverlayScreenGeometryTests
 	@/tmp/OverlayScreenGeometryTests
 	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/AudioInputDevice.swift Sources/RecordingOverlay.swift Tests/RecordingOverlayGeometryTests.swift -o /tmp/RecordingOverlayGeometryTests

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ WHISPER_CPP_REPO ?= https://github.com/ggml-org/whisper.cpp.git
 WHISPER_CPP_DIR = .build/checkouts/whisper.cpp
 WHISPER_HELPER = $(WHISPER_CPP_DIR)/build/bin/whisper-cli
 WHISPER_STAMP = $(BUILD_DIR)/.whisper-helper
+WHISPER_BUILD_SETTINGS = $(BUILD_DIR)/.whisper-build-settings
 empty :=
 space := $(empty) $(empty)
 APP_EXECUTABLE = $(MACOS_DIR)/$(APP_NAME)
@@ -68,8 +69,13 @@ $(SPARKLE_STAMP): Package.swift BuildSupport/SparkleResolver/main.swift
 		fi; \
 		printf '%s\n' "$$framework" > "$@"
 
-$(WHISPER_STAMP): BuildSupport/WhisperRuntime/build-whisper.cpp.sh
-	@BuildSupport/WhisperRuntime/build-whisper.cpp.sh "$(WHISPER_CPP_REPO)" "$(WHISPER_CPP_VERSION)" "$(WHISPER_CPP_DIR)"
+$(WHISPER_BUILD_SETTINGS): FORCE
+	@mkdir -p "$(BUILD_DIR)"
+	@printf '%s\n%s\n%s\n' "$(WHISPER_CPP_REPO)" "$(WHISPER_CPP_VERSION)" "$(ARCH)" > "$@.tmp"
+	@if [ ! -f "$@" ] || ! cmp -s "$@.tmp" "$@"; then mv "$@.tmp" "$@"; else rm "$@.tmp"; fi
+
+$(WHISPER_STAMP): BuildSupport/WhisperRuntime/build-whisper.cpp.sh $(WHISPER_BUILD_SETTINGS)
+	@BuildSupport/WhisperRuntime/build-whisper.cpp.sh "$(WHISPER_CPP_REPO)" "$(WHISPER_CPP_VERSION)" "$(WHISPER_CPP_DIR)" "$(ARCH)"
 	@mkdir -p "$(BUILD_DIR)"
 	@printf '%s\n' "$(WHISPER_HELPER)" > "$@"
 

--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,8 @@ test: $(SPARKLE_STAMP)
 	@/tmp/TranscriptionModelCacheTests
 	@swiftc -parse-as-library Sources/NativeWhisperModel.swift Tests/NativeWhisperModelTests.swift -o /tmp/NativeWhisperModelTests
 	@/tmp/NativeWhisperModelTests
+	@swiftc -parse-as-library Sources/NativeWhisperModel.swift Sources/NativeWhisperRuntime.swift Tests/NativeWhisperRuntimeTests.swift -o /tmp/NativeWhisperRuntimeTests
+	@/tmp/NativeWhisperRuntimeTests
 	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Tests/OverlayScreenGeometryTests.swift -o /tmp/OverlayScreenGeometryTests
 	@/tmp/OverlayScreenGeometryTests
 	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/AudioInputDevice.swift Sources/RecordingOverlay.swift Tests/RecordingOverlayGeometryTests.swift -o /tmp/RecordingOverlayGeometryTests

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -109,6 +109,7 @@ private struct AudioImportTaskConfiguration {
     let transcriptionAPIKey: String
     let transcriptionAPIBaseURL: String
     let localWhisperPath: String
+    let useLegacyMlxWhisper: Bool
     let transcriptionLanguage: TranscriptionLanguage
     let transcriptionModel: String
     let customVocabulary: String
@@ -127,6 +128,7 @@ private struct AudioImportTaskConfiguration {
         transcriptionAPIKey: String,
         transcriptionAPIBaseURL: String,
         localWhisperPath: String,
+        useLegacyMlxWhisper: Bool,
         transcriptionLanguage: TranscriptionLanguage,
         transcriptionModel: String,
         customVocabulary: String,
@@ -146,6 +148,7 @@ private struct AudioImportTaskConfiguration {
         self.transcriptionAPIKey = transcriptionAPIKey
         self.transcriptionAPIBaseURL = transcriptionAPIBaseURL
         self.localWhisperPath = localWhisperPath
+        self.useLegacyMlxWhisper = useLegacyMlxWhisper
         self.transcriptionLanguage = transcriptionLanguage
         self.transcriptionModel = transcriptionModel
         self.customVocabulary = customVocabulary
@@ -180,6 +183,7 @@ private struct AudioImportTaskConfiguration {
             baseURL: transcriptionAPIBaseURL,
             useLocalTranscription: useLocalTranscription,
             localWhisperPath: localWhisperPath.isEmpty ? nil : localWhisperPath,
+            useLegacyMlxWhisper: useLegacyMlxWhisper,
             transcriptionLanguage: transcriptionLanguage,
             localTranscriptionModel: localTranscriptionModel,
             transcriptionModel: transcriptionModel
@@ -200,6 +204,7 @@ private struct RetrySnapshot {
     let outputLanguage: String
     let postProcessingEnabled: Bool
     let localWhisperPath: String?
+    let useLegacyMlxWhisper: Bool
 }
 
 private struct TranscriptCommandParsingResult {
@@ -2558,6 +2563,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             transcriptionAPIKey: resolvedTranscriptionAPIKey,
             transcriptionAPIBaseURL: resolvedTranscriptionBaseURL,
             localWhisperPath: localWhisperPath,
+            useLegacyMlxWhisper: useLegacyMlxWhisper,
             transcriptionLanguage: transcriptionLanguage,
             transcriptionModel: transcriptionModel,
             customVocabulary: customVocabulary,
@@ -2762,6 +2768,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     baseURL: resolvedTranscriptionBaseURL,
                     useLocalTranscription: snapshot.useLocalTranscription,
                     localWhisperPath: snapshot.localWhisperPath,
+                    useLegacyMlxWhisper: snapshot.useLegacyMlxWhisper,
                     transcriptionLanguage: snapshot.transcriptionLanguage,
                     localTranscriptionModel: snapshot.localTranscriptionModel,
                     transcriptionModel: transcriptionModel
@@ -2875,7 +2882,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             customSystemPrompt: item.customSystemPrompt,
             outputLanguage: outputLanguage,
             postProcessingEnabled: item.usedPostProcessing,
-            localWhisperPath: localWhisperPath.isEmpty ? nil : localWhisperPath
+            localWhisperPath: localWhisperPath.isEmpty ? nil : localWhisperPath,
+            useLegacyMlxWhisper: useLegacyMlxWhisper
         )
     }
 
@@ -5065,6 +5073,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let capturedApiBaseURL = resolvedTranscriptionBaseURL
         let capturedUseLocalTranscription = useLocalTranscription
         let capturedLocalWhisperPath = localWhisperPath
+        let capturedUseLegacyMlxWhisper = useLegacyMlxWhisper
         let capturedTranscriptionLanguage = transcriptionLanguage
         let capturedLocalTranscriptionModel = localTranscriptionModel
         let capturedTranscriptionModel = transcriptionModel
@@ -5254,6 +5263,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             baseURL: capturedApiBaseURL,
                             useLocalTranscription: capturedUseLocalTranscription,
                             localWhisperPath: capturedLocalWhisperPath.isEmpty ? nil : capturedLocalWhisperPath,
+                            useLegacyMlxWhisper: capturedUseLegacyMlxWhisper,
                             transcriptionLanguage: capturedTranscriptionLanguage,
                             localTranscriptionModel: capturedLocalTranscriptionModel,
                             transcriptionModel: capturedTranscriptionModel

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -739,6 +739,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var useLegacyMlxWhisper: Bool {
         didSet {
             UserDefaults.standard.set(useLegacyMlxWhisper, forKey: useLegacyMlxWhisperStorageKey)
+            normalizeNoteBrowserTranscriptionModeForProviderConfiguration()
         }
     }
 
@@ -784,6 +785,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @Published private(set) var nativeWhisperInstallStatus: NativeWhisperInstallStatus = NativeWhisperModelStore().installStatus(for: .recommended)
+    @Published private(set) var nativeWhisperInstallProgress = NativeWhisperDownloadProgress(downloadedBytes: 0, totalBytes: NativeWhisperModelCatalog.recommended.approximateBytes)
+    @Published private(set) var isInstallingNativeWhisper = false
+    @Published private(set) var nativeWhisperInstallError: String?
+    private var nativeWhisperInstallTask: NativeWhisperInstallTask?
+    private var nativeWhisperInstallCancellationMessage: String?
+
     var noteBrowserTranscriptionModeLabel: String {
         label(for: currentNoteBrowserTranscriptionMode)
     }
@@ -819,11 +827,92 @@ final class AppState: ObservableObject, @unchecked Sendable {
         if useLegacyMlxWhisper {
             return hasLegacyLocalWhisperModel
         }
-        return NativeWhisperModelStore().installStatus(for: .recommended) == .ready
+        return nativeWhisperInstallStatus == .ready
     }
 
     var hasLegacyLocalWhisperModel: Bool {
         TranscriptionModel.all.contains { !$0.isAppleSpeech && $0.isInstalled }
+    }
+
+    @MainActor
+    func refreshNativeWhisperInstallStatus() {
+        nativeWhisperInstallStatus = NativeWhisperModelStore().installStatus(for: .recommended)
+        normalizeNoteBrowserTranscriptionModeForProviderConfiguration()
+    }
+
+    @MainActor
+    func installNativeWhisperModel() {
+        guard !isInstallingNativeWhisper else { return }
+        let model = NativeWhisperModelCatalog.recommended
+        nativeWhisperInstallError = nil
+        nativeWhisperInstallCancellationMessage = nil
+        isInstallingNativeWhisper = true
+        nativeWhisperInstallProgress = NativeWhisperDownloadProgress(downloadedBytes: 0, totalBytes: model.approximateBytes)
+        let installer = NativeWhisperInstaller()
+        nativeWhisperInstallTask = installer.install(
+            model: model,
+            progress: { [weak self] progress in
+                DispatchQueue.main.async {
+                    self?.nativeWhisperInstallProgress = progress
+                }
+            },
+            completion: { [weak self] result in
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    self.nativeWhisperInstallTask = nil
+                    self.isInstallingNativeWhisper = false
+                    self.refreshNativeWhisperInstallStatus()
+                    if case .failure(let error) = result {
+                        switch error {
+                        case .cancelled:
+                            self.nativeWhisperInstallError = self.nativeWhisperInstallCancellationMessage
+                            self.nativeWhisperInstallCancellationMessage = nil
+                        default:
+                            self.nativeWhisperInstallError = error.localizedDescription
+                        }
+                    }
+                }
+            }
+        )
+    }
+
+    @MainActor
+    func cancelNativeWhisperInstall() {
+        nativeWhisperInstallCancellationMessage = nil
+        nativeWhisperInstallTask?.cancel()
+        let model = NativeWhisperModelCatalog.recommended
+        try? NativeWhisperModelStore().deletePartialModel(model)
+        nativeWhisperInstallProgress = NativeWhisperDownloadProgress(
+            downloadedBytes: nativeWhisperInstallProgress.downloadedBytes,
+            totalBytes: nativeWhisperInstallProgress.totalBytes,
+            isCancelled: true
+        )
+        refreshNativeWhisperInstallStatus()
+    }
+
+    @MainActor
+    func cancelNativeWhisperInstallForSettingsClose() {
+        guard isInstallingNativeWhisper else { return }
+        nativeWhisperInstallCancellationMessage = "Local Whisper download was canceled because Settings was closed. Start the install again when you're ready."
+        nativeWhisperInstallTask?.cancel()
+        try? NativeWhisperModelStore().deletePartialModel(.recommended)
+        nativeWhisperInstallProgress = NativeWhisperDownloadProgress(
+            downloadedBytes: nativeWhisperInstallProgress.downloadedBytes,
+            totalBytes: nativeWhisperInstallProgress.totalBytes,
+            isCancelled: true
+        )
+        refreshNativeWhisperInstallStatus()
+    }
+
+    @MainActor
+    func deleteNativeWhisperModel() {
+        do {
+            try NativeWhisperModelStore().deleteModel(.recommended)
+            nativeWhisperInstallError = nil
+        } catch {
+            nativeWhisperInstallError = error.localizedDescription
+        }
+        refreshNativeWhisperInstallStatus()
     }
 
     @MainActor
@@ -864,7 +953,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         case .apiRealtime:
             return hasTranscriptionAPIKey && !AudioInputDevice.isSystemDefaultAndSystemAudio(selectedMicrophoneID)
         case .localWhisper:
-            return true
+            return hasInstalledLocalWhisperModel
         case .localAppleLive:
             return !AudioInputDevice.isSystemDefaultAndSystemAudio(selectedMicrophoneID)
         }
@@ -892,14 +981,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func normalizedNoteBrowserTranscriptionMode(_ mode: NoteBrowserTranscriptionMode) -> NoteBrowserTranscriptionMode {
         guard !isNoteBrowserTranscriptionModeAvailable(mode) else { return mode }
+        let fallbackOrder: [NoteBrowserTranscriptionMode]
         switch mode {
         case .apiRealtime:
-            return isNoteBrowserTranscriptionModeAvailable(.apiStandard) ? .apiStandard : .localWhisper
-        case .apiStandard, .localAppleLive:
-            return .localWhisper
+            fallbackOrder = [.apiStandard, .localWhisper, .localAppleLive]
+        case .apiStandard:
+            fallbackOrder = [.localWhisper, .localAppleLive, .apiRealtime]
+        case .localAppleLive:
+            fallbackOrder = [.localWhisper, .apiStandard, .apiRealtime]
         case .localWhisper:
-            return mode
+            fallbackOrder = [.apiStandard, .localAppleLive, .apiRealtime]
         }
+        return fallbackOrder.first(where: isNoteBrowserTranscriptionModeAvailable) ?? mode
     }
 
     private func applyNoteBrowserTranscriptionMode(_ mode: NoteBrowserTranscriptionMode) {
@@ -911,6 +1004,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             useLocalTranscription = false
             realtimeStreamingEnabled = true
         case .localWhisper:
+            guard isNoteBrowserTranscriptionModeAvailable(.localWhisper) else { return }
             useLocalTranscription = true
             realtimeStreamingEnabled = false
             if localTranscriptionModel.isAppleSpeech,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -816,11 +816,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     var hasInstalledLocalWhisperModel: Bool {
+        if useLegacyMlxWhisper {
+            return hasLegacyLocalWhisperModel
+        }
+        return NativeWhisperModelStore().installStatus(for: .recommended) == .ready
+    }
+
+    var hasLegacyLocalWhisperModel: Bool {
         TranscriptionModel.all.contains { !$0.isAppleSpeech && $0.isInstalled }
     }
 
     @MainActor
-    func audioImportConfiguration(for mode: NoteBrowserTranscriptionMode) -> AudioImportTranscriptionConfiguration {
+    func audioImportConfiguration(
+        for mode: NoteBrowserTranscriptionMode,
+        allowsNativeWhisper: Bool = false
+    ) -> AudioImportTranscriptionConfiguration {
         switch mode {
         case .apiStandard, .apiRealtime:
             return AudioImportTranscriptionConfiguration(
@@ -829,6 +839,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 localTranscriptionModel: localTranscriptionModel
             )
         case .localWhisper, .localAppleLive:
+            guard allowsNativeWhisper || useLegacyMlxWhisper else {
+                return AudioImportTranscriptionConfiguration(
+                    mode: .apiStandard,
+                    useLocalTranscription: false,
+                    localTranscriptionModel: localTranscriptionModel
+                )
+            }
             let model = localTranscriptionModel.isAppleSpeech
                 ? TranscriptionModel.all.first(where: { !$0.isAppleSpeech }) ?? localTranscriptionModel
                 : localTranscriptionModel
@@ -2857,7 +2874,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         guard let retryMode = options.defaultMode else {
             throw TranscriptionError.submissionFailed("No transcription method is available. Configure an API key or install a Local Whisper model, then try again.")
         }
-        let configuration = audioImportConfiguration(for: retryMode)
+        let configuration = audioImportConfiguration(for: retryMode, allowsNativeWhisper: true)
 
         return RetrySnapshot(
             item: item,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -362,6 +362,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let voiceMacrosStorageKey = "voice_macros"
     private let useLocalTranscriptionStorageKey = "use_local_transcription"
     private let localWhisperPathStorageKey = "local_whisper_path"
+    private let useLegacyMlxWhisperStorageKey = "use_legacy_mlx_whisper"
     private let disableContextCaptureStorageKey = "disable_context_capture"
     private let disableAutoPasteStorageKey = "disable_auto_paste"
     private let disablePostProcessingStorageKey = "disable_post_processing"
@@ -727,6 +728,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var localWhisperPath: String {
         didSet {
             UserDefaults.standard.set(localWhisperPath, forKey: localWhisperPathStorageKey)
+        }
+    }
+
+    @Published var useLegacyMlxWhisper: Bool {
+        didSet {
+            UserDefaults.standard.set(useLegacyMlxWhisper, forKey: useLegacyMlxWhisperStorageKey)
         }
     }
 
@@ -1323,6 +1330,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             : UserDefaults.standard.bool(forKey: pressEnterVoiceCommandStorageKey)
         let useLocalTranscription = UserDefaults.standard.bool(forKey: useLocalTranscriptionStorageKey)
         let localWhisperPath = UserDefaults.standard.string(forKey: localWhisperPathStorageKey) ?? ""
+        let useLegacyMlxWhisper = UserDefaults.standard.bool(forKey: useLegacyMlxWhisperStorageKey)
         let disableContextCapture = UserDefaults.standard.bool(forKey: disableContextCaptureStorageKey)
         let disableAutoPaste = UserDefaults.standard.bool(forKey: disableAutoPasteStorageKey)
         let disablePostProcessing = UserDefaults.standard.bool(forKey: disablePostProcessingStorageKey)
@@ -1437,6 +1445,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.alertSoundsEnabled = alertSoundsEnabled
         self.useLocalTranscription = useLocalTranscription
         self.localWhisperPath = localWhisperPath
+        self.useLegacyMlxWhisper = useLegacyMlxWhisper
         self.disableContextCapture = disableContextCapture
         self.disableAutoPaste = disableAutoPaste
         self.disablePostProcessing = disablePostProcessing
@@ -1953,6 +1962,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             baseURL: resolvedTranscriptionBaseURL,
             useLocalTranscription: useLocalTranscription,
             localWhisperPath: localWhisperPath.isEmpty ? nil : localWhisperPath,
+            useLegacyMlxWhisper: useLegacyMlxWhisper,
             transcriptionLanguage: transcriptionLanguage,
             localTranscriptionModel: localTranscriptionModel,
             transcriptionModel: transcriptionModel

--- a/Sources/NativeWhisperInstaller.swift
+++ b/Sources/NativeWhisperInstaller.swift
@@ -1,0 +1,153 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+enum NativeWhisperInstallerError: LocalizedError, Equatable {
+    case cancelled
+    case downloadFailed(String)
+    case verificationFailed(String)
+    case moveFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .cancelled:
+            return "Local Whisper installation was canceled."
+        case .downloadFailed:
+            return "Could not download Local Whisper. Check your network connection and free disk space, then try again."
+        case .verificationFailed:
+            return "Could not verify the Local Whisper model. Try downloading it again."
+        case .moveFailed:
+            return "Could not finish installing Local Whisper."
+        }
+    }
+}
+
+final class NativeWhisperInstallTask {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+}
+
+struct NativeWhisperInstaller {
+    typealias DownloadFunction = (
+        _ source: URL,
+        _ destination: URL,
+        _ progress: @escaping (NativeWhisperDownloadProgress) -> Void,
+        _ shouldCancel: @escaping () -> Bool
+    ) throws -> Void
+
+    let store: NativeWhisperModelStore
+    let download: DownloadFunction
+    private let queue: DispatchQueue
+
+    init(
+        store: NativeWhisperModelStore = NativeWhisperModelStore(),
+        queue: DispatchQueue = DispatchQueue(label: "quill.native-whisper-installer", qos: .utility),
+        download: @escaping DownloadFunction = NativeWhisperInstaller.urlSessionDownload
+    ) {
+        self.store = store
+        self.queue = queue
+        self.download = download
+    }
+
+    @discardableResult
+    func install(
+        model: NativeWhisperModel,
+        progress: @escaping (NativeWhisperDownloadProgress) -> Void,
+        completion: @escaping (Result<Void, NativeWhisperInstallerError>) -> Void
+    ) -> NativeWhisperInstallTask {
+        let task = NativeWhisperInstallTask()
+        queue.async {
+            let result = performInstall(model: model, progress: progress, task: task)
+            completion(result)
+        }
+        return task
+    }
+
+    private func performInstall(
+        model: NativeWhisperModel,
+        progress: @escaping (NativeWhisperDownloadProgress) -> Void,
+        task: NativeWhisperInstallTask
+    ) -> Result<Void, NativeWhisperInstallerError> {
+        let partial = store.partialModelURL(for: model)
+        do {
+            try store.ensureModelsDirectoryExists()
+            let final = store.modelURL(for: model)
+            try? store.fileManager.removeItem(at: partial)
+            try download(model.downloadURL, partial, progress, { task.isCancelled })
+            guard !task.isCancelled else {
+                try? store.fileManager.removeItem(at: partial)
+                return .failure(.cancelled)
+            }
+            guard store.fileManager.fileExists(atPath: partial.path) else {
+                return .failure(.downloadFailed("Download produced no file."))
+            }
+            try? store.fileManager.removeItem(at: final)
+            do {
+                try store.fileManager.moveItem(at: partial, to: final)
+            } catch {
+                try? store.fileManager.removeItem(at: partial)
+                return .failure(.moveFailed(error.localizedDescription))
+            }
+            return .success(())
+        } catch let error as NativeWhisperInstallerError {
+            try? store.fileManager.removeItem(at: partial)
+            return .failure(error)
+        } catch {
+            try? store.fileManager.removeItem(at: partial)
+            return .failure(.downloadFailed(error.localizedDescription))
+        }
+    }
+
+    private static func urlSessionDownload(
+        source: URL,
+        destination: URL,
+        progress: @escaping (NativeWhisperDownloadProgress) -> Void,
+        shouldCancel: @escaping () -> Bool
+    ) throws {
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: Result<Void, Error> = .failure(NativeWhisperInstallerError.downloadFailed("Download did not start."))
+        let task = URLSession.shared.downloadTask(with: source) { temporaryURL, response, error in
+            defer { semaphore.signal() }
+            if let error {
+                result = .failure(NativeWhisperInstallerError.downloadFailed(error.localizedDescription))
+                return
+            }
+            guard let temporaryURL else {
+                result = .failure(NativeWhisperInstallerError.downloadFailed("No downloaded file was produced."))
+                return
+            }
+            do {
+                let total = response?.expectedContentLength ?? -1
+                let data = try Data(contentsOf: temporaryURL)
+                if shouldCancel() {
+                    result = .failure(NativeWhisperInstallerError.cancelled)
+                    return
+                }
+                try data.write(to: destination, options: .atomic)
+                progress(NativeWhisperDownloadProgress(
+                    downloadedBytes: Int64(data.count),
+                    totalBytes: total > 0 ? total : Int64(data.count)
+                ))
+                result = .success(())
+            } catch {
+                result = .failure(NativeWhisperInstallerError.downloadFailed(error.localizedDescription))
+            }
+        }
+        task.resume()
+        semaphore.wait()
+        try result.get()
+    }
+}

--- a/Sources/NativeWhisperInstaller.swift
+++ b/Sources/NativeWhisperInstaller.swift
@@ -8,6 +8,7 @@ enum NativeWhisperInstallerError: LocalizedError, Equatable {
     case downloadFailed(String)
     case verificationFailed(String)
     case moveFailed(String)
+    case alreadyInProgress
 
     var errorDescription: String? {
         switch self {
@@ -19,6 +20,8 @@ enum NativeWhisperInstallerError: LocalizedError, Equatable {
             return "Could not verify the Local Whisper model. Try downloading it again."
         case .moveFailed:
             return "Could not finish installing Local Whisper."
+        case .alreadyInProgress:
+            return "Local Whisper is already being installed."
         }
     }
 }
@@ -66,6 +69,8 @@ struct NativeWhisperInstaller {
     let store: NativeWhisperModelStore
     let download: DownloadFunction
     private let queue: DispatchQueue
+    private static let inFlightLock = NSLock()
+    private static var inFlightInstallKeys: Set<String> = []
 
     init(
         store: NativeWhisperModelStore = NativeWhisperModelStore(),
@@ -84,11 +89,31 @@ struct NativeWhisperInstaller {
         completion: @escaping (Result<Void, NativeWhisperInstallerError>) -> Void
     ) -> NativeWhisperInstallTask {
         let task = NativeWhisperInstallTask()
+        let installKey = store.modelURL(for: model).path
+        guard Self.beginInstall(key: installKey) else {
+            completion(.failure(.alreadyInProgress))
+            return task
+        }
         queue.async {
             let result = performInstall(model: model, progress: progress, task: task)
+            Self.endInstall(key: installKey)
             completion(result)
         }
         return task
+    }
+
+    private static func beginInstall(key: String) -> Bool {
+        inFlightLock.lock()
+        defer { inFlightLock.unlock() }
+        guard !inFlightInstallKeys.contains(key) else { return false }
+        inFlightInstallKeys.insert(key)
+        return true
+    }
+
+    private static func endInstall(key: String) {
+        inFlightLock.lock()
+        inFlightInstallKeys.remove(key)
+        inFlightLock.unlock()
     }
 
     private func performInstall(
@@ -116,7 +141,7 @@ struct NativeWhisperInstaller {
             }
             do {
                 if store.fileManager.fileExists(atPath: final.path) {
-                    _ = try store.fileManager.replaceItemAt(final, withItemAt: partial)
+                    _ = try store.fileManager.replaceItemAt(final, withItemAt: partial, backupItemName: nil, options: [])
                 } else {
                     try store.fileManager.moveItem(at: partial, to: final)
                 }
@@ -173,7 +198,16 @@ private final class URLSessionStreamingDownloader: NSObject, URLSessionDataDeleg
 
     func download(from source: URL) throws {
         try Data().write(to: destination)
-        fileHandle = try FileHandle(forWritingTo: destination)
+        do {
+            fileHandle = try FileHandle(forWritingTo: destination)
+        } catch {
+            try? FileManager.default.removeItem(at: destination)
+            throw error
+        }
+        defer {
+            try? fileHandle?.close()
+            fileHandle = nil
+        }
 
         let configuration = URLSessionConfiguration.default
         let session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
@@ -191,8 +225,6 @@ private final class URLSessionStreamingDownloader: NSObject, URLSessionDataDeleg
 
         semaphore.wait()
         installTask.setCancellationHandler(nil)
-        try fileHandle?.close()
-        fileHandle = nil
         session.invalidateAndCancel()
         try result.get()
     }
@@ -228,6 +260,7 @@ private final class URLSessionStreamingDownloader: NSObject, URLSessionDataDeleg
             progress(NativeWhisperDownloadProgress(downloadedBytes: downloadedBytes, totalBytes: totalBytes))
         } catch {
             result = .failure(NativeWhisperInstallerError.downloadFailed(error.localizedDescription))
+            preserveCompletionFailure = true
             dataTask.cancel()
         }
     }

--- a/Sources/NativeWhisperInstaller.swift
+++ b/Sources/NativeWhisperInstaller.swift
@@ -26,6 +26,7 @@ enum NativeWhisperInstallerError: LocalizedError, Equatable {
 final class NativeWhisperInstallTask {
     private let lock = NSLock()
     private var cancelled = false
+    private var cancellationHandler: (() -> Void)?
 
     var isCancelled: Bool {
         lock.lock()
@@ -34,9 +35,23 @@ final class NativeWhisperInstallTask {
     }
 
     func cancel() {
+        let handler: (() -> Void)?
         lock.lock()
         cancelled = true
+        handler = cancellationHandler
         lock.unlock()
+        handler?()
+    }
+
+    func setCancellationHandler(_ handler: (() -> Void)?) {
+        let shouldCancelImmediately: Bool
+        lock.lock()
+        cancellationHandler = handler
+        shouldCancelImmediately = cancelled && handler != nil
+        lock.unlock()
+        if shouldCancelImmediately {
+            handler?()
+        }
     }
 }
 
@@ -45,7 +60,7 @@ struct NativeWhisperInstaller {
         _ source: URL,
         _ destination: URL,
         _ progress: @escaping (NativeWhisperDownloadProgress) -> Void,
-        _ shouldCancel: @escaping () -> Bool
+        _ task: NativeWhisperInstallTask
     ) throws -> Void
 
     let store: NativeWhisperModelStore
@@ -86,7 +101,8 @@ struct NativeWhisperInstaller {
             try store.ensureModelsDirectoryExists()
             let final = store.modelURL(for: model)
             try? store.fileManager.removeItem(at: partial)
-            try download(model.downloadURL, partial, progress, { task.isCancelled })
+            try download(model.downloadURL, partial, progress, task)
+            task.setCancellationHandler(nil)
             guard !task.isCancelled else {
                 try? store.fileManager.removeItem(at: partial)
                 return .failure(.cancelled)
@@ -94,9 +110,16 @@ struct NativeWhisperInstaller {
             guard store.fileManager.fileExists(atPath: partial.path) else {
                 return .failure(.downloadFailed("Download produced no file."))
             }
-            try? store.fileManager.removeItem(at: final)
+            guard isRegularFile(at: partial) else {
+                try? store.fileManager.removeItem(at: partial)
+                return .failure(.moveFailed("Downloaded model is not a file."))
+            }
             do {
-                try store.fileManager.moveItem(at: partial, to: final)
+                if store.fileManager.fileExists(atPath: final.path) {
+                    _ = try store.fileManager.replaceItemAt(final, withItemAt: partial)
+                } else {
+                    try store.fileManager.moveItem(at: partial, to: final)
+                }
             } catch {
                 try? store.fileManager.removeItem(at: partial)
                 return .failure(.moveFailed(error.localizedDescription))
@@ -111,43 +134,118 @@ struct NativeWhisperInstaller {
         }
     }
 
+    private func isRegularFile(at url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true
+    }
+
     private static func urlSessionDownload(
         source: URL,
         destination: URL,
         progress: @escaping (NativeWhisperDownloadProgress) -> Void,
-        shouldCancel: @escaping () -> Bool
+        task installTask: NativeWhisperInstallTask
     ) throws {
-        let semaphore = DispatchSemaphore(value: 0)
-        var result: Result<Void, Error> = .failure(NativeWhisperInstallerError.downloadFailed("Download did not start."))
-        let task = URLSession.shared.downloadTask(with: source) { temporaryURL, response, error in
-            defer { semaphore.signal() }
-            if let error {
-                result = .failure(NativeWhisperInstallerError.downloadFailed(error.localizedDescription))
-                return
-            }
-            guard let temporaryURL else {
-                result = .failure(NativeWhisperInstallerError.downloadFailed("No downloaded file was produced."))
-                return
-            }
-            do {
-                let total = response?.expectedContentLength ?? -1
-                let data = try Data(contentsOf: temporaryURL)
-                if shouldCancel() {
-                    result = .failure(NativeWhisperInstallerError.cancelled)
-                    return
-                }
-                try data.write(to: destination, options: .atomic)
-                progress(NativeWhisperDownloadProgress(
-                    downloadedBytes: Int64(data.count),
-                    totalBytes: total > 0 ? total : Int64(data.count)
-                ))
-                result = .success(())
-            } catch {
-                result = .failure(NativeWhisperInstallerError.downloadFailed(error.localizedDescription))
-            }
+        let downloader = URLSessionStreamingDownloader(
+            destination: destination,
+            progress: progress,
+            installTask: installTask
+        )
+        try downloader.download(from: source)
+    }
+}
+
+private final class URLSessionStreamingDownloader: NSObject, URLSessionDataDelegate {
+    private let destination: URL
+    private let progress: (NativeWhisperDownloadProgress) -> Void
+    private let installTask: NativeWhisperInstallTask
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var fileHandle: FileHandle?
+    private var session: URLSession?
+    private var downloadedBytes: Int64 = 0
+    private var totalBytes: Int64?
+    private var result: Result<Void, Error> = .failure(NativeWhisperInstallerError.downloadFailed("Download did not start."))
+
+    init(
+        destination: URL,
+        progress: @escaping (NativeWhisperDownloadProgress) -> Void,
+        installTask: NativeWhisperInstallTask
+    ) {
+        self.destination = destination
+        self.progress = progress
+        self.installTask = installTask
+    }
+
+    func download(from source: URL) throws {
+        try Data().write(to: destination)
+        fileHandle = try FileHandle(forWritingTo: destination)
+
+        let configuration = URLSessionConfiguration.default
+        let session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+        self.session = session
+        let urlSessionTask = session.dataTask(with: source)
+        installTask.setCancellationHandler { [weak urlSessionTask] in
+            urlSessionTask?.cancel()
         }
-        task.resume()
+
+        if installTask.isCancelled {
+            urlSessionTask.cancel()
+        } else {
+            urlSessionTask.resume()
+        }
+
         semaphore.wait()
+        installTask.setCancellationHandler(nil)
+        try fileHandle?.close()
+        fileHandle = nil
+        session.invalidateAndCancel()
         try result.get()
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        let expected = response.expectedContentLength
+        totalBytes = expected > 0 ? expected : nil
+        progress(NativeWhisperDownloadProgress(downloadedBytes: downloadedBytes, totalBytes: totalBytes))
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        if installTask.isCancelled {
+            dataTask.cancel()
+            return
+        }
+
+        do {
+            try fileHandle?.write(contentsOf: data)
+            downloadedBytes += Int64(data.count)
+            progress(NativeWhisperDownloadProgress(downloadedBytes: downloadedBytes, totalBytes: totalBytes))
+        } catch {
+            result = .failure(NativeWhisperInstallerError.downloadFailed(error.localizedDescription))
+            dataTask.cancel()
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        defer { semaphore.signal() }
+
+        if installTask.isCancelled {
+            result = .failure(NativeWhisperInstallerError.cancelled)
+            progress(NativeWhisperDownloadProgress(
+                downloadedBytes: downloadedBytes,
+                totalBytes: totalBytes,
+                isCancelled: true
+            ))
+            return
+        }
+
+        if let error {
+            result = .failure(NativeWhisperInstallerError.downloadFailed(error.localizedDescription))
+            return
+        }
+
+        result = .success(())
     }
 }

--- a/Sources/NativeWhisperInstaller.swift
+++ b/Sources/NativeWhisperInstaller.swift
@@ -110,9 +110,9 @@ struct NativeWhisperInstaller {
             guard store.fileManager.fileExists(atPath: partial.path) else {
                 return .failure(.downloadFailed("Download produced no file."))
             }
-            guard isRegularFile(at: partial) else {
+            if let validationError = store.validationError(for: model, at: partial) {
                 try? store.fileManager.removeItem(at: partial)
-                return .failure(.moveFailed("Downloaded model is not a file."))
+                return .failure(.verificationFailed(validationError))
             }
             do {
                 if store.fileManager.fileExists(atPath: final.path) {
@@ -132,10 +132,6 @@ struct NativeWhisperInstaller {
             try? store.fileManager.removeItem(at: partial)
             return .failure(.downloadFailed(error.localizedDescription))
         }
-    }
-
-    private func isRegularFile(at url: URL) -> Bool {
-        (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true
     }
 
     private static func urlSessionDownload(
@@ -162,7 +158,8 @@ private final class URLSessionStreamingDownloader: NSObject, URLSessionDataDeleg
     private var session: URLSession?
     private var downloadedBytes: Int64 = 0
     private var totalBytes: Int64?
-    private var result: Result<Void, Error> = .failure(NativeWhisperInstallerError.downloadFailed("Download did not start."))
+    private var result: Result<Void, Error> = .success(())
+    private var preserveCompletionFailure = false
 
     init(
         destination: URL,
@@ -206,6 +203,13 @@ private final class URLSessionStreamingDownloader: NSObject, URLSessionDataDeleg
         didReceive response: URLResponse,
         completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
     ) {
+        if let httpResponse = response as? HTTPURLResponse,
+           !(200...299).contains(httpResponse.statusCode) {
+            result = .failure(NativeWhisperInstallerError.downloadFailed("HTTP \(httpResponse.statusCode)"))
+            preserveCompletionFailure = true
+            completionHandler(.cancel)
+            return
+        }
         let expected = response.expectedContentLength
         totalBytes = expected > 0 ? expected : nil
         progress(NativeWhisperDownloadProgress(downloadedBytes: downloadedBytes, totalBytes: totalBytes))
@@ -242,7 +246,9 @@ private final class URLSessionStreamingDownloader: NSObject, URLSessionDataDeleg
         }
 
         if let error {
-            result = .failure(NativeWhisperInstallerError.downloadFailed(error.localizedDescription))
+            if !preserveCompletionFailure {
+                result = .failure(NativeWhisperInstallerError.downloadFailed(error.localizedDescription))
+            }
             return
         }
 

--- a/Sources/NativeWhisperModel.swift
+++ b/Sources/NativeWhisperModel.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 struct NativeWhisperModel: Identifiable, Hashable, Codable {
@@ -7,7 +8,7 @@ struct NativeWhisperModel: Identifiable, Hashable, Codable {
     let downloadURL: URL
     let expectedFileName: String
     let approximateBytes: Int64
-    let checksumSHA256: String?
+    let checksumSHA256: String
 
     static var recommended: NativeWhisperModel { NativeWhisperModelCatalog.recommended }
 }
@@ -19,8 +20,8 @@ struct NativeWhisperModelCatalog {
         description: "Fast local transcription with high accuracy. Recommended.",
         downloadURL: URL(string: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin")!,
         expectedFileName: "ggml-large-v3-turbo.bin",
-        approximateBytes: 1_620_000_000,
-        checksumSHA256: nil
+        approximateBytes: 1_624_555_275,
+        checksumSHA256: "1fc70f774d38eb169993ac391eea357ef47c88757ef72ee5943879b7e8e2bc69"
     )
 
     static let all: [NativeWhisperModel] = [recommended]
@@ -146,15 +147,42 @@ struct NativeWhisperModelStore {
             let minimum = ByteCountFormatter.string(fromByteCount: minimumBytes, countStyle: .file)
             return "Model file is too small (\(actual)); expected at least \(minimum)."
         }
-        if let checksum = model.checksumSHA256, !checksum.isEmpty {
-            return "Checksum verification is not implemented for this model yet."
+        if let checksumError = checksumValidationError(for: model, at: url) {
+            return checksumError
         }
         return nil
     }
 
     private func minimumReadyBytes(for model: NativeWhisperModel) -> Int64 {
         guard model.approximateBytes > 0 else { return 1 }
-        return min(max(1, model.approximateBytes / 10), 100_000_000)
+        return max(1, Int64((Double(model.approximateBytes) * 0.95).rounded()))
+    }
+
+    private func checksumValidationError(for model: NativeWhisperModel, at url: URL) -> String? {
+        let expected = model.checksumSHA256.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !expected.isEmpty else {
+            return "Model checksum is missing."
+        }
+        guard let actual = sha256HexDigest(at: url) else {
+            return "Could not read model file for checksum verification."
+        }
+        guard actual == expected else {
+            return "Model checksum mismatch."
+        }
+        return nil
+    }
+
+    private func sha256HexDigest(at url: URL) -> String? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+
+        var hasher = SHA256()
+        while true {
+            let data = handle.readData(ofLength: 1_048_576)
+            if data.isEmpty { break }
+            hasher.update(data: data)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
     }
 
     private func fileSize(at url: URL) -> Int64 {

--- a/Sources/NativeWhisperModel.swift
+++ b/Sources/NativeWhisperModel.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+struct NativeWhisperModel: Identifiable, Hashable, Codable {
+    let id: String
+    let displayName: String
+    let description: String
+    let downloadURL: URL
+    let expectedFileName: String
+    let approximateBytes: Int64
+    let checksumSHA256: String?
+
+    static var recommended: NativeWhisperModel { NativeWhisperModelCatalog.recommended }
+}
+
+struct NativeWhisperModelCatalog {
+    static let recommended = NativeWhisperModel(
+        id: "whisper-large-v3-turbo",
+        displayName: "Whisper Large v3 Turbo",
+        description: "Fast local transcription with high accuracy. Recommended.",
+        downloadURL: URL(string: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin")!,
+        expectedFileName: "ggml-large-v3-turbo.bin",
+        approximateBytes: 1_620_000_000,
+        checksumSHA256: nil
+    )
+
+    static let all: [NativeWhisperModel] = [recommended]
+
+    static func find(id: String) -> NativeWhisperModel {
+        all.first { $0.id == id } ?? recommended
+    }
+}
+
+enum NativeWhisperInstallStatus: Equatable {
+    case notInstalled
+    case partial(downloadedBytes: Int64, expectedBytes: Int64?)
+    case ready
+    case corrupt(String)
+}
+
+struct NativeWhisperDownloadProgress: Equatable {
+    let downloadedBytes: Int64
+    let totalBytes: Int64?
+    let isCancelled: Bool
+
+    init(downloadedBytes: Int64, totalBytes: Int64?, isCancelled: Bool = false) {
+        self.downloadedBytes = downloadedBytes
+        self.totalBytes = totalBytes
+        self.isCancelled = isCancelled
+    }
+
+    var fractionCompleted: Double? {
+        guard let totalBytes, totalBytes > 0 else { return nil }
+        return min(Double(downloadedBytes) / Double(totalBytes), 1)
+    }
+
+    var displayText: String {
+        if isCancelled { return "Canceled" }
+        guard downloadedBytes > 0 else { return "Starting..." }
+        let sizeText = ByteCountFormatter.string(fromByteCount: downloadedBytes, countStyle: .file)
+        if let fractionCompleted {
+            return "\(Int((fractionCompleted * 100).rounded()))% · \(sizeText)"
+        }
+        return sizeText
+    }
+}
+
+struct NativeWhisperModelStore {
+    let rootDirectory: URL
+    let fileManager: FileManager
+
+    init(
+        rootDirectory: URL = NativeWhisperModelStore.defaultRootDirectory(),
+        fileManager: FileManager = .default
+    ) {
+        self.rootDirectory = rootDirectory
+        self.fileManager = fileManager
+    }
+
+    var modelsDirectory: URL {
+        rootDirectory
+            .appendingPathComponent("LocalWhisper", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+    }
+
+    static func defaultRootDirectory() -> URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "Quill"
+        return appSupport.appendingPathComponent(appName, isDirectory: true)
+    }
+
+    func modelURL(for model: NativeWhisperModel) -> URL {
+        modelsDirectory.appendingPathComponent(model.expectedFileName, isDirectory: false)
+    }
+
+    func partialModelURL(for model: NativeWhisperModel) -> URL {
+        modelsDirectory.appendingPathComponent("\(model.expectedFileName).download", isDirectory: false)
+    }
+
+    func installStatus(for model: NativeWhisperModel) -> NativeWhisperInstallStatus {
+        let finalURL = modelURL(for: model)
+        if fileManager.fileExists(atPath: finalURL.path) {
+            if let checksum = model.checksumSHA256, !checksum.isEmpty {
+                return .corrupt("Checksum verification is not implemented for this model yet.")
+            }
+            return .ready
+        }
+
+        let partialURL = partialModelURL(for: model)
+        if fileManager.fileExists(atPath: partialURL.path) {
+            let bytes = fileSize(at: partialURL)
+            return .partial(downloadedBytes: bytes, expectedBytes: model.approximateBytes)
+        }
+
+        return .notInstalled
+    }
+
+    func ensureModelsDirectoryExists() throws {
+        try fileManager.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
+    }
+
+    func deleteModel(_ model: NativeWhisperModel) throws {
+        let paths = [modelURL(for: model), partialModelURL(for: model)]
+        for url in paths where fileManager.fileExists(atPath: url.path) {
+            try fileManager.removeItem(at: url)
+        }
+    }
+
+    private func fileSize(at url: URL) -> Int64 {
+        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
+        return Int64(size)
+    }
+}

--- a/Sources/NativeWhisperModel.swift
+++ b/Sources/NativeWhisperModel.swift
@@ -125,6 +125,13 @@ struct NativeWhisperModelStore {
         }
     }
 
+    func deletePartialModel(_ model: NativeWhisperModel) throws {
+        let partialURL = partialModelURL(for: model)
+        if fileManager.fileExists(atPath: partialURL.path) {
+            try fileManager.removeItem(at: partialURL)
+        }
+    }
+
     func validationError(for model: NativeWhisperModel, at url: URL) -> String? {
         guard fileManager.fileExists(atPath: url.path) else {
             return "Model file is missing."

--- a/Sources/NativeWhisperModel.swift
+++ b/Sources/NativeWhisperModel.swift
@@ -99,8 +99,8 @@ struct NativeWhisperModelStore {
     func installStatus(for model: NativeWhisperModel) -> NativeWhisperInstallStatus {
         let finalURL = modelURL(for: model)
         if fileManager.fileExists(atPath: finalURL.path) {
-            if let checksum = model.checksumSHA256, !checksum.isEmpty {
-                return .corrupt("Checksum verification is not implemented for this model yet.")
+            if let error = validationError(for: model, at: finalURL) {
+                return .corrupt(error)
             }
             return .ready
         }
@@ -123,6 +123,31 @@ struct NativeWhisperModelStore {
         for url in paths where fileManager.fileExists(atPath: url.path) {
             try fileManager.removeItem(at: url)
         }
+    }
+
+    func validationError(for model: NativeWhisperModel, at url: URL) -> String? {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return "Model file is missing."
+        }
+        guard ((try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true) else {
+            return "Model path is not a regular file."
+        }
+        let bytes = fileSize(at: url)
+        let minimumBytes = minimumReadyBytes(for: model)
+        guard bytes >= minimumBytes else {
+            let actual = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+            let minimum = ByteCountFormatter.string(fromByteCount: minimumBytes, countStyle: .file)
+            return "Model file is too small (\(actual)); expected at least \(minimum)."
+        }
+        if let checksum = model.checksumSHA256, !checksum.isEmpty {
+            return "Checksum verification is not implemented for this model yet."
+        }
+        return nil
+    }
+
+    private func minimumReadyBytes(for model: NativeWhisperModel) -> Int64 {
+        guard model.approximateBytes > 0 else { return 1 }
+        return min(max(1, model.approximateBytes / 10), 100_000_000)
     }
 
     private func fileSize(at url: URL) -> Int64 {

--- a/Sources/NativeWhisperRuntime.swift
+++ b/Sources/NativeWhisperRuntime.swift
@@ -92,8 +92,16 @@ struct NativeWhisperRuntime {
             process.standardOutput = stdout
             process.standardError = stderr
 
-            let processLock = NSLock()
-            try process.run()
+            let processState = ProcessCancellationState(process: process)
+            let exitObserver = ProcessExitObserver()
+            process.terminationHandler = { _ in
+                exitObserver.processDidExit()
+            }
+            try await withTaskCancellationHandler {
+                try processState.run()
+            } onCancel: {
+                processState.terminateIfRunning()
+            }
             let stdoutReader = Task.detached {
                 String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
             }
@@ -101,13 +109,9 @@ struct NativeWhisperRuntime {
                 String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
             }
             await withTaskCancellationHandler {
-                process.waitUntilExit()
+                await exitObserver.wait()
             } onCancel: {
-                processLock.lock()
-                if process.isRunning {
-                    process.terminate()
-                }
-                processLock.unlock()
+                processState.terminateIfRunning()
             }
             try Task.checkCancellation()
 
@@ -138,6 +142,61 @@ struct NativeWhisperRuntime {
         Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
     }
 
+    private final class ProcessCancellationState: @unchecked Sendable {
+        private let lock = NSLock()
+        private let process: Process
+
+        init(process: Process) {
+            self.process = process
+        }
+
+        func run() throws {
+            lock.lock()
+            defer { lock.unlock() }
+            try Task.checkCancellation()
+            try process.run()
+        }
+
+        func terminateIfRunning() {
+            lock.lock()
+            defer { lock.unlock() }
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+    }
+
+    private final class ProcessExitObserver {
+        private let lock = NSLock()
+        private var didExit = false
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        func wait() async {
+            await withCheckedContinuation { continuation in
+                let continuationToResume: CheckedContinuation<Void, Never>?
+                lock.lock()
+                if didExit {
+                    continuationToResume = continuation
+                } else {
+                    self.continuation = continuation
+                    continuationToResume = nil
+                }
+                lock.unlock()
+                continuationToResume?.resume()
+            }
+        }
+
+        func processDidExit() {
+            let continuationToResume: CheckedContinuation<Void, Never>?
+            lock.lock()
+            didExit = true
+            continuationToResume = continuation
+            continuation = nil
+            lock.unlock()
+            continuationToResume?.resume()
+        }
+    }
+
     private static func transcriptFromJSON(at url: URL) -> String? {
         guard let data = try? Data(contentsOf: url),
               let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
@@ -157,7 +216,7 @@ struct NativeWhisperRuntime {
         text
             .split(separator: "\n")
             .map { line in
-                line.replacingOccurrences(of: #"^\[[^\]]+\]\s*"#, with: "", options: .regularExpression)
+                String(line).replacingOccurrences(of: #"^\[[^\]]+\]\s*"#, with: "", options: .regularExpression)
                     .trimmingCharacters(in: .whitespacesAndNewlines)
             }
             .filter { !$0.isEmpty }

--- a/Sources/NativeWhisperRuntime.swift
+++ b/Sources/NativeWhisperRuntime.swift
@@ -50,7 +50,7 @@ struct NativeWhisperRuntime {
     }
 
     func transcribe(audioURL: URL, modelURL: URL, languageCode: String?) async throws -> String {
-        try await Task.detached(priority: .userInitiated) {
+        let worker = Task.detached(priority: .userInitiated) {
             guard fileManager.isExecutableFile(atPath: runnerURL.path) else {
                 throw NativeWhisperRuntimeError.runnerNotFound(runnerURL.path)
             }
@@ -91,6 +91,7 @@ struct NativeWhisperRuntime {
             process.standardOutput = stdout
             process.standardError = stderr
 
+            let processLock = NSLock()
             try process.run()
             let stdoutReader = Task.detached {
                 String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
@@ -98,7 +99,15 @@ struct NativeWhisperRuntime {
             let stderrReader = Task.detached {
                 String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
             }
-            process.waitUntilExit()
+            await withTaskCancellationHandler {
+                process.waitUntilExit()
+            } onCancel: {
+                processLock.lock()
+                if process.isRunning {
+                    process.terminate()
+                }
+                processLock.unlock()
+            }
             try Task.checkCancellation()
 
             let stdoutText = await stdoutReader.value
@@ -116,7 +125,12 @@ struct NativeWhisperRuntime {
                 return stdoutTranscript
             }
             throw NativeWhisperRuntimeError.noTranscript(output: combinedOutput)
-        }.value
+        }
+        return try await withTaskCancellationHandler {
+            try await worker.value
+        } onCancel: {
+            worker.cancel()
+        }
     }
 
     private func fileSize(at url: URL) -> Int64 {

--- a/Sources/NativeWhisperRuntime.swift
+++ b/Sources/NativeWhisperRuntime.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+enum NativeWhisperRuntimeError: LocalizedError, Equatable {
+    case runnerNotFound(String)
+    case modelNotFound(String)
+    case audioNotReadable(String)
+    case processFailed(exitCode: Int32, output: String)
+    case noTranscript(output: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .runnerNotFound:
+            return "Local Whisper runtime is not available in this app build."
+        case .modelNotFound:
+            return "Local Whisper model is not installed yet."
+        case .audioNotReadable:
+            return "Local Whisper could not read this recording."
+        case .processFailed:
+            return "Local Whisper failed while transcribing this recording."
+        case .noTranscript:
+            return "Local Whisper produced no transcript."
+        }
+    }
+
+    var technicalDetails: String {
+        switch self {
+        case .runnerNotFound(let path): return "Runner not found or not executable: \(path)"
+        case .modelNotFound(let path): return "Model file not found: \(path)"
+        case .audioNotReadable(let path): return "Audio file missing, empty, or unreadable: \(path)"
+        case .processFailed(let exitCode, let output): return "Exit code \(exitCode). Output: \(output)"
+        case .noTranscript(let output): return "No transcript. Output: \(output)"
+        }
+    }
+}
+
+struct NativeWhisperRuntime {
+    let runnerURL: URL
+    let fileManager: FileManager
+
+    init(
+        runnerURL: URL = NativeWhisperRuntime.defaultRunnerURL() ?? URL(fileURLWithPath: "/__missing_whisper_cli__"),
+        fileManager: FileManager = .default
+    ) {
+        self.runnerURL = runnerURL
+        self.fileManager = fileManager
+    }
+
+    static func defaultRunnerURL(bundle: Bundle = .main) -> URL? {
+        bundle.url(forResource: "whisper-cli", withExtension: nil, subdirectory: "whisper")
+    }
+
+    func transcribe(audioURL: URL, modelURL: URL, languageCode: String?) async throws -> String {
+        try await Task.detached(priority: .userInitiated) {
+            guard fileManager.isExecutableFile(atPath: runnerURL.path) else {
+                throw NativeWhisperRuntimeError.runnerNotFound(runnerURL.path)
+            }
+            guard fileManager.fileExists(atPath: modelURL.path) else {
+                throw NativeWhisperRuntimeError.modelNotFound(modelURL.path)
+            }
+            guard fileManager.isReadableFile(atPath: audioURL.path), fileSize(at: audioURL) > 0 else {
+                throw NativeWhisperRuntimeError.audioNotReadable(audioURL.path)
+            }
+
+            let outputBase = fileManager.temporaryDirectory
+                .appendingPathComponent("quill-native-whisper-\(UUID().uuidString)")
+            defer {
+                try? fileManager.removeItem(at: outputBase.appendingPathExtension("json"))
+                try? fileManager.removeItem(at: outputBase.appendingPathExtension("txt"))
+            }
+
+            let process = Process()
+            process.executableURL = runnerURL
+            var arguments = [
+                "-m", modelURL.path,
+                "-f", audioURL.path,
+                "-nt",
+                "-oj",
+                "-of", outputBase.path
+            ]
+            if let languageCode, !languageCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                arguments += ["-l", languageCode]
+            }
+            process.arguments = arguments
+            process.environment = [
+                "PATH": "/usr/bin:/bin",
+                "HOME": fileManager.homeDirectoryForCurrentUser.path
+            ]
+
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.standardOutput = stdout
+            process.standardError = stderr
+
+            try process.run()
+            let stdoutReader = Task.detached {
+                String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            }
+            let stderrReader = Task.detached {
+                String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            }
+            process.waitUntilExit()
+            try Task.checkCancellation()
+
+            let stdoutText = await stdoutReader.value
+            let stderrText = await stderrReader.value
+            let combinedOutput = Self.summarizedOutput(stderrText.isEmpty ? stdoutText : stderrText)
+            guard process.terminationStatus == 0 else {
+                throw NativeWhisperRuntimeError.processFailed(exitCode: process.terminationStatus, output: combinedOutput)
+            }
+
+            if let jsonTranscript = Self.transcriptFromJSON(at: outputBase.appendingPathExtension("json")), !jsonTranscript.isEmpty {
+                return jsonTranscript
+            }
+            let stdoutTranscript = Self.normalizedTranscript(stdoutText)
+            if !stdoutTranscript.isEmpty {
+                return stdoutTranscript
+            }
+            throw NativeWhisperRuntimeError.noTranscript(output: combinedOutput)
+        }.value
+    }
+
+    private func fileSize(at url: URL) -> Int64 {
+        Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+    }
+
+    private static func transcriptFromJSON(at url: URL) -> String? {
+        guard let data = try? Data(contentsOf: url),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        if let text = object["text"] as? String {
+            return normalizedTranscript(text)
+        }
+        if let transcription = object["transcription"] as? [[String: Any]] {
+            let joined = transcription.compactMap { $0["text"] as? String }.joined(separator: " ")
+            return normalizedTranscript(joined)
+        }
+        return nil
+    }
+
+    private static func normalizedTranscript(_ text: String) -> String {
+        text
+            .split(separator: "\n")
+            .map { line in
+                line.replacingOccurrences(of: #"^\[[^\]]+\]\s*"#, with: "", options: .regularExpression)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func summarizedOutput(_ text: String) -> String {
+        let lines = text.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: "\n").map(String.init)
+        guard !lines.isEmpty else { return "" }
+        if lines.count <= 8 { return lines.joined(separator: "\n") }
+        let head = lines.prefix(4)
+        let tail = lines.suffix(4)
+        return (head + ["... (\(lines.count - 8) more lines)"] + tail).joined(separator: "\n")
+    }
+}

--- a/Sources/NativeWhisperRuntime.swift
+++ b/Sources/NativeWhisperRuntime.swift
@@ -74,6 +74,7 @@ struct NativeWhisperRuntime {
                 "-m", modelURL.path,
                 "-f", audioURL.path,
                 "-nt",
+                "-mc", "0",
                 "-oj",
                 "-of", outputBase.path
             ]

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -689,7 +689,7 @@ struct NoteBrowserView: View {
                 fileURL: url,
                 currentMode: appState.currentNoteBrowserTranscriptionMode,
                 hasAPIKey: appState.hasTranscriptionAPIKey,
-                hasLocalWhisperModel: appState.hasInstalledLocalWhisperModel
+                hasLocalWhisperModel: appState.useLegacyMlxWhisper && appState.hasLegacyLocalWhisperModel
             )
         }
     }

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -348,7 +348,7 @@ private struct AudioImportSheet: View {
                                         .font(.system(size: 10))
                                         .foregroundStyle(.tertiary)
                                 } else if mode == .localWhisper && !isSupported {
-                                    Text("No Local Whisper model is installed")
+                                    Text("Imported audio uses API unless legacy mlx-whisper is enabled")
                                         .font(.system(size: 10))
                                         .foregroundStyle(.tertiary)
                                 }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1622,32 +1622,43 @@ struct ModelsSettingsView: View {
                 Text("Local Options")
                     .font(.caption.weight(.semibold))
 
-                ForEach(TranscriptionModel.all) { model in
-                    ModelRowView(
-                        model: model,
-                        isSelected: appState.localTranscriptionModel == model,
-                        whisperBin: appState.localWhisperPath.isEmpty
-                            ? "\(FileManager.default.homeDirectoryForCurrentUser.path)/.local/bin/mlx_whisper"
-                            : appState.localWhisperPath,
-                        onSelect: { appState.localTranscriptionModel = model },
-                        onDeleted: {
-                            if appState.localTranscriptionModel == model {
-                                appState.localTranscriptionModel = .default
-                            }
-                        }
-                    )
+                ModelRowView(
+                    model: TranscriptionModel.find(id: "apple-speech"),
+                    isSelected: appState.localTranscriptionModel.isAppleSpeech,
+                    whisperBin: "",
+                    onSelect: { appState.localTranscriptionModel = .find(id: "apple-speech") },
+                    onDeleted: {}
+                )
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Local Whisper")
+                        .font(.caption.weight(.semibold))
+                    Text("Private transcription on your Mac. Quill installs the native model it needs.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    NativeWhisperModelRowView()
+                    Button("Use Local Whisper") {
+                        appState.useLocalTranscription = true
+                        appState.localTranscriptionModel = .find(id: "mlx-community/whisper-large-v3-turbo")
+                        appState.useLegacyMlxWhisper = false
+                    }
+                    .font(.caption)
+                    .buttonStyle(.bordered)
                 }
             }
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text("mlx_whisper Path (optional)")
-                    .font(.caption.weight(.semibold))
-                Text("Leave empty to use the default path (~/.local/bin/mlx_whisper).")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                TextField("~/.local/bin/mlx_whisper", text: $appState.localWhisperPath)
-                    .textFieldStyle(.roundedBorder)
-                    .font(.system(.body, design: .monospaced))
+            DisclosureGroup("Advanced Legacy mlx-whisper") {
+                VStack(alignment: .leading, spacing: 8) {
+                    Toggle("Use legacy mlx-whisper", isOn: $appState.useLegacyMlxWhisper)
+                    Text("Only enable this if you already manage mlx-whisper yourself.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextField("~/.local/bin/mlx_whisper", text: $appState.localWhisperPath)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.body, design: .monospaced))
+                        .disabled(!appState.useLegacyMlxWhisper)
+                }
+                .padding(.top, 4)
             }
         }
     }
@@ -3590,6 +3601,131 @@ struct DonutProgressView: View {
                 .rotationEffect(.degrees(-90))
         }
         .frame(width: 18, height: 18)
+    }
+}
+
+struct NativeWhisperModelRowView: View {
+    let model: NativeWhisperModel
+    let store: NativeWhisperModelStore
+
+    @State private var installStatus: NativeWhisperInstallStatus = .notInstalled
+    @State private var isInstalling = false
+    @State private var progress = NativeWhisperDownloadProgress(downloadedBytes: 0, totalBytes: nil)
+    @State private var installTask: NativeWhisperInstallTask?
+    @State private var errorMessage: String?
+
+    init(
+        model: NativeWhisperModel = NativeWhisperModelCatalog.recommended,
+        store: NativeWhisperModelStore = NativeWhisperModelStore()
+    ) {
+        self.model = model
+        self.store = store
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 10) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(model.displayName)
+                        .font(.caption.weight(.semibold))
+                    Text("Fast local transcription. About \(ByteCountFormatter.string(fromByteCount: model.approximateBytes, countStyle: .file)).")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                actionView
+            }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "xmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(8)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .cornerRadius(6)
+        .onAppear { refreshInstallState() }
+    }
+
+    @ViewBuilder
+    private var actionView: some View {
+        if isInstalling {
+            HStack(spacing: 8) {
+                Text(progress.displayText)
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                Button("Cancel") { cancelInstall() }
+                    .font(.caption)
+                    .controlSize(.small)
+            }
+        } else if installStatus == .ready {
+            HStack(spacing: 8) {
+                Label("Ready", systemImage: "checkmark.circle.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.green)
+                Button("Delete Model") { deleteModel() }
+                    .font(.caption)
+                    .controlSize(.small)
+            }
+        } else {
+            Button("Install Local Whisper") { installModel() }
+                .font(.caption)
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+        }
+    }
+
+    private func refreshInstallState() {
+        installStatus = store.installStatus(for: model)
+    }
+
+    private func installModel() {
+        errorMessage = nil
+        isInstalling = true
+        progress = NativeWhisperDownloadProgress(downloadedBytes: 0, totalBytes: model.approximateBytes)
+        let installer = NativeWhisperInstaller(store: store)
+        installTask = installer.install(
+            model: model,
+            progress: { progress in
+                DispatchQueue.main.async {
+                    self.progress = progress
+                }
+            },
+            completion: { result in
+                DispatchQueue.main.async {
+                    installTask = nil
+                    isInstalling = false
+                    refreshInstallState()
+                    if case .failure(let error) = result {
+                        errorMessage = error.localizedDescription
+                    }
+                }
+            }
+        )
+    }
+
+    private func cancelInstall() {
+        installTask?.cancel()
+        installTask = nil
+        isInstalling = false
+        progress = NativeWhisperDownloadProgress(
+            downloadedBytes: progress.downloadedBytes,
+            totalBytes: progress.totalBytes,
+            isCancelled: true
+        )
+        refreshInstallState()
+    }
+
+    private func deleteModel() {
+        do {
+            try store.deleteModel(model)
+            errorMessage = nil
+            refreshInstallState()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1510,6 +1510,7 @@ struct ModelsSettingsView: View {
     @State private var keyValidationSuccess = false
     @State private var customVocabularyInput: String = ""
     @State private var advancedProviderSettingsExpanded = false
+    @State private var nativeWhisperInstallStatus: NativeWhisperInstallStatus = NativeWhisperModelStore().installStatus(for: .recommended)
 
     @State private var customSystemPromptInput: String = ""
     @State private var customContextPromptInput: String = ""
@@ -1636,7 +1637,7 @@ struct ModelsSettingsView: View {
                     Text("Private transcription on your Mac. Quill installs the native model it needs.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    NativeWhisperModelRowView()
+                    NativeWhisperModelRowView(onStatusChanged: { nativeWhisperInstallStatus = $0 })
                     Button("Use Local Whisper") {
                         appState.useLocalTranscription = true
                         appState.localTranscriptionModel = .find(id: "mlx-community/whisper-large-v3-turbo")
@@ -1644,6 +1645,8 @@ struct ModelsSettingsView: View {
                     }
                     .font(.caption)
                     .buttonStyle(.bordered)
+                    .disabled(nativeWhisperInstallStatus != .ready)
+                    .help(nativeWhisperInstallStatus == .ready ? "Use the built-in native Local Whisper runtime." : "Install Local Whisper before selecting it.")
                 }
             }
 
@@ -3607,6 +3610,7 @@ struct DonutProgressView: View {
 struct NativeWhisperModelRowView: View {
     let model: NativeWhisperModel
     let store: NativeWhisperModelStore
+    let onStatusChanged: (NativeWhisperInstallStatus) -> Void
 
     @State private var installStatus: NativeWhisperInstallStatus = .notInstalled
     @State private var isInstalling = false
@@ -3616,10 +3620,12 @@ struct NativeWhisperModelRowView: View {
 
     init(
         model: NativeWhisperModel = NativeWhisperModelCatalog.recommended,
-        store: NativeWhisperModelStore = NativeWhisperModelStore()
+        store: NativeWhisperModelStore = NativeWhisperModelStore(),
+        onStatusChanged: @escaping (NativeWhisperInstallStatus) -> Void = { _ in }
     ) {
         self.model = model
         self.store = store
+        self.onStatusChanged = onStatusChanged
     }
 
     var body: some View {
@@ -3679,6 +3685,7 @@ struct NativeWhisperModelRowView: View {
 
     private func refreshInstallState() {
         installStatus = store.installStatus(for: model)
+        onStatusChanged(installStatus)
     }
 
     private func installModel() {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -3764,16 +3764,16 @@ struct NativeWhisperModelRowView: View {
                         .controlSize(.small)
                         .opacity(isHoveringDownloadProgress ? 0.25 : 1)
                 }
-                if isHoveringDownloadProgress {
-                    Button {
-                        appState.cancelNativeWhisperInstall()
-                    } label: {
-                        Image(systemName: "xmark")
-                            .font(.system(size: 8, weight: .bold))
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
+                Button {
+                    appState.cancelNativeWhisperInstall()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 8, weight: .bold))
                 }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .opacity(isHoveringDownloadProgress ? 1 : 0.001)
+                .accessibilityLabel("Cancel Local Whisper download")
             }
             .frame(width: 24, height: 24)
             .contentShape(Circle())

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -3644,6 +3644,7 @@ struct NativeWhisperModelRowView: View {
 
     @State private var showDeleteConfirmation = false
     @State private var isHoveringDownloadProgress = false
+    @FocusState private var isCancelDownloadFocused: Bool
 
     init(
         model: NativeWhisperModel = NativeWhisperModelCatalog.recommended,
@@ -3758,11 +3759,11 @@ struct NativeWhisperModelRowView: View {
             ZStack {
                 if let fractionCompleted = appState.nativeWhisperInstallProgress.fractionCompleted {
                     DonutProgressView(fractionCompleted: fractionCompleted)
-                        .opacity(isHoveringDownloadProgress ? 0.25 : 1)
+                        .opacity((isHoveringDownloadProgress || isCancelDownloadFocused) ? 0.25 : 1)
                 } else {
                     ProgressView()
                         .controlSize(.small)
-                        .opacity(isHoveringDownloadProgress ? 0.25 : 1)
+                        .opacity((isHoveringDownloadProgress || isCancelDownloadFocused) ? 0.25 : 1)
                 }
                 Button {
                     appState.cancelNativeWhisperInstall()
@@ -3772,7 +3773,8 @@ struct NativeWhisperModelRowView: View {
                 }
                 .buttonStyle(.plain)
                 .foregroundStyle(.secondary)
-                .opacity(isHoveringDownloadProgress ? 1 : 0.001)
+                .focused($isCancelDownloadFocused)
+                .opacity((isHoveringDownloadProgress || isCancelDownloadFocused) ? 1 : 0.001)
                 .accessibilityLabel("Cancel Local Whisper download")
             }
             .frame(width: 24, height: 24)

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -409,6 +409,9 @@ struct SettingsView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .onDisappear {
+            appState.cancelNativeWhisperInstallForSettingsClose()
+        }
     }
 }
 
@@ -1505,12 +1508,12 @@ struct ModelsSettingsView: View {
     @State private var apiBaseURLInput: String = ""
     @State private var transcriptionAPIURLInput: String = ""
     @State private var transcriptionAPIKeyInput: String = ""
+    @State private var showingLocalTranscriptionSettings = true
     @State private var isValidatingKey = false
     @State private var keyValidationError: String?
     @State private var keyValidationSuccess = false
     @State private var customVocabularyInput: String = ""
     @State private var advancedProviderSettingsExpanded = false
-    @State private var nativeWhisperInstallStatus: NativeWhisperInstallStatus = NativeWhisperModelStore().installStatus(for: .recommended)
 
     @State private var customSystemPromptInput: String = ""
     @State private var customContextPromptInput: String = ""
@@ -1567,6 +1570,7 @@ struct ModelsSettingsView: View {
             apiBaseURLInput = appState.apiBaseURL
             transcriptionAPIURLInput = appState.transcriptionAPIURL
             transcriptionAPIKeyInput = appState.transcriptionAPIKey
+            showingLocalTranscriptionSettings = appState.useLocalTranscription
             customVocabularyInput = appState.customVocabulary
             customSystemPromptInput = appState.customSystemPrompt.isEmpty
                 ? PostProcessingService.defaultSystemPrompt
@@ -1589,14 +1593,21 @@ struct ModelsSettingsView: View {
                 Text("Transcription Mode")
                     .font(.caption.weight(.semibold))
 
-                Picker("Transcription Mode", selection: $appState.useLocalTranscription) {
+                Picker("Transcription Mode", selection: $showingLocalTranscriptionSettings) {
                     Text("Local").tag(true)
                     Text("API Provider").tag(false)
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
+                .onChange(of: showingLocalTranscriptionSettings) { showsLocal in
+                    if showsLocal {
+                        appState.useLocalTranscription = true
+                    } else if appState.hasTranscriptionAPIKey {
+                        appState.setNoteBrowserTranscriptionMode(.apiStandard)
+                    }
+                }
 
-                Text(appState.useLocalTranscription
+                Text(showingLocalTranscriptionSettings
                     ? "Run speech recognition on this Mac and configure only local transcription options."
                     : "Use your configured OpenAI-compatible provider and configure only provider-specific options.")
                     .font(.caption)
@@ -1605,7 +1616,7 @@ struct ModelsSettingsView: View {
 
             Divider()
 
-            if appState.useLocalTranscription {
+            if showingLocalTranscriptionSettings {
                 localTranscriptionSettings
             } else {
                 apiProviderTranscriptionSettings
@@ -1631,23 +1642,17 @@ struct ModelsSettingsView: View {
                     onDeleted: {}
                 )
 
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Local Whisper")
-                        .font(.caption.weight(.semibold))
-                    Text("Private transcription on your Mac. Quill installs the native model it needs.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    NativeWhisperModelRowView(onStatusChanged: { nativeWhisperInstallStatus = $0 })
-                    Button("Use Local Whisper") {
+                NativeWhisperModelRowView(
+                    isSelected: !appState.localTranscriptionModel.isAppleSpeech && !appState.useLegacyMlxWhisper,
+                    onSelect: {
                         appState.useLocalTranscription = true
                         appState.localTranscriptionModel = .find(id: "mlx-community/whisper-large-v3-turbo")
                         appState.useLegacyMlxWhisper = false
                     }
-                    .font(.caption)
-                    .buttonStyle(.bordered)
-                    .disabled(nativeWhisperInstallStatus != .ready)
-                    .help(nativeWhisperInstallStatus == .ready ? "Use the built-in native Local Whisper runtime." : "Install Local Whisper before selecting it.")
-                }
+                )
+                Text("If you close Settings while the model is downloading, Quill cancels the download and removes the partial file.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
             }
 
             DisclosureGroup("Advanced Legacy mlx-whisper") {
@@ -1656,6 +1661,26 @@ struct ModelsSettingsView: View {
                     Text("Only enable this if you already manage mlx-whisper yourself.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                    ForEach(TranscriptionModel.all.filter { !$0.isAppleSpeech }) { model in
+                        ModelRowView(
+                            model: model,
+                            isSelected: appState.useLegacyMlxWhisper && appState.localTranscriptionModel.id == model.id,
+                            whisperBin: appState.localWhisperPath.isEmpty
+                                ? "\(FileManager.default.homeDirectoryForCurrentUser.path)/.local/bin/mlx_whisper"
+                                : appState.localWhisperPath,
+                            onSelect: {
+                                appState.useLocalTranscription = true
+                                appState.useLegacyMlxWhisper = true
+                                appState.localTranscriptionModel = model
+                            },
+                            onDeleted: {
+                                appState.localTranscriptionModel = .find(id: "mlx-community/whisper-large-v3-turbo")
+                            }
+                        )
+                        .disabled(!appState.useLegacyMlxWhisper)
+                        .opacity(appState.useLegacyMlxWhisper ? 1 : 0.55)
+                    }
+
                     TextField("~/.local/bin/mlx_whisper", text: $appState.localWhisperPath)
                         .textFieldStyle(.roundedBorder)
                         .font(.system(.body, design: .monospaced))
@@ -1840,6 +1865,9 @@ struct ModelsSettingsView: View {
                 isValidatingKey = false
                 if valid {
                     appState.apiKey = key
+                    if !showingLocalTranscriptionSettings {
+                        appState.setNoteBrowserTranscriptionMode(.apiStandard)
+                    }
                     keyValidationSuccess = true
                 } else {
                     keyValidationError = "Validation failed. Please check your API key and provider settings, then try again."
@@ -3608,41 +3636,56 @@ struct DonutProgressView: View {
 }
 
 struct NativeWhisperModelRowView: View {
-    let model: NativeWhisperModel
-    let store: NativeWhisperModelStore
-    let onStatusChanged: (NativeWhisperInstallStatus) -> Void
+    @EnvironmentObject var appState: AppState
 
-    @State private var installStatus: NativeWhisperInstallStatus = .notInstalled
-    @State private var isInstalling = false
-    @State private var progress = NativeWhisperDownloadProgress(downloadedBytes: 0, totalBytes: nil)
-    @State private var installTask: NativeWhisperInstallTask?
-    @State private var errorMessage: String?
+    let model: NativeWhisperModel
+    let isSelected: Bool
+    let onSelect: () -> Void
+
+    @State private var showDeleteConfirmation = false
+    @State private var isHoveringDownloadProgress = false
 
     init(
         model: NativeWhisperModel = NativeWhisperModelCatalog.recommended,
-        store: NativeWhisperModelStore = NativeWhisperModelStore(),
-        onStatusChanged: @escaping (NativeWhisperInstallStatus) -> Void = { _ in }
+        isSelected: Bool,
+        onSelect: @escaping () -> Void
     ) {
         self.model = model
-        self.store = store
-        self.onStatusChanged = onStatusChanged
+        self.isSelected = isSelected
+        self.onSelect = onSelect
+    }
+
+    private var isInstalled: Bool {
+        appState.nativeWhisperInstallStatus == .ready
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 10) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(model.displayName)
-                        .font(.caption.weight(.semibold))
-                    Text("Fast local transcription. About \(ByteCountFormatter.string(fromByteCount: model.approximateBytes, countStyle: .file)).")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
+                Button {
+                    onSelect()
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                            .foregroundStyle(isInstalled ? Color.accentColor : .secondary)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(model.displayName)
+                                .font(.caption.weight(isSelected ? .semibold : .regular))
+                            Text("Fast local transcription. About \(ByteCountFormatter.string(fromByteCount: model.approximateBytes, countStyle: .file)).")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
                 }
-                Spacer()
+                .buttonStyle(.plain)
+                .disabled(!isInstalled || appState.isInstallingNativeWhisper)
+
                 actionView
             }
 
-            if let errorMessage {
+            if let errorMessage = appState.nativeWhisperInstallError {
                 Label(errorMessage, systemImage: "xmark.circle.fill")
                     .font(.caption)
                     .foregroundStyle(.red)
@@ -3650,89 +3693,114 @@ struct NativeWhisperModelRowView: View {
             }
         }
         .padding(8)
-        .background(Color(nsColor: .controlBackgroundColor))
+        .background(isSelected ? Color.accentColor.opacity(0.08) : Color(nsColor: .controlBackgroundColor))
         .cornerRadius(6)
-        .onAppear { refreshInstallState() }
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(isSelected ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
+        )
+        .confirmationDialog(
+            "Delete \(model.displayName)?",
+            isPresented: $showDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete Model", role: .destructive) {
+                deleteModel()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes the downloaded Local Whisper model. You can download it again later.")
+        }
+        .onAppear {
+            appState.refreshNativeWhisperInstallStatus()
+        }
     }
 
     @ViewBuilder
     private var actionView: some View {
-        if isInstalling {
+        if appState.isInstallingNativeWhisper {
+            downloadProgressView
+        } else if appState.nativeWhisperInstallProgress.isCancelled {
+            canceledDownloadView
+        } else if isInstalled {
             HStack(spacing: 8) {
-                Text(progress.displayText)
-                    .font(.caption2.monospacedDigit())
-                    .foregroundStyle(.secondary)
-                Button("Cancel") { cancelInstall() }
-                    .font(.caption)
-                    .controlSize(.small)
-            }
-        } else if installStatus == .ready {
-            HStack(spacing: 8) {
-                Label("Ready", systemImage: "checkmark.circle.fill")
+                Label("Installed", systemImage: "checkmark.circle.fill")
                     .font(.caption2)
                     .foregroundStyle(.green)
-                Button("Delete Model") { deleteModel() }
-                    .font(.caption)
-                    .controlSize(.small)
+                Button {
+                    showDeleteConfirmation = true
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .font(.caption)
+                .buttonStyle(.bordered)
+                .controlSize(.small)
             }
         } else {
-            Button("Install Local Whisper") { installModel() }
-                .font(.caption)
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
+            Button("Download") {
+                appState.installNativeWhisperModel()
+            }
+            .font(.caption)
+            .buttonStyle(.bordered)
+            .controlSize(.small)
         }
     }
 
-    private func refreshInstallState() {
-        installStatus = store.installStatus(for: model)
-        onStatusChanged(installStatus)
-    }
+    private var downloadProgressView: some View {
+        HStack(spacing: 8) {
+            Text(appState.nativeWhisperInstallProgress.displayText)
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(minWidth: 104, alignment: .trailing)
 
-    private func installModel() {
-        errorMessage = nil
-        isInstalling = true
-        progress = NativeWhisperDownloadProgress(downloadedBytes: 0, totalBytes: model.approximateBytes)
-        let installer = NativeWhisperInstaller(store: store)
-        installTask = installer.install(
-            model: model,
-            progress: { progress in
-                DispatchQueue.main.async {
-                    self.progress = progress
+            ZStack {
+                if let fractionCompleted = appState.nativeWhisperInstallProgress.fractionCompleted {
+                    DonutProgressView(fractionCompleted: fractionCompleted)
+                        .opacity(isHoveringDownloadProgress ? 0.25 : 1)
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                        .opacity(isHoveringDownloadProgress ? 0.25 : 1)
                 }
-            },
-            completion: { result in
-                DispatchQueue.main.async {
-                    installTask = nil
-                    isInstalling = false
-                    refreshInstallState()
-                    if case .failure(let error) = result {
-                        errorMessage = error.localizedDescription
+                if isHoveringDownloadProgress {
+                    Button {
+                        appState.cancelNativeWhisperInstall()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 8, weight: .bold))
                     }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
                 }
             }
-        )
+            .frame(width: 24, height: 24)
+            .contentShape(Circle())
+            .onHover { hovering in
+                isHoveringDownloadProgress = hovering
+            }
+        }
     }
 
-    private func cancelInstall() {
-        installTask?.cancel()
-        installTask = nil
-        isInstalling = false
-        progress = NativeWhisperDownloadProgress(
-            downloadedBytes: progress.downloadedBytes,
-            totalBytes: progress.totalBytes,
-            isCancelled: true
-        )
-        refreshInstallState()
+    private var canceledDownloadView: some View {
+        HStack(spacing: 8) {
+            Text(appState.nativeWhisperInstallProgress.displayText)
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .frame(minWidth: 72, alignment: .trailing)
+            Button("Download") {
+                appState.installNativeWhisperModel()
+            }
+            .font(.caption)
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
     }
 
     private func deleteModel() {
-        do {
-            try store.deleteModel(model)
-            errorMessage = nil
-            refreshInstallState()
-        } catch {
-            errorMessage = error.localizedDescription
-        }
+        appState.deleteNativeWhisperModel()
     }
 }
 

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -10,6 +10,7 @@ class TranscriptionService {
     private let baseURL: URL
     private let useLocalTranscription: Bool
     private let localWhisperPath: String?
+    private let useLegacyMlxWhisper: Bool
     private let transcriptionLanguage: TranscriptionLanguage
     private let localTranscriptionModel: TranscriptionModel
     private let transcriptionModel: String
@@ -26,6 +27,7 @@ class TranscriptionService {
         baseURL: String = "https://api.groq.com/openai/v1",
         useLocalTranscription: Bool = false,
         localWhisperPath: String? = nil,
+        useLegacyMlxWhisper: Bool = false,
         transcriptionLanguage: TranscriptionLanguage = .auto,
         localTranscriptionModel: TranscriptionModel = .default,
         transcriptionModel: String = AppState.defaultTranscriptionModel,
@@ -35,6 +37,7 @@ class TranscriptionService {
         self.baseURL = try Self.normalizedBaseURL(from: baseURL)
         self.useLocalTranscription = useLocalTranscription
         self.localWhisperPath = localWhisperPath
+        self.useLegacyMlxWhisper = useLegacyMlxWhisper
         self.transcriptionLanguage = transcriptionLanguage
         self.localTranscriptionModel = localTranscriptionModel
         let trimmedModel = transcriptionModel.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -131,12 +134,32 @@ class TranscriptionService {
         }
     }
 
-    // Run local transcription: Apple Speech or mlx_whisper
+    // Run local transcription: Apple Speech, native Whisper, or legacy mlx_whisper
     private func transcribeAudioLocally(fileURL: URL) async throws -> String {
         if localTranscriptionModel.isAppleSpeech {
             return try await transcribeWithAppleSpeech(fileURL: fileURL)
         }
-        return try await transcribeWithMlxWhisper(fileURL: fileURL)
+        if useLegacyMlxWhisper {
+            return try await transcribeWithMlxWhisper(fileURL: fileURL)
+        }
+        return try await transcribeWithNativeWhisper(fileURL: fileURL)
+    }
+
+    private func transcribeWithNativeWhisper(fileURL: URL) async throws -> String {
+        let model = NativeWhisperModelCatalog.recommended
+        let store = NativeWhisperModelStore()
+        guard store.installStatus(for: model) == .ready else {
+            throw TranscriptionError.submissionFailed("Local Whisper is not installed yet. Install the recommended model to use local transcription.")
+        }
+        do {
+            return try await NativeWhisperRuntime().transcribe(
+                audioURL: fileURL,
+                modelURL: store.modelURL(for: model),
+                languageCode: transcriptionLanguage.whisperArgument
+            )
+        } catch let error as NativeWhisperRuntimeError {
+            throw TranscriptionError.submissionFailed(error.localizedDescription)
+        }
     }
 
     private func transcribeWithAppleSpeech(fileURL: URL) async throws -> String {

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -158,7 +158,8 @@ class TranscriptionService {
                 languageCode: transcriptionLanguage.whisperArgument
             )
         } catch let error as NativeWhisperRuntimeError {
-            throw TranscriptionError.submissionFailed(error.localizedDescription)
+            let userMessage = error.localizedDescription
+            throw TranscriptionError.submissionFailed("\(userMessage)\n\nDetails: \(error.technicalDetails)")
         }
     }
 

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -152,11 +152,12 @@ class TranscriptionService {
             throw TranscriptionError.submissionFailed("Local Whisper is not installed yet. Install the recommended model to use local transcription.")
         }
         do {
-            return try await NativeWhisperRuntime().transcribe(
+            let transcript = try await NativeWhisperRuntime().transcribe(
                 audioURL: fileURL,
                 modelURL: store.modelURL(for: model),
                 languageCode: transcriptionLanguage.whisperArgument
             )
+            return normalizedTranscriptText(transcript)
         } catch let error as NativeWhisperRuntimeError {
             let userMessage = error.localizedDescription
             throw TranscriptionError.submissionFailed("\(userMessage)\n\nDetails: \(error.technicalDetails)")

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -6,6 +6,8 @@ struct AppStateTranscriptionConfigurationTests {
     static func main() async throws {
         try testMakeTranscriptionServiceUsesLocalConfiguration()
         try testMakeTranscriptionServiceMapsEmptyLocalWhisperPathToNil()
+        try testMakeTranscriptionServiceDefaultsLegacyMlxWhisperOff()
+        try testMakeTranscriptionServicePassesLegacyMlxWhisperToggle()
         testPermissionStatusUpdateSkipsUnchangedValues()
         testRecordingOverlayLayoutPersistsWithoutCompactOverlayBoolean()
         testRecordingCancelShortcutDefaultsToEscape()
@@ -82,6 +84,30 @@ struct AppStateTranscriptionConfigurationTests {
         let configuration = mirroredTranscriptionConfiguration(service)
 
         assert(configuration.localWhisperPath == nil)
+    }
+
+    private static func testMakeTranscriptionServiceDefaultsLegacyMlxWhisperOff() throws {
+        resetDefaults()
+        let appState = AppState()
+        appState.useLocalTranscription = true
+        appState.localTranscriptionModel = .find(id: "mlx-community/whisper-large-v3-turbo")
+
+        let service = try appState.makeTranscriptionService()
+        let configuration = mirroredTranscriptionConfiguration(service)
+
+        assert(configuration.useLegacyMlxWhisper == false)
+    }
+
+    private static func testMakeTranscriptionServicePassesLegacyMlxWhisperToggle() throws {
+        resetDefaults()
+        let appState = AppState()
+        appState.useLocalTranscription = true
+        appState.useLegacyMlxWhisper = true
+
+        let service = try appState.makeTranscriptionService()
+        let configuration = mirroredTranscriptionConfiguration(service)
+
+        assert(configuration.useLegacyMlxWhisper == true)
     }
 
     private static func testPermissionStatusUpdateSkipsUnchangedValues() {
@@ -890,6 +916,7 @@ struct AppStateTranscriptionConfigurationTests {
             defaults.removeObject(forKey: key)
         }
         defaults.removeObject(forKey: "use_local_transcription")
+        defaults.removeObject(forKey: "use_legacy_mlx_whisper")
         defaults.removeObject(forKey: "local_transcription_model")
         defaults.removeObject(forKey: "transcription_language")
         defaults.removeObject(forKey: "selected_microphone_id")
@@ -918,13 +945,15 @@ struct AppStateTranscriptionConfigurationTests {
         useLocalTranscription: Bool,
         localTranscriptionModelID: String,
         transcriptionLanguageCode: String,
-        localWhisperPath: String?
+        localWhisperPath: String?,
+        useLegacyMlxWhisper: Bool
     ) {
         let mirror = Mirror(reflecting: service)
         let useLocalTranscription = mirror.descendant("useLocalTranscription") as? Bool ?? false
         let localTranscriptionModel = mirror.descendant("localTranscriptionModel") as? TranscriptionModel ?? .default
         let transcriptionLanguage = mirror.descendant("transcriptionLanguage") as? TranscriptionLanguage ?? .auto
         let localWhisperPath = mirror.descendant("localWhisperPath") as? String
-        return (useLocalTranscription, localTranscriptionModel.id, transcriptionLanguage.code, localWhisperPath)
+        let useLegacyMlxWhisper = mirror.descendant("useLegacyMlxWhisper") as? Bool ?? false
+        return (useLocalTranscription, localTranscriptionModel.id, transcriptionLanguage.code, localWhisperPath, useLegacyMlxWhisper)
     }
 }

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -31,16 +31,17 @@ struct AppStateTranscriptionConfigurationTests {
         try testAppStateCreatedTranscriptionServicesPassLegacyMlxWhisperToggle()
         try testNoteBrowserTranscriptionMenuUsesFlatNativeCheckedItems()
         await testAPITranscriptionModesRequireResolvedAPIKey()
+        try testSettingsAPIProviderTabDoesNotForceUnavailableAPIMode()
         await testTranscriptionAPIKeyEnablesAPIModesWithoutGlobalAPIKey()
         await testEmptyTranscriptionAPIKeyFallsBackToGlobalAPIKey()
         await testRemovingAPIKeyNormalizesSelectedAPIMode()
         await testRemovingAPIKeyDoesNotNormalizeWhileRecording()
         await testSystemDefaultAndSystemAudioConvertsAPIRealtimeToStandard()
-        await testSystemDefaultAndSystemAudioConvertsAppleLiveToWhisper()
+        await testSystemDefaultAndSystemAudioKeepsAppleLiveWhenNoFallbackIsAvailable()
         await testSystemDefaultAndSystemAudioRejectsLiveModeSelections()
         await testSystemDefaultAndSystemAudioNormalizesStoredAPIRealtimeOnStartup()
-        await testSystemDefaultAndSystemAudioNormalizesStoredAPIRealtimeWithoutAPIKeyToLocalWhisper()
-        await testSystemDefaultAndSystemAudioNormalizesStoredAppleLiveOnStartup()
+        await testSystemDefaultAndSystemAudioKeepsStoredAPIRealtimeWhenNoFallbackIsAvailable()
+        await testSystemDefaultAndSystemAudioKeepsStoredAppleLiveWhenWhisperIsUnavailable()
         try testGoogleCalendarConnectionMetadataRestoresStartupState()
         testGoogleCalendarConnectionMetadataClearsCorruptValue()
         testCalendarRecordingReminderLeadMinutesMigrateLegacyValue()
@@ -444,7 +445,7 @@ struct AppStateTranscriptionConfigurationTests {
         let stoppedRecordingBody = sourceBlock(
             in: source,
             from: "let capturedUseLocalTranscription = useLocalTranscription",
-            to: "\n    @MainActor\n    private func updateTranscribingOverlay"
+            to: "\n    @MainActor\n    private func createLiveNote"
         )
 
         precondition(source.contains("let useLegacyMlxWhisper: Bool"))
@@ -453,7 +454,6 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(importBody.contains("let transcriptionService = try configuration.makeTranscriptionService()"))
         precondition(source.contains("let useLegacyMlxWhisper: Bool"))
         precondition(retryBody.contains("useLegacyMlxWhisper: snapshot.useLegacyMlxWhisper,"))
-        precondition(retryBody.contains("useLegacyMlxWhisper: useLegacyMlxWhisper"))
         precondition(stoppedRecordingBody.contains("let capturedUseLegacyMlxWhisper = useLegacyMlxWhisper"))
         precondition(stoppedRecordingBody.contains("useLegacyMlxWhisper: capturedUseLegacyMlxWhisper,"))
     }
@@ -485,15 +485,39 @@ struct AppStateTranscriptionConfigurationTests {
 
             precondition(!appState.isNoteBrowserTranscriptionModeAvailable(.apiStandard))
             precondition(!appState.isNoteBrowserTranscriptionModeAvailable(.apiRealtime))
-            precondition(appState.isNoteBrowserTranscriptionModeAvailable(.localWhisper))
+            precondition(!appState.isNoteBrowserTranscriptionModeAvailable(.localWhisper))
             precondition(appState.isNoteBrowserTranscriptionModeAvailable(.localAppleLive))
 
             appState.setNoteBrowserTranscriptionMode(.apiStandard)
-            precondition(appState.currentNoteBrowserTranscriptionMode == .localWhisper)
+            precondition(appState.currentNoteBrowserTranscriptionMode == .localAppleLive)
 
             appState.setNoteBrowserTranscriptionMode(.apiRealtime)
-            precondition(appState.currentNoteBrowserTranscriptionMode == .localWhisper)
+            precondition(appState.currentNoteBrowserTranscriptionMode == .localAppleLive)
         }
+    }
+
+    private static func testSettingsAPIProviderTabDoesNotForceUnavailableAPIMode() throws {
+        let source = try String(contentsOfFile: "Sources/SettingsView.swift", encoding: .utf8)
+        let transcriptionSection = sourceBlock(
+            in: source,
+            from: "private var transcriptionSection: some View",
+            to: "\n    private var localTranscriptionSettings"
+        )
+        let saveKeyBody = sourceBlock(
+            in: source,
+            from: "private func validateAndSaveKey()",
+            to: "\n    // MARK: System Prompt"
+        )
+
+        precondition(source.contains("@State private var showingLocalTranscriptionSettings = true"))
+        precondition(transcriptionSection.contains("Picker(\"Transcription Mode\", selection: $showingLocalTranscriptionSettings)"))
+        precondition(transcriptionSection.contains("if showsLocal {"))
+        precondition(transcriptionSection.contains("appState.useLocalTranscription = true"))
+        precondition(transcriptionSection.contains("} else if appState.hasTranscriptionAPIKey {"))
+        precondition(transcriptionSection.contains("appState.setNoteBrowserTranscriptionMode(.apiStandard)"))
+        precondition(!transcriptionSection.contains("selection: $appState.useLocalTranscription"))
+        precondition(saveKeyBody.contains("if !showingLocalTranscriptionSettings"))
+        precondition(saveKeyBody.contains("appState.setNoteBrowserTranscriptionMode(.apiStandard)"))
     }
 
     private static func testTranscriptionAPIKeyEnablesAPIModesWithoutGlobalAPIKey() async {
@@ -532,7 +556,7 @@ struct AppStateTranscriptionConfigurationTests {
 
             appState.apiKey = ""
 
-            precondition(appState.currentNoteBrowserTranscriptionMode == .localWhisper)
+            precondition(appState.currentNoteBrowserTranscriptionMode == .localAppleLive)
             precondition(appState.useLocalTranscription)
         }
     }
@@ -570,7 +594,7 @@ struct AppStateTranscriptionConfigurationTests {
         }
     }
 
-    private static func testSystemDefaultAndSystemAudioConvertsAppleLiveToWhisper() async {
+    private static func testSystemDefaultAndSystemAudioKeepsAppleLiveWhenNoFallbackIsAvailable() async {
         resetDefaults()
         await MainActor.run {
             let appState = AppState()
@@ -579,9 +603,9 @@ struct AppStateTranscriptionConfigurationTests {
 
             appState.selectedMicrophoneID = AudioInputDevice.systemDefaultAndSystemAudioID
 
-            precondition(appState.currentNoteBrowserTranscriptionMode == .localWhisper)
+            precondition(appState.currentNoteBrowserTranscriptionMode == .localAppleLive)
             precondition(appState.useLocalTranscription)
-            precondition(!appState.localTranscriptionModel.isAppleSpeech)
+            precondition(appState.localTranscriptionModel.isAppleSpeech)
         }
     }
 
@@ -594,13 +618,13 @@ struct AppStateTranscriptionConfigurationTests {
             precondition(!appState.isNoteBrowserTranscriptionModeAvailable(.apiRealtime))
             precondition(!appState.isNoteBrowserTranscriptionModeAvailable(.localAppleLive))
             precondition(appState.isNoteBrowserTranscriptionModeAvailable(.apiStandard))
-            precondition(appState.isNoteBrowserTranscriptionModeAvailable(.localWhisper))
+            precondition(!appState.isNoteBrowserTranscriptionModeAvailable(.localWhisper))
 
             appState.setNoteBrowserTranscriptionMode(.apiRealtime)
             precondition(appState.currentNoteBrowserTranscriptionMode == .apiStandard)
 
             appState.setNoteBrowserTranscriptionMode(.localAppleLive)
-            precondition(appState.currentNoteBrowserTranscriptionMode == .localWhisper)
+            precondition(appState.currentNoteBrowserTranscriptionMode == .apiStandard)
         }
     }
 
@@ -621,7 +645,7 @@ struct AppStateTranscriptionConfigurationTests {
         }
     }
 
-    private static func testSystemDefaultAndSystemAudioNormalizesStoredAPIRealtimeWithoutAPIKeyToLocalWhisper() async {
+    private static func testSystemDefaultAndSystemAudioKeepsStoredAPIRealtimeWhenNoFallbackIsAvailable() async {
         resetDefaults()
         let defaults = UserDefaults.standard
         defaults.set(AudioInputDevice.systemDefaultAndSystemAudioID, forKey: "selected_microphone_id")
@@ -631,13 +655,13 @@ struct AppStateTranscriptionConfigurationTests {
         await MainActor.run {
             let appState = AppState()
 
-            precondition(appState.currentNoteBrowserTranscriptionMode == .localWhisper)
-            precondition(appState.useLocalTranscription)
-            precondition(!appState.realtimeStreamingEnabled)
+            precondition(appState.currentNoteBrowserTranscriptionMode == .apiRealtime)
+            precondition(!appState.useLocalTranscription)
+            precondition(appState.realtimeStreamingEnabled)
         }
     }
 
-    private static func testSystemDefaultAndSystemAudioNormalizesStoredAppleLiveOnStartup() async {
+    private static func testSystemDefaultAndSystemAudioKeepsStoredAppleLiveWhenWhisperIsUnavailable() async {
         resetDefaults()
         let defaults = UserDefaults.standard
         defaults.set(AudioInputDevice.systemDefaultAndSystemAudioID, forKey: "selected_microphone_id")
@@ -647,9 +671,9 @@ struct AppStateTranscriptionConfigurationTests {
         await MainActor.run {
             let appState = AppState()
 
-            precondition(appState.currentNoteBrowserTranscriptionMode == .localWhisper)
+            precondition(appState.currentNoteBrowserTranscriptionMode == .localAppleLive)
             precondition(appState.useLocalTranscription)
-            precondition(!appState.localTranscriptionModel.isAppleSpeech)
+            precondition(appState.localTranscriptionModel.isAppleSpeech)
         }
     }
 

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -28,6 +28,7 @@ struct AppStateTranscriptionConfigurationTests {
         testStoppedTranscriptionCompletionSummaryShowsFallbackIndicatorForNonEmptyRawFallback()
         testStoppedTranscriptionCompletionSummaryHidesFallbackIndicatorForEmptyRawFallback()
         testStoppedTranscriptionSettingsSnapshotCapturesHistoryMetadata()
+        try testAppStateCreatedTranscriptionServicesPassLegacyMlxWhisperToggle()
         try testNoteBrowserTranscriptionMenuUsesFlatNativeCheckedItems()
         await testAPITranscriptionModesRequireResolvedAPIKey()
         await testTranscriptionAPIKeyEnablesAPIModesWithoutGlobalAPIKey()
@@ -426,6 +427,35 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(summary.finalTranscript.isEmpty)
         precondition(summary.shouldPressEnterAfterPaste)
         precondition(!summary.shouldPersistRawDictationFallback)
+    }
+
+    private static func testAppStateCreatedTranscriptionServicesPassLegacyMlxWhisperToggle() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let importBody = sourceBlock(
+            in: source,
+            from: "func importAudioFile(_ fileURL: URL, mode: NoteBrowserTranscriptionMode)",
+            to: "\n    @MainActor\n    func retryTranscription"
+        )
+        let retryBody = sourceBlock(
+            in: source,
+            from: "func retryTranscription(item: PipelineHistoryItem)",
+            to: "\n    @MainActor\n    private func copyRetryTranscriptToPasteboardIfNeeded"
+        )
+        let stoppedRecordingBody = sourceBlock(
+            in: source,
+            from: "let capturedUseLocalTranscription = useLocalTranscription",
+            to: "\n    @MainActor\n    private func updateTranscribingOverlay"
+        )
+
+        precondition(source.contains("let useLegacyMlxWhisper: Bool"))
+        precondition(source.contains("useLegacyMlxWhisper: useLegacyMlxWhisper,"))
+        precondition(importBody.contains("useLegacyMlxWhisper: useLegacyMlxWhisper,"))
+        precondition(importBody.contains("let transcriptionService = try configuration.makeTranscriptionService()"))
+        precondition(source.contains("let useLegacyMlxWhisper: Bool"))
+        precondition(retryBody.contains("useLegacyMlxWhisper: snapshot.useLegacyMlxWhisper,"))
+        precondition(retryBody.contains("useLegacyMlxWhisper: useLegacyMlxWhisper"))
+        precondition(stoppedRecordingBody.contains("let capturedUseLegacyMlxWhisper = useLegacyMlxWhisper"))
+        precondition(stoppedRecordingBody.contains("useLegacyMlxWhisper: capturedUseLegacyMlxWhisper,"))
     }
 
     private static func testNoteBrowserTranscriptionMenuUsesFlatNativeCheckedItems() throws {
@@ -939,6 +969,14 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.removeObject(forKey: "calendar_recording_reminder_lead_minutes_list")
         defaults.removeObject(forKey: "calendar_recording_reminder_refresh_interval_minutes")
         defaults.removeObject(forKey: GoogleCalendarConnectionMetadata.storageKey)
+    }
+
+    private static func sourceBlock(in source: String, from startMarker: String, to endMarker: String) -> String {
+        guard let start = source.range(of: startMarker),
+              let end = source.range(of: endMarker, range: start.upperBound..<source.endIndex) else {
+            preconditionFailure("Expected source block from \(startMarker) to \(endMarker)")
+        }
+        return String(source[start.lowerBound..<end.lowerBound])
     }
 
     private static func mirroredTranscriptionConfiguration(_ service: TranscriptionService) -> (

--- a/Tests/NativeWhisperInstallerTests.swift
+++ b/Tests/NativeWhisperInstallerTests.swift
@@ -6,6 +6,9 @@ struct NativeWhisperInstallerTests {
         try testSuccessfulInstallMovesPartialFileToFinalPath()
         try testFailedDownloadKeepsFailureMessageAndRemovesPartial()
         try testCancelPreventsReadyInstall()
+        try testProgressCanBeReportedBeforeDownloadCompletes()
+        try testCancelInvokesDownloaderCancellationHandler()
+        try testMoveFailurePreservesExistingFinalModel()
         print("NativeWhisperInstallerTests passed")
     }
 
@@ -16,8 +19,8 @@ struct NativeWhisperInstallerTests {
         let model = NativeWhisperModelCatalog.recommended
         var progressValues: [NativeWhisperDownloadProgress] = []
         let completion = CompletionWaiter<Void, NativeWhisperInstallerError>()
-        let installer = NativeWhisperInstaller(store: store) { _, destination, progress, shouldCancel in
-            assert(!shouldCancel())
+        let installer = NativeWhisperInstaller(store: store) { _, destination, progress, task in
+            assert(!task.isCancelled)
             try Data(repeating: 3, count: 12).write(to: destination)
             progress(NativeWhisperDownloadProgress(downloadedBytes: 12, totalBytes: 12))
         }
@@ -58,11 +61,11 @@ struct NativeWhisperInstallerTests {
         let completion = CompletionWaiter<Void, NativeWhisperInstallerError>()
         let started = DispatchSemaphore(value: 0)
         let allowCancelCheck = DispatchSemaphore(value: 0)
-        let installer = NativeWhisperInstaller(store: store) { _, destination, _, shouldCancel in
+        let installer = NativeWhisperInstaller(store: store) { _, destination, _, task in
             started.signal()
             _ = allowCancelCheck.wait(timeout: .now() + 2)
             try Data([1, 2, 3]).write(to: destination)
-            if shouldCancel() { throw NativeWhisperInstallerError.cancelled }
+            if task.isCancelled { throw NativeWhisperInstallerError.cancelled }
         }
         let task = installer.install(model: model, progress: { _ in }) { completion.complete($0) }
         _ = started.wait(timeout: .now() + 2)
@@ -74,6 +77,96 @@ struct NativeWhisperInstallerTests {
         assert(task.isCancelled)
         assertResultFailed(result, .cancelled)
         assert(store.installStatus(for: model) != .ready)
+    }
+
+    private static func testProgressCanBeReportedBeforeDownloadCompletes() throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NativeWhisperModelStore(rootDirectory: root)
+        let model = NativeWhisperModelCatalog.recommended
+        var progressValues: [NativeWhisperDownloadProgress] = []
+        let completion = CompletionWaiter<Void, NativeWhisperInstallerError>()
+        let firstChunkWritten = DispatchSemaphore(value: 0)
+        let finishDownload = DispatchSemaphore(value: 0)
+        let installer = NativeWhisperInstaller(store: store) { _, destination, progress, _ in
+            try Data([1, 2, 3]).write(to: destination)
+            progress(NativeWhisperDownloadProgress(downloadedBytes: 3, totalBytes: 6))
+            firstChunkWritten.signal()
+            _ = finishDownload.wait(timeout: .now() + 2)
+            try Data([1, 2, 3, 4, 5, 6]).write(to: destination)
+            progress(NativeWhisperDownloadProgress(downloadedBytes: 6, totalBytes: 6))
+        }
+
+        _ = installer.install(model: model, progress: { progressValues.append($0) }) { completion.complete($0) }
+        guard firstChunkWritten.wait(timeout: .now() + 2) == .success else {
+            throw TestFailure(message: "Timed out waiting for early progress")
+        }
+
+        assert(progressValues == [NativeWhisperDownloadProgress(downloadedBytes: 3, totalBytes: 6)])
+        finishDownload.signal()
+        assertResultSucceeded(try completion.wait())
+        assert(progressValues.last == NativeWhisperDownloadProgress(downloadedBytes: 6, totalBytes: 6))
+    }
+
+    private static func testCancelInvokesDownloaderCancellationHandler() throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NativeWhisperModelStore(rootDirectory: root)
+        let model = NativeWhisperModelCatalog.recommended
+        let completion = CompletionWaiter<Void, NativeWhisperInstallerError>()
+        let handlerInstalled = DispatchSemaphore(value: 0)
+        let cancellationForwarded = DispatchSemaphore(value: 0)
+        let installer = NativeWhisperInstaller(store: store) { _, destination, _, task in
+            try Data([1, 2, 3]).write(to: destination)
+            task.setCancellationHandler {
+                cancellationForwarded.signal()
+            }
+            handlerInstalled.signal()
+            guard cancellationForwarded.wait(timeout: .now() + 2) == .success else {
+                throw NativeWhisperInstallerError.downloadFailed("cancel handler was not called")
+            }
+            throw NativeWhisperInstallerError.cancelled
+        }
+
+        let task = installer.install(model: model, progress: { _ in }) { completion.complete($0) }
+        guard handlerInstalled.wait(timeout: .now() + 2) == .success else {
+            throw TestFailure(message: "Timed out waiting for cancellation handler installation")
+        }
+        task.cancel()
+
+        assertResultFailed(try completion.wait(), .cancelled)
+        assert(!FileManager.default.fileExists(atPath: store.partialModelURL(for: model).path))
+    }
+
+    private static func testMoveFailurePreservesExistingFinalModel() throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NativeWhisperModelStore(rootDirectory: root)
+        let model = NativeWhisperModelCatalog.recommended
+        let completion = CompletionWaiter<Void, NativeWhisperInstallerError>()
+        try store.ensureModelsDirectoryExists()
+        let final = store.modelURL(for: model)
+        try Data([8, 8, 8]).write(to: final)
+        let partialDirectory = store.partialModelURL(for: model)
+        let installer = NativeWhisperInstaller(store: store) { _, destination, _, _ in
+            try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+            try Data([1]).write(to: destination.appendingPathComponent("invalid-replacement"))
+        }
+
+        _ = installer.install(model: model, progress: { _ in }) { completion.complete($0) }
+        let result = try completion.wait()
+
+        switch result {
+        case .success:
+            assertionFailure("Expected move failure, got success")
+        case .failure(.moveFailed):
+            break
+        case .failure(let error):
+            assertionFailure("Expected move failure, got \(error)")
+        }
+        let preservedData = try Data(contentsOf: final)
+        assert(preservedData == Data([8, 8, 8]))
+        assert(!FileManager.default.fileExists(atPath: partialDirectory.path))
     }
 
     private static func assertResultSucceeded(_ result: Result<Void, NativeWhisperInstallerError>) {
@@ -125,6 +218,12 @@ private struct TestFailure: Error, CustomStringConvertible {
     let message: String
     let file: StaticString
     let line: UInt
+
+    init(message: String, file: StaticString = #filePath, line: UInt = #line) {
+        self.message = message
+        self.file = file
+        self.line = line
+    }
 
     var description: String { "\(file):\(line): \(message)" }
 }

--- a/Tests/NativeWhisperInstallerTests.swift
+++ b/Tests/NativeWhisperInstallerTests.swift
@@ -8,7 +8,7 @@ struct NativeWhisperInstallerTests {
         try testCancelPreventsReadyInstall()
         try testProgressCanBeReportedBeforeDownloadCompletes()
         try testCancelInvokesDownloaderCancellationHandler()
-        try testMoveFailurePreservesExistingFinalModel()
+        try testInvalidDownloadedModelPreservesExistingFinalModel()
         print("NativeWhisperInstallerTests passed")
     }
 
@@ -16,7 +16,7 @@ struct NativeWhisperInstallerTests {
         let root = temporaryRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let store = NativeWhisperModelStore(rootDirectory: root)
-        let model = NativeWhisperModelCatalog.recommended
+        let model = testModel(approximateBytes: 12)
         var progressValues: [NativeWhisperDownloadProgress] = []
         let completion = CompletionWaiter<Void, NativeWhisperInstallerError>()
         let installer = NativeWhisperInstaller(store: store) { _, destination, progress, task in
@@ -83,7 +83,7 @@ struct NativeWhisperInstallerTests {
         let root = temporaryRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let store = NativeWhisperModelStore(rootDirectory: root)
-        let model = NativeWhisperModelCatalog.recommended
+        let model = testModel(approximateBytes: 6)
         var progressValues: [NativeWhisperDownloadProgress] = []
         let completion = CompletionWaiter<Void, NativeWhisperInstallerError>()
         let firstChunkWritten = DispatchSemaphore(value: 0)
@@ -138,7 +138,7 @@ struct NativeWhisperInstallerTests {
         assert(!FileManager.default.fileExists(atPath: store.partialModelURL(for: model).path))
     }
 
-    private static func testMoveFailurePreservesExistingFinalModel() throws {
+    private static func testInvalidDownloadedModelPreservesExistingFinalModel() throws {
         let root = temporaryRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let store = NativeWhisperModelStore(rootDirectory: root)
@@ -158,15 +158,27 @@ struct NativeWhisperInstallerTests {
 
         switch result {
         case .success:
-            assertionFailure("Expected move failure, got success")
-        case .failure(.moveFailed):
+            assertionFailure("Expected verification failure, got success")
+        case .failure(.verificationFailed):
             break
         case .failure(let error):
-            assertionFailure("Expected move failure, got \(error)")
+            assertionFailure("Expected verification failure, got \(error)")
         }
         let preservedData = try Data(contentsOf: final)
         assert(preservedData == Data([8, 8, 8]))
         assert(!FileManager.default.fileExists(atPath: partialDirectory.path))
+    }
+
+    private static func testModel(approximateBytes: Int64) -> NativeWhisperModel {
+        NativeWhisperModel(
+            id: "test-model-\(approximateBytes)",
+            displayName: "Test Model",
+            description: "Small test model",
+            downloadURL: URL(string: "https://example.com/test-model.bin")!,
+            expectedFileName: "test-model-\(approximateBytes).bin",
+            approximateBytes: approximateBytes,
+            checksumSHA256: nil
+        )
     }
 
     private static func assertResultSucceeded(_ result: Result<Void, NativeWhisperInstallerError>) {

--- a/Tests/NativeWhisperInstallerTests.swift
+++ b/Tests/NativeWhisperInstallerTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 @main
@@ -8,6 +9,7 @@ struct NativeWhisperInstallerTests {
         try testCancelPreventsReadyInstall()
         try testProgressCanBeReportedBeforeDownloadCompletes()
         try testCancelInvokesDownloaderCancellationHandler()
+        try testConcurrentInstallForSameModelIsRejected()
         try testInvalidDownloadedModelPreservesExistingFinalModel()
         print("NativeWhisperInstallerTests passed")
     }
@@ -16,12 +18,13 @@ struct NativeWhisperInstallerTests {
         let root = temporaryRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let store = NativeWhisperModelStore(rootDirectory: root)
-        let model = testModel(approximateBytes: 12)
+        let data = Data(repeating: 3, count: 12)
+        let model = testModel(approximateBytes: 12, checksumSHA256: sha256HexDigest(for: data))
         var progressValues: [NativeWhisperDownloadProgress] = []
         let completion = CompletionWaiter<Void, NativeWhisperInstallerError>()
         let installer = NativeWhisperInstaller(store: store) { _, destination, progress, task in
             assert(!task.isCancelled)
-            try Data(repeating: 3, count: 12).write(to: destination)
+            try data.write(to: destination)
             progress(NativeWhisperDownloadProgress(downloadedBytes: 12, totalBytes: 12))
         }
 
@@ -83,7 +86,8 @@ struct NativeWhisperInstallerTests {
         let root = temporaryRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let store = NativeWhisperModelStore(rootDirectory: root)
-        let model = testModel(approximateBytes: 6)
+        let finalData = Data([1, 2, 3, 4, 5, 6])
+        let model = testModel(approximateBytes: 6, checksumSHA256: sha256HexDigest(for: finalData))
         var progressValues: [NativeWhisperDownloadProgress] = []
         let completion = CompletionWaiter<Void, NativeWhisperInstallerError>()
         let firstChunkWritten = DispatchSemaphore(value: 0)
@@ -93,7 +97,7 @@ struct NativeWhisperInstallerTests {
             progress(NativeWhisperDownloadProgress(downloadedBytes: 3, totalBytes: 6))
             firstChunkWritten.signal()
             _ = finishDownload.wait(timeout: .now() + 2)
-            try Data([1, 2, 3, 4, 5, 6]).write(to: destination)
+            try finalData.write(to: destination)
             progress(NativeWhisperDownloadProgress(downloadedBytes: 6, totalBytes: 6))
         }
 
@@ -138,6 +142,36 @@ struct NativeWhisperInstallerTests {
         assert(!FileManager.default.fileExists(atPath: store.partialModelURL(for: model).path))
     }
 
+    private static func testConcurrentInstallForSameModelIsRejected() throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NativeWhisperModelStore(rootDirectory: root)
+        let data = Data(repeating: 4, count: 12)
+        let model = testModel(approximateBytes: 12, checksumSHA256: sha256HexDigest(for: data))
+        let firstStarted = DispatchSemaphore(value: 0)
+        let finishFirst = DispatchSemaphore(value: 0)
+        let firstCompletion = CompletionWaiter<Void, NativeWhisperInstallerError>()
+        let secondCompletion = CompletionWaiter<Void, NativeWhisperInstallerError>()
+        let firstInstaller = NativeWhisperInstaller(store: store) { _, destination, _, _ in
+            firstStarted.signal()
+            _ = finishFirst.wait(timeout: .now() + 2)
+            try data.write(to: destination)
+        }
+        let secondInstaller = NativeWhisperInstaller(store: store) { _, _, _, _ in
+            throw NativeWhisperInstallerError.downloadFailed("second install should not start")
+        }
+
+        _ = firstInstaller.install(model: model, progress: { _ in }) { firstCompletion.complete($0) }
+        guard firstStarted.wait(timeout: .now() + 2) == .success else {
+            throw TestFailure(message: "Timed out waiting for first install")
+        }
+        _ = secondInstaller.install(model: model, progress: { _ in }) { secondCompletion.complete($0) }
+
+        assertResultFailed(try secondCompletion.wait(), .alreadyInProgress)
+        finishFirst.signal()
+        assertResultSucceeded(try firstCompletion.wait())
+    }
+
     private static func testInvalidDownloadedModelPreservesExistingFinalModel() throws {
         let root = temporaryRoot()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -169,7 +203,7 @@ struct NativeWhisperInstallerTests {
         assert(!FileManager.default.fileExists(atPath: partialDirectory.path))
     }
 
-    private static func testModel(approximateBytes: Int64) -> NativeWhisperModel {
+    private static func testModel(approximateBytes: Int64, checksumSHA256: String) -> NativeWhisperModel {
         NativeWhisperModel(
             id: "test-model-\(approximateBytes)",
             displayName: "Test Model",
@@ -177,8 +211,12 @@ struct NativeWhisperInstallerTests {
             downloadURL: URL(string: "https://example.com/test-model.bin")!,
             expectedFileName: "test-model-\(approximateBytes).bin",
             approximateBytes: approximateBytes,
-            checksumSHA256: nil
+            checksumSHA256: checksumSHA256
         )
+    }
+
+    private static func sha256HexDigest(for data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 
     private static func assertResultSucceeded(_ result: Result<Void, NativeWhisperInstallerError>) {

--- a/Tests/NativeWhisperInstallerTests.swift
+++ b/Tests/NativeWhisperInstallerTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+@main
+struct NativeWhisperInstallerTests {
+    static func main() throws {
+        try testSuccessfulInstallMovesPartialFileToFinalPath()
+        try testFailedDownloadKeepsFailureMessageAndRemovesPartial()
+        try testCancelPreventsReadyInstall()
+        print("NativeWhisperInstallerTests passed")
+    }
+
+    private static func testSuccessfulInstallMovesPartialFileToFinalPath() throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NativeWhisperModelStore(rootDirectory: root)
+        let model = NativeWhisperModelCatalog.recommended
+        var progressValues: [NativeWhisperDownloadProgress] = []
+        let completion = CompletionWaiter<Void, NativeWhisperInstallerError>()
+        let installer = NativeWhisperInstaller(store: store) { _, destination, progress, shouldCancel in
+            assert(!shouldCancel())
+            try Data(repeating: 3, count: 12).write(to: destination)
+            progress(NativeWhisperDownloadProgress(downloadedBytes: 12, totalBytes: 12))
+        }
+
+        _ = installer.install(model: model, progress: { progressValues.append($0) }) { completion.complete($0) }
+        let result = try completion.wait()
+
+        assertResultSucceeded(result)
+        assert(store.installStatus(for: model) == .ready)
+        assert(!FileManager.default.fileExists(atPath: store.partialModelURL(for: model).path))
+        assert(progressValues.last == NativeWhisperDownloadProgress(downloadedBytes: 12, totalBytes: 12))
+    }
+
+    private static func testFailedDownloadKeepsFailureMessageAndRemovesPartial() throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NativeWhisperModelStore(rootDirectory: root)
+        let model = NativeWhisperModelCatalog.recommended
+        let completion = CompletionWaiter<Void, NativeWhisperInstallerError>()
+        let installer = NativeWhisperInstaller(store: store) { _, destination, _, _ in
+            try Data([9]).write(to: destination)
+            throw NativeWhisperInstallerError.downloadFailed("network down")
+        }
+
+        _ = installer.install(model: model, progress: { _ in }) { completion.complete($0) }
+        let result = try completion.wait()
+
+        assertResultFailed(result, .downloadFailed("network down"))
+        assert(store.installStatus(for: model) == .notInstalled)
+        assert(!FileManager.default.fileExists(atPath: store.partialModelURL(for: model).path))
+    }
+
+    private static func testCancelPreventsReadyInstall() throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NativeWhisperModelStore(rootDirectory: root)
+        let model = NativeWhisperModelCatalog.recommended
+        let completion = CompletionWaiter<Void, NativeWhisperInstallerError>()
+        let started = DispatchSemaphore(value: 0)
+        let allowCancelCheck = DispatchSemaphore(value: 0)
+        let installer = NativeWhisperInstaller(store: store) { _, destination, _, shouldCancel in
+            started.signal()
+            _ = allowCancelCheck.wait(timeout: .now() + 2)
+            try Data([1, 2, 3]).write(to: destination)
+            if shouldCancel() { throw NativeWhisperInstallerError.cancelled }
+        }
+        let task = installer.install(model: model, progress: { _ in }) { completion.complete($0) }
+        _ = started.wait(timeout: .now() + 2)
+
+        task.cancel()
+        allowCancelCheck.signal()
+        let result = try completion.wait()
+
+        assert(task.isCancelled)
+        assertResultFailed(result, .cancelled)
+        assert(store.installStatus(for: model) != .ready)
+    }
+
+    private static func assertResultSucceeded(_ result: Result<Void, NativeWhisperInstallerError>) {
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            assertionFailure("Expected success, got \(error)")
+        }
+    }
+
+    private static func assertResultFailed(
+        _ result: Result<Void, NativeWhisperInstallerError>,
+        _ expectedError: NativeWhisperInstallerError
+    ) {
+        switch result {
+        case .success:
+            assertionFailure("Expected failure \(expectedError), got success")
+        case .failure(let error):
+            assert(error == expectedError)
+        }
+    }
+
+    private static func temporaryRoot() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-native-whisper-installer-tests-")
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    }
+}
+
+private final class CompletionWaiter<Success, Failure: Error> {
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var result: Result<Success, Failure>?
+
+    func complete(_ result: Result<Success, Failure>) {
+        self.result = result
+        semaphore.signal()
+    }
+
+    func wait(file: StaticString = #filePath, line: UInt = #line) throws -> Result<Success, Failure> {
+        guard semaphore.wait(timeout: .now() + 2) == .success, let result else {
+            throw TestFailure(message: "Timed out waiting for installer completion", file: file, line: line)
+        }
+        return result
+    }
+}
+
+private struct TestFailure: Error, CustomStringConvertible {
+    let message: String
+    let file: StaticString
+    let line: UInt
+
+    var description: String { "\(file):\(line): \(message)" }
+}

--- a/Tests/NativeWhisperModelTests.swift
+++ b/Tests/NativeWhisperModelTests.swift
@@ -7,6 +7,7 @@ struct NativeWhisperModelTests {
         try testStoreUsesQuillOwnedDirectory()
         try testMissingModelReportsNotInstalled()
         try testCompleteModelReportsReadyWithoutChecksum()
+        try testSmallCompleteModelReportsCorrupt()
         try testPartialModelReportsPartial()
         try testDeleteRemovesOnlySelectedNativeModel()
         try testDeleteMissingModelSucceeds()
@@ -47,11 +48,26 @@ struct NativeWhisperModelTests {
         let root = temporaryRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let store = NativeWhisperModelStore(rootDirectory: root)
-        let model = NativeWhisperModelCatalog.recommended
+        let model = testModel(approximateBytes: 16)
         try FileManager.default.createDirectory(at: store.modelsDirectory, withIntermediateDirectories: true)
         FileManager.default.createFile(atPath: store.modelURL(for: model).path, contents: Data(repeating: 7, count: 16))
 
         assert(store.installStatus(for: model) == .ready)
+    }
+
+    private static func testSmallCompleteModelReportsCorrupt() throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NativeWhisperModelStore(rootDirectory: root)
+        let model = NativeWhisperModelCatalog.recommended
+        try FileManager.default.createDirectory(at: store.modelsDirectory, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: store.modelURL(for: model).path, contents: Data(repeating: 7, count: 16))
+
+        if case .corrupt(let message) = store.installStatus(for: model) {
+            assert(message.contains("too small"))
+        } else {
+            assertionFailure("Expected tiny recommended model file to be corrupt")
+        }
     }
 
     private static func testPartialModelReportsPartial() throws {
@@ -103,6 +119,18 @@ struct NativeWhisperModelTests {
         assert(NativeWhisperDownloadProgress(downloadedBytes: 0, totalBytes: 100).displayText == "Starting...")
         assert(NativeWhisperDownloadProgress(downloadedBytes: 50, totalBytes: 100).displayText == "50% · 50 bytes")
         assert(NativeWhisperDownloadProgress(downloadedBytes: 100, totalBytes: 100, isCancelled: true).displayText == "Canceled")
+    }
+
+    private static func testModel(approximateBytes: Int64) -> NativeWhisperModel {
+        NativeWhisperModel(
+            id: "test-model-\(approximateBytes)",
+            displayName: "Test Model",
+            description: "Small test model",
+            downloadURL: URL(string: "https://example.com/test-model.bin")!,
+            expectedFileName: "test-model-\(approximateBytes).bin",
+            approximateBytes: approximateBytes,
+            checksumSHA256: nil
+        )
     }
 
     private static func temporaryRoot() -> URL {

--- a/Tests/NativeWhisperModelTests.swift
+++ b/Tests/NativeWhisperModelTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 @main
@@ -6,7 +7,9 @@ struct NativeWhisperModelTests {
         try testRecommendedModelMetadata()
         try testStoreUsesQuillOwnedDirectory()
         try testMissingModelReportsNotInstalled()
-        try testCompleteModelReportsReadyWithoutChecksum()
+        try testCompleteModelReportsReadyWithChecksum()
+        try testChecksumMismatchReportsCorrupt()
+        try testTruncatedLargeModelReportsCorrupt()
         try testSmallCompleteModelReportsCorrupt()
         try testPartialModelReportsPartial()
         try testDeleteRemovesOnlySelectedNativeModel()
@@ -22,7 +25,8 @@ struct NativeWhisperModelTests {
         assert(model.displayName == "Whisper Large v3 Turbo")
         assert(model.expectedFileName == "ggml-large-v3-turbo.bin")
         assert(model.downloadURL.absoluteString == "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin")
-        assert(model.approximateBytes == 1_620_000_000)
+        assert(model.approximateBytes == 1_624_555_275)
+        assert(model.checksumSHA256 == "1fc70f774d38eb169993ac391eea357ef47c88757ef72ee5943879b7e8e2bc69")
     }
 
     private static func testStoreUsesQuillOwnedDirectory() throws {
@@ -44,15 +48,49 @@ struct NativeWhisperModelTests {
         assert(store.installStatus(for: .recommended) == .notInstalled)
     }
 
-    private static func testCompleteModelReportsReadyWithoutChecksum() throws {
+    private static func testCompleteModelReportsReadyWithChecksum() throws {
         let root = temporaryRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let store = NativeWhisperModelStore(rootDirectory: root)
-        let model = testModel(approximateBytes: 16)
+        let data = Data(repeating: 7, count: 16)
+        let model = testModel(approximateBytes: 16, checksumSHA256: sha256HexDigest(for: data))
+        try FileManager.default.createDirectory(at: store.modelsDirectory, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: store.modelURL(for: model).path, contents: data)
+
+        assert(store.installStatus(for: model) == .ready)
+    }
+
+    private static func testChecksumMismatchReportsCorrupt() throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NativeWhisperModelStore(rootDirectory: root)
+        let model = testModel(approximateBytes: 16, checksumSHA256: String(repeating: "0", count: 64))
         try FileManager.default.createDirectory(at: store.modelsDirectory, withIntermediateDirectories: true)
         FileManager.default.createFile(atPath: store.modelURL(for: model).path, contents: Data(repeating: 7, count: 16))
 
-        assert(store.installStatus(for: model) == .ready)
+        if case .corrupt(let message) = store.installStatus(for: model) {
+            assert(message.contains("checksum mismatch"))
+        } else {
+            assertionFailure("Expected checksum mismatch to be corrupt")
+        }
+    }
+
+    private static func testTruncatedLargeModelReportsCorrupt() throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NativeWhisperModelStore(rootDirectory: root)
+        let model = testModel(approximateBytes: 1_000_000_000)
+        try FileManager.default.createDirectory(at: store.modelsDirectory, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: store.modelURL(for: model).path, contents: nil)
+        let handle = try FileHandle(forWritingTo: store.modelURL(for: model))
+        try handle.truncate(atOffset: 100_000_000)
+        try handle.close()
+
+        if case .corrupt(let message) = store.installStatus(for: model) {
+            assert(message.contains("too small"))
+        } else {
+            assertionFailure("Expected truncated large model file to be corrupt")
+        }
     }
 
     private static func testSmallCompleteModelReportsCorrupt() throws {
@@ -93,7 +131,7 @@ struct NativeWhisperModelTests {
             downloadURL: URL(string: "https://example.com/other.bin")!,
             expectedFileName: "other.bin",
             approximateBytes: 8,
-            checksumSHA256: nil
+            checksumSHA256: sha256HexDigest(for: Data([2]))
         )
         try FileManager.default.createDirectory(at: store.modelsDirectory, withIntermediateDirectories: true)
         FileManager.default.createFile(atPath: store.modelURL(for: selected).path, contents: Data([1]))
@@ -121,7 +159,10 @@ struct NativeWhisperModelTests {
         assert(NativeWhisperDownloadProgress(downloadedBytes: 100, totalBytes: 100, isCancelled: true).displayText == "Canceled")
     }
 
-    private static func testModel(approximateBytes: Int64) -> NativeWhisperModel {
+    private static func testModel(
+        approximateBytes: Int64,
+        checksumSHA256: String = String(repeating: "0", count: 64)
+    ) -> NativeWhisperModel {
         NativeWhisperModel(
             id: "test-model-\(approximateBytes)",
             displayName: "Test Model",
@@ -129,8 +170,12 @@ struct NativeWhisperModelTests {
             downloadURL: URL(string: "https://example.com/test-model.bin")!,
             expectedFileName: "test-model-\(approximateBytes).bin",
             approximateBytes: approximateBytes,
-            checksumSHA256: nil
+            checksumSHA256: checksumSHA256
         )
+    }
+
+    private static func sha256HexDigest(for data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 
     private static func temporaryRoot() -> URL {

--- a/Tests/NativeWhisperModelTests.swift
+++ b/Tests/NativeWhisperModelTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+@main
+struct NativeWhisperModelTests {
+    static func main() throws {
+        try testRecommendedModelMetadata()
+        try testStoreUsesQuillOwnedDirectory()
+        try testMissingModelReportsNotInstalled()
+        try testCompleteModelReportsReadyWithoutChecksum()
+        try testPartialModelReportsPartial()
+        try testDeleteRemovesOnlySelectedNativeModel()
+        try testDeleteMissingModelSucceeds()
+        try testDownloadProgressDisplayText()
+        print("NativeWhisperModelTests passed")
+    }
+
+    private static func testRecommendedModelMetadata() throws {
+        let model = NativeWhisperModelCatalog.recommended
+
+        assert(model.id == "whisper-large-v3-turbo")
+        assert(model.displayName == "Whisper Large v3 Turbo")
+        assert(model.expectedFileName == "ggml-large-v3-turbo.bin")
+        assert(model.downloadURL.absoluteString == "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin")
+        assert(model.approximateBytes == 1_620_000_000)
+    }
+
+    private static func testStoreUsesQuillOwnedDirectory() throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NativeWhisperModelStore(rootDirectory: root)
+        let model = NativeWhisperModelCatalog.recommended
+
+        assert(store.modelsDirectory.path == root.appendingPathComponent("LocalWhisper/Models", isDirectory: true).path)
+        assert(store.modelURL(for: model).path.hasSuffix("LocalWhisper/Models/ggml-large-v3-turbo.bin"))
+        assert(store.partialModelURL(for: model).path.hasSuffix("LocalWhisper/Models/ggml-large-v3-turbo.bin.download"))
+    }
+
+    private static func testMissingModelReportsNotInstalled() throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NativeWhisperModelStore(rootDirectory: root)
+
+        assert(store.installStatus(for: .recommended) == .notInstalled)
+    }
+
+    private static func testCompleteModelReportsReadyWithoutChecksum() throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NativeWhisperModelStore(rootDirectory: root)
+        let model = NativeWhisperModelCatalog.recommended
+        try FileManager.default.createDirectory(at: store.modelsDirectory, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: store.modelURL(for: model).path, contents: Data(repeating: 7, count: 16))
+
+        assert(store.installStatus(for: model) == .ready)
+    }
+
+    private static func testPartialModelReportsPartial() throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NativeWhisperModelStore(rootDirectory: root)
+        let model = NativeWhisperModelCatalog.recommended
+        try FileManager.default.createDirectory(at: store.modelsDirectory, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: store.partialModelURL(for: model).path, contents: Data(repeating: 1, count: 4))
+
+        assert(store.installStatus(for: model) == .partial(downloadedBytes: 4, expectedBytes: model.approximateBytes))
+    }
+
+    private static func testDeleteRemovesOnlySelectedNativeModel() throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NativeWhisperModelStore(rootDirectory: root)
+        let selected = NativeWhisperModelCatalog.recommended
+        let other = NativeWhisperModel(
+            id: "other",
+            displayName: "Other",
+            description: "Other test model",
+            downloadURL: URL(string: "https://example.com/other.bin")!,
+            expectedFileName: "other.bin",
+            approximateBytes: 8,
+            checksumSHA256: nil
+        )
+        try FileManager.default.createDirectory(at: store.modelsDirectory, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: store.modelURL(for: selected).path, contents: Data([1]))
+        FileManager.default.createFile(atPath: store.modelURL(for: other).path, contents: Data([2]))
+
+        try store.deleteModel(selected)
+
+        assert(!FileManager.default.fileExists(atPath: store.modelURL(for: selected).path))
+        assert(FileManager.default.fileExists(atPath: store.modelURL(for: other).path))
+    }
+
+    private static func testDeleteMissingModelSucceeds() throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NativeWhisperModelStore(rootDirectory: root)
+
+        try store.deleteModel(.recommended)
+
+        assert(store.installStatus(for: .recommended) == .notInstalled)
+    }
+
+    private static func testDownloadProgressDisplayText() throws {
+        assert(NativeWhisperDownloadProgress(downloadedBytes: 0, totalBytes: 100).displayText == "Starting...")
+        assert(NativeWhisperDownloadProgress(downloadedBytes: 50, totalBytes: 100).displayText == "50% · 50 bytes")
+        assert(NativeWhisperDownloadProgress(downloadedBytes: 100, totalBytes: 100, isCancelled: true).displayText == "Canceled")
+    }
+
+    private static func temporaryRoot() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-native-whisper-model-tests-")
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    }
+}

--- a/Tests/NativeWhisperRuntimeTests.swift
+++ b/Tests/NativeWhisperRuntimeTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+@main
+struct NativeWhisperRuntimeTests {
+    static func main() async throws {
+        try await testRuntimeReturnsStdoutTranscript()
+        try await testRuntimeReadsOutputJSONTextField()
+        try await testRuntimeRejectsMissingRunner()
+        try await testRuntimeRejectsMissingModel()
+        try await testRuntimeRejectsMissingAudio()
+        try await testRuntimeReportsNonZeroExitWithTailDetails()
+        print("NativeWhisperRuntimeTests passed")
+    }
+
+    private static func testRuntimeReturnsStdoutTranscript() async throws {
+        let root = try temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let helper = try writeHelper(root: root, body: """
+        #!/bin/sh
+        echo "hello from native whisper"
+        """)
+        let model = try writeFile(root.appendingPathComponent("model.bin"), data: Data([1]))
+        let audio = try writeFile(root.appendingPathComponent("audio.wav"), data: Data([2]))
+        let runtime = NativeWhisperRuntime(runnerURL: helper)
+
+        let transcript = try await runtime.transcribe(audioURL: audio, modelURL: model, languageCode: "en")
+
+        assert(transcript == "hello from native whisper")
+    }
+
+    private static func testRuntimeReadsOutputJSONTextField() async throws {
+        let root = try temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let helper = try writeHelper(root: root, body: """
+        #!/bin/sh
+        while [ "$#" -gt 0 ]; do
+          if [ "$1" = "-of" ]; then
+            shift
+            printf '{"text":"json transcript"}' > "$1.json"
+            exit 0
+          fi
+          shift
+        done
+        exit 2
+        """)
+        let model = try writeFile(root.appendingPathComponent("model.bin"), data: Data([1]))
+        let audio = try writeFile(root.appendingPathComponent("audio.wav"), data: Data([2]))
+        let runtime = NativeWhisperRuntime(runnerURL: helper)
+
+        let transcript = try await runtime.transcribe(audioURL: audio, modelURL: model, languageCode: "ko")
+
+        assert(transcript == "json transcript")
+    }
+
+    private static func testRuntimeRejectsMissingRunner() async throws {
+        let root = try temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let model = try writeFile(root.appendingPathComponent("model.bin"), data: Data([1]))
+        let audio = try writeFile(root.appendingPathComponent("audio.wav"), data: Data([2]))
+        let runtime = NativeWhisperRuntime(runnerURL: root.appendingPathComponent("missing-helper"))
+
+        do {
+            _ = try await runtime.transcribe(audioURL: audio, modelURL: model, languageCode: nil)
+            assertionFailure("Expected missing runner error")
+        } catch let error as NativeWhisperRuntimeError {
+            assert(error == .runnerNotFound(runtime.runnerURL.path))
+        }
+    }
+
+    private static func testRuntimeRejectsMissingModel() async throws {
+        let root = try temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let helper = try writeHelper(root: root, body: "#!/bin/sh\necho should-not-run\n")
+        let audio = try writeFile(root.appendingPathComponent("audio.wav"), data: Data([2]))
+        let runtime = NativeWhisperRuntime(runnerURL: helper)
+
+        do {
+            _ = try await runtime.transcribe(audioURL: audio, modelURL: root.appendingPathComponent("missing.bin"), languageCode: nil)
+            assertionFailure("Expected missing model error")
+        } catch let error as NativeWhisperRuntimeError {
+            assert(error == .modelNotFound(root.appendingPathComponent("missing.bin").path))
+        }
+    }
+
+    private static func testRuntimeRejectsMissingAudio() async throws {
+        let root = try temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let helper = try writeHelper(root: root, body: "#!/bin/sh\necho should-not-run\n")
+        let model = try writeFile(root.appendingPathComponent("model.bin"), data: Data([1]))
+        let runtime = NativeWhisperRuntime(runnerURL: helper)
+
+        do {
+            _ = try await runtime.transcribe(audioURL: root.appendingPathComponent("missing.wav"), modelURL: model, languageCode: nil)
+            assertionFailure("Expected missing audio error")
+        } catch let error as NativeWhisperRuntimeError {
+            assert(error == .audioNotReadable(root.appendingPathComponent("missing.wav").path))
+        }
+    }
+
+    private static func testRuntimeReportsNonZeroExitWithTailDetails() async throws {
+        let root = try temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let helper = try writeHelper(root: root, body: """
+        #!/bin/sh
+        echo "first line" >&2
+        echo "second line" >&2
+        echo "final cause" >&2
+        exit 7
+        """)
+        let model = try writeFile(root.appendingPathComponent("model.bin"), data: Data([1]))
+        let audio = try writeFile(root.appendingPathComponent("audio.wav"), data: Data([2]))
+        let runtime = NativeWhisperRuntime(runnerURL: helper)
+
+        do {
+            _ = try await runtime.transcribe(audioURL: audio, modelURL: model, languageCode: nil)
+            assertionFailure("Expected process failure")
+        } catch let error as NativeWhisperRuntimeError {
+            guard case .processFailed(let exitCode, let output) = error else {
+                assertionFailure("Unexpected error: \(error)")
+                return
+            }
+            assert(exitCode == 7)
+            assert(output.contains("final cause"))
+        }
+    }
+
+    private static func temporaryRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-native-whisper-runtime-tests-")
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    @discardableResult
+    private static func writeFile(_ url: URL, data: Data) throws -> URL {
+        FileManager.default.createFile(atPath: url.path, contents: data)
+        return url
+    }
+
+    private static func writeHelper(root: URL, body: String) throws -> URL {
+        let helper = root.appendingPathComponent("fake-whisper-cli")
+        try body.write(to: helper, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: helper.path)
+        return helper
+    }
+}

--- a/Tests/NativeWhisperRuntimeTests.swift
+++ b/Tests/NativeWhisperRuntimeTests.swift
@@ -5,6 +5,7 @@ struct NativeWhisperRuntimeTests {
     static func main() async throws {
         try await testRuntimeReturnsStdoutTranscript()
         try await testRuntimeReadsOutputJSONTextField()
+        try await testRuntimeDisablesTextContext()
         try await testRuntimeRejectsMissingRunner()
         try await testRuntimeRejectsMissingModel()
         try await testRuntimeRejectsMissingAudio()
@@ -51,6 +52,27 @@ struct NativeWhisperRuntimeTests {
         let transcript = try await runtime.transcribe(audioURL: audio, modelURL: model, languageCode: "ko")
 
         assert(transcript == "json transcript")
+    }
+
+    private static func testRuntimeDisablesTextContext() async throws {
+        let root = try temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let argsFile = root.appendingPathComponent("args.txt")
+        let helper = try writeHelper(root: root, body: """
+        #!/bin/sh
+        printf '%s\n' "$@" > "\(argsFile.path)"
+        echo "ok"
+        """)
+        let model = try writeFile(root.appendingPathComponent("model.bin"), data: Data([1]))
+        let audio = try writeFile(root.appendingPathComponent("audio.wav"), data: Data([2]))
+        let runtime = NativeWhisperRuntime(runnerURL: helper)
+
+        _ = try await runtime.transcribe(audioURL: audio, modelURL: model, languageCode: nil)
+
+        let args = try String(contentsOf: argsFile, encoding: .utf8).split(separator: "\n").map(String.init)
+        let maxContextIndex = args.firstIndex(of: "-mc")
+        assert(maxContextIndex != nil, "Expected native whisper runtime to set max context")
+        assert(args.dropFirst(maxContextIndex! + 1).first == "0", "Expected native whisper runtime to disable previous text conditioning")
     }
 
     private static func testRuntimeRejectsMissingRunner() async throws {

--- a/Tests/NativeWhisperRuntimeTests.swift
+++ b/Tests/NativeWhisperRuntimeTests.swift
@@ -9,6 +9,7 @@ struct NativeWhisperRuntimeTests {
         try await testRuntimeRejectsMissingModel()
         try await testRuntimeRejectsMissingAudio()
         try await testRuntimeReportsNonZeroExitWithTailDetails()
+        try await testRuntimeTerminatesHelperOnCancellation()
         print("NativeWhisperRuntimeTests passed")
     }
 
@@ -124,6 +125,36 @@ struct NativeWhisperRuntimeTests {
         }
     }
 
+    private static func testRuntimeTerminatesHelperOnCancellation() async throws {
+        let root = try temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let pidFile = root.appendingPathComponent("helper.pid")
+        let helper = try writeHelper(root: root, body: """
+        #!/bin/sh
+        echo $$ > "\(pidFile.path)"
+        while true; do sleep 1; done
+        """)
+        let model = try writeFile(root.appendingPathComponent("model.bin"), data: Data([1]))
+        let audio = try writeFile(root.appendingPathComponent("audio.wav"), data: Data([2]))
+        let runtime = NativeWhisperRuntime(runnerURL: helper)
+        let task = Task {
+            try await runtime.transcribe(audioURL: audio, modelURL: model, languageCode: nil)
+        }
+        assert(waitForFile(pidFile, timeout: 5), "Expected helper to write its pid")
+        let pid = try String(contentsOf: pidFile, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        task.cancel()
+        do {
+            _ = try await task.value
+            assertionFailure("Expected cancellation")
+        } catch is CancellationError {
+        } catch {
+            assertionFailure("Expected cancellation, got \(error)")
+        }
+
+        assert(waitForProcessExit(pid: pid, timeout: 5), "Expected helper process to exit on cancellation")
+    }
+
     private static func temporaryRoot() throws -> URL {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("quill-native-whisper-runtime-tests-")
@@ -143,5 +174,33 @@ struct NativeWhisperRuntimeTests {
         try body.write(to: helper, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: helper.path)
         return helper
+    }
+
+    private static func waitForFile(_ url: URL, timeout seconds: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline {
+            if FileManager.default.fileExists(atPath: url.path) {
+                return true
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        return FileManager.default.fileExists(atPath: url.path)
+    }
+
+    private static func waitForProcessExit(pid: String, timeout seconds: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/bin/kill")
+            process.arguments = ["-0", pid]
+            process.standardError = Pipe()
+            try? process.run()
+            process.waitUntilExit()
+            if process.terminationStatus != 0 {
+                return true
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        return false
     }
 }

--- a/docs/superpowers/specs/2026-07-04-local-whisper-native-runtime-design.md
+++ b/docs/superpowers/specs/2026-07-04-local-whisper-native-runtime-design.md
@@ -120,7 +120,7 @@ struct NativeWhisperModel: Identifiable, Equatable, Codable {
     let downloadURL: URL
     let expectedFileName: String
     let approximateBytes: Int64
-    let checksumSHA256: String?
+    let checksumSHA256: String
 }
 ```
 
@@ -153,7 +153,7 @@ Responsibilities:
 - return the expected final model path;
 - return a temporary partial-download path;
 - detect installed, missing, partial, and corrupt states;
-- verify expected size and checksum when available;
+- verify expected size and required checksum;
 - safely delete a model;
 - avoid touching non-Quill-owned Hugging Face caches.
 
@@ -251,7 +251,7 @@ Do not silently fall back from native Whisper to legacy `mlx_whisper` unless the
 
 The first native path supports Quill-recorded audio only.
 
-The runner should receive an audio file produced by Quill's recording pipeline. If the recording format is not already compatible with the selected whisper.cpp runner, add a small Quill-controlled conversion step for recordings only, preferably using AVFoundation or by adjusting the recording output format.
+The runner should receive an audio file produced by Quill's recording pipeline. Require the recording pipeline to emit a whisper.cpp-compatible WAV/PCM format for phase 1. Defer any conversion work to a separate follow-up.
 
 External imports remain on the existing supported path until a later phase decides how to handle decoding/conversion.
 

--- a/docs/superpowers/specs/2026-07-04-local-whisper-native-runtime-design.md
+++ b/docs/superpowers/specs/2026-07-04-local-whisper-native-runtime-design.md
@@ -1,0 +1,429 @@
+# Local Whisper native runtime design
+
+GitHub issues: [#75](https://github.com/woosublee/quill/issues/75), [#145](https://github.com/woosublee/quill/issues/145), [#9](https://github.com/woosublee/quill/issues/9), [#132](https://github.com/woosublee/quill/issues/132)
+
+## Goal
+
+Replace Quill's default Local Whisper path from the current Python/`mlx_whisper` CLI dependency to a Quill-managed native Whisper runtime based on whisper.cpp.
+
+The first implementation should make this flow work:
+
+```text
+Quill recording
+→ Quill-managed native Whisper runner
+→ Quill-managed whisper.cpp model
+→ local transcript
+```
+
+This is the first phase of #75 and the Phase 1 transcription work inside #145. The intent is not to build a new local provider abstraction first; it is to replace the existing `mlx_whisper` execution path with a native equivalent that normal users can use after installing Quill.
+
+## Current problem
+
+Today the Settings model download UI looks like it prepares Local Whisper, but it only downloads model files after a separate Python `mlx_whisper` environment already exists.
+
+Current default path:
+
+```text
+Quill
+→ ~/.local/bin/mlx_whisper
+→ mlx-whisper Python environment
+→ MLX model cache under Hugging Face cache
+→ ffmpeg invoked internally by mlx_whisper
+```
+
+On a clean Mac, this fails before model download because the user has not installed Python tooling, `pipx`, `mlx-whisper`, Hugging Face dependencies, or `ffmpeg`. The resulting error also exposes an expanded home path such as `/Users/<name>/.local/bin/mlx_whisper`, which feels like an internal developer path in product UI.
+
+## Decision
+
+Introduce a Quill-managed native Whisper path as the default non-Apple local transcription path.
+
+```text
+Quill
+→ bundled whisper.cpp runner
+→ model stored under Quill Application Support
+→ Quill recording WAV/PCM input
+→ transcript
+```
+
+Keep the existing `mlx_whisper` code path only as a legacy/advanced escape hatch for now. Do not build a complex migration UI for existing `mlx_whisper` users in the first implementation, because Quill is currently mostly self-used and the priority is unblocking the clean-install product path.
+
+## Relationship to upstream local-provider support
+
+This design does not replace the upstream-aligned OpenAI-compatible local-provider path.
+
+There are two different ideas that both use the words "local model":
+
+1. **Quill-managed native runtime** — Quill ships or manages the runtime/model. This is #75 and is the no-extra-setup path for Local Whisper.
+2. **BYO OpenAI-compatible provider** — the user runs Ollama, LM Studio, or another local/self-hosted server and Quill points API settings at it. This belongs to #64 / #145 Phase 2 and remains important for post-processing, Edit Mode, context, and advanced transcription providers.
+
+For #75, the implementation should focus on replacing `mlx_whisper` with whisper.cpp for Quill's own Local Whisper flow. Provider settings cleanup remains separate.
+
+## First implementation scope
+
+### In scope
+
+- Bundle or otherwise include a whisper.cpp-based runner in the app build.
+- Add a Quill-owned model store for whisper.cpp-compatible model files.
+- Add one recommended installable model for the first version.
+- Download, verify, delete, and report readiness for that model.
+- Transcribe Quill-recorded audio files through the native runner.
+- Route Local Whisper to native runner by default once the native model is installed.
+- Keep Apple Speech working as the no-download built-in local option.
+- Keep `mlx_whisper` available as a legacy advanced path.
+- Hide Python, `pipx`, Hugging Face CLI, and raw `/Users/...` paths from the normal Local Whisper UI.
+- Preserve technical details for debugging while showing concise user-facing errors.
+
+### Out of scope for the first implementation
+
+- External audio import support for `mp3`, `m4a`, `mp4`, `webm`, `ogg`, `flac`, and similar formats.
+- Bundling or selecting an FFmpeg build.
+- AVFoundation import conversion pipeline.
+- Reusing or migrating existing MLX model caches.
+- Detecting every existing `mlx_whisper` installation and presenting a migration wizard.
+- Embedded local LLM / meeting-note generation.
+- OpenAI-compatible local provider configuration cleanup.
+
+## Model format and migration
+
+`mlx_whisper` and whisper.cpp use different model formats.
+
+Existing MLX models such as:
+
+```text
+mlx-community/whisper-large-v3-turbo
+weights.npz / weights.safetensors
+```
+
+are not treated as installed native Whisper models. The native path uses a whisper.cpp-compatible model file stored in Quill-owned storage.
+
+The first implementation should not delete or modify the existing Hugging Face / MLX cache. It should simply require a one-time download of the native model.
+
+User-facing copy can be simple:
+
+```text
+Native Whisper uses a different model format from legacy mlx-whisper. Download the recommended model once to use the built-in local engine.
+```
+
+## Components
+
+### `NativeWhisperModel`
+
+Represents one whisper.cpp-compatible model.
+
+Initial fields:
+
+```swift
+struct NativeWhisperModel: Identifiable, Equatable, Codable {
+    let id: String
+    let displayName: String
+    let description: String
+    let downloadURL: URL
+    let expectedFileName: String
+    let approximateBytes: Int64
+    let checksumSHA256: String?
+}
+```
+
+The first version should expose one recommended model. Additional models can be added later by extending the catalog.
+
+### `NativeWhisperModelCatalog`
+
+Small static catalog for installable native models.
+
+Responsibilities:
+
+- provide the recommended model;
+- find a model by id;
+- keep display metadata separate from install state.
+
+This should not replace the broader model-selection design from the 2026-06-19 spec. It is the concrete native transcription catalog for #75 Phase 1.
+
+### `NativeWhisperModelStore`
+
+Owns model files under Quill Application Support.
+
+Recommended root:
+
+```text
+~/Library/Application Support/<Bundle display name or Quill>/LocalWhisper/Models
+```
+
+Responsibilities:
+
+- return the expected final model path;
+- return a temporary partial-download path;
+- detect installed, missing, partial, and corrupt states;
+- verify expected size and checksum when available;
+- safely delete a model;
+- avoid touching non-Quill-owned Hugging Face caches.
+
+The store should follow the existing app-owned storage pattern used by audio persistence rather than writing to `~/.cache/huggingface`.
+
+### `NativeWhisperInstaller`
+
+Downloads and verifies the recommended native model.
+
+States:
+
+```swift
+enum NativeWhisperInstallState: Equatable {
+    case notInstalled
+    case downloading(downloadedBytes: Int64, totalBytes: Int64?)
+    case verifying
+    case ready
+    case failed(message: String, details: String?)
+}
+```
+
+Responsibilities:
+
+- stream download with progress;
+- write to a partial file first;
+- support cancel/retry;
+- verify before moving into the final path;
+- clean partial files on cancel/failure when safe;
+- surface concise messages and optional technical details.
+
+### `NativeWhisperRuntime`
+
+Runs the whisper.cpp helper.
+
+Responsibilities:
+
+- find the bundled runner;
+- check executable availability;
+- build arguments for model path and audio path;
+- run the process with a minimal controlled environment;
+- capture stdout/stderr;
+- return normalized transcript text;
+- classify runner/model/audio failures.
+
+The first implementation should use a CLI helper process, not a linked C/C++ library. This keeps Swift integration small and leaves room to change the internals later without changing `TranscriptionService` call sites.
+
+Potential bundle locations:
+
+```text
+Quill.app/Contents/Resources/whisper/whisper-cli
+```
+
+or:
+
+```text
+Quill.app/Contents/MacOS/whisper-cli
+```
+
+Prefer a bundle-owned path that is code-signed with the app. The Makefile should copy and sign the helper explicitly rather than relying on a developer-local binary path.
+
+### Legacy `mlx_whisper`
+
+The existing path remains as advanced fallback.
+
+Initial UI treatment:
+
+```text
+Advanced
+Use legacy mlx-whisper
+mlx_whisper Path
+```
+
+The first implementation does not need to detect all legacy users, show a migration wizard, or manage legacy caches. If the user enables the legacy path, Quill uses the current `mlx_whisper` code path.
+
+## Transcription routing
+
+After the first implementation, local transcription routing should be conceptually:
+
+```text
+if selected model is Apple Speech:
+    use Apple Speech
+else if legacy mlx_whisper is explicitly enabled:
+    use legacy mlx_whisper
+else if native model is installed:
+    use NativeWhisperRuntime
+else:
+    report Local Whisper is not installed and show install action
+```
+
+This keeps the default path native while preserving an escape hatch.
+
+Do not silently fall back from native Whisper to legacy `mlx_whisper` unless the user explicitly enabled the legacy path. Silent fallback would make failures harder to diagnose and could reintroduce Python/ffmpeg dependency surprises.
+
+## Audio input strategy
+
+The first native path supports Quill-recorded audio only.
+
+The runner should receive an audio file produced by Quill's recording pipeline. If the recording format is not already compatible with the selected whisper.cpp runner, add a small Quill-controlled conversion step for recordings only, preferably using AVFoundation or by adjusting the recording output format.
+
+External imports remain on the existing supported path until a later phase decides how to handle decoding/conversion.
+
+This keeps #9 contained:
+
+- `mlx_whisper` currently calls `ffmpeg` internally even for prepared WAV files.
+- whisper.cpp can avoid user-installed `ffmpeg` when given compatible WAV/PCM input.
+- broad import support may still need AVFoundation conversion or a bundled LGPL-only FFmpeg later, but that is not required for the first Quill-recording path.
+
+## Settings UX
+
+The normal Local Whisper section should describe the Quill-managed path.
+
+Not installed:
+
+```text
+Local Whisper
+Private transcription on your Mac.
+
+Whisper Large v3 Turbo
+Fast local transcription. About 900 MB.
+
+[Install Local Whisper]
+```
+
+Installing:
+
+```text
+Installing Local Whisper
+Downloading model… 42%
+[Cancel]
+```
+
+Ready:
+
+```text
+Local Whisper is ready.
+[Use Local Whisper]
+[Delete Model]
+```
+
+Failed:
+
+```text
+Could not install Local Whisper.
+Check your network connection and free disk space, then try again.
+[Retry]
+[Show Details]
+```
+
+Advanced:
+
+```text
+Use legacy mlx-whisper
+Path: ~/.local/bin/mlx_whisper
+```
+
+Normal users should not see Python, `pipx`, Hugging Face cache paths, or expanded `/Users/<name>` paths unless they open technical details.
+
+## Error handling
+
+Use two layers for errors.
+
+### User-facing messages
+
+Examples:
+
+```text
+Local Whisper is not installed yet. Install the recommended model to use local transcription.
+```
+
+```text
+Local Whisper could not read this recording. Try again or switch to Apple Speech.
+```
+
+```text
+Could not install Local Whisper. Check your network connection and free disk space, then try again.
+```
+
+### Technical details
+
+Preserve details for debugging:
+
+- runner path;
+- runner executable status;
+- model path;
+- model file size;
+- model checksum result when available;
+- input audio path;
+- input audio existence/readability/size;
+- process exit code;
+- stdout/stderr summary with both head and tail when useful.
+
+This aligns with #132 without turning the first implementation into a full diagnostic-export project.
+
+## Build and packaging
+
+The app build must not depend on a developer-local whisper.cpp binary.
+
+First implementation should add an explicit build/package path for the helper:
+
+- build or vendor the whisper.cpp CLI helper in a reproducible location;
+- copy it into the app bundle;
+- code-sign it with the same identity as the app;
+- verify it exists in the built app before marking build successful.
+
+The exact helper acquisition method can be decided in the implementation plan. The design requirement is that release builds produce an app whose native Local Whisper runtime does not depend on `/opt/homebrew`, `~/.local`, or a manually installed `mlx_whisper`.
+
+## Testing strategy
+
+### Unit-level tests
+
+Add tests for:
+
+- model catalog lookup;
+- model store paths under a temporary Application Support root;
+- installed/missing/partial/corrupt state detection;
+- safe delete behavior;
+- install state display text;
+- routing decision: Apple Speech vs native vs legacy.
+
+### Runtime tests
+
+Add a test seam so `NativeWhisperRuntime` can run a fake helper script in tests.
+
+Fake-helper tests should cover:
+
+- successful transcript output;
+- empty transcript;
+- non-zero exit;
+- missing runner;
+- missing model;
+- missing/zero-byte audio file;
+- stdout/stderr summarization.
+
+### Manual verification
+
+Before claiming the implementation works:
+
+1. Build Quill Dev in the isolated worktree.
+2. Confirm the bundled runner exists inside the app bundle.
+3. Install/download the native model through Settings.
+4. Record a short sample through Quill.
+5. Confirm local transcription returns text without `mlx_whisper`, Python, `pipx`, or user-installed `ffmpeg` in the normal path.
+6. Confirm Apple Speech still works.
+7. Confirm legacy `mlx_whisper` remains available only when explicitly enabled.
+
+## Baseline note
+
+Before this design was written, `make test` was run in the isolated worktree. Several existing tests passed, then the suite failed on SwiftUI macro plugin lookup errors such as:
+
+```text
+external macro implementation type 'SwiftUIMacros.StateMacro' could not be found for macro 'State()'; plugin for module 'SwiftUIMacros' not found
+```
+
+No product code had been changed at that point. Treat this as a pre-existing local toolchain/baseline issue to resolve or work around before using full `make test` as the final verification signal.
+
+## Implementation order
+
+1. Add the native model catalog/store types and tests.
+2. Add installer state and model delete/retry behavior.
+3. Add `NativeWhisperRuntime` with a fake-helper test seam.
+4. Add build packaging for the whisper.cpp helper.
+5. Wire native runtime into `TranscriptionService` routing.
+6. Update Settings Local Options UI for install/ready/failure states.
+7. Move existing `mlx_whisper Path` under Advanced/Legacy.
+8. Run focused tests, then resolve or document the full-suite SwiftUI macro baseline before final verification.
+
+## Explicit non-goals
+
+- Do not implement #64 provider settings split in this work.
+- Do not implement local LLM or meeting-note generation in this work.
+- Do not implement external import conversion in this work.
+- Do not delete legacy MLX/Hugging Face caches.
+- Do not require users to install Homebrew, Python, `pipx`, `mlx-whisper`, or `ffmpeg` for the normal native Local Whisper path.


### PR DESCRIPTION
## Summary
Closes #75

- Package native `whisper.cpp` as the default Local Whisper runtime, with static helper validation and model install/readiness checks.
- Add the native Local Whisper Settings flow: radio-style model row, persisted download progress across tab switches, cancellation/partial-file cleanup on Settings close, and delete support.
- Keep legacy `mlx_whisper` as an Advanced escape hatch with the previous model list, while routing normal local transcription through native Whisper.
- Tighten Note Browser transcription availability so unavailable Whisper/API modes are not selected, and keep the current transcription mode when viewing API Provider settings without a configured API key.
- Add runtime cancellation propagation and use `-mc 0` to avoid carrying previous text context in the bundled `whisper-cli` version.

## Beta notes / follow-ups
- This keeps Local Whisper in a beta-style rollout: native install/runtime is packaged, but speaker diarization is not claimed as supported.
- Native external audio import conversion remains out of this first pass; imported audio still uses API unless legacy `mlx_whisper` is enabled.
- Future beta work can evaluate speaker-turn cleanup/diarization separately after measuring transcript quality.

## Verification
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make test BUILD_DIR="/tmp/quill-dev-build"`
- Rebuilt and opened `/tmp/quill-dev-build/Quill Dev.app`
- Verified bundled helper architecture and that it does not depend on `libwhisper`/`libggml` dylibs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 로컬 전사에 whisper.cpp 기반 네이티브 Whisper 실행 경로와 런타임 전사가 추가되었습니다.
  * 앱에서 로컬 Whisper 모델 다운로드/검증/설치 상태 확인 및 삭제가 제공됩니다.
  * 전사 설정에서 레거시 방식과 네이티브 방식을 더 명확히 구분해 선택할 수 있습니다.
* **Bug Fixes**
  * 설정 변경/종료 시 진행 중 설치 취소 등 상태 전환 안정성을 개선했습니다.
* **Tests**
  * 모델 설치·런타임 전사·설정 전환 관련 테스트를 확장했습니다.
* **Documentation**
  * 네이티브 로컬 Whisper 실행 설계 문서를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
