### PR TITLE
CI: run make test on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,41 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    name: Tests
+    runs-on: macos-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Select Xcode and show toolchain
+        run: |
+          sudo xcode-select -s /Applications/Xcode.app
+          xcodebuild -version
+          swift --version
+
+      - name: Restore SwiftPM build cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .build
+          key: spm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
+
+      - name: Run tests
+        run: make test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -32,7 +32,7 @@ jobs:
           swift --version
 
       - name: Restore SwiftPM build cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.0
         with:
           path: .build
           key: spm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Package.resolved') }}

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ICON_ICNS = Resources/AppIcon.icns
 endif
 
 # Usage: make install CODESIGN_IDENTITY="Apple Development: you@example.com (TEAMID)"
-.PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run test print-app-version print-build-number print-build-tag print-version-metadata FORCE
+.PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run check-test-wiring test print-app-version print-build-number print-build-tag print-version-metadata FORCE
 
 all: $(APP_EXECUTABLE_TARGET)
 
@@ -262,7 +262,21 @@ print-version-metadata:
 
 FORCE:
 
-test: $(SPARKLE_STAMP)
+check-test-wiring:
+	@for test_file in Tests/*.swift; do \
+		test_name="$${test_file##*/}"; \
+		test_name="$${test_name%.swift}"; \
+		if ! grep -F -- "$$test_file" Makefile | grep -Eq '^[[:space:]]+@.*swiftc '; then \
+			echo "Test file is not compiled: $$test_file" >&2; \
+			exit 1; \
+		fi; \
+		if ! grep -F -- "/tmp/$$test_name" Makefile | grep -Fv -- 'swiftc ' | grep -Eq "^[[:space:]]+@.*/tmp/$$test_name([ ;]|$$)"; then \
+			echo "Test executable is not run: /tmp/$$test_name" >&2; \
+			exit 1; \
+		fi; \
+	done
+
+test: check-test-wiring $(SPARKLE_STAMP)
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/CalendarEventMatcher.swift Tests/CalendarEventMatcherTests.swift -o /tmp/CalendarEventMatcherTests
 	@swiftc -parse-as-library Sources/AppName.swift Sources/ModifierKeyEventState.swift Sources/ShortcutCore/ShortcutModels.swift Sources/ShortcutCore/ShortcutMatcher.swift Sources/GlobalShortcutBackend.swift Sources/HotkeyManager.swift Tests/ShortcutMatcherTests.swift -o /tmp/ShortcutMatcherTests
 	@swiftc -parse-as-library Sources/ShortcutCore/ShortcutModels.swift Sources/ShortcutBinding.swift Sources/ShortcutCaptureKeyHandling.swift Tests/ShortcutCaptureKeyHandlingTests.swift -o /tmp/ShortcutCaptureKeyHandlingTests
@@ -337,3 +351,9 @@ test: $(SPARKLE_STAMP)
 	@/tmp/MeetingReminderOverlayGeometryTests
 	@framework="$$(cat "$(SPARKLE_STAMP)")"; framework_parent="$$(dirname "$$framework")"; swiftc -parse-as-library -F "$$framework_parent" -framework Sparkle -Xlinker -rpath -Xlinker "$$framework_parent" -target $(shell uname -m)-apple-macosx13.0 $(filter-out Sources/App.swift,$(SOURCES)) Tests/AppStateTranscriptionConfigurationTests.swift -o /tmp/AppStateTranscriptionConfigurationTests
 	@isolated_home="$$(mktemp -d /tmp/quill-app-state-tests.XXXXXX)"; trap 'rm -rf "$$isolated_home"' EXIT; CFFIXED_USER_HOME="$$isolated_home" /tmp/AppStateTranscriptionConfigurationTests
+	@swiftc -parse-as-library Sources/AppBuild.swift Tests/AppBuildTests.swift -o /tmp/AppBuildTests
+	@/tmp/AppBuildTests
+	@swiftc -parse-as-library Sources/CriticalDictationActivityState.swift Tests/CriticalDictationActivityStateTests.swift -o /tmp/CriticalDictationActivityStateTests
+	@/tmp/CriticalDictationActivityStateTests
+	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Tests/TranscriptionRecoveryPlaceholderTests.swift -o /tmp/TranscriptionRecoveryPlaceholderTests
+	@/tmp/TranscriptionRecoveryPlaceholderTests

--- a/Sources/AppBuild.swift
+++ b/Sources/AppBuild.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum AppBuild {
+    static var isDevBundle: Bool {
+        isDevBundleName(Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String)
+    }
+
+    static func isDevBundleName(_ bundleName: String?) -> Bool {
+        bundleName == "Quill Dev"
+    }
+}

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -21,16 +21,6 @@ struct PrecomputedMacro {
     let normalizedCommand: String
 }
 
-enum AppBuild {
-    static var isDevBundle: Bool {
-        isDevBundleName(Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String)
-    }
-
-    static func isDevBundleName(_ bundleName: String?) -> Bool {
-        bundleName == "Quill Dev"
-    }
-}
-
 private struct PreservedPasteboardEntry {
     let type: NSPasteboard.PasteboardType
     let value: Value

--- a/Tests/BuildMetadataTests.swift
+++ b/Tests/BuildMetadataTests.swift
@@ -46,7 +46,7 @@ struct BuildMetadataTests {
     private static func testMakefilePrintsVersionMetadata() throws {
         let makefile = try String(contentsOfFile: "Makefile", encoding: .utf8)
 
-        assertContains(makefile, ".PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run test print-app-version print-build-number print-build-tag print-version-metadata FORCE")
+        assertContains(makefile, ".PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run check-test-wiring test print-app-version print-build-number print-build-tag print-version-metadata FORCE")
         assertContains(makefile, "print-app-version:")
         assertContains(makefile, "print-build-number:")
         assertContains(makefile, "print-build-tag:")


### PR DESCRIPTION
## Summary

- run `make test` for every pull request and push to `main` on a macOS runner
- cache SwiftPM build artifacts with read-only workflow permissions
- wire all 40 Swift test entry points into `make test`
- fail fast when a test file is not compiled or its executable is not run

## Verification

- `make check-test-wiring`
- `make test`
- Ruby YAML syntax validation for `.github/workflows/tests.yml`
- built and launched `Quill Dev.app`; confirmed the development-only Debug settings tab is available
- verified the wiring guard rejects both an uncompiled test file and a compiled-but-unexecuted test

Refs #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 앱이 개발용 번들인지 자동으로 식별하는 기능을 추가했습니다.

* **버그 수정**
  * 개발용 번들 판별 로직을 일관된 방식으로 관리하도록 개선했습니다.

* **테스트**
  * 주요 테스트가 실제로 빌드 및 실행되는지 자동 검증합니다.
  * 앱 빌드, 받아쓰기 상태, 복구 관련 테스트를 테스트 과정에 포함했습니다.
  * `main` 브랜치 변경 및 풀 리퀘스트 시 macOS 환경에서 자동 테스트를 실행합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->