### PR TITLE
Enable native Local Whisper for audio imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,6 +299,8 @@ test: $(SPARKLE_STAMP)
 	@/tmp/SystemDefaultAndSystemAudioRecorderSourceTests
 	@swiftc -parse-as-library "$(CURDIR)/Sources/AudioMixdownService.swift" "$(CURDIR)/Tests/AudioMixdownServiceTests.swift" -o /tmp/AudioMixdownServiceTests
 	@/tmp/AudioMixdownServiceTests
+	@swiftc -parse-as-library "$(CURDIR)/Sources/AudioImportConversionService.swift" "$(CURDIR)/Tests/AudioImportConversionServiceTests.swift" -o /tmp/AudioImportConversionServiceTests
+	@/tmp/AudioImportConversionServiceTests
 	@swiftc -parse-as-library Sources/AudioWaveformHeights.swift Tests/AudioWaveformHeightsTests.swift -o /tmp/AudioWaveformHeightsTests
 	@/tmp/AudioWaveformHeightsTests
 	@swiftc -parse-as-library Tests/SystemAudioAppStateRoutingTests.swift -o /tmp/SystemAudioAppStateRoutingTests

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -917,8 +917,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func audioImportConfiguration(
-        for mode: NoteBrowserTranscriptionMode,
-        allowsNativeWhisper: Bool = false
+        for mode: NoteBrowserTranscriptionMode
     ) -> AudioImportTranscriptionConfiguration {
         switch mode {
         case .apiStandard, .apiRealtime:
@@ -928,13 +927,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 localTranscriptionModel: localTranscriptionModel
             )
         case .localWhisper, .localAppleLive:
-            guard allowsNativeWhisper || useLegacyMlxWhisper else {
-                return AudioImportTranscriptionConfiguration(
-                    mode: .apiStandard,
-                    useLocalTranscription: false,
-                    localTranscriptionModel: localTranscriptionModel
-                )
-            }
             let model = localTranscriptionModel.isAppleSpeech
                 ? TranscriptionModel.all.first(where: { !$0.isAppleSpeech }) ?? localTranscriptionModel
                 : localTranscriptionModel
@@ -2670,7 +2662,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @MainActor
     func importAudioFile(_ fileURL: URL, mode: NoteBrowserTranscriptionMode) {
         let configuration = AudioImportTaskConfiguration(
-            transcriptionConfiguration: audioImportConfiguration(for: mode, allowsNativeWhisper: true),
+            transcriptionConfiguration: audioImportConfiguration(for: mode),
             transcriptionAPIKey: resolvedTranscriptionAPIKey,
             transcriptionAPIBaseURL: resolvedTranscriptionBaseURL,
             localWhisperPath: localWhisperPath,
@@ -2968,7 +2960,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         guard let retryMode = options.defaultMode else {
             throw TranscriptionError.submissionFailed("No transcription method is available. Configure an API key or install a Local Whisper model, then try again.")
         }
-        let configuration = audioImportConfiguration(for: retryMode, allowsNativeWhisper: true)
+        let configuration = audioImportConfiguration(for: retryMode)
 
         return RetrySnapshot(
             item: item,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2670,7 +2670,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @MainActor
     func importAudioFile(_ fileURL: URL, mode: NoteBrowserTranscriptionMode) {
         let configuration = AudioImportTaskConfiguration(
-            transcriptionConfiguration: audioImportConfiguration(for: mode),
+            transcriptionConfiguration: audioImportConfiguration(for: mode, allowsNativeWhisper: true),
             transcriptionAPIKey: resolvedTranscriptionAPIKey,
             transcriptionAPIBaseURL: resolvedTranscriptionBaseURL,
             localWhisperPath: localWhisperPath,

--- a/Sources/AudioImportConversionService.swift
+++ b/Sources/AudioImportConversionService.swift
@@ -37,16 +37,32 @@ struct AudioImportConversionService {
     private static let targetSampleRate: Double = 16_000
     private static let targetChannelCount: AVAudioChannelCount = 1
 
+    private let convert: (@Sendable (URL) throws -> PreparedNativeWhisperAudio)?
+
+    init(convert: (@Sendable (URL) throws -> PreparedNativeWhisperAudio)? = nil) {
+        self.convert = convert
+    }
+
     func prepareForNativeWhisper(_ sourceURL: URL) async throws -> PreparedNativeWhisperAudio {
         try Task.checkCancellation()
         if Self.isNativeWhisperCompatibleWAV(sourceURL) {
             return PreparedNativeWhisperAudio(fileURL: sourceURL)
         }
 
-        return try await Task.detached(priority: .userInitiated) {
+        let convert = self.convert
+        let conversionTask = Task.detached(priority: .userInitiated) {
             try Task.checkCancellation()
+            if let convert {
+                return try convert(sourceURL)
+            }
             return try Self.convertToNativeWhisperWAV(sourceURL)
-        }.value
+        }
+
+        return try await withTaskCancellationHandler {
+            try await conversionTask.value
+        } onCancel: {
+            conversionTask.cancel()
+        }
     }
 
     private static func isNativeWhisperCompatibleWAV(_ url: URL) -> Bool {

--- a/Sources/AudioImportConversionService.swift
+++ b/Sources/AudioImportConversionService.swift
@@ -1,0 +1,178 @@
+import AVFoundation
+import Foundation
+
+struct PreparedNativeWhisperAudio {
+    let fileURL: URL
+    private let temporaryFileURL: URL?
+
+    init(fileURL: URL, temporaryFileURL: URL? = nil) {
+        self.fileURL = fileURL
+        self.temporaryFileURL = temporaryFileURL
+    }
+
+    func cleanup() {
+        guard let temporaryFileURL else { return }
+        try? FileManager.default.removeItem(at: temporaryFileURL)
+    }
+}
+
+enum AudioImportConversionError: LocalizedError {
+    case unreadableAudio(String)
+    case converterUnavailable
+    case conversionFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unreadableAudio(let path):
+            return "Quill couldn't read this audio file for local transcription: \(path). Try API transcription, legacy mlx-whisper, or convert the file to MP3, M4A, MP4, or WAV."
+        case .converterUnavailable:
+            return "Quill couldn't prepare this audio file for native Local Whisper. Try API transcription or convert the file to MP3, M4A, MP4, or WAV."
+        case .conversionFailed(let message):
+            return "Quill couldn't prepare this audio file for native Local Whisper: \(message)"
+        }
+    }
+}
+
+struct AudioImportConversionService {
+    private static let targetSampleRate: Double = 16_000
+    private static let targetChannelCount: AVAudioChannelCount = 1
+
+    func prepareForNativeWhisper(_ sourceURL: URL) async throws -> PreparedNativeWhisperAudio {
+        try Task.checkCancellation()
+        if Self.isNativeWhisperCompatibleWAV(sourceURL) {
+            return PreparedNativeWhisperAudio(fileURL: sourceURL)
+        }
+
+        return try await Task.detached(priority: .userInitiated) {
+            try Task.checkCancellation()
+            return try Self.convertToNativeWhisperWAV(sourceURL)
+        }.value
+    }
+
+    private static func isNativeWhisperCompatibleWAV(_ url: URL) -> Bool {
+        guard url.pathExtension.lowercased() == "wav" else { return false }
+        guard let file = try? AVAudioFile(forReading: url) else { return false }
+        let format = file.fileFormat
+        return abs(format.sampleRate - targetSampleRate) < 0.5
+            && format.channelCount == targetChannelCount
+            && format.commonFormat == .pcmFormatInt16
+            && format.isInterleaved
+    }
+
+    private static func convertToNativeWhisperWAV(_ sourceURL: URL) throws -> PreparedNativeWhisperAudio {
+        let inputFile: AVAudioFile
+        do {
+            inputFile = try AVAudioFile(forReading: sourceURL)
+        } catch {
+            throw AudioImportConversionError.unreadableAudio(sourceURL.lastPathComponent)
+        }
+
+        let inputFormat = inputFile.processingFormat
+        guard let targetFormat = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: targetSampleRate,
+            channels: targetChannelCount,
+            interleaved: true
+        ) else {
+            throw AudioImportConversionError.converterUnavailable
+        }
+        guard let converter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
+            throw AudioImportConversionError.converterUnavailable
+        }
+
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-native-whisper-import-\(UUID().uuidString)")
+            .appendingPathExtension("wav")
+
+        do {
+            let outputFile = try AVAudioFile(
+                forWriting: outputURL,
+                settings: pcmFileSettings(for: targetFormat),
+                commonFormat: targetFormat.commonFormat,
+                interleaved: targetFormat.isInterleaved
+            )
+
+            var didFinish = false
+            while !didFinish {
+                try Task.checkCancellation()
+
+                guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: 4_096) else {
+                    throw AudioImportConversionError.converterUnavailable
+                }
+
+                var readError: Error?
+                var conversionError: NSError?
+                let status = converter.convert(to: outputBuffer, error: &conversionError) { packetCount, outStatus in
+                    guard inputFile.framePosition < inputFile.length else {
+                        outStatus.pointee = .endOfStream
+                        return nil
+                    }
+
+                    let remainingFrames = inputFile.length - inputFile.framePosition
+                    let requestedFrames = AVAudioFrameCount(min(AVAudioFramePosition(packetCount), remainingFrames))
+                    guard let inputBuffer = AVAudioPCMBuffer(
+                        pcmFormat: inputFormat,
+                        frameCapacity: max(requestedFrames, AVAudioFrameCount(1))
+                    ) else {
+                        outStatus.pointee = .noDataNow
+                        return nil
+                    }
+
+                    do {
+                        try inputFile.read(into: inputBuffer, frameCount: requestedFrames)
+                    } catch {
+                        readError = error
+                        outStatus.pointee = .noDataNow
+                        return nil
+                    }
+
+                    guard inputBuffer.frameLength > 0 else {
+                        outStatus.pointee = .endOfStream
+                        return nil
+                    }
+
+                    outStatus.pointee = .haveData
+                    return inputBuffer
+                }
+
+                if let conversionError {
+                    throw AudioImportConversionError.conversionFailed(conversionError.localizedDescription)
+                }
+                if let readError {
+                    throw AudioImportConversionError.conversionFailed(readError.localizedDescription)
+                }
+                if outputBuffer.frameLength > 0 {
+                    try outputFile.write(from: outputBuffer)
+                }
+
+                switch status {
+                case .haveData, .inputRanDry:
+                    continue
+                case .endOfStream:
+                    didFinish = true
+                case .error:
+                    throw AudioImportConversionError.conversionFailed("Audio conversion failed.")
+                @unknown default:
+                    throw AudioImportConversionError.conversionFailed("Audio conversion returned an unknown status.")
+                }
+            }
+
+            return PreparedNativeWhisperAudio(fileURL: outputURL, temporaryFileURL: outputURL)
+        } catch {
+            try? FileManager.default.removeItem(at: outputURL)
+            throw error
+        }
+    }
+
+    private static func pcmFileSettings(for format: AVAudioFormat) -> [String: Any] {
+        [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: format.sampleRate,
+            AVNumberOfChannelsKey: Int(format.channelCount),
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: !format.isInterleaved,
+        ]
+    }
+}

--- a/Sources/AudioImportConversionService.swift
+++ b/Sources/AudioImportConversionService.swift
@@ -72,7 +72,6 @@ struct AudioImportConversionService {
         return abs(format.sampleRate - targetSampleRate) < 0.5
             && format.channelCount == targetChannelCount
             && format.commonFormat == .pcmFormatInt16
-            && format.isInterleaved
     }
 
     private static func convertToNativeWhisperWAV(_ sourceURL: URL) throws -> PreparedNativeWhisperAudio {

--- a/Sources/AudioImportConversionService.swift
+++ b/Sources/AudioImportConversionService.swift
@@ -108,13 +108,14 @@ struct AudioImportConversionService {
                 interleaved: targetFormat.isInterleaved
             )
 
+            guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: 16_384) else {
+                throw AudioImportConversionError.converterUnavailable
+            }
+
             var didFinish = false
             while !didFinish {
                 try Task.checkCancellation()
-
-                guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: 4_096) else {
-                    throw AudioImportConversionError.converterUnavailable
-                }
+                outputBuffer.frameLength = 0
 
                 var readError: Error?
                 var conversionError: NSError?
@@ -130,6 +131,7 @@ struct AudioImportConversionService {
                         pcmFormat: inputFormat,
                         frameCapacity: max(requestedFrames, AVAudioFrameCount(1))
                     ) else {
+                        readError = AudioImportConversionError.converterUnavailable
                         outStatus.pointee = .noDataNow
                         return nil
                     }

--- a/Sources/AudioImportOptions.swift
+++ b/Sources/AudioImportOptions.swift
@@ -11,6 +11,9 @@ struct AudioImportOptions {
     static let broadlySupportedExtensions: Set<String> = [
         "flac", "mp3", "mp4", "mpeg", "mpga", "m4a", "ogg", "wav", "webm"
     ]
+    static let nativeLocalWhisperExtensions: Set<String> = [
+        "mp3", "mp4", "mpeg", "mpga", "m4a", "wav"
+    ]
     static let apiUploadLimitBytes: Int64 = 25_000_000
 
     static func storageExtension(for fileName: String) -> String {
@@ -52,6 +55,18 @@ struct AudioImportOptions {
         return "API transcription is unavailable"
     }
 
+    var localWhisperUnavailableReason: String {
+        let normalizedExtension = fileExtension.lowercased()
+        if Self.broadlySupportedExtensions.contains(normalizedExtension),
+           !Self.nativeLocalWhisperExtensions.contains(normalizedExtension) {
+            return "Local Whisper supports MP3, MP4, M4A, MPEG, MPGA, and WAV imports"
+        }
+        if !hasLocalWhisperModel {
+            return "Install the native Local Whisper model to import locally"
+        }
+        return "Local Whisper is unavailable for this file"
+    }
+
     var supportedModes: [NoteBrowserTranscriptionMode] {
         let normalizedExtension = fileExtension.lowercased()
         guard Self.broadlySupportedExtensions.contains(normalizedExtension) else { return [] }
@@ -60,7 +75,7 @@ struct AudioImportOptions {
         if hasAPIKey, fileSizeBytes.map({ $0 <= Self.apiUploadLimitBytes }) ?? true {
             modes.append(.apiStandard)
         }
-        if hasLocalWhisperModel {
+        if hasLocalWhisperModel, Self.nativeLocalWhisperExtensions.contains(normalizedExtension) {
             modes.append(.localWhisper)
         }
         return modes

--- a/Sources/NativeWhisperRuntime.swift
+++ b/Sources/NativeWhisperRuntime.swift
@@ -49,17 +49,19 @@ struct NativeWhisperRuntime {
         bundle.url(forResource: "whisper-cli", withExtension: nil, subdirectory: "whisper")
     }
 
+    func validateRunnerAndModel(modelURL: URL) throws {
+        guard fileManager.isExecutableFile(atPath: runnerURL.path) else {
+            throw NativeWhisperRuntimeError.runnerNotFound(runnerURL.path)
+        }
+        guard fileManager.fileExists(atPath: modelURL.path), fileManager.isReadableFile(atPath: modelURL.path) else {
+            throw NativeWhisperRuntimeError.modelNotFound(modelURL.path)
+        }
+    }
+
     func transcribe(audioURL: URL, modelURL: URL, languageCode: String?) async throws -> String {
         let worker = Task.detached(priority: .userInitiated) {
-            guard fileManager.isExecutableFile(atPath: runnerURL.path) else {
-                throw NativeWhisperRuntimeError.runnerNotFound(runnerURL.path)
-            }
-            guard fileManager.fileExists(atPath: modelURL.path) else {
-                throw NativeWhisperRuntimeError.modelNotFound(modelURL.path)
-            }
-            guard fileManager.isReadableFile(atPath: audioURL.path), fileSize(at: audioURL) > 0 else {
-                throw NativeWhisperRuntimeError.audioNotReadable(audioURL.path)
-            }
+            try validateRunnerAndModel(modelURL: modelURL)
+            try validateAudio(at: audioURL)
 
             let outputBase = fileManager.temporaryDirectory
                 .appendingPathComponent("quill-native-whisper-\(UUID().uuidString)")
@@ -135,6 +137,12 @@ struct NativeWhisperRuntime {
             try await worker.value
         } onCancel: {
             worker.cancel()
+        }
+    }
+
+    private func validateAudio(at url: URL) throws {
+        guard fileManager.isReadableFile(atPath: url.path), fileSize(at: url) > 0 else {
+            throw NativeWhisperRuntimeError.audioNotReadable(url.path)
         }
     }
 

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -689,7 +689,7 @@ struct NoteBrowserView: View {
                 fileURL: url,
                 currentMode: appState.currentNoteBrowserTranscriptionMode,
                 hasAPIKey: appState.hasTranscriptionAPIKey,
-                hasLocalWhisperModel: appState.useLegacyMlxWhisper && appState.hasLegacyLocalWhisperModel
+                hasLocalWhisperModel: appState.hasInstalledLocalWhisperModel
             )
         }
     }

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -348,7 +348,9 @@ private struct AudioImportSheet: View {
                                         .font(.system(size: 10))
                                         .foregroundStyle(.tertiary)
                                 } else if mode == .localWhisper && !isSupported {
-                                    Text("Imported audio uses API unless legacy mlx-whisper is enabled")
+                                    Text(appState.useLegacyMlxWhisper
+                                        ? "Install a legacy mlx-whisper model to import locally"
+                                        : "Install the native Local Whisper model to import locally")
                                         .font(.system(size: 10))
                                         .foregroundStyle(.tertiary)
                                 }

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -348,9 +348,7 @@ private struct AudioImportSheet: View {
                                         .font(.system(size: 10))
                                         .foregroundStyle(.tertiary)
                                 } else if mode == .localWhisper && !isSupported {
-                                    Text(appState.useLegacyMlxWhisper
-                                        ? "Install a legacy mlx-whisper model to import locally"
-                                        : "Install the native Local Whisper model to import locally")
+                                    Text(importRequest.options.localWhisperUnavailableReason)
                                         .font(.system(size: 10))
                                         .foregroundStyle(.tertiary)
                                 }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1713,7 +1713,7 @@ struct ModelsSettingsView: View {
                 Button(isValidatingKey ? "Validating..." : "Save") {
                     validateAndSaveKey()
                 }
-                .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isValidatingKey)
+                .disabled(isValidatingKey)
             }
 
             if let error = keyValidationError {
@@ -1721,7 +1721,7 @@ struct ModelsSettingsView: View {
                     .foregroundStyle(.red)
                     .font(.caption)
             } else if keyValidationSuccess {
-                Label("API key saved", systemImage: "checkmark.circle.fill")
+                Label(appState.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "API key cleared" : "API key saved", systemImage: "checkmark.circle.fill")
                     .foregroundStyle(.green)
                     .font(.caption)
             }
@@ -1851,10 +1851,18 @@ struct ModelsSettingsView: View {
 
     private func validateAndSaveKey() {
         let key = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        let baseURL = apiBaseURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        isValidatingKey = true
+        apiKeyInput = key
         keyValidationError = nil
         keyValidationSuccess = false
+        if key.isEmpty {
+            appState.apiKey = ""
+            keyValidationSuccess = true
+            isValidatingKey = false
+            return
+        }
+
+        let baseURL = apiBaseURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        isValidatingKey = true
 
         Task {
             let valid = await TranscriptionService.validateAPIKey(

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1851,7 +1851,6 @@ struct ModelsSettingsView: View {
 
     private func validateAndSaveKey() {
         let key = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        apiKeyInput = key
         keyValidationError = nil
         keyValidationSuccess = false
         if key.isEmpty {

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -151,12 +151,15 @@ class TranscriptionService {
         guard store.installStatus(for: model) == .ready else {
             throw TranscriptionError.submissionFailed("Local Whisper is not installed yet. Install the recommended model to use local transcription.")
         }
-        let preparedAudio = try await AudioImportConversionService().prepareForNativeWhisper(fileURL)
-        defer { preparedAudio.cleanup() }
+        let runtime = NativeWhisperRuntime()
+        let modelURL = store.modelURL(for: model)
         do {
-            let transcript = try await NativeWhisperRuntime().transcribe(
+            try runtime.validateRunnerAndModel(modelURL: modelURL)
+            let preparedAudio = try await AudioImportConversionService().prepareForNativeWhisper(fileURL)
+            defer { preparedAudio.cleanup() }
+            let transcript = try await runtime.transcribe(
                 audioURL: preparedAudio.fileURL,
-                modelURL: store.modelURL(for: model),
+                modelURL: modelURL,
                 languageCode: transcriptionLanguage.whisperArgument
             )
             return normalizedTranscriptText(transcript)

--- a/Sources/TranscriptionService.swift
+++ b/Sources/TranscriptionService.swift
@@ -151,9 +151,11 @@ class TranscriptionService {
         guard store.installStatus(for: model) == .ready else {
             throw TranscriptionError.submissionFailed("Local Whisper is not installed yet. Install the recommended model to use local transcription.")
         }
+        let preparedAudio = try await AudioImportConversionService().prepareForNativeWhisper(fileURL)
+        defer { preparedAudio.cleanup() }
         do {
             let transcript = try await NativeWhisperRuntime().transcribe(
-                audioURL: fileURL,
+                audioURL: preparedAudio.fileURL,
                 modelURL: store.modelURL(for: model),
                 languageCode: transcriptionLanguage.whisperArgument
             )

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -32,7 +32,7 @@ struct AppStateTranscriptionConfigurationTests {
         try testNativeWhisperPreparesAudioBeforeRuntime()
         try testNoteBrowserTranscriptionMenuUsesFlatNativeCheckedItems()
         try testInitialAudioImportAllowsNativeLocalWhisper()
-        try testAudioImportSheetExplainsNativeAndLegacyLocalWhisper()
+        try testAudioImportSheetUsesAudioImportOptionsLocalWhisperReason()
         await testAPITranscriptionModesRequireResolvedAPIKey()
         try testSettingsAPIProviderTabDoesNotForceUnavailableAPIMode()
         await testTranscriptionAPIKeyEnablesAPIModesWithoutGlobalAPIKey()
@@ -514,7 +514,7 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(!pickerBody.contains("appState.useLegacyMlxWhisper && appState.hasLegacyLocalWhisperModel"))
     }
 
-    private static func testAudioImportSheetExplainsNativeAndLegacyLocalWhisper() throws {
+    private static func testAudioImportSheetUsesAudioImportOptionsLocalWhisperReason() throws {
         let source = try String(contentsOfFile: "Sources/NoteBrowserView.swift", encoding: .utf8)
         let sheetBody = sourceBlock(
             in: source,
@@ -522,9 +522,9 @@ struct AppStateTranscriptionConfigurationTests {
             to: "private func transcriptionModeMenuItem"
         )
 
-        precondition(sheetBody.contains("appState.useLegacyMlxWhisper"))
-        precondition(sheetBody.contains("Install a legacy mlx-whisper model to import locally"))
-        precondition(sheetBody.contains("Install the native Local Whisper model to import locally"))
+        precondition(sheetBody.contains("Text(importRequest.options.localWhisperUnavailableReason)"))
+        precondition(!sheetBody.contains("appState.useLegacyMlxWhisper"))
+        precondition(!sheetBody.contains("Install a legacy mlx-whisper model to import locally"))
         precondition(!sheetBody.contains("Imported audio uses API unless legacy mlx-whisper is enabled"))
     }
 

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -36,6 +36,7 @@ struct AppStateTranscriptionConfigurationTests {
         try testAudioImportSheetUsesAudioImportOptionsLocalWhisperReason()
         await testAPITranscriptionModesRequireResolvedAPIKey()
         try testSettingsAPIProviderTabDoesNotForceUnavailableAPIMode()
+        try testSettingsGlobalAPIKeyCanBeCleared()
         await testTranscriptionAPIKeyEnablesAPIModesWithoutGlobalAPIKey()
         await testEmptyTranscriptionAPIKeyFallsBackToGlobalAPIKey()
         await testRemovingAPIKeyNormalizesSelectedAPIMode()
@@ -598,6 +599,31 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(!transcriptionSection.contains("selection: $appState.useLocalTranscription"))
         precondition(saveKeyBody.contains("if !showingLocalTranscriptionSettings"))
         precondition(saveKeyBody.contains("appState.setNoteBrowserTranscriptionMode(.apiStandard)"))
+    }
+
+    private static func testSettingsGlobalAPIKeyCanBeCleared() throws {
+        let source = try String(contentsOfFile: "Sources/SettingsView.swift", encoding: .utf8)
+        let providerSection = sourceBlock(
+            in: source,
+            from: "private var apiProviderTranscriptionSettings: some View",
+            to: "\n    private var languageSettings"
+        )
+        let saveKeyBody = sourceBlock(
+            in: source,
+            from: "private func validateAndSaveKey()",
+            to: "\n    // MARK: System Prompt"
+        )
+        guard let emptyKeyRange = saveKeyBody.range(of: "if key.isEmpty"),
+              let validationRange = saveKeyBody.range(of: "TranscriptionService.validateAPIKey") else {
+            preconditionFailure("Expected global API key clear branch before validation")
+        }
+
+        precondition(emptyKeyRange.lowerBound < validationRange.lowerBound)
+        precondition(saveKeyBody.contains("appState.apiKey = \"\""))
+        precondition(saveKeyBody.contains("keyValidationSuccess = true"))
+        precondition(providerSection.contains(".disabled(isValidatingKey)"))
+        precondition(!providerSection.contains(".disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isValidatingKey)"))
+        precondition(providerSection.contains("API key cleared"))
     }
 
     private static func testTranscriptionAPIKeyEnablesAPIModesWithoutGlobalAPIKey() async {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -32,6 +32,7 @@ struct AppStateTranscriptionConfigurationTests {
         try testNativeWhisperPreparesAudioBeforeRuntime()
         try testNoteBrowserTranscriptionMenuUsesFlatNativeCheckedItems()
         try testInitialAudioImportAllowsNativeLocalWhisper()
+        try testAudioImportSheetExplainsNativeAndLegacyLocalWhisper()
         await testAPITranscriptionModesRequireResolvedAPIKey()
         try testSettingsAPIProviderTabDoesNotForceUnavailableAPIMode()
         await testTranscriptionAPIKeyEnablesAPIModesWithoutGlobalAPIKey()
@@ -511,6 +512,20 @@ struct AppStateTranscriptionConfigurationTests {
         )
         precondition(pickerBody.contains("hasLocalWhisperModel: appState.hasInstalledLocalWhisperModel"))
         precondition(!pickerBody.contains("appState.useLegacyMlxWhisper && appState.hasLegacyLocalWhisperModel"))
+    }
+
+    private static func testAudioImportSheetExplainsNativeAndLegacyLocalWhisper() throws {
+        let source = try String(contentsOfFile: "Sources/NoteBrowserView.swift", encoding: .utf8)
+        let sheetBody = sourceBlock(
+            in: source,
+            from: "private struct AudioImportSheet",
+            to: "private func transcriptionModeMenuItem"
+        )
+
+        precondition(sheetBody.contains("appState.useLegacyMlxWhisper"))
+        precondition(sheetBody.contains("Install a legacy mlx-whisper model to import locally"))
+        precondition(sheetBody.contains("Install the native Local Whisper model to import locally"))
+        precondition(!sheetBody.contains("Imported audio uses API unless legacy mlx-whisper is enabled"))
     }
 
     private static func testAPITranscriptionModesRequireResolvedAPIKey() async {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -29,6 +29,7 @@ struct AppStateTranscriptionConfigurationTests {
         testStoppedTranscriptionCompletionSummaryHidesFallbackIndicatorForEmptyRawFallback()
         testStoppedTranscriptionSettingsSnapshotCapturesHistoryMetadata()
         try testAppStateCreatedTranscriptionServicesPassLegacyMlxWhisperToggle()
+        try testNativeWhisperPreparesAudioBeforeRuntime()
         try testNoteBrowserTranscriptionMenuUsesFlatNativeCheckedItems()
         await testAPITranscriptionModesRequireResolvedAPIKey()
         try testSettingsAPIProviderTabDoesNotForceUnavailableAPIMode()
@@ -456,6 +457,20 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(retryBody.contains("useLegacyMlxWhisper: snapshot.useLegacyMlxWhisper,"))
         precondition(stoppedRecordingBody.contains("let capturedUseLegacyMlxWhisper = useLegacyMlxWhisper"))
         precondition(stoppedRecordingBody.contains("useLegacyMlxWhisper: capturedUseLegacyMlxWhisper,"))
+    }
+
+    private static func testNativeWhisperPreparesAudioBeforeRuntime() throws {
+        let source = try String(contentsOfFile: "Sources/TranscriptionService.swift", encoding: .utf8)
+        let nativeBody = sourceBlock(
+            in: source,
+            from: "private func transcribeWithNativeWhisper(fileURL: URL)",
+            to: "    // Run mlx_whisper locally"
+        )
+
+        precondition(nativeBody.contains("let preparedAudio = try await AudioImportConversionService().prepareForNativeWhisper(fileURL)"))
+        precondition(nativeBody.contains("defer { preparedAudio.cleanup() }"))
+        precondition(nativeBody.contains("audioURL: preparedAudio.fileURL"))
+        precondition(!nativeBody.contains("audioURL: fileURL"))
     }
 
     private static func testNoteBrowserTranscriptionMenuUsesFlatNativeCheckedItems() throws {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -31,6 +31,7 @@ struct AppStateTranscriptionConfigurationTests {
         try testAppStateCreatedTranscriptionServicesPassLegacyMlxWhisperToggle()
         try testNativeWhisperPreparesAudioBeforeRuntime()
         try testNoteBrowserTranscriptionMenuUsesFlatNativeCheckedItems()
+        try testInitialAudioImportAllowsNativeLocalWhisper()
         await testAPITranscriptionModesRequireResolvedAPIKey()
         try testSettingsAPIProviderTabDoesNotForceUnavailableAPIMode()
         await testTranscriptionAPIKeyEnablesAPIModesWithoutGlobalAPIKey()
@@ -491,6 +492,25 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(menuItemSource.contains(".disabled(!appState.isNoteBrowserTranscriptionModeAvailable(mode))"))
         precondition(!menuItemSource.contains("Picker(\"Transcription\", selection:"))
         precondition(!menuItemSource.contains("Image(systemName: \"checkmark\")"))
+    }
+
+    private static func testInitialAudioImportAllowsNativeLocalWhisper() throws {
+        let appStateSource = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let importBody = sourceBlock(
+            in: appStateSource,
+            from: "func importAudioFile(_ fileURL: URL, mode: NoteBrowserTranscriptionMode)",
+            to: "\n    @MainActor\n    func retryTranscription"
+        )
+        precondition(importBody.contains("transcriptionConfiguration: audioImportConfiguration(for: mode, allowsNativeWhisper: true)"))
+
+        let noteBrowserSource = try String(contentsOfFile: "Sources/NoteBrowserView.swift", encoding: .utf8)
+        let pickerBody = sourceBlock(
+            in: noteBrowserSource,
+            from: "private func showAudioImportPicker()",
+            to: "\n    private var emptyListState"
+        )
+        precondition(pickerBody.contains("hasLocalWhisperModel: appState.hasInstalledLocalWhisperModel"))
+        precondition(!pickerBody.contains("appState.useLegacyMlxWhisper && appState.hasLegacyLocalWhisperModel"))
     }
 
     private static func testAPITranscriptionModesRequireResolvedAPIKey() async {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -31,7 +31,8 @@ struct AppStateTranscriptionConfigurationTests {
         try testAppStateCreatedTranscriptionServicesPassLegacyMlxWhisperToggle()
         try testNativeWhisperPreparesAudioBeforeRuntime()
         try testNoteBrowserTranscriptionMenuUsesFlatNativeCheckedItems()
-        try testInitialAudioImportAllowsNativeLocalWhisper()
+        try testAudioImportConfigurationUsesLocalWhisperWithoutNativeFlag()
+        try testInitialAudioImportUsesLocalWhisperConfiguration()
         try testAudioImportSheetUsesAudioImportOptionsLocalWhisperReason()
         await testAPITranscriptionModesRequireResolvedAPIKey()
         try testSettingsAPIProviderTabDoesNotForceUnavailableAPIMode()
@@ -468,10 +469,17 @@ struct AppStateTranscriptionConfigurationTests {
             from: "private func transcribeWithNativeWhisper(fileURL: URL)",
             to: "    // Run mlx_whisper locally"
         )
+        guard let preflightRange = nativeBody.range(of: "try runtime.validateRunnerAndModel(modelURL: modelURL)"),
+              let conversionRange = nativeBody.range(of: "let preparedAudio = try await AudioImportConversionService().prepareForNativeWhisper(fileURL)") else {
+            preconditionFailure("Expected native Whisper preflight before audio conversion")
+        }
 
-        precondition(nativeBody.contains("let preparedAudio = try await AudioImportConversionService().prepareForNativeWhisper(fileURL)"))
+        precondition(preflightRange.lowerBound < conversionRange.lowerBound)
+        precondition(nativeBody.contains("let runtime = NativeWhisperRuntime()"))
+        precondition(nativeBody.contains("let modelURL = store.modelURL(for: model)"))
         precondition(nativeBody.contains("defer { preparedAudio.cleanup() }"))
         precondition(nativeBody.contains("audioURL: preparedAudio.fileURL"))
+        precondition(nativeBody.contains("modelURL: modelURL"))
         precondition(!nativeBody.contains("audioURL: fileURL"))
     }
 
@@ -495,14 +503,36 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(!menuItemSource.contains("Image(systemName: \"checkmark\")"))
     }
 
-    private static func testInitialAudioImportAllowsNativeLocalWhisper() throws {
+    private static func testAudioImportConfigurationUsesLocalWhisperWithoutNativeFlag() throws {
+        let appStateSource = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let configurationBody = sourceBlock(
+            in: appStateSource,
+            from: "func audioImportConfiguration(",
+            to: "\n\n    func isNoteBrowserTranscriptionModeAvailable"
+        )
+
+        let localWhisperBranch = sourceBlock(
+            in: configurationBody,
+            from: "case .localWhisper, .localAppleLive:",
+            to: "        }\n    }"
+        )
+
+        precondition(!appStateSource.contains("allowsNativeWhisper"))
+        precondition(!localWhisperBranch.contains("useLegacyMlxWhisper else"))
+        precondition(!localWhisperBranch.contains("mode: .apiStandard"))
+        precondition(localWhisperBranch.contains("mode: .localWhisper"))
+        precondition(localWhisperBranch.contains("useLocalTranscription: true"))
+    }
+
+    private static func testInitialAudioImportUsesLocalWhisperConfiguration() throws {
         let appStateSource = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
         let importBody = sourceBlock(
             in: appStateSource,
             from: "func importAudioFile(_ fileURL: URL, mode: NoteBrowserTranscriptionMode)",
             to: "\n    @MainActor\n    func retryTranscription"
         )
-        precondition(importBody.contains("transcriptionConfiguration: audioImportConfiguration(for: mode, allowsNativeWhisper: true)"))
+        precondition(importBody.contains("transcriptionConfiguration: audioImportConfiguration(for: mode)"))
+        precondition(!importBody.contains("allowsNativeWhisper"))
 
         let noteBrowserSource = try String(contentsOfFile: "Sources/NoteBrowserView.swift", encoding: .utf8)
         let pickerBody = sourceBlock(

--- a/Tests/AudioImportConversionServiceTests.swift
+++ b/Tests/AudioImportConversionServiceTests.swift
@@ -1,0 +1,170 @@
+import AVFoundation
+import Foundation
+
+@main
+struct AudioImportConversionServiceTests {
+    static func main() async throws {
+        try await testCompatibleWAVReturnsOriginalURL()
+        try await testReadableNonNativeWAVConvertsToNativeWhisperShape()
+        try await testInvalidAudioThrowsReadableLocalConversionError()
+        print("AudioImportConversionServiceTests passed")
+    }
+
+    private static func testCompatibleWAVReturnsOriginalURL() async throws {
+        let sourceURL = try writeTinyNativeWAV(samples: [100, -100, 200])
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        let prepared = try await AudioImportConversionService().prepareForNativeWhisper(sourceURL)
+        defer { prepared.cleanup() }
+
+        try expectEqual(prepared.fileURL.standardizedFileURL, sourceURL.standardizedFileURL, "compatible WAV should be reused")
+        guard FileManager.default.fileExists(atPath: sourceURL.path) else {
+            throw TestFailure("cleanup must not remove the original compatible WAV")
+        }
+    }
+
+    private static func testReadableNonNativeWAVConvertsToNativeWhisperShape() async throws {
+        let sourceURL = try writeStereoFloatWAV(sampleRate: 44_100, frameCount: 4_410)
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        let prepared = try await AudioImportConversionService().prepareForNativeWhisper(sourceURL)
+        defer { prepared.cleanup() }
+
+        guard prepared.fileURL.pathExtension == "wav" else {
+            throw TestFailure("expected converted file to use .wav, got \(prepared.fileURL.lastPathComponent)")
+        }
+        guard prepared.fileURL.standardizedFileURL != sourceURL.standardizedFileURL else {
+            throw TestFailure("non-native source should be converted to a temporary WAV")
+        }
+
+        let convertedFile = try AVAudioFile(forReading: prepared.fileURL)
+        let convertedFormat = convertedFile.fileFormat
+        try expectEqual(Int(convertedFormat.sampleRate.rounded()), 16_000, "converted sample rate")
+        try expectEqual(convertedFormat.channelCount, 1, "converted channel count")
+        guard convertedFormat.commonFormat == .pcmFormatInt16 else {
+            throw TestFailure("expected converted common format pcmFormatInt16, got \(convertedFormat.commonFormat)")
+        }
+        guard convertedFormat.isInterleaved else {
+            throw TestFailure("expected converted WAV to be interleaved")
+        }
+        guard convertedFile.length > 0 else {
+            throw TestFailure("converted file should contain audio frames")
+        }
+    }
+
+    private static func testInvalidAudioThrowsReadableLocalConversionError() async throws {
+        let sourceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-invalid-import-\(ProcessInfo.processInfo.globallyUniqueString)")
+            .appendingPathExtension("webm")
+        try Data("not an audio file".utf8).write(to: sourceURL)
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        do {
+            _ = try await AudioImportConversionService().prepareForNativeWhisper(sourceURL)
+            throw TestFailure("invalid audio should throw AudioImportConversionError.unreadableAudio")
+        } catch AudioImportConversionError.unreadableAudio(let path) {
+            guard path.contains(sourceURL.lastPathComponent) else {
+                throw TestFailure("error should include the file name, got \(path)")
+            }
+        } catch {
+            throw TestFailure("expected unreadableAudio, got \(error)")
+        }
+    }
+
+    private static func writeTinyNativeWAV(samples: [Int16]) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-native-wav-\(ProcessInfo.processInfo.globallyUniqueString)")
+            .appendingPathExtension("wav")
+        var data = Data()
+        let sampleDataByteCount = UInt32(samples.count * MemoryLayout<Int16>.size)
+
+        data.appendASCII("RIFF")
+        data.appendUInt32LE(36 + sampleDataByteCount)
+        data.appendASCII("WAVE")
+        data.appendASCII("fmt ")
+        data.appendUInt32LE(16)
+        data.appendUInt16LE(1)
+        data.appendUInt16LE(1)
+        data.appendUInt32LE(16_000)
+        data.appendUInt32LE(16_000 * 2)
+        data.appendUInt16LE(2)
+        data.appendUInt16LE(16)
+        data.appendASCII("data")
+        data.appendUInt32LE(sampleDataByteCount)
+        for sample in samples {
+            data.appendUInt16LE(UInt16(bitPattern: sample))
+        }
+
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+
+    private static func writeStereoFloatWAV(sampleRate: Double, frameCount: AVAudioFrameCount) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-stereo-float-\(ProcessInfo.processInfo.globallyUniqueString)")
+            .appendingPathExtension("wav")
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 2,
+            interleaved: false
+        )!
+        let settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: format.sampleRate,
+            AVNumberOfChannelsKey: Int(format.channelCount),
+            AVLinearPCMBitDepthKey: 32,
+            AVLinearPCMIsFloatKey: true,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: true,
+        ]
+        let file = try AVAudioFile(
+            forWriting: url,
+            settings: settings,
+            commonFormat: format.commonFormat,
+            interleaved: format.isInterleaved
+        )
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount)!
+        buffer.frameLength = frameCount
+        for channel in 0..<Int(format.channelCount) {
+            let channelData = buffer.floatChannelData![channel]
+            for frame in 0..<Int(frameCount) {
+                channelData[frame] = channel == 0 ? 0.25 : -0.25
+            }
+        }
+        try file.write(from: buffer)
+        return url
+    }
+
+    private static func expectEqual<T: Equatable>(_ actual: T, _ expected: T, _ label: String) throws {
+        guard actual == expected else {
+            throw TestFailure("\(label): expected \(expected), got \(actual)")
+        }
+    }
+
+    private struct TestFailure: Error, CustomStringConvertible {
+        let description: String
+
+        init(_ description: String) {
+            self.description = description
+        }
+    }
+}
+
+private extension Data {
+    mutating func appendASCII(_ value: String) {
+        append(contentsOf: value.utf8)
+    }
+
+    mutating func appendUInt16LE(_ value: UInt16) {
+        append(UInt8(value & 0x00ff))
+        append(UInt8((value & 0xff00) >> 8))
+    }
+
+    mutating func appendUInt32LE(_ value: UInt32) {
+        append(UInt8(value & 0x000000ff))
+        append(UInt8((value & 0x0000ff00) >> 8))
+        append(UInt8((value & 0x00ff0000) >> 16))
+        append(UInt8((value & 0xff000000) >> 24))
+    }
+}

--- a/Tests/AudioImportConversionServiceTests.swift
+++ b/Tests/AudioImportConversionServiceTests.swift
@@ -16,9 +16,9 @@ struct AudioImportConversionServiceTests {
         defer { try? FileManager.default.removeItem(at: sourceURL) }
 
         let prepared = try await AudioImportConversionService().prepareForNativeWhisper(sourceURL)
-        defer { prepared.cleanup() }
 
         try expectEqual(prepared.fileURL.standardizedFileURL, sourceURL.standardizedFileURL, "compatible WAV should be reused")
+        prepared.cleanup()
         guard FileManager.default.fileExists(atPath: sourceURL.path) else {
             throw TestFailure("cleanup must not remove the original compatible WAV")
         }

--- a/Tests/AudioImportConversionServiceTests.swift
+++ b/Tests/AudioImportConversionServiceTests.swift
@@ -7,6 +7,7 @@ struct AudioImportConversionServiceTests {
         try await testCompatibleWAVReturnsOriginalURL()
         try await testReadableNonNativeWAVConvertsToNativeWhisperShape()
         try await testInvalidAudioThrowsReadableLocalConversionError()
+        try await testCancellationCancelsWorkerConversionTask()
         print("AudioImportConversionServiceTests passed")
     }
 
@@ -69,6 +70,41 @@ struct AudioImportConversionServiceTests {
         } catch {
             throw TestFailure("expected unreadableAudio, got \(error)")
         }
+    }
+
+    private static func testCancellationCancelsWorkerConversionTask() async throws {
+        let sourceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-cancellable-import-\(ProcessInfo.processInfo.globallyUniqueString)")
+            .appendingPathExtension("mp3")
+        try Data("placeholder audio that forces injected conversion".utf8).write(to: sourceURL)
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        let workerStarted = ThreadSignal()
+        let workerCancelled = ThreadSignal()
+        let service = AudioImportConversionService { _ in
+            workerStarted.signal()
+            while !Task.isCancelled {
+                Thread.sleep(forTimeInterval: 0.01)
+            }
+            workerCancelled.signal()
+            throw CancellationError()
+        }
+
+        let task = Task {
+            try await service.prepareForNativeWhisper(sourceURL)
+        }
+        try await workerStarted.wait()
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            throw TestFailure("cancelled preparation should throw CancellationError")
+        } catch is CancellationError {
+        } catch {
+            throw TestFailure("expected CancellationError, got \(error)")
+        }
+
+        try await workerCancelled.wait()
     }
 
     private static func writeTinyNativeWAV(samples: [Int16]) throws -> URL {
@@ -142,11 +178,41 @@ struct AudioImportConversionServiceTests {
         }
     }
 
-    private struct TestFailure: Error, CustomStringConvertible {
+    fileprivate struct TestFailure: Error, CustomStringConvertible {
         let description: String
 
         init(_ description: String) {
             self.description = description
+        }
+    }
+}
+
+private final class ThreadSignal: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var signaled = false
+
+    func signal() {
+        condition.lock()
+        signaled = true
+        condition.broadcast()
+        condition.unlock()
+    }
+
+    func wait() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            Thread {
+                let deadline = Date().addingTimeInterval(1)
+                self.condition.lock()
+                defer { self.condition.unlock() }
+
+                while !self.signaled {
+                    if !self.condition.wait(until: deadline) {
+                        continuation.resume(throwing: AudioImportConversionServiceTests.TestFailure("timed out waiting for worker conversion task cancellation"))
+                        return
+                    }
+                }
+                continuation.resume()
+            }.start()
         }
     }
 }

--- a/Tests/AudioImportOptionsTests.swift
+++ b/Tests/AudioImportOptionsTests.swift
@@ -13,6 +13,7 @@ struct AudioImportOptionsTests {
         testImportedAudioContextSummaryIsEmpty()
         testAPIStandardDisabledAboveTwentyFiveMegabytes()
         testLocalWhisperStillEnabledAboveTwentyFiveMegabytes()
+        testNativeLocalWhisperDoesNotSupportWebMImport()
         print("AudioImportOptionsTests passed")
     }
 
@@ -27,7 +28,7 @@ struct AudioImportOptionsTests {
         assert(options.defaultMode == .apiStandard)
         assert(options.supportedModes.contains(.apiStandard))
         assert(!options.supportedModes.contains(.apiRealtime))
-        assert(options.supportedModes.contains(.localWhisper))
+        assert(!options.supportedModes.contains(.localWhisper))
         assert(!options.supportedModes.contains(.localAppleLive))
     }
 
@@ -115,5 +116,19 @@ struct AudioImportOptionsTests {
         )
 
         assert(options.supportedModes.contains(.localWhisper))
+    }
+
+    private static func testNativeLocalWhisperDoesNotSupportWebMImport() {
+        let options = AudioImportOptions(
+            fileExtension: "webm",
+            currentMode: .localWhisper,
+            hasAPIKey: false,
+            hasLocalWhisperModel: true
+        )
+
+        assert(!options.supportedModes.contains(.apiStandard))
+        assert(!options.supportedModes.contains(.localWhisper))
+        assert(options.defaultMode == nil)
+        assert(options.localWhisperUnavailableReason == "Local Whisper supports MP3, MP4, M4A, MPEG, MPGA, and WAV imports")
     }
 }

--- a/Tests/NativeWhisperRuntimeTests.swift
+++ b/Tests/NativeWhisperRuntimeTests.swift
@@ -9,6 +9,7 @@ struct NativeWhisperRuntimeTests {
         try await testRuntimeRejectsMissingRunner()
         try await testRuntimeRejectsMissingModel()
         try await testRuntimeRejectsMissingAudio()
+        try testRuntimePreflightsRunnerAndModel()
         try await testRuntimeReportsNonZeroExitWithTailDetails()
         try await testRuntimeTerminatesHelperOnCancellation()
         print("NativeWhisperRuntimeTests passed")
@@ -117,6 +118,31 @@ struct NativeWhisperRuntimeTests {
             assertionFailure("Expected missing audio error")
         } catch let error as NativeWhisperRuntimeError {
             assert(error == .audioNotReadable(root.appendingPathComponent("missing.wav").path))
+        }
+    }
+
+    private static func testRuntimePreflightsRunnerAndModel() throws {
+        let root = try temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let helper = try writeHelper(root: root, body: "#!/bin/sh\necho should-not-run\n")
+        let model = try writeFile(root.appendingPathComponent("model.bin"), data: Data([1]))
+        let runtime = NativeWhisperRuntime(runnerURL: helper)
+
+        try runtime.validateRunnerAndModel(modelURL: model)
+
+        do {
+            try NativeWhisperRuntime(runnerURL: root.appendingPathComponent("missing-helper"))
+                .validateRunnerAndModel(modelURL: model)
+            assertionFailure("Expected missing runner error")
+        } catch let error as NativeWhisperRuntimeError {
+            assert(error == .runnerNotFound(root.appendingPathComponent("missing-helper").path))
+        }
+
+        do {
+            try runtime.validateRunnerAndModel(modelURL: root.appendingPathComponent("missing.bin"))
+            assertionFailure("Expected missing model error")
+        } catch let error as NativeWhisperRuntimeError {
+            assert(error == .modelNotFound(root.appendingPathComponent("missing.bin").path))
         }
     }
 


### PR DESCRIPTION
## Summary
- Prepare imported audio for native whisper.cpp by converting supported imports to 16 kHz mono PCM WAV.
- Allow native Local Whisper in the audio import and retry flows without the hidden native-import flag fallback.
- Limit Local Whisper import availability to native-supported formats while keeping API-compatible import formats selectable.
- Preflight the bundled native runner and model before audio conversion.
- Allow clearing a previously saved global API key from Settings by saving an empty key.

## Verification
- `swiftc -parse-as-library Sources/AudioImportOptions.swift Tests/AudioImportOptionsTests.swift -o /tmp/AudioImportOptionsTests && /tmp/AudioImportOptionsTests`
- `swiftc -parse-as-library Sources/AudioImportConversionService.swift Tests/AudioImportConversionServiceTests.swift -o /tmp/AudioImportConversionServiceTests && /tmp/AudioImportConversionServiceTests`
- `swiftc -parse-as-library Sources/NativeWhisperModel.swift Sources/NativeWhisperRuntime.swift Sources/AudioImportConversionService.swift Tests/NativeWhisperRuntimeTests.swift -o /tmp/NativeWhisperRuntimeTests && /tmp/NativeWhisperRuntimeTests`
- Source sanity checks for extension gating, removed `allowsNativeWhisper`, preflight-before-conversion order, and API key clear behavior.
- `git diff --check`

## Runtime verification

**Verdict:** PASS for the Settings API key clear fix; native Local Whisper import flow is ready for manual app testing in the development build.

**Claim:** Native Local Whisper import should gate unsupported formats, avoid the hidden API fallback, preflight runner/model availability before audio conversion, and Settings should allow a saved global API key to be cleared.

**Method:** Built and opened the development app with `make run CODESIGN_IDENTITY=-` after selecting the full Xcode developer directory.

### Steps

1. ✅ Built and launched `Quill Dev.app` with ad-hoc signing.

```text
Built build/Quill Dev.app
open "build/Quill Dev.app"
```

2. ✅ Manually cleared the saved global API key in Settings by emptying the field and clicking Save → the app accepted the empty save and showed the cleared state.

3. 🔍 Earlier build attempts with `CODESIGN_IDENTITY=Quill` failed because the local keychain did not contain a `Quill` signing identity. Re-running with `CODESIGN_IDENTITY=-` succeeded for development verification.

### Findings

- The full Xcode developer directory is required for this repo’s SwiftUI macro build path. Command Line Tools alone fails with `SwiftUIMacros.StateMacro plugin not found`.
- Local development verification can use ad-hoc signing with `CODESIGN_IDENTITY=-` when the `Quill` signing identity is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 로컬 Whisper용 오디오를 미리 검사하고, 필요 시 16kHz 모노 PCM WAV로 자동 변환한 뒤 전사를 진행합니다.
  * 로컬 Whisper 사용 가능 여부를 파일 확장자와 설치 상태를 함께 반영해 더 정교하게 판단합니다.
* **버그 수정**
  * 로컬 Whisper 전사 설정 및 재시도 흐름이 더 일관되게 동작하도록 개선했습니다.
  * 지원되지 않는 파일에 대해 더 정확한 안내 문구가 표시됩니다.
* **테스트**
  * 오디오 변환/취소 전파/런타임 사전 검증/전사 흐름 및 설정 UI 관련 테스트가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->