### PR TITLE
Separate legacy model options and add scrollable note titles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,6 +277,8 @@ test: $(SPARKLE_STAMP)
 	@/tmp/MeetingSourcePayloadTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/NoteTitleResolver.swift Sources/NoteListRowDisplayData.swift Tests/NoteListRowDisplayDataTests.swift -o /tmp/NoteListRowDisplayDataTests
 	@/tmp/NoteListRowDisplayDataTests
+	@swiftc -parse-as-library Tests/NoteTitleHorizontalScrollFieldTests.swift -o /tmp/NoteTitleHorizontalScrollFieldTests
+	@/tmp/NoteTitleHorizontalScrollFieldTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/LegacyNoteTitleMigration.swift Tests/LegacyNoteTitleMigrationTests.swift -o /tmp/LegacyNoteTitleMigrationTests
 	@/tmp/LegacyNoteTitleMigrationTests
 	@swiftc -parse-as-library Tests/ManualReleaseWorkflowTests.swift -o /tmp/ManualReleaseWorkflowTests

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -368,6 +368,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let useLocalTranscriptionStorageKey = "use_local_transcription"
     private let localWhisperPathStorageKey = "local_whisper_path"
     private let useLegacyMlxWhisperStorageKey = "use_legacy_mlx_whisper"
+    private let showLegacyMlxWhisperOptionsStorageKey = "show_legacy_mlx_whisper_options"
     private let disableContextCaptureStorageKey = "disable_context_capture"
     private let disableAutoPasteStorageKey = "disable_auto_paste"
     private let disablePostProcessingStorageKey = "disable_post_processing"
@@ -740,6 +741,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         didSet {
             UserDefaults.standard.set(useLegacyMlxWhisper, forKey: useLegacyMlxWhisperStorageKey)
             normalizeNoteBrowserTranscriptionModeForProviderConfiguration()
+        }
+    }
+
+    @Published var showLegacyMlxWhisperOptions: Bool {
+        didSet {
+            UserDefaults.standard.set(showLegacyMlxWhisperOptions, forKey: showLegacyMlxWhisperOptionsStorageKey)
         }
     }
 
@@ -1439,6 +1446,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let useLocalTranscription = UserDefaults.standard.bool(forKey: useLocalTranscriptionStorageKey)
         let localWhisperPath = UserDefaults.standard.string(forKey: localWhisperPathStorageKey) ?? ""
         let useLegacyMlxWhisper = UserDefaults.standard.bool(forKey: useLegacyMlxWhisperStorageKey)
+        let hasStoredLegacyMlxWhisperOptionsVisibility = UserDefaults.standard.object(forKey: showLegacyMlxWhisperOptionsStorageKey) != nil
+        let showLegacyMlxWhisperOptions = hasStoredLegacyMlxWhisperOptionsVisibility
+            ? UserDefaults.standard.bool(forKey: showLegacyMlxWhisperOptionsStorageKey)
+            : useLegacyMlxWhisper
+        if !hasStoredLegacyMlxWhisperOptionsVisibility {
+            UserDefaults.standard.set(showLegacyMlxWhisperOptions, forKey: showLegacyMlxWhisperOptionsStorageKey)
+        }
         let disableContextCapture = UserDefaults.standard.bool(forKey: disableContextCaptureStorageKey)
         let disableAutoPaste = UserDefaults.standard.bool(forKey: disableAutoPasteStorageKey)
         let disablePostProcessing = UserDefaults.standard.bool(forKey: disablePostProcessingStorageKey)
@@ -1554,6 +1568,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.useLocalTranscription = useLocalTranscription
         self.localWhisperPath = localWhisperPath
         self.useLegacyMlxWhisper = useLegacyMlxWhisper
