### PR TITLE
Shorten note browser transcription label

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -807,6 +807,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     var noteBrowserTranscriptionChoiceLabel: String {
+        noteBrowserTranscriptionDisplay(for: currentNoteBrowserTranscriptionChoice).title
+    }
+
+    @MainActor
+    var noteBrowserTranscriptionChoiceDetailLabel: String {
         noteBrowserTranscriptionDisplay(for: currentNoteBrowserTranscriptionChoice).currentLabel
     }
 

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -623,10 +623,9 @@ struct NoteBrowserView: View {
                         .padding(.horizontal, 10)
                         .padding(.vertical, 5)
                         .background(Color.primary.opacity(0.06), in: Capsule())
-                        .frame(maxWidth: 170, alignment: .trailing)
                 }
                 .menuStyle(.borderlessButton)
-                .help(appState.noteBrowserTranscriptionChoiceLabel)
+                .accessibilityLabel("Transcription method: \(appState.noteBrowserTranscriptionChoiceDetailLabel)")
                 .disabled(appState.isRecording || appState.isTranscribing)
             }
             .padding(.horizontal, 12)

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -628,20 +628,30 @@ struct AppStateTranscriptionConfigurationTests {
             appState.realtimeStreamingModel = ""
 
             let apiDisplay = appState.noteBrowserTranscriptionDisplay(for: .apiStandard(modelID: appState.transcriptionModel))
+            precondition(apiDisplay.title == "Standard")
             precondition(apiDisplay.currentLabel == "API · Standard · whisper-large-v3-turbo")
 
             let realtimeDisplay = appState.noteBrowserTranscriptionDisplay(for: .apiRealtime(modelID: nil))
+            precondition(realtimeDisplay.title == "Realtime")
             precondition(realtimeDisplay.currentLabel == "API · Realtime · Provider default")
 
             let nativeDisplay = appState.noteBrowserTranscriptionDisplay(for: .nativeWhisper(modelID: NativeWhisperModelCatalog.recommended.id))
+            precondition(nativeDisplay.title == "Native Whisper")
             precondition(nativeDisplay.currentLabel == "Local · Native Whisper · Whisper Large v3 Turbo")
 
             let legacyModel = TranscriptionModel.find(id: "mlx-community/whisper-medium-mlx")
             let legacyDisplay = appState.noteBrowserTranscriptionDisplay(for: .legacyMlxWhisper(model: legacyModel))
+            precondition(legacyDisplay.title == "Legacy mlx-whisper")
             precondition(legacyDisplay.currentLabel == "Local · Legacy · Whisper Medium")
 
             let appleDisplay = appState.noteBrowserTranscriptionDisplay(for: .appleLive)
+            precondition(appleDisplay.title == "Apple Live")
             precondition(appleDisplay.currentLabel == "Local · Apple Live · Apple Speech")
+
+            appState.useLocalTranscription = false
+            appState.realtimeStreamingEnabled = false
+            precondition(appState.noteBrowserTranscriptionChoiceLabel == "Standard")
+            precondition(appState.noteBrowserTranscriptionChoiceDetailLabel == "API · Standard · whisper-large-v3-turbo")
         }
     }
 


### PR DESCRIPTION
## Summary
- Keep the Note Browser transcription row label while showing a shorter selected backend name.
- Preserve the full selected backend description for accessibility.
- Update transcription configuration coverage for the compact/current label split.

## Tests
- `make test`
- Built and opened the `Quill Dev` development build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 전사(Transcription) 메뉴에서 표시되는 라벨이 더 정확하게 분리되어, 선택 항목의 이름과 보조 설명이 각각 올바르게 보이도록 개선되었습니다.
  * 전사 방식 선택 메뉴의 접근성 라벨이 추가되어, 보조 기술 사용 시 안내가 더 명확해졌습니다.
  * 전사 메뉴의 버튼 스타일이 일관되게 유지되도록 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->