+        self.showLegacyMlxWhisperOptions = showLegacyMlxWhisperOptions
         self.disableContextCapture = disableContextCapture
         self.disableAutoPaste = disableAutoPaste
         self.disablePostProcessing = disablePostProcessing

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -872,49 +872,58 @@ private struct HorizontallyScrollableTitleField: NSViewRepresentable {
 }
 
 private final class TitleHorizontalScrollView: NSScrollView {
-    override func layout() {
-        super.layout()
+    private var maximumScrollX: CGFloat {
+        max(0, (documentView?.bounds.width ?? 0) - contentView.bounds.width)
+    }
+
+    override func resizeSubviews(withOldSize oldSize: NSSize) {
+        super.resizeSubviews(withOldSize: oldSize)
         (documentView as? TitleSingleLineTextView)?.updateDocumentWidth(minimumWidth: contentView.bounds.width)
     }
 
     override func scrollWheel(with event: NSEvent) {
-        if abs(event.scrollingDeltaX) > 0.1 {
-            guard canScrollHorizontally(by: event.scrollingDeltaX) else {
-                super.scrollWheel(with: event)
-                return
-            }
-            scrollHorizontally(by: event.scrollingDeltaX)
+        if abs(event.scrollingDeltaX) > 0.01 {
+            super.scrollWheel(with: event)
             return
         }
 
-        if abs(event.scrollingDeltaY) > 0.1,
-           canScrollHorizontally(by: event.scrollingDeltaY) {
-            scrollHorizontally(by: event.scrollingDeltaY)
+        guard abs(event.scrollingDeltaY) > 0.1 else {
+            super.scrollWheel(with: event)
             return
         }
 
-        super.scrollWheel(with: event)
+        let delta = -normalizedScrollDelta(event.scrollingDeltaY, precise: event.hasPreciseScrollingDeltas)
+        guard canScrollHorizontally(by: delta) else {
+            super.scrollWheel(with: event)
+            return
+        }
+
+        scrollHorizontally(by: delta)
     }
 
     private func canScrollHorizontally(by delta: CGFloat) -> Bool {
-        let maximumX = max(0, (documentView?.bounds.width ?? 0) - contentView.bounds.width)
+        let maximumX = maximumScrollX
         guard maximumX > 0 else { return false }
         let currentX = contentView.bounds.origin.x
         return delta > 0 ? currentX < maximumX : currentX > 0
     }
 
     func clampHorizontalScrollOffset() {
-        let maximumX = max(0, (documentView?.bounds.width ?? 0) - contentView.bounds.width)
+        let maximumX = maximumScrollX
         let nextX = min(max(contentView.bounds.origin.x, 0), maximumX)
         contentView.scroll(to: NSPoint(x: nextX, y: 0))
         reflectScrolledClipView(contentView)
     }
 
     private func scrollHorizontally(by delta: CGFloat) {
-        let maximumX = max(0, (documentView?.bounds.width ?? 0) - contentView.bounds.width)
+        let maximumX = maximumScrollX
         let nextX = min(max(contentView.bounds.origin.x + delta, 0), maximumX)
         contentView.scroll(to: NSPoint(x: nextX, y: 0))
         reflectScrolledClipView(contentView)
+    }
+
+    private func normalizedScrollDelta(_ delta: CGFloat, precise: Bool) -> CGFloat {
+        precise ? delta : delta * 38
     }
 }
 

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -785,6 +785,190 @@ struct NoteBrowserView: View {
     }
 }
 
+// MARK: - Horizontally Scrollable Title Field
+
+private struct HorizontallyScrollableTitleField: NSViewRepresentable {
+    let placeholder: String
+    @Binding var text: String
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeNSView(context: Context) -> TitleHorizontalScrollView {
+        let scrollView = TitleHorizontalScrollView()
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+        scrollView.hasVerticalScroller = false
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.verticalScrollElasticity = .none
+        scrollView.horizontalScrollElasticity = .automatic
+
+        let textView = TitleSingleLineTextView()
+        textView.delegate = context.coordinator
+        textView.placeholder = placeholder
+        textView.string = text
+        textView.font = .systemFont(ofSize: 28, weight: .bold)
+        textView.textColor = .labelColor
+        textView.drawsBackground = false
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.isRichText = false
+        textView.importsGraphics = false
+        textView.allowsUndo = true
+        textView.textContainerInset = .zero
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainer?.maximumNumberOfLines = 1
+        textView.textContainer?.lineBreakMode = .byClipping
+        textView.textContainer?.widthTracksTextView = false
+        textView.textContainer?.heightTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: 38)
+        textView.isHorizontallyResizable = true
+        textView.isVerticallyResizable = false
+        textView.minSize = NSSize(width: 0, height: 38)
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: 38)
+        textView.updateDocumentWidth(minimumWidth: 0)
+
+        scrollView.documentView = textView
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: TitleHorizontalScrollView, context: Context) {
+        context.coordinator.parent = self
+        guard let textView = scrollView.documentView as? TitleSingleLineTextView else { return }
+        textView.placeholder = placeholder
+        textView.font = .systemFont(ofSize: 28, weight: .bold)
+        textView.textColor = .labelColor
+        if textView.string != text {
+            let selectedRanges = textView.selectedRanges
+            textView.string = text
+            let stringLength = (textView.string as NSString).length
+            let clampedRanges = selectedRanges.map { value -> NSValue in
+                let range = value.rangeValue
+                let location = min(range.location, stringLength)
+                let length = min(range.length, stringLength - location)
+                return NSValue(range: NSRange(location: location, length: length))
+            }
+            textView.selectedRanges = clampedRanges
+        }
+        textView.updateDocumentWidth(minimumWidth: scrollView.contentView.bounds.width)
+        textView.needsDisplay = true
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: HorizontallyScrollableTitleField
+
+        init(_ parent: HorizontallyScrollableTitleField) {
+            self.parent = parent
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? TitleSingleLineTextView else { return }
+            textView.updateDocumentWidth(minimumWidth: textView.enclosingScrollView?.contentView.bounds.width ?? 0)
+            parent.text = textView.string
+        }
+    }
+}
+
+private final class TitleHorizontalScrollView: NSScrollView {
+    override func layout() {
+        super.layout()
+        (documentView as? TitleSingleLineTextView)?.updateDocumentWidth(minimumWidth: contentView.bounds.width)
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        if abs(event.scrollingDeltaX) > 0.1 {
+            guard canScrollHorizontally(by: event.scrollingDeltaX) else {
+                super.scrollWheel(with: event)
+                return
+            }
+            scrollHorizontally(by: event.scrollingDeltaX)
+            return
+        }
+
+        if abs(event.scrollingDeltaY) > 0.1,
+           canScrollHorizontally(by: event.scrollingDeltaY) {
+            scrollHorizontally(by: event.scrollingDeltaY)
+            return
+        }
+
+        super.scrollWheel(with: event)
+    }
+
+    private func canScrollHorizontally(by delta: CGFloat) -> Bool {
+        let maximumX = max(0, (documentView?.bounds.width ?? 0) - contentView.bounds.width)
+        guard maximumX > 0 else { return false }
+        let currentX = contentView.bounds.origin.x
+        return delta > 0 ? currentX < maximumX : currentX > 0
+    }
+
+    func clampHorizontalScrollOffset() {
+        let maximumX = max(0, (documentView?.bounds.width ?? 0) - contentView.bounds.width)
+        let nextX = min(max(contentView.bounds.origin.x, 0), maximumX)
+        contentView.scroll(to: NSPoint(x: nextX, y: 0))
+        reflectScrolledClipView(contentView)
+    }
+
+    private func scrollHorizontally(by delta: CGFloat) {
+        let maximumX = max(0, (documentView?.bounds.width ?? 0) - contentView.bounds.width)
+        let nextX = min(max(contentView.bounds.origin.x + delta, 0), maximumX)
+        contentView.scroll(to: NSPoint(x: nextX, y: 0))
+        reflectScrolledClipView(contentView)
+    }
+}
+
+private final class TitleSingleLineTextView: NSTextView {
+    var placeholder: String = ""
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: 38)
+    }
+
+    override func insertNewline(_ sender: Any?) {
+        window?.makeFirstResponder(nil)
+    }
+
+    override func insertText(_ insertString: Any, replacementRange: NSRange) {
+        if let string = insertString as? String {
+            super.insertText(Self.singleLine(string), replacementRange: replacementRange)
+        } else if let attributedString = insertString as? NSAttributedString {
+            super.insertText(NSAttributedString(string: Self.singleLine(attributedString.string)), replacementRange: replacementRange)
+        } else {
+            super.insertText(insertString, replacementRange: replacementRange)
+        }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        guard string.isEmpty, !placeholder.isEmpty else { return }
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font ?? NSFont.systemFont(ofSize: 28, weight: .bold),
+            .foregroundColor: NSColor.placeholderTextColor
+        ]
+        placeholder.draw(at: .zero, withAttributes: attributes)
+    }
+
+    func updateDocumentWidth(minimumWidth: CGFloat) {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font ?? NSFont.systemFont(ofSize: 28, weight: .bold)
+        ]
+        let measuredText = string.isEmpty ? placeholder : string
+        let measuredWidth = ceil((measuredText as NSString).size(withAttributes: attributes).width) + 8
+        let width = max(minimumWidth, measuredWidth)
+        setFrameSize(NSSize(width: width, height: 38))
+        textContainer?.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: 38)
+        (enclosingScrollView as? TitleHorizontalScrollView)?.clampHorizontalScrollOffset()
+    }
+
+    private static func singleLine(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "\r\n", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+    }
+}
+
 // MARK: - Note List Row
 
 private struct NoteListRow: View {
@@ -981,14 +1165,11 @@ private struct NoteDetailView: View {
             metadataLine
 
             // Title — auto-save on change
-            TextField(
-                item.timestamp.formatted(date: .long, time: .shortened),
+            HorizontallyScrollableTitleField(
+                placeholder: item.timestamp.formatted(date: .long, time: .shortened),
                 text: $titleDraft
             )
-            .font(.system(size: 28, weight: .bold))
-            .textFieldStyle(.plain)
-            .foregroundStyle(.primary)
-            .frame(minHeight: 38, alignment: .leading)
+            .frame(minHeight: 38, maxHeight: 38, alignment: .leading)
             .onChange(of: titleDraft) { newValue in
                 titleDebounceTimer?.invalidate()
                 let timer = Timer(timeInterval: 0.5, repeats: false) { _ in

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1638,7 +1638,10 @@ struct ModelsSettingsView: View {
                     model: TranscriptionModel.find(id: "apple-speech"),
                     isSelected: appState.localTranscriptionModel.isAppleSpeech,
                     whisperBin: "",
-                    onSelect: { appState.localTranscriptionModel = .find(id: "apple-speech") },
+                    onSelect: {
+                        appState.localTranscriptionModel = .find(id: "apple-speech")
+                        appState.useLegacyMlxWhisper = false
+                    },
                     onDeleted: {}
                 )
 
@@ -1657,7 +1660,7 @@ struct ModelsSettingsView: View {
 
             DisclosureGroup("Advanced Legacy mlx-whisper") {
                 VStack(alignment: .leading, spacing: 8) {
-                    Toggle("Use legacy mlx-whisper", isOn: $appState.useLegacyMlxWhisper)
+                    Toggle("Use legacy mlx-whisper", isOn: $appState.showLegacyMlxWhisperOptions)
                     Text("Only enable this if you already manage mlx-whisper yourself.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -1671,20 +1674,22 @@ struct ModelsSettingsView: View {
                             onSelect: {
                                 appState.useLocalTranscription = true
                                 appState.useLegacyMlxWhisper = true
+                                appState.showLegacyMlxWhisperOptions = true
                                 appState.localTranscriptionModel = model
                             },
                             onDeleted: {
                                 appState.localTranscriptionModel = .find(id: "mlx-community/whisper-large-v3-turbo")
+                                appState.useLegacyMlxWhisper = false
                             }
                         )
-                        .disabled(!appState.useLegacyMlxWhisper)
-                        .opacity(appState.useLegacyMlxWhisper ? 1 : 0.55)
+                        .disabled(!appState.showLegacyMlxWhisperOptions)
+                        .opacity(appState.showLegacyMlxWhisperOptions ? 1 : 0.55)
                     }
 
                     TextField("~/.local/bin/mlx_whisper", text: $appState.localWhisperPath)
                         .textFieldStyle(.roundedBorder)
                         .font(.system(.body, design: .monospaced))
-                        .disabled(!appState.useLegacyMlxWhisper)
+                        .disabled(!appState.showLegacyMlxWhisperOptions)
                 }
                 .padding(.top, 4)
             }

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -8,6 +8,10 @@ struct AppStateTranscriptionConfigurationTests {
         try testMakeTranscriptionServiceMapsEmptyLocalWhisperPathToNil()
         try testMakeTranscriptionServiceDefaultsLegacyMlxWhisperOff()
         try testMakeTranscriptionServicePassesLegacyMlxWhisperToggle()
+        testLegacyMlxWhisperOptionsDefaultToOff()
+        testLegacyMlxWhisperOptionsPersistIndependentlyFromEngine()
+        testLegacyMlxWhisperOptionsFallBackToLegacyEnginePreference()
+        testLegacyMlxWhisperOptionsStayVisibleWhenEngineIsTurnedOff()
         testPermissionStatusUpdateSkipsUnchangedValues()
         testRecordingOverlayLayoutPersistsWithoutCompactOverlayBoolean()
         testRecordingCancelShortcutDefaultsToEscape()
@@ -36,6 +40,7 @@ struct AppStateTranscriptionConfigurationTests {
         try testAudioImportSheetUsesAudioImportOptionsLocalWhisperReason()
         await testAPITranscriptionModesRequireResolvedAPIKey()
         try testSettingsAPIProviderTabDoesNotForceUnavailableAPIMode()
+        try testSettingsLegacyMlxWhisperToggleControlsOptionsVisibilityOnly()
         try testSettingsGlobalAPIKeyCanBeCleared()
         await testTranscriptionAPIKeyEnablesAPIModesWithoutGlobalAPIKey()
         await testEmptyTranscriptionAPIKeyFallsBackToGlobalAPIKey()
@@ -115,6 +120,54 @@ struct AppStateTranscriptionConfigurationTests {
         let configuration = mirroredTranscriptionConfiguration(service)
 
         assert(configuration.useLegacyMlxWhisper == true)
+    }
+
+    private static func testLegacyMlxWhisperOptionsDefaultToOff() {
+        resetDefaults()
+        let appState = AppState()
+
+        assert(appState.showLegacyMlxWhisperOptions == false)
+        assert(appState.useLegacyMlxWhisper == false)
+    }
+
+    private static func testLegacyMlxWhisperOptionsPersistIndependentlyFromEngine() {
+        resetDefaults()
+        let defaults = UserDefaults.standard
+        defaults.set(true, forKey: "show_legacy_mlx_whisper_options")
+        defaults.set(false, forKey: "use_legacy_mlx_whisper")
+
+        let appState = AppState()
+
+        assert(appState.showLegacyMlxWhisperOptions == true)
+        assert(appState.useLegacyMlxWhisper == false)
+
+        appState.showLegacyMlxWhisperOptions = false
+
+        assert(defaults.bool(forKey: "show_legacy_mlx_whisper_options") == false)
+    }
+
+    private static func testLegacyMlxWhisperOptionsFallBackToLegacyEnginePreference() {
+        resetDefaults()
+        let defaults = UserDefaults.standard
+        defaults.set(true, forKey: "use_legacy_mlx_whisper")
+
+        let appState = AppState()
+
+        assert(appState.useLegacyMlxWhisper == true)
+        assert(appState.showLegacyMlxWhisperOptions == true)
+        assert(defaults.bool(forKey: "show_legacy_mlx_whisper_options") == true)
+    }
+
+    private static func testLegacyMlxWhisperOptionsStayVisibleWhenEngineIsTurnedOff() {
+        resetDefaults()
+        let appState = AppState()
+        appState.showLegacyMlxWhisperOptions = true
+        appState.useLegacyMlxWhisper = true
+
+        appState.useLegacyMlxWhisper = false
+
+        assert(appState.showLegacyMlxWhisperOptions == true)
+        assert(appState.useLegacyMlxWhisper == false)
     }
 
     private static func testPermissionStatusUpdateSkipsUnchangedValues() {
@@ -601,6 +654,41 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(saveKeyBody.contains("appState.setNoteBrowserTranscriptionMode(.apiStandard)"))
     }
 
+    private static func testSettingsLegacyMlxWhisperToggleControlsOptionsVisibilityOnly() throws {
+        let source = try String(contentsOfFile: "Sources/SettingsView.swift", encoding: .utf8)
+        let localSettings = sourceBlock(
+            in: source,
+            from: "private var localTranscriptionSettings: some View",
+            to: "\n    private var apiProviderTranscriptionSettings"
+        )
+        let appleSpeechRow = sourceBlock(
+            in: localSettings,
+            from: "ModelRowView(\n                    model: TranscriptionModel.find(id: \"apple-speech\")",
+            to: "\n\n                NativeWhisperModelRowView"
+        )
+        let nativeWhisperRow = sourceBlock(
+            in: localSettings,
+            from: "NativeWhisperModelRowView(",
+            to: "\n                Text(\"If you close Settings while the model is downloading"
+        )
+        let legacyRows = sourceBlock(
+            in: localSettings,
+            from: "ForEach(TranscriptionModel.all.filter { !$0.isAppleSpeech })",
+            to: "\n\n                    TextField(\"~/.local/bin/mlx_whisper\""
+        )
+
+        precondition(localSettings.contains("Toggle(\"Use legacy mlx-whisper\", isOn: $appState.showLegacyMlxWhisperOptions)"))
+        precondition(!localSettings.contains("Toggle(\"Use legacy mlx-whisper\", isOn: $appState.useLegacyMlxWhisper)"))
+        precondition(appleSpeechRow.contains("appState.useLegacyMlxWhisper = false"))
+        precondition(!appleSpeechRow.contains("showLegacyMlxWhisperOptions"))
+        precondition(nativeWhisperRow.contains("appState.useLegacyMlxWhisper = false"))
+        precondition(!nativeWhisperRow.contains("showLegacyMlxWhisperOptions"))
+        precondition(legacyRows.contains("appState.useLegacyMlxWhisper = true"))
+        precondition(legacyRows.contains("appState.showLegacyMlxWhisperOptions = true"))
+        precondition(localSettings.contains(".disabled(!appState.showLegacyMlxWhisperOptions)"))
+        precondition(localSettings.contains(".opacity(appState.showLegacyMlxWhisperOptions ? 1 : 0.55)"))
+    }
+
     private static func testSettingsGlobalAPIKeyCanBeCleared() throws {
         let source = try String(contentsOfFile: "Sources/SettingsView.swift", encoding: .utf8)
         let providerSection = sourceBlock(
@@ -1077,6 +1165,7 @@ struct AppStateTranscriptionConfigurationTests {
         }
         defaults.removeObject(forKey: "use_local_transcription")
         defaults.removeObject(forKey: "use_legacy_mlx_whisper")
+        defaults.removeObject(forKey: "show_legacy_mlx_whisper_options")
         defaults.removeObject(forKey: "local_transcription_model")
         defaults.removeObject(forKey: "transcription_language")
         defaults.removeObject(forKey: "selected_microphone_id")

--- a/Tests/NoteTitleHorizontalScrollFieldTests.swift
+++ b/Tests/NoteTitleHorizontalScrollFieldTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+@main
+struct NoteTitleHorizontalScrollFieldTests {
+    static func main() throws {
+        try testDetailTitleUsesHorizontallyScrollableField()
+        try testHorizontallyScrollableTitleFieldDefinesSingleLineAppKitWrapper()
+        try testTitleFieldClampsSelectionAfterProgrammaticTextShrink()
+        try testTitleFieldHandlesHorizontalWheelDeltaBeforeVerticalFallback()
+        try testTitleFieldClampsClipOriginAfterDocumentWidthChanges()
+        print("NoteTitleHorizontalScrollFieldTests passed")
+    }
+
+    private static func testDetailTitleUsesHorizontallyScrollableField() throws {
+        let source = try String(contentsOfFile: "Sources/NoteBrowserView.swift", encoding: .utf8)
+        let header = sourceBlock(
+            in: source,
+            from: "private var noteHeader: some View",
+            to: "\n            if let suggestedCalendarTitle"
+        )
+
+        precondition(header.contains("HorizontallyScrollableTitleField("))
+        precondition(header.contains("placeholder: item.timestamp.formatted(date: .long, time: .shortened),"))
+        precondition(header.contains("text: $titleDraft"))
+        precondition(!header.contains("TextField(\n                item.timestamp.formatted(date: .long, time: .shortened),\n                text: $titleDraft"))
+        precondition(header.contains(".onChange(of: titleDraft)"))
+        precondition(header.contains("appState.updateHistoryItemTitle(id: item.id, title: newValue)"))
+        precondition(header.contains(".overrideCursor(.iBeam)"))
+    }
+
+    private static func testHorizontallyScrollableTitleFieldDefinesSingleLineAppKitWrapper() throws {
+        let source = try String(contentsOfFile: "Sources/NoteBrowserView.swift", encoding: .utf8)
+        let component = sourceBlock(
+            in: source,
+            from: "private struct HorizontallyScrollableTitleField: NSViewRepresentable",
+            to: "\n// MARK: - Note List Row"
+        )
+
+        precondition(component.contains("@Binding var text: String"))
+        precondition(component.contains("func makeNSView(context: Context) -> TitleHorizontalScrollView"))
+        precondition(component.contains("TitleSingleLineTextView"))
+        precondition(component.contains("textView.textContainer?.maximumNumberOfLines = 1"))
+        precondition(component.contains("textView.textContainer?.widthTracksTextView = false"))
+        precondition(component.contains("textView.textContainer?.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude"))
+        precondition(component.contains("parent.text = textView.string"))
+        precondition(component.contains("override func scrollWheel(with event: NSEvent)"))
+        precondition(component.contains("scrollHorizontally(by: event.scrollingDeltaY)"))
+        precondition(!component.contains("appState.updateHistoryItemTitle"))
+    }
+
+    private static func testTitleFieldClampsSelectionAfterProgrammaticTextShrink() throws {
+        let source = try String(contentsOfFile: "Sources/NoteBrowserView.swift", encoding: .utf8)
+        let updateNSView = sourceBlock(
+            in: source,
+            from: "func updateNSView(_ scrollView: TitleHorizontalScrollView, context: Context)",
+            to: "\n        textView.updateDocumentWidth(minimumWidth: scrollView.contentView.bounds.width)"
+        )
+
+        precondition(updateNSView.contains("clampedRanges"))
+        precondition(updateNSView.contains("textView.selectedRanges = clampedRanges"))
+    }
+
+    private static func testTitleFieldHandlesHorizontalWheelDeltaBeforeVerticalFallback() throws {
+        let source = try String(contentsOfFile: "Sources/NoteBrowserView.swift", encoding: .utf8)
+        let scrollView = sourceBlock(
+            in: source,
+            from: "private final class TitleHorizontalScrollView: NSScrollView",
+            to: "\nprivate final class TitleSingleLineTextView: NSTextView"
+        )
+
+        precondition(scrollView.contains("scrollHorizontally(by: event.scrollingDeltaX)"))
+        precondition(scrollView.contains("scrollHorizontally(by: event.scrollingDeltaY)"))
+    }
+
+    private static func testTitleFieldClampsClipOriginAfterDocumentWidthChanges() throws {
+        let source = try String(contentsOfFile: "Sources/NoteBrowserView.swift", encoding: .utf8)
+        let textView = sourceBlock(
+            in: source,
+            from: "func updateDocumentWidth(minimumWidth: CGFloat)",
+            to: "\n    private static func singleLine(_ string: String) -> String"
+        )
+        let scrollView = sourceBlock(
+            in: source,
+            from: "private final class TitleHorizontalScrollView: NSScrollView",
+            to: "\nprivate final class TitleSingleLineTextView: NSTextView"
+        )
+
+        precondition(textView.contains("clampHorizontalScrollOffset()"))
+        precondition(scrollView.contains("func clampHorizontalScrollOffset()"))
+        precondition(scrollView.contains("reflectScrolledClipView(contentView)"))
+    }
+
+    private static func sourceBlock(in source: String, from startMarker: String, to endMarker: String) -> String {
+        guard let start = source.range(of: startMarker),
+              let end = source.range(of: endMarker, range: start.upperBound..<source.endIndex) else {
+            preconditionFailure("Expected source block from \(startMarker) to \(endMarker)")
+        }
+        return String(source[start.lowerBound..<end.lowerBound])
+    }
+}

--- a/Tests/NoteTitleHorizontalScrollFieldTests.swift
+++ b/Tests/NoteTitleHorizontalScrollFieldTests.swift
@@ -6,7 +6,8 @@ struct NoteTitleHorizontalScrollFieldTests {
         try testDetailTitleUsesHorizontallyScrollableField()
         try testHorizontallyScrollableTitleFieldDefinesSingleLineAppKitWrapper()
         try testTitleFieldClampsSelectionAfterProgrammaticTextShrink()
-        try testTitleFieldHandlesHorizontalWheelDeltaBeforeVerticalFallback()
+        try testTitleFieldDelegatesHorizontalWheelAndMapsVerticalWheel()
+        try testTitleFieldUsesSafeResizeAndSharedScrollBounds()
         try testTitleFieldClampsClipOriginAfterDocumentWidthChanges()
         print("NoteTitleHorizontalScrollFieldTests passed")
     }
@@ -44,7 +45,7 @@ struct NoteTitleHorizontalScrollFieldTests {
         precondition(component.contains("textView.textContainer?.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude"))
         precondition(component.contains("parent.text = textView.string"))
         precondition(component.contains("override func scrollWheel(with event: NSEvent)"))
-        precondition(component.contains("scrollHorizontally(by: event.scrollingDeltaY)"))
+        precondition(component.contains("scrollHorizontally(by: delta)"))
         precondition(!component.contains("appState.updateHistoryItemTitle"))
     }
 
@@ -60,7 +61,7 @@ struct NoteTitleHorizontalScrollFieldTests {
         precondition(updateNSView.contains("textView.selectedRanges = clampedRanges"))
     }
 
-    private static func testTitleFieldHandlesHorizontalWheelDeltaBeforeVerticalFallback() throws {
+    private static func testTitleFieldDelegatesHorizontalWheelAndMapsVerticalWheel() throws {
         let source = try String(contentsOfFile: "Sources/NoteBrowserView.swift", encoding: .utf8)
         let scrollView = sourceBlock(
             in: source,
@@ -68,8 +69,27 @@ struct NoteTitleHorizontalScrollFieldTests {
             to: "\nprivate final class TitleSingleLineTextView: NSTextView"
         )
 
-        precondition(scrollView.contains("scrollHorizontally(by: event.scrollingDeltaX)"))
-        precondition(scrollView.contains("scrollHorizontally(by: event.scrollingDeltaY)"))
+        precondition(scrollView.contains("if abs(event.scrollingDeltaX) > 0.01"))
+        precondition(scrollView.contains("super.scrollWheel(with: event)"))
+        precondition(scrollView.contains("let delta = -normalizedScrollDelta(event.scrollingDeltaY, precise: event.hasPreciseScrollingDeltas)"))
+        precondition(scrollView.contains("scrollHorizontally(by: delta)"))
+        precondition(!scrollView.contains("scrollHorizontally(by: event.scrollingDeltaX)"))
+        precondition(!scrollView.contains("scrollHorizontally(by: event.scrollingDeltaY)"))
+    }
+
+    private static func testTitleFieldUsesSafeResizeAndSharedScrollBounds() throws {
+        let source = try String(contentsOfFile: "Sources/NoteBrowserView.swift", encoding: .utf8)
+        let scrollView = sourceBlock(
+            in: source,
+            from: "private final class TitleHorizontalScrollView: NSScrollView",
+            to: "\nprivate final class TitleSingleLineTextView: NSTextView"
+        )
+
+        precondition(scrollView.contains("override func resizeSubviews(withOldSize oldSize: NSSize)"))
+        precondition(!scrollView.contains("override func layout()"))
+        precondition(scrollView.contains("private var maximumScrollX: CGFloat"))
+        precondition(scrollView.contains("let maximumX = maximumScrollX"))
+        precondition(scrollView.contains("private func normalizedScrollDelta(_ delta: CGFloat, precise: Bool) -> CGFloat"))
     }
 
     private static func testTitleFieldClampsClipOriginAfterDocumentWidthChanges() throws {

--- a/docs/superpowers/specs/2026-07-07-legacy-model-selector-design.md
+++ b/docs/superpowers/specs/2026-07-07-legacy-model-selector-design.md
@@ -1,0 +1,126 @@
+# Legacy mlx-whisper 모델 선택권 노출 분리 설계
+
+## 배경
+
+현재 Settings의 `Advanced Legacy mlx-whisper` 영역에서 `Use legacy mlx-whisper` 토글은 두 가지 의미를 동시에 갖는다.
+
+1. legacy mlx-whisper 모델 선택지를 Settings에 노출할지 결정한다.
+2. 실제 전사 실행 시 `legacy mlx_whisper` 경로를 사용할지 결정한다.
+
+이 때문에 사용자가 “레거시 모델을 선택할 수 있게 해두고 싶다”는 의미로 토글을 켜면, 앱은 즉시 legacy 엔진을 사용하는 상태가 된다. 반대로 Native Whisper나 Apple Speech 같은 다른 모델을 선택하면 `useLegacyMlxWhisper`가 꺼지면서 legacy 모델 선택권도 함께 사라진다.
+
+사용자가 원하는 동작은 토글이 실제 엔진 강제 사용이 아니라, legacy 모델 선택권을 계속 노출하는 조건으로 동작하는 것이다.
+
+## 목표
+
+- `Use legacy mlx-whisper` 토글의 UI 문구는 유지한다.
+- 토글은 legacy 모델 선택권 노출 여부를 제어한다.
+- 실제 legacy 엔진 사용 여부는 사용자가 legacy 모델 행을 선택했을 때만 켜진다.
+- 다른 로컬 모델을 선택해도 legacy 모델 선택권 노출 상태는 유지된다.
+- 기존에 legacy mlx-whisper를 사용하던 사용자는 업데이트 후에도 legacy 선택 영역을 계속 볼 수 있어야 한다.
+
+## 비목표
+
+- legacy mlx-whisper 실행 방식 자체를 바꾸지 않는다.
+- Native Whisper 설치/다운로드 흐름을 바꾸지 않는다.
+- 모델 목록 디자인을 대폭 재구성하지 않는다.
+- `Use legacy mlx-whisper` 표시 문구를 이번 변경에서 바꾸지 않는다.
+
+## 설계
+
+### 상태 분리
+
+`AppState`에 새 설정 상태를 추가한다.
+
+- 기존 `useLegacyMlxWhisper`
+  - 의미: 실제 전사 시 legacy mlx-whisper 엔진을 사용할지 여부
+  - 기존 전사 실행 경로와 호환성을 위해 의미를 유지한다.
+
+- 새 `showLegacyMlxWhisperOptions`
+  - 의미: Settings에서 legacy mlx-whisper 모델 선택권과 경로 입력 UI를 활성화할지 여부
+  - 별도 `UserDefaults` key에 저장한다.
+
+초기화 규칙은 다음과 같다.
+
+1. 저장된 `showLegacyMlxWhisperOptions` 값이 있으면 그 값을 사용한다.
+2. 저장된 값이 없고 기존 `useLegacyMlxWhisper`가 true이면 true로 시작한다.
+3. 그 외에는 false로 시작한다.
+
+이 규칙으로 기존 legacy 사용자는 선택 영역을 잃지 않고, 새 사용자나 legacy를 쓰지 않던 사용자의 기본 동작은 바뀌지 않는다.
+
+### Settings UI 동작
+
+`SettingsView.localTranscriptionSettings`의 `Advanced Legacy mlx-whisper` 영역을 다음처럼 조정한다.
+
+- `Use legacy mlx-whisper` 토글은 `appState.showLegacyMlxWhisperOptions`에 바인딩한다.
+- legacy 모델 행의 `disabled`와 `opacity` 조건도 `showLegacyMlxWhisperOptions`를 따른다.
+- legacy 모델 행의 선택 상태는 계속 `appState.useLegacyMlxWhisper && appState.localTranscriptionModel.id == model.id`로 판단한다.
+
+모델 선택 시 상태 변경 규칙은 다음과 같다.
+
+- Apple Speech 선택
+  - `localTranscriptionModel = apple-speech`
+  - `useLegacyMlxWhisper = false`
+  - `showLegacyMlxWhisperOptions`는 변경하지 않는다.
+
+- Native Whisper 선택
+  - `useLocalTranscription = true`
+  - `localTranscriptionModel = mlx-community/whisper-large-v3-turbo`
+  - `useLegacyMlxWhisper = false`
+  - `showLegacyMlxWhisperOptions`는 변경하지 않는다.
+
+- legacy 모델 선택
+  - `useLocalTranscription = true`
+  - `useLegacyMlxWhisper = true`
+  - `showLegacyMlxWhisperOptions = true`
+  - `localTranscriptionModel = 선택한 legacy 모델`
+
+- legacy 모델 삭제 처리
+  - `localTranscriptionModel`은 Native Whisper 추천 모델로 되돌린다.
+  - 삭제만으로 `showLegacyMlxWhisperOptions`를 끄지 않는다.
+  - 필요한 경우 실제 legacy 선택은 해제되도록 `useLegacyMlxWhisper = false`를 함께 보정한다.
+
+### 전사 실행 경로
+
+`TranscriptionService`의 실행 분기는 변경하지 않는다.
+
+- `localTranscriptionModel.isAppleSpeech`이면 Apple Speech를 사용한다.
+- 그렇지 않고 `useLegacyMlxWhisper`가 true이면 legacy `mlx_whisper`를 사용한다.
+- 그렇지 않으면 Native Whisper를 사용한다.
+
+즉, `showLegacyMlxWhisperOptions`가 true여도 사용자가 legacy 모델을 선택하지 않았다면 legacy 엔진은 실행되지 않는다.
+
+### 테스트
+
+회귀를 막기 위해 상태 분리 중심 테스트를 추가하거나 기존 `AppStateTranscriptionConfigurationTests`에 보강한다.
+
+검증할 동작은 다음과 같다.
+
+1. Native Whisper 선택은 `useLegacyMlxWhisper`를 false로 만들지만 `showLegacyMlxWhisperOptions`는 유지한다.
+2. Apple Speech 선택도 `showLegacyMlxWhisperOptions`를 유지한다.
+3. legacy 모델 선택은 `useLegacyMlxWhisper`와 `showLegacyMlxWhisperOptions`를 모두 true로 만든다.
+4. 저장된 표시 설정이 없을 때 기존 `use_legacy_mlx_whisper = true`이면 `showLegacyMlxWhisperOptions`가 true로 초기화된다.
+5. 전사 실행 경로는 계속 `useLegacyMlxWhisper`에만 의존하고, `showLegacyMlxWhisperOptions`만으로 legacy 엔진을 실행하지 않는다.
+
+## 예상 파일 변경
+
+- `Sources/AppState.swift`
+  - `showLegacyMlxWhisperOptions` 저장 key 추가
+  - `@Published var showLegacyMlxWhisperOptions` 추가
+  - 초기화에서 기존 `useLegacyMlxWhisper` 기반 fallback 적용
+
+- `Sources/SettingsView.swift`
+  - `Use legacy mlx-whisper` 토글 바인딩 변경
+  - legacy 모델 행의 활성화 조건 변경
+  - Apple Speech, Native Whisper, legacy 모델 선택 핸들러의 상태 갱신 규칙 정리
+
+- `Tests/AppStateTranscriptionConfigurationTests.swift`
+  - 상태 분리 회귀 테스트 추가
+
+## 성공 기준
+
+- 사용자가 `Use legacy mlx-whisper`를 체크한 뒤 Native Whisper를 선택해도 legacy 모델 선택권이 계속 노출된다.
+- 단순히 토글을 체크했다는 이유만으로 legacy 엔진이 실제 전사에 사용되지 않는다.
+- legacy 모델 행을 선택했을 때만 `useLegacyMlxWhisper`가 true가 된다.
+- 기존 legacy 사용자는 업데이트 후에도 legacy 설정 UI를 볼 수 있다.
+- 관련 테스트가 통과한다.

--- a/docs/superpowers/specs/2026-07-07-note-title-horizontal-scroll-design.md
+++ b/docs/superpowers/specs/2026-07-07-note-title-horizontal-scroll-design.md
@@ -1,0 +1,96 @@
+# Note Title Horizontal Scroll Design
+
+## 배경
+
+노트브라우저 상세 패널 상단의 큰 제목 입력칸은 현재 SwiftUI `TextField` 한 줄 입력으로 구성되어 있다. 제목이 표시 가능한 폭보다 길어지면 보이는 영역까지만 노출되고, 사용자는 키보드 커서 이동으로만 뒤쪽 내용을 확인할 수 있다.
+
+사용자가 원하는 동작은 제목 편집 흐름은 유지하되, 긴 제목의 가려진 뒤쪽 내용을 제목 필드 위에서 가로 스크롤로 확인할 수 있게 하는 것이다.
+
+## 목표
+
+- 상세 패널 상단의 큰 제목 입력칸에만 적용한다.
+- 제목 입력칸은 한 줄 UI를 유지한다.
+- 긴 제목이 폭을 넘으면 트랙패드/마우스 가로 스크롤로 숨은 영역을 볼 수 있게 한다.
+- 클릭 편집, 키보드 커서 이동, 텍스트 선택, 복사/붙여넣기 동작은 기존처럼 유지한다.
+- 기존 debounce 저장 흐름은 그대로 유지한다.
+
+## 비목표
+
+- 왼쪽 노트 목록 제목 행은 변경하지 않는다.
+- 제목을 여러 줄로 확장하지 않는다.
+- 본문 스크롤, 노트 목록 스크롤, 제목 결정 로직(`NoteTitleResolver`)은 변경하지 않는다.
+- 제목 저장 방식이나 저장 타이밍은 변경하지 않는다.
+
+## 설계
+
+### 컴포넌트
+
+`NoteBrowserView.swift`에 상세 제목 전용 컴포넌트를 추가한다.
+
+- 이름: `HorizontallyScrollableTitleField`
+- 입력:
+  - `placeholder: String`
+  - `text: Binding<String>`
+- 역할:
+  - AppKit 기반 한 줄 텍스트 필드를 SwiftUI에서 사용할 수 있게 감싼다.
+  - 긴 텍스트가 필드 폭을 넘어갈 때 내부 가로 스크롤 위치를 변경할 수 있게 한다.
+  - 텍스트 변경은 `Binding<String>`으로 상위 `titleDraft`에 전달한다.
+
+이 컴포넌트는 저장 로직을 알지 않는다. 저장은 기존처럼 `NoteDetailView`의 `titleDraft` 변경 감지와 debounce 타이머가 담당한다.
+
+### 상세 헤더 적용
+
+`NoteDetailView.noteHeader`의 제목 `TextField`를 `HorizontallyScrollableTitleField`로 교체한다.
+
+기존 시각 속성은 유지한다.
+
+- 폰트: `.system(size: 28, weight: .bold)`에 해당하는 AppKit 폰트
+- 텍스트 색: primary label 색상
+- plain 스타일
+- 최소 높이 38
+- iBeam 커서
+
+`onChange(of: titleDraft)`, `onAppear`, `overrideCursor(.iBeam)` 흐름은 기존처럼 `NoteDetailView`에 남긴다.
+
+### 스크롤 동작
+
+컴포넌트 내부 AppKit 뷰는 다음 동작을 지원한다.
+
+- 한 줄 편집을 유지한다.
+- 사용자가 제목 필드 위에서 horizontal scroll 이벤트를 보내면 필드 내부 표시 위치가 좌우로 이동한다.
+- 텍스트가 짧거나 더 이상 이동할 영역이 없으면 기존 입력 동작을 방해하지 않는다.
+- 키보드 커서 이동, 클릭 위치 지정, 드래그 선택은 기존 AppKit 텍스트 필드 동작을 따른다.
+
+### 테스트
+
+자동화 테스트는 source-level 회귀 테스트로 시작한다. 이 프로젝트의 기존 UI 테스트 패턴처럼 SwiftUI 런타임 상호작용을 직접 구동하지 않고, 의도한 배선이 유지되는지 확인한다.
+
+검증 항목:
+
+1. `NoteBrowserView.swift`에 `HorizontallyScrollableTitleField`가 정의되어 있다.
+2. `NoteDetailView.noteHeader`가 제목 입력에 기본 `TextField` 대신 `HorizontallyScrollableTitleField`를 사용한다.
+3. 새 컴포넌트가 `Binding<String>`을 받아 상위 `titleDraft`와 연결된다.
+4. 기존 `onChange(of: titleDraft)` debounce 저장 로직은 `NoteDetailView`에 남아 있다.
+
+수동/빌드 검증 항목:
+
+- 긴 제목을 가진 노트를 열었을 때 제목 필드가 한 줄로 유지된다.
+- 제목 필드 위에서 가로 스크롤하면 보이지 않던 뒤쪽 제목이 보인다.
+- 제목을 편집하면 기존처럼 저장된다.
+
+## 예상 파일 변경
+
+- `Sources/NoteBrowserView.swift`
+  - `HorizontallyScrollableTitleField` 추가
+  - `NoteDetailView.noteHeader`의 제목 필드 교체
+
+- `Tests/AppStateTranscriptionConfigurationTests.swift` 또는 별도 source-level 테스트 파일
+  - 상세 제목 필드 배선 회귀 테스트 추가
+
+## 성공 기준
+
+- 상세 패널 제목이 긴 경우 커서 이동 없이 가로 스크롤로 숨은 부분을 볼 수 있다.
+- 제목 필드는 한 줄로 유지된다.
+- 제목 편집과 자동 저장은 기존처럼 동작한다.
+- 왼쪽 노트 목록과 본문 스크롤 동작은 바뀌지 않는다.
+- 관련 테스트와 앱 빌드가 통과한다.


### PR DESCRIPTION
## Summary
- Separate legacy mlx-whisper option visibility from the actual legacy engine selection so the model choices stay available after switching models
- Add a horizontally scrollable AppKit-backed note title field in the Note Browser detail panel
- Add regression coverage for both Settings wiring and the title field wrapper

## Testing
- `git diff --check origin/main..HEAD`
- `make test CODESIGN_IDENTITY=Quill`
- `make all CODESIGN_IDENTITY=-`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 제목이 긴 노트도 한 줄에서 가로 스크롤로 확인하고 편집할 수 있게 되었습니다.
  * 설정에서 레거시 mlx-whisper 옵션 표시 여부를 별도로 제어할 수 있게 되었습니다.

* **Bug Fixes**
  * 레거시 전사 엔진 사용 여부와 옵션 표시 상태가 분리되어, 설정 변경 시 원치 않는 동작이 줄어듭니다.
  * Apple Speech 모델을 선택하면 레거시 엔진 사용 상태가 자동으로 해제됩니다.

* **Tests**
  * 새 UI와 설정 동작을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->