### PR TITLE
Add English and Korean localization

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,4 +41,4 @@ jobs:
         run: make test
 
       - name: Validate app localization bundle
-        run: make localization-bundle-test
+        run: make localization-bundle-test CODESIGN_IDENTITY=-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,3 +39,6 @@ jobs:
 
       - name: Run tests
         run: make test
+
+      - name: Validate app localization bundle
+        run: make localization-bundle-test

--- a/Info.plist
+++ b/Info.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleLocalizations</key>
+    <array>
+        <string>en</string>
+        <string>ko</string>
+    </array>
     <key>CFBundleName</key>
     <string>Quill</string>
     <key>CFBundleDisplayName</key>

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ ICON_ICNS = Resources/AppIcon.icns
 endif
 
 # Usage: make install CODESIGN_IDENTITY="Apple Development: you@example.com (TEAMID)"
-.PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run check-test-wiring test print-app-version print-build-number print-build-tag print-version-metadata FORCE
+.PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run check-test-wiring test localization-bundle-test print-app-version print-build-number print-build-tag print-version-metadata FORCE /tmp/LocalizationResourceTests
 
 all: $(APP_EXECUTABLE_TARGET)
 
@@ -297,6 +297,18 @@ check-test-wiring:
 		fi; \
 	done
 
+/tmp/LocalizationResourceTests: Tests/LocalizationResourceTests.swift
+	@swiftc -parse-as-library Tests/LocalizationResourceTests.swift -o /tmp/LocalizationResourceTests
+
+localization-bundle-test: /tmp/LocalizationResourceTests $(LOCALIZATION_STAMP)
+	@bundle="$(BUILD_DIR)/Quill Localization Test.app"; \
+		rm -rf "$$bundle"; \
+		mkdir -p "$$bundle/Contents/Resources"; \
+		ditto --norsrc --noextattr "$(LOCALIZATION_BUILD_DIR)/en.lproj" "$$bundle/Contents/Resources/en.lproj"; \
+		ditto --norsrc --noextattr "$(LOCALIZATION_BUILD_DIR)/ko.lproj" "$$bundle/Contents/Resources/ko.lproj"; \
+		printf '%s\n' '"object" = "%@";' '"integer" = "%d";' '"longLong" = "%lld";' '"unknown" = "%arg";' > "$$bundle/Contents/Resources/PlaceholderFixtures.strings"; \
+		/tmp/LocalizationResourceTests --bundle "$$bundle"
+
 test: check-test-wiring $(SPARKLE_STAMP) $(LOCALIZATION_STAMP)
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/CalendarEventMatcher.swift Tests/CalendarEventMatcherTests.swift -o /tmp/CalendarEventMatcherTests
 	@swiftc -parse-as-library Sources/AppName.swift Sources/ModifierKeyEventState.swift Sources/ShortcutCore/ShortcutModels.swift Sources/ShortcutCore/ShortcutMatcher.swift Sources/GlobalShortcutBackend.swift Sources/HotkeyManager.swift Tests/ShortcutMatcherTests.swift -o /tmp/ShortcutMatcherTests
@@ -326,7 +338,7 @@ test: check-test-wiring $(SPARKLE_STAMP) $(LOCALIZATION_STAMP)
 	@/tmp/OverlayDisplayCopyTests
 	@swiftc -parse-as-library Tests/BuildMetadataTests.swift -o /tmp/BuildMetadataTests
 	@/tmp/BuildMetadataTests
-	@swiftc -parse-as-library Tests/LocalizationResourceTests.swift -o /tmp/LocalizationResourceTests
+	@$(MAKE) /tmp/LocalizationResourceTests
 	@/tmp/LocalizationResourceTests
 	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/TranscriptionLanguage.swift Sources/TranscriptionModel.swift Sources/NativeWhisperModel.swift Sources/AudioImportOptions.swift Tests/SettingsLocalizationTests.swift -o /tmp/SettingsLocalizationTests
 	@/tmp/SettingsLocalizationTests

--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ test: check-test-wiring $(SPARKLE_STAMP) $(LOCALIZATION_STAMP)
 	@/tmp/BuildMetadataTests
 	@swiftc -parse-as-library Tests/LocalizationResourceTests.swift -o /tmp/LocalizationResourceTests
 	@/tmp/LocalizationResourceTests
-	@swiftc -parse-as-library Sources/TranscriptionLanguage.swift Sources/TranscriptionModel.swift Sources/NativeWhisperModel.swift Sources/AudioImportOptions.swift Tests/SettingsLocalizationTests.swift -o /tmp/SettingsLocalizationTests
+	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/TranscriptionLanguage.swift Sources/TranscriptionModel.swift Sources/NativeWhisperModel.swift Sources/AudioImportOptions.swift Tests/SettingsLocalizationTests.swift -o /tmp/SettingsLocalizationTests
 	@/tmp/SettingsLocalizationTests
 	@swiftc -parse-as-library Sources/InstructionExecutionDetector.swift Tests/InstructionExecutionDetectorTests.swift -o /tmp/InstructionExecutionDetectorTests
 	@/tmp/InstructionExecutionDetectorTests
@@ -346,23 +346,23 @@ test: check-test-wiring $(SPARKLE_STAMP) $(LOCALIZATION_STAMP)
 	@/tmp/AudioWaveformHeightsTests
 	@swiftc -parse-as-library Tests/SystemAudioAppStateRoutingTests.swift -o /tmp/SystemAudioAppStateRoutingTests
 	@/tmp/SystemAudioAppStateRoutingTests
-	@swiftc -parse-as-library Sources/AppName.swift Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/TranscriptionModel.swift Sources/PipelineHistoryStore.swift Tests/PipelineHistoryCalendarMetadataTests.swift -o /tmp/PipelineHistoryCalendarMetadataTests
+	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/AppName.swift Sources/CalendarIntegrationModels.swift Sources/PipelineHistoryItem.swift Sources/TranscriptionModel.swift Sources/PipelineHistoryStore.swift Tests/PipelineHistoryCalendarMetadataTests.swift -o /tmp/PipelineHistoryCalendarMetadataTests
 	@/tmp/PipelineHistoryCalendarMetadataTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/GoogleCalendarTokenStore.swift Sources/GoogleCalendarAuthService.swift Sources/GoogleCalendarService.swift Tests/GoogleCalendarServiceTests.swift -o /tmp/GoogleCalendarServiceTests
 	@/tmp/GoogleCalendarServiceTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/AppNotificationManager.swift Sources/CalendarRecordingReminderScheduler.swift Tests/CalendarRecordingReminderSchedulerTests.swift -o /tmp/CalendarRecordingReminderSchedulerTests
 	@/tmp/CalendarRecordingReminderSchedulerTests
-	@swiftc -parse-as-library Sources/TranscriptionModel.swift Sources/SetupFlow.swift Tests/SetupFlowTests.swift -o /tmp/SetupFlowTests
+	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/TranscriptionModel.swift Sources/SetupFlow.swift Tests/SetupFlowTests.swift -o /tmp/SetupFlowTests
 	@/tmp/SetupFlowTests
-	@swiftc -parse-as-library Sources/TranscriptionModel.swift Tests/TranscriptionModelCacheTests.swift -o /tmp/TranscriptionModelCacheTests
+	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/TranscriptionModel.swift Tests/TranscriptionModelCacheTests.swift -o /tmp/TranscriptionModelCacheTests
 	@/tmp/TranscriptionModelCacheTests
-	@swiftc -parse-as-library Sources/TranscriptionModel.swift Sources/AudioImportOptions.swift Tests/AudioImportOptionsTests.swift -o /tmp/AudioImportOptionsTests
+	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/TranscriptionModel.swift Sources/AudioImportOptions.swift Tests/AudioImportOptionsTests.swift -o /tmp/AudioImportOptionsTests
 	@/tmp/AudioImportOptionsTests
-	@swiftc -parse-as-library Sources/NativeWhisperModel.swift Tests/NativeWhisperModelTests.swift -o /tmp/NativeWhisperModelTests
+	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/NativeWhisperModel.swift Tests/NativeWhisperModelTests.swift -o /tmp/NativeWhisperModelTests
 	@/tmp/NativeWhisperModelTests
-	@swiftc -parse-as-library Sources/NativeWhisperModel.swift Sources/NativeWhisperRuntime.swift Tests/NativeWhisperRuntimeTests.swift -o /tmp/NativeWhisperRuntimeTests
+	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/NativeWhisperModel.swift Sources/NativeWhisperRuntime.swift Tests/NativeWhisperRuntimeTests.swift -o /tmp/NativeWhisperRuntimeTests
 	@/tmp/NativeWhisperRuntimeTests
-	@swiftc -parse-as-library Sources/NativeWhisperModel.swift Sources/NativeWhisperInstaller.swift Tests/NativeWhisperInstallerTests.swift -o /tmp/NativeWhisperInstallerTests
+	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/NativeWhisperModel.swift Sources/NativeWhisperInstaller.swift Tests/NativeWhisperInstallerTests.swift -o /tmp/NativeWhisperInstallerTests
 	@/tmp/NativeWhisperInstallerTests
 	@swiftc -parse-as-library Sources/LLMCooldownManager.swift Tests/LLMCooldownManagerTests.swift -o /tmp/LLMCooldownManagerTests
 	@/tmp/LLMCooldownManagerTests

--- a/Makefile
+++ b/Makefile
@@ -300,14 +300,8 @@ check-test-wiring:
 /tmp/LocalizationResourceTests: Tests/LocalizationResourceTests.swift
 	@swiftc -parse-as-library Tests/LocalizationResourceTests.swift -o /tmp/LocalizationResourceTests
 
-localization-bundle-test: /tmp/LocalizationResourceTests $(LOCALIZATION_STAMP)
-	@bundle="$(BUILD_DIR)/Quill Localization Test.app"; \
-		rm -rf "$$bundle"; \
-		mkdir -p "$$bundle/Contents/Resources"; \
-		ditto --norsrc --noextattr "$(LOCALIZATION_BUILD_DIR)/en.lproj" "$$bundle/Contents/Resources/en.lproj"; \
-		ditto --norsrc --noextattr "$(LOCALIZATION_BUILD_DIR)/ko.lproj" "$$bundle/Contents/Resources/ko.lproj"; \
-		printf '%s\n' '"object" = "%@";' '"integer" = "%d";' '"longLong" = "%lld";' '"unknown" = "%arg";' > "$$bundle/Contents/Resources/PlaceholderFixtures.strings"; \
-		/tmp/LocalizationResourceTests --bundle "$$bundle"
+localization-bundle-test: /tmp/LocalizationResourceTests $(APP_EXECUTABLE_TARGET)
+	@/tmp/LocalizationResourceTests --bundle "$(APP_BUNDLE)"
 
 test: check-test-wiring $(SPARKLE_STAMP) $(LOCALIZATION_STAMP)
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/CalendarEventMatcher.swift Tests/CalendarEventMatcherTests.swift -o /tmp/CalendarEventMatcherTests

--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,8 @@ test: check-test-wiring $(SPARKLE_STAMP)
 	@/tmp/BuildMetadataTests
 	@swiftc -parse-as-library Tests/LocalizationResourceTests.swift -o /tmp/LocalizationResourceTests
 	@/tmp/LocalizationResourceTests
+	@swiftc -parse-as-library Sources/TranscriptionLanguage.swift Sources/TranscriptionModel.swift Sources/NativeWhisperModel.swift Sources/AudioImportOptions.swift Tests/SettingsLocalizationTests.swift -o /tmp/SettingsLocalizationTests
+	@/tmp/SettingsLocalizationTests
 	@swiftc -parse-as-library Sources/InstructionExecutionDetector.swift Tests/InstructionExecutionDetectorTests.swift -o /tmp/InstructionExecutionDetectorTests
 	@/tmp/InstructionExecutionDetectorTests
 	@swiftc -parse-as-library Tests/ReleaseSDKCompatibilityTests.swift -o /tmp/ReleaseSDKCompatibilityTests

--- a/Makefile
+++ b/Makefile
@@ -322,6 +322,8 @@ test: check-test-wiring $(SPARKLE_STAMP) $(LOCALIZATION_STAMP)
 	@/tmp/UpdateManagerSafetyTests
 	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/LocalizedUserMessage.swift Tests/LocalizedUserMessageTests.swift -o /tmp/LocalizedUserMessageTests
 	@/tmp/LocalizedUserMessageTests
+	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/OverlayDisplayCopy.swift Tests/OverlayDisplayCopyTests.swift -o /tmp/OverlayDisplayCopyTests
+	@/tmp/OverlayDisplayCopyTests
 	@swiftc -parse-as-library Tests/BuildMetadataTests.swift -o /tmp/BuildMetadataTests
 	@/tmp/BuildMetadataTests
 	@swiftc -parse-as-library Tests/LocalizationResourceTests.swift -o /tmp/LocalizationResourceTests
@@ -370,11 +372,11 @@ test: check-test-wiring $(SPARKLE_STAMP) $(LOCALIZATION_STAMP)
 	@/tmp/LLMCooldownManagerTests
 	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Tests/OverlayScreenGeometryTests.swift -o /tmp/OverlayScreenGeometryTests
 	@/tmp/OverlayScreenGeometryTests
-	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/AudioInputDevice.swift Sources/RecordingOverlay.swift Tests/RecordingOverlayGeometryTests.swift -o /tmp/RecordingOverlayGeometryTests
+	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/AudioInputDevice.swift Sources/LocalizedStringLookup.swift Sources/OverlayDisplayCopy.swift Sources/RecordingOverlay.swift Tests/RecordingOverlayGeometryTests.swift -o /tmp/RecordingOverlayGeometryTests
 	@/tmp/RecordingOverlayGeometryTests
 	@swiftc -parse-as-library Tests/UpstreamMergeBehaviorTests.swift -o /tmp/UpstreamMergeBehaviorTests
 	@/tmp/UpstreamMergeBehaviorTests
-	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/OverlayScreenGeometry.swift Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/AudioInputDevice.swift Sources/RecordingOverlay.swift Sources/CalendarIntegrationModels.swift Sources/AppNotificationManager.swift Sources/CalendarRecordingReminderScheduler.swift Sources/MeetingReminderOverlay.swift Tests/MeetingReminderOverlayGeometryTests.swift -o /tmp/MeetingReminderOverlayGeometryTests
+	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/OverlayDisplayCopy.swift Sources/OverlayScreenGeometry.swift Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/AudioInputDevice.swift Sources/RecordingOverlay.swift Sources/CalendarIntegrationModels.swift Sources/AppNotificationManager.swift Sources/CalendarRecordingReminderScheduler.swift Sources/MeetingReminderOverlay.swift Tests/MeetingReminderOverlayGeometryTests.swift -o /tmp/MeetingReminderOverlayGeometryTests
 	@/tmp/MeetingReminderOverlayGeometryTests
 	@framework="$$(cat "$(SPARKLE_STAMP)")"; framework_parent="$$(dirname "$$framework")"; swiftc -parse-as-library -F "$$framework_parent" -framework Sparkle -Xlinker -rpath -Xlinker "$$framework_parent" -target $(shell uname -m)-apple-macosx13.0 $(filter-out Sources/App.swift,$(SOURCES)) Tests/AppStateTranscriptionConfigurationTests.swift -o /tmp/AppStateTranscriptionConfigurationTests
 	@isolated_home="$$(mktemp -d /tmp/quill-app-state-tests.XXXXXX)"; trap 'rm -rf "$$isolated_home"' EXIT; CFFIXED_USER_HOME="$$isolated_home" /tmp/AppStateTranscriptionConfigurationTests

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ APP_EXECUTABLE_TARGET := $(subst $(space),\ ,$(APP_EXECUTABLE))
 
 SOURCES = $(shell find Sources -name '*.swift' -type f | LC_ALL=C sort)
 RESOURCES = $(CONTENTS)/Resources
+LOCALIZATION_CATALOG = Resources/Localization/Localizable.xcstrings
+LOCALIZATION_INFO_DIR = Resources/Localization
+LOCALIZATION_BUILD_DIR = $(BUILD_DIR)/localization
+LOCALIZATION_STAMP = $(LOCALIZATION_BUILD_DIR)/.compiled
 ARCH ?= $(shell uname -m)
 
 # Pick the icon source based on which bundle we are building. Dev builds get
@@ -79,7 +83,21 @@ $(WHISPER_STAMP): BuildSupport/WhisperRuntime/build-whisper.cpp.sh $(WHISPER_BUI
 	@mkdir -p "$(BUILD_DIR)"
 	@printf '%s\n' "$(WHISPER_HELPER)" > "$@"
 
-$(APP_EXECUTABLE_TARGET): $(SOURCES) Info.plist $(ICON_ICNS) $(BUILD_SETTINGS) $(SPARKLE_STAMP) $(WHISPER_STAMP)
+$(LOCALIZATION_STAMP): $(LOCALIZATION_CATALOG) $(LOCALIZATION_INFO_DIR)/en.lproj/InfoPlist.strings $(LOCALIZATION_INFO_DIR)/ko.lproj/InfoPlist.strings
+	@rm -rf "$(LOCALIZATION_BUILD_DIR)"
+	@mkdir -p "$(LOCALIZATION_BUILD_DIR)"
+	@xcrun xcstringstool compile "$(LOCALIZATION_CATALOG)" \
+		--output-directory "$(LOCALIZATION_BUILD_DIR)" \
+		-l en -l ko \
+		--serialization-format text
+	@for language in en ko; do \
+		test -f "$(LOCALIZATION_BUILD_DIR)/$$language.lproj/Localizable.strings"; \
+		cp "$(LOCALIZATION_INFO_DIR)/$$language.lproj/InfoPlist.strings" \
+			"$(LOCALIZATION_BUILD_DIR)/$$language.lproj/InfoPlist.strings"; \
+	done
+	@touch "$@"
+
+$(APP_EXECUTABLE_TARGET): $(SOURCES) Info.plist $(ICON_ICNS) $(BUILD_SETTINGS) $(SPARKLE_STAMP) $(WHISPER_STAMP) $(LOCALIZATION_STAMP)
 	@mkdir -p "$(MACOS_DIR)" "$(RESOURCES)" "$(FRAMEWORKS)"
 	@framework="$$(cat "$(SPARKLE_STAMP)" 2>/dev/null)"; \
 		if [ -z "$$framework" ] || [ ! -d "$$framework" ]; then \
@@ -136,6 +154,9 @@ endif
 	@plutil -replace GoogleCalendarOAuthClientID -string "$(GOOGLE_CALENDAR_OAUTH_CLIENT_ID)" "$(CONTENTS)/Info.plist"
 	@plutil -replace GoogleCalendarOAuthClientSecret -string "$(GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET)" "$(CONTENTS)/Info.plist"
 	@cp $(ICON_ICNS) "$(RESOURCES)/AppIcon.icns"
+	@rm -rf "$(RESOURCES)/en.lproj" "$(RESOURCES)/ko.lproj"
+	@ditto --norsrc --noextattr "$(LOCALIZATION_BUILD_DIR)/en.lproj" "$(RESOURCES)/en.lproj"
+	@ditto --norsrc --noextattr "$(LOCALIZATION_BUILD_DIR)/ko.lproj" "$(RESOURCES)/ko.lproj"
 	@mkdir -p "$(RESOURCES)/whisper"
 	@whisper_helper="$$(cat "$(WHISPER_STAMP)")"; \
 		if [ -z "$$whisper_helper" ] || [ ! -x "$$whisper_helper" ]; then \
@@ -301,6 +322,8 @@ test: check-test-wiring $(SPARKLE_STAMP)
 	@/tmp/UpdateManagerSafetyTests
 	@swiftc -parse-as-library Tests/BuildMetadataTests.swift -o /tmp/BuildMetadataTests
 	@/tmp/BuildMetadataTests
+	@swiftc -parse-as-library Tests/LocalizationResourceTests.swift -o /tmp/LocalizationResourceTests
+	@/tmp/LocalizationResourceTests
 	@swiftc -parse-as-library Sources/InstructionExecutionDetector.swift Tests/InstructionExecutionDetectorTests.swift -o /tmp/InstructionExecutionDetectorTests
 	@/tmp/InstructionExecutionDetectorTests
 	@swiftc -parse-as-library Tests/ReleaseSDKCompatibilityTests.swift -o /tmp/ReleaseSDKCompatibilityTests

--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ check-test-wiring:
 		fi; \
 	done
 
-test: check-test-wiring $(SPARKLE_STAMP)
+test: check-test-wiring $(SPARKLE_STAMP) $(LOCALIZATION_STAMP)
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/CalendarEventMatcher.swift Tests/CalendarEventMatcherTests.swift -o /tmp/CalendarEventMatcherTests
 	@swiftc -parse-as-library Sources/AppName.swift Sources/ModifierKeyEventState.swift Sources/ShortcutCore/ShortcutModels.swift Sources/ShortcutCore/ShortcutMatcher.swift Sources/GlobalShortcutBackend.swift Sources/HotkeyManager.swift Tests/ShortcutMatcherTests.swift -o /tmp/ShortcutMatcherTests
 	@swiftc -parse-as-library Sources/ShortcutCore/ShortcutModels.swift Sources/ShortcutBinding.swift Sources/ShortcutCaptureKeyHandling.swift Tests/ShortcutCaptureKeyHandlingTests.swift -o /tmp/ShortcutCaptureKeyHandlingTests

--- a/Makefile
+++ b/Makefile
@@ -318,8 +318,10 @@ test: check-test-wiring $(SPARKLE_STAMP) $(LOCALIZATION_STAMP)
 	@/tmp/LegacyNoteTitleMigrationTests
 	@swiftc -parse-as-library Tests/ManualReleaseWorkflowTests.swift -o /tmp/ManualReleaseWorkflowTests
 	@/tmp/ManualReleaseWorkflowTests
-	@framework="$$(cat "$(SPARKLE_STAMP)")"; framework_parent="$$(dirname "$$framework")"; swiftc -parse-as-library -F "$$framework_parent" -framework Sparkle -Xlinker -rpath -Xlinker "$$framework_parent" Sources/UpdateManager.swift Tests/UpdateManagerSafetyTests.swift -o /tmp/UpdateManagerSafetyTests
+	@framework="$$(cat "$(SPARKLE_STAMP)")"; framework_parent="$$(dirname "$$framework")"; swiftc -parse-as-library -F "$$framework_parent" -framework Sparkle -Xlinker -rpath -Xlinker "$$framework_parent" Sources/LocalizedStringLookup.swift Sources/LocalizedUserMessage.swift Sources/UpdateManager.swift Tests/UpdateManagerSafetyTests.swift -o /tmp/UpdateManagerSafetyTests
 	@/tmp/UpdateManagerSafetyTests
+	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/LocalizedUserMessage.swift Tests/LocalizedUserMessageTests.swift -o /tmp/LocalizedUserMessageTests
+	@/tmp/LocalizedUserMessageTests
 	@swiftc -parse-as-library Tests/BuildMetadataTests.swift -o /tmp/BuildMetadataTests
 	@/tmp/BuildMetadataTests
 	@swiftc -parse-as-library Tests/LocalizationResourceTests.swift -o /tmp/LocalizationResourceTests
@@ -350,7 +352,7 @@ test: check-test-wiring $(SPARKLE_STAMP) $(LOCALIZATION_STAMP)
 	@/tmp/PipelineHistoryCalendarMetadataTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/GoogleCalendarTokenStore.swift Sources/GoogleCalendarAuthService.swift Sources/GoogleCalendarService.swift Tests/GoogleCalendarServiceTests.swift -o /tmp/GoogleCalendarServiceTests
 	@/tmp/GoogleCalendarServiceTests
-	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/AppNotificationManager.swift Sources/CalendarRecordingReminderScheduler.swift Tests/CalendarRecordingReminderSchedulerTests.swift -o /tmp/CalendarRecordingReminderSchedulerTests
+	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/CalendarIntegrationModels.swift Sources/AppNotificationManager.swift Sources/CalendarRecordingReminderScheduler.swift Tests/CalendarRecordingReminderSchedulerTests.swift -o /tmp/CalendarRecordingReminderSchedulerTests
 	@/tmp/CalendarRecordingReminderSchedulerTests
 	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/TranscriptionModel.swift Sources/SetupFlow.swift Tests/SetupFlowTests.swift -o /tmp/SetupFlowTests
 	@/tmp/SetupFlowTests
@@ -372,7 +374,7 @@ test: check-test-wiring $(SPARKLE_STAMP) $(LOCALIZATION_STAMP)
 	@/tmp/RecordingOverlayGeometryTests
 	@swiftc -parse-as-library Tests/UpstreamMergeBehaviorTests.swift -o /tmp/UpstreamMergeBehaviorTests
 	@/tmp/UpstreamMergeBehaviorTests
-	@swiftc -parse-as-library Sources/OverlayScreenGeometry.swift Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/AudioInputDevice.swift Sources/RecordingOverlay.swift Sources/CalendarIntegrationModels.swift Sources/AppNotificationManager.swift Sources/CalendarRecordingReminderScheduler.swift Sources/MeetingReminderOverlay.swift Tests/MeetingReminderOverlayGeometryTests.swift -o /tmp/MeetingReminderOverlayGeometryTests
+	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/OverlayScreenGeometry.swift Sources/FixedIntrinsicHostingView.swift Sources/ShortcutCore/ShortcutModels.swift Sources/AudioInputDevice.swift Sources/RecordingOverlay.swift Sources/CalendarIntegrationModels.swift Sources/AppNotificationManager.swift Sources/CalendarRecordingReminderScheduler.swift Sources/MeetingReminderOverlay.swift Tests/MeetingReminderOverlayGeometryTests.swift -o /tmp/MeetingReminderOverlayGeometryTests
 	@/tmp/MeetingReminderOverlayGeometryTests
 	@framework="$$(cat "$(SPARKLE_STAMP)")"; framework_parent="$$(dirname "$$framework")"; swiftc -parse-as-library -F "$$framework_parent" -framework Sparkle -Xlinker -rpath -Xlinker "$$framework_parent" -target $(shell uname -m)-apple-macosx13.0 $(filter-out Sources/App.swift,$(SOURCES)) Tests/AppStateTranscriptionConfigurationTests.swift -o /tmp/AppStateTranscriptionConfigurationTests
 	@isolated_home="$$(mktemp -d /tmp/quill-app-state-tests.XXXXXX)"; trap 'rm -rf "$$isolated_home"' EXIT; CFFIXED_USER_HOME="$$isolated_home" /tmp/AppStateTranscriptionConfigurationTests

--- a/Makefile
+++ b/Makefile
@@ -326,6 +326,8 @@ test: check-test-wiring $(SPARKLE_STAMP) $(LOCALIZATION_STAMP)
 	@/tmp/ManualReleaseWorkflowTests
 	@framework="$$(cat "$(SPARKLE_STAMP)")"; framework_parent="$$(dirname "$$framework")"; swiftc -parse-as-library -F "$$framework_parent" -framework Sparkle -Xlinker -rpath -Xlinker "$$framework_parent" Sources/LocalizedStringLookup.swift Sources/LocalizedUserMessage.swift Sources/UpdateManager.swift Tests/UpdateManagerSafetyTests.swift -o /tmp/UpdateManagerSafetyTests
 	@/tmp/UpdateManagerSafetyTests
+	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Tests/LocalizedStringLookupTests.swift -o /tmp/LocalizedStringLookupTests
+	@/tmp/LocalizedStringLookupTests
 	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/LocalizedUserMessage.swift Tests/LocalizedUserMessageTests.swift -o /tmp/LocalizedUserMessageTests
 	@/tmp/LocalizedUserMessageTests
 	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/OverlayDisplayCopy.swift Tests/OverlayDisplayCopyTests.swift -o /tmp/OverlayDisplayCopyTests

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -1008,6 +1008,1910 @@
           }
         }
       }
+    },
+    "  %arg": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "  %arg"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "  %arg"
+          }
+        }
+      }
+    },
+    "  Custom: %arg": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "  Custom: %arg"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "  사용자 지정: %arg"
+          }
+        }
+      }
+    },
+    "  Disabled": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "  Disabled"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "  비활성화됨"
+          }
+        }
+      }
+    },
+    "  System Audio": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "  System Audio"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "  시스템 오디오"
+          }
+        }
+      }
+    },
+    "  System Default": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "  System Default"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "  시스템 기본값"
+          }
+        }
+      }
+    },
+    "  System Default + System Audio": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "  System Default + System Audio"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "  시스템 기본값 + 시스템 오디오"
+          }
+        }
+      }
+    },
+    "%arg to try again": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg to try again"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg하여 다시 시도하세요"
+          }
+        }
+      }
+    },
+    "%arg v%arg": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg v%arg"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg v%arg"
+          }
+        }
+      }
+    },
+    "(no transcript)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(no transcript)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(전사 없음)"
+          }
+        }
+      }
+    },
+    "API Key": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API Key"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 키"
+          }
+        }
+      }
+    },
+    "Accessibility": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accessibility"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "손쉬운 사용"
+          }
+        }
+      }
+    },
+    "Accessibility Access": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accessibility Access"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "손쉬운 사용 접근"
+          }
+        }
+      }
+    },
+    "Accessibility Required": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accessibility Required"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "손쉬운 사용 권한 필요"
+          }
+        }
+      }
+    },
+    "Add an API key for cloud transcription, AI cleanup, context-aware output, and Edit Mode. If you only want local transcription right now, skip this step and configure an API provider later in Settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add an API key for cloud transcription, AI cleanup, context-aware output, and Edit Mode. If you only want local transcription right now, skip this step and configure an API provider later in Settings."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클라우드 전사, AI 정리, 상황 인식 출력 및 편집 모드를 위한 API 키를 추가하세요. 지금 로컬 전사만 사용하려면 이 단계를 건너뛰고 나중에 설정에서 API 제공자를 구성하세요."
+          }
+        }
+      }
+    },
+    "Add words and phrases that should be preserved in post-processing.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add words and phrases that should be preserved in post-processing."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후처리 중 보존할 단어와 문구를 추가하세요."
+          }
+        }
+      }
+    },
+    "Advanced Provider Settings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advanced Provider Settings"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고급 제공자 설정"
+          }
+        }
+      }
+    },
+    "Apple Live transcription needs Speech Recognition permission in addition to microphone access.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Live transcription needs Speech Recognition permission in addition to microphone access."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple 실시간 전사를 사용하려면 마이크 접근 권한 외에 음성 인식 권한이 필요합니다."
+          }
+        }
+      }
+    },
+    "Automatic mode uses your normal dictation shortcut. If text is selected, Quill transforms that selection instead of dictating new text.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic mode uses your normal dictation shortcut. If text is selected, Quill transforms that selection instead of dictating new text."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동 모드는 일반 받아쓰기 단축키를 사용합니다. 텍스트를 선택하면 Quill이 새 텍스트를 받아쓰는 대신 선택 영역을 변환합니다."
+          }
+        }
+      }
+    },
+    "Back": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "뒤로"
+          }
+        }
+      }
+    },
+    "Base URL and model IDs": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Base URL and model IDs"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 URL 및 모델 ID"
+          }
+        }
+      }
+    },
+    "Check for Updates": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Updates"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트 확인"
+          }
+        }
+      }
+    },
+    "Checking for Updates...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking for Updates..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트 확인 중..."
+          }
+        }
+      }
+    },
+    "Choose how Quill shows recording status while you dictate. You can change this later in Settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose how Quill shows recording status while you dictate. You can change this later in Settings."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓰기 중 Quill이 녹음 상태를 표시하는 방식을 선택하세요. 나중에 설정에서 변경할 수 있습니다."
+          }
+        }
+      }
+    },
+    "Choose the shortcut you want to hold while speaking.\nRelease it to stop unless you latch into tap mode later, or disable hold-to-talk entirely.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose the shortcut you want to hold while speaking.\nRelease it to stop unless you latch into tap mode later, or disable hold-to-talk entirely."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "말하는 동안 누르고 있을 단축키를 선택하세요. 나중에 탭 모드로 고정하지 않는 한 놓으면 중지됩니다. 길게 누르기 기능을 비활성화할 수도 있습니다."
+          }
+        }
+      }
+    },
+    "Choose the shortcut you want to tap once to start dictating and tap again to stop.\nIf this shortcut becomes active while you are holding the hold shortcut, Quill latches into tap mode. You can also disable tap-to-toggle entirely.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose the shortcut you want to tap once to start dictating and tap again to stop.\nIf this shortcut becomes active while you are holding the hold shortcut, Quill latches into tap mode. You can also disable tap-to-toggle entirely."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한 번 탭하여 받아쓰기를 시작하고 다시 탭하여 중지할 단축키를 선택하세요. 길게 누르기 단축키를 누르는 동안 이 단축키가 활성화되면 Quill이 탭 모드로 고정됩니다. 탭 전환 기능을 비활성화할 수도 있습니다."
+          }
+        }
+      }
+    },
+    "Custom Vocabulary": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom Vocabulary"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용자 지정 어휘"
+          }
+        }
+      }
+    },
+    "Customize…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Customize…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용자 지정…"
+          }
+        }
+      }
+    },
+    "Dictate text anywhere on your Mac.\nHold to talk or tap to toggle dictation.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dictate text anywhere on your Mac.\nHold to talk or tap to toggle dictation."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac 어디에서나 텍스트를 받아쓰세요. 말할 때 길게 누르거나 탭하여 받아쓰기를 전환하세요."
+          }
+        }
+      }
+    },
+    "Done": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "완료"
+          }
+        }
+      }
+    },
+    "Downloading update...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloading update..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트 다운로드 중..."
+          }
+        }
+      }
+    },
+    "Edit Mode": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Mode"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집 모드"
+          }
+        }
+      }
+    },
+    "Enable Edit Mode": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Edit Mode"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집 모드 활성화"
+          }
+        }
+      }
+    },
+    "Extra Modifier": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extra Modifier"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "추가 보조 키"
+          }
+        }
+      }
+    },
+    "Get Started": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get Started"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시작하기"
+          }
+        }
+      }
+    },
+    "Grant Access": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grant Access"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "접근 허용"
+          }
+        }
+      }
+    },
+    "Granted": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Granted"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "허용됨"
+          }
+        }
+      }
+    },
+    "History": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "History"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기록"
+          }
+        }
+      }
+    },
+    "Hold %arg": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hold %arg"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg 길게 누르기"
+          }
+        }
+      }
+    },
+    "Hold %arg or tap %arg": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hold %arg or tap %arg"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg 길게 누르기 또는 %arg 탭하기"
+          }
+        }
+      }
+    },
+    "Hold Shortcut": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hold Shortcut"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "길게 누르기 단축키"
+          }
+        }
+      }
+    },
+    "Hold to Talk Shortcut": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hold to Talk Shortcut"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "말하려면 길게 누르기 단축키"
+          }
+        }
+      }
+    },
+    "Input:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Input:"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "입력:"
+          }
+        }
+      }
+    },
+    "Invocation Style": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invocation Style"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 방식"
+          }
+        }
+      }
+    },
+    "It needs this permission to see which app you're working in and any in-progress work. Nothing is stored on Quill's servers (Quill doesn't have servers).": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "It needs this permission to see which app you're working in and any in-progress work. Nothing is stored on Quill's servers (Quill doesn't have servers)."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 작업 중인 앱과 진행 중인 작업을 확인하려면 이 권한이 필요합니다. Quill 서버에는 아무것도 저장되지 않습니다(Quill은 서버를 운영하지 않습니다)."
+          }
+        }
+      }
+    },
+    "Launch Quill at login": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launch Quill at login"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인 시 Quill 실행"
+          }
+        }
+      }
+    },
+    "Launch at Login": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launch at Login"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인 시 실행"
+          }
+        }
+      }
+    },
+    "Let's Try It Out!": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Let's Try It Out!"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "직접 사용해 볼까요!"
+          }
+        }
+      }
+    },
+    "Listening...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listening..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "듣는 중..."
+          }
+        }
+      }
+    },
+    "Manual mode only triggers when you hold an extra modifier together with your normal dictation shortcut.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manual mode only triggers when you hold an extra modifier together with your normal dictation shortcut."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "수동 모드는 일반 받아쓰기 단축키와 추가 보조 키를 함께 누를 때만 실행됩니다."
+          }
+        }
+      }
+    },
+    "Microphone": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Microphone"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마이크"
+          }
+        }
+      }
+    },
+    "Microphone Access": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Microphone Access"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마이크 접근"
+          }
+        }
+      }
+    },
+    "No audio file was created.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No audio file was created."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오 파일이 생성되지 않았습니다."
+          }
+        }
+      }
+    },
+    "No speech detected": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No speech detected"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성이 감지되지 않았습니다."
+          }
+        }
+      }
+    },
+    "No transcripts yet": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No transcripts yet"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아직 전사가 없습니다."
+          }
+        }
+      }
+    },
+    "Notifications": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알림"
+          }
+        }
+      }
+    },
+    "Open Settings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Settings"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정 열기"
+          }
+        }
+      }
+    },
+    "Optional. Choose a shortcut to paste your last transcript again into the active text field, without opening the menu bar. Leave disabled if you do not want one.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional. Choose a shortcut to paste your last transcript again into the active text field, without opening the menu bar. Leave disabled if you do not want one."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택 사항입니다. 메뉴 막대를 열지 않고 마지막 전사를 활성 텍스트 필드에 다시 붙여넣을 단축키를 선택하세요. 필요하지 않으면 비활성화된 상태로 두세요."
+          }
+        }
+      }
+    },
+    "Paste Again": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paste Again"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다시 붙여넣기"
+          }
+        }
+      }
+    },
+    "Paste Again  (%arg)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paste Again  (%arg)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다시 붙여넣기  (%arg)"
+          }
+        }
+      }
+    },
+    "Paste Again Shortcut": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paste Again Shortcut"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다시 붙여넣기 단축키"
+          }
+        }
+      }
+    },
+    "Paste Custom Word to Vocabulary": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paste Custom Word to Vocabulary"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용자 지정 단어를 어휘에 붙여넣기"
+          }
+        }
+      }
+    },
+    "Paste your API key (optional for local-only)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paste your API key (optional for local-only)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 키 붙여넣기(로컬 전용에서는 선택 사항)"
+          }
+        }
+      }
+    },
+    "Perfect — Quill is ready to go.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Perfect — Quill is ready to go."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "완벽합니다 — Quill을 사용할 준비가 되었습니다."
+          }
+        }
+      }
+    },
+    "Preparing update...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing update..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트 준비 중..."
+          }
+        }
+      }
+    },
+    "Quill can show calendar recording reminders before meetings so you can start recording from the notification.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill can show calendar recording reminders before meetings so you can start recording from the notification."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill은 회의 전에 캘린더 녹음 알림을 표시하여 알림에서 바로 녹음을 시작할 수 있습니다."
+          }
+        }
+      }
+    },
+    "Quill intelligently adapts the transcription to the current app you're working in (ex. spelling names in an email correctly).": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill intelligently adapts the transcription to the current app you're working in (ex. spelling names in an email correctly)."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill은 현재 작업 중인 앱에 맞춰 전사를 지능적으로 조정합니다(예: 이메일의 이름 철자를 정확히 표기)."
+          }
+        }
+      }
+    },
+    "Quill lives in your menu bar.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill lives in your menu bar."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill은 메뉴 막대에 있습니다."
+          }
+        }
+      }
+    },
+    "Quill needs Accessibility access to paste transcribed text into your apps.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill needs Accessibility access to paste transcribed text into your apps."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill이 전사한 텍스트를 앱에 붙여넣으려면 손쉬운 사용 접근 권한이 필요합니다."
+          }
+        }
+      }
+    },
+    "Quill needs access to your microphone to record audio for transcription.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill needs access to your microphone to record audio for transcription."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill이 전사할 오디오를 녹음하려면 마이크 접근 권한이 필요합니다."
+          }
+        }
+      }
+    },
+    "Quit %arg": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit %arg"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg 종료"
+          }
+        }
+      }
+    },
+    "Re-run Setup...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Re-run Setup..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정 다시 실행..."
+          }
+        }
+      }
+    },
+    "Recording overlay style": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording overlay style"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 오버레이 스타일"
+          }
+        }
+      }
+    },
+    "Recording...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 중..."
+          }
+        }
+      }
+    },
+    "Say anything — a sentence or two is perfect.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Say anything — a sentence or two is perfect."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아무 말이나 해보세요 — 한두 문장이 적당합니다."
+          }
+        }
+      }
+    },
+    "Screen Recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screen Recording"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "화면 기록"
+          }
+        }
+      }
+    },
+    "Screen Recording Permission Needed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screen Recording Permission Needed"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "화면 기록 권한 필요"
+          }
+        }
+      }
+    },
+    "Separate entries with commas, new lines, or semicolons.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Separate entries with commas, new lines, or semicolons."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "쉼표, 줄 바꿈 또는 세미콜론으로 항목을 구분하세요."
+          }
+        }
+      }
+    },
+    "Settings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정"
+          }
+        }
+      }
+    },
+    "Settings...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정..."
+          }
+        }
+      }
+    },
+    "Skip": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "건너뛰기"
+          }
+        }
+      }
+    },
+    "Something went wrong": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Something went wrong"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문제가 발생했습니다."
+          }
+        }
+      }
+    },
+    "Speech Recognition": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speech Recognition"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 인식"
+          }
+        }
+      }
+    },
+    "Start Dictating": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start Dictating"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓰기 시작"
+          }
+        }
+      }
+    },
+    "Start Quill automatically when you log in so it's always ready.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start Quill automatically when you log in so it's always ready."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인할 때 Quill을 자동으로 시작하여 항상 준비된 상태로 유지하세요."
+          }
+        }
+      }
+    },
+    "Starting...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starting..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시작 중..."
+          }
+        }
+      }
+    },
+    "Stop Recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop Recording"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 중지"
+          }
+        }
+      }
+    },
+    "System Audio": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Audio"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 오디오"
+          }
+        }
+      }
+    },
+    "System Default": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Default"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 기본값"
+          }
+        }
+      }
+    },
+    "System Default + System Audio": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Default + System Audio"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 기본값 + 시스템 오디오"
+          }
+        }
+      }
+    },
+    "Tap %arg": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap %arg"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg 탭하기"
+          }
+        }
+      }
+    },
+    "Tap to Toggle Shortcut": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to Toggle Shortcut"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭하여 전환 단축키"
+          }
+        }
+      }
+    },
+    "This permission is optional. You can skip and grant it later in Settings if needed.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This permission is optional. You can skip and grant it later in Settings if needed."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 권한은 선택 사항입니다. 지금 건너뛰고 필요할 때 나중에 설정에서 허용할 수 있습니다."
+          }
+        }
+      }
+    },
+    "This permission is optional. You can skip it now and enable notifications later in Settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This permission is optional. You can skip it now and enable notifications later in Settings."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 권한은 선택 사항입니다. 지금 건너뛰고 나중에 설정에서 알림을 활성화할 수 있습니다."
+          }
+        }
+      }
+    },
+    "Tip: If Fn opens Emoji picker, go to System Settings > Keyboard and change \"Press fn key to\" to \"Do Nothing\".": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tip: If Fn opens Emoji picker, go to System Settings > Keyboard and change \"Press fn key to\" to \"Do Nothing\"."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "팁: Fn 키로 이모티콘 선택기가 열리면 시스템 설정 > 키보드에서 \"fn 키를 누르면\"을 \"아무 작업 안 함\"으로 변경하세요."
+          }
+        }
+      }
+    },
+    "Toggle Shortcut": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Shortcut"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전환 단축키"
+          }
+        }
+      }
+    },
+    "Transcribing...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcribing..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사 중..."
+          }
+        }
+      }
+    },
+    "Transform selected text with a spoken instruction instead of dictating over it.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transform selected text with a spoken instruction instead of dictating over it."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택한 텍스트 위에 받아쓰기하는 대신 음성 명령으로 변환하세요."
+          }
+        }
+      }
+    },
+    "Update available": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update available"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트 사용 가능"
+          }
+        }
+      }
+    },
+    "Use Start Dictating from the menu bar": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use Start Dictating from the menu bar"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메뉴 막대에서 받아쓰기 시작을 사용하세요."
+          }
+        }
+      }
+    },
+    "Use these fields when pointing Quill at another OpenAI-compatible provider or when you need custom model IDs.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use these fields when pointing Quill at another OpenAI-compatible provider or when you need custom model IDs."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill을 다른 OpenAI 호환 제공자에 연결하거나 사용자 지정 모델 ID가 필요한 경우 이 필드를 사용하세요."
+          }
+        }
+      }
+    },
+    "Using Groq?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Using Groq?"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Groq를 사용하시나요?"
+          }
+        }
+      }
+    },
+    "Validation failed. Please check your API key and provider settings, then try again.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Validation failed. Please check your API key and provider settings, then try again."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "유효성 검사에 실패했습니다. API 키와 제공자 설정을 확인한 후 다시 시도하세요."
+          }
+        }
+      }
+    },
+    "Vocabulary": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocabulary"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "어휘"
+          }
+        }
+      }
+    },
+    "Welcome to %arg": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welcome to %arg"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg에 오신 것을 환영합니다."
+          }
+        }
+      }
+    },
+    "You can change this later in the menu bar or settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can change this later in the menu bar or settings."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "나중에 메뉴 막대나 설정에서 변경할 수 있습니다."
+          }
+        }
+      }
+    },
+    "You're All Set!": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You're All Set!"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 준비가 끝났습니다!"
+          }
+        }
+      }
+    },
+    "“%arg”": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%arg”"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%arg”"
+          }
+        }
+      }
+    },
+    "✓ %arg": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ %arg"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ %arg"
+          }
+        }
+      }
+    },
+    "✓ Custom: %arg": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ Custom: %arg"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ 사용자 지정: %arg"
+          }
+        }
+      }
+    },
+    "✓ Disabled": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ Disabled"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ 비활성화됨"
+          }
+        }
+      }
+    },
+    "✓ System Audio": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ System Audio"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ 시스템 오디오"
+          }
+        }
+      }
+    },
+    "✓ System Default": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ System Default"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ 시스템 기본값"
+          }
+        }
+      }
+    },
+    "✓ System Default + System Audio": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ System Default + System Audio"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "✓ 시스템 기본값 + 시스템 오디오"
+          }
+        }
+      }
+    },
+    "Hold %arg to record": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hold %arg to record"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg 길게 눌러 녹음"
+          }
+        }
+      }
+    },
+    "Hold %arg with your normal shortcut to transform selected text": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hold %arg with your normal shortcut to transform selected text"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일반 단축키와 함께 %arg 길게 눌러 선택한 텍스트 변환"
+          }
+        }
+      }
+    },
+    "Tap %arg to start and stop": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap %arg to start and stop"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg 탭하여 시작 및 중지"
+          }
+        }
+      }
+    },
+    "Text is typed at your cursor & copied": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text is typed at your cursor & copied"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "텍스트가 커서 위치에 입력되고 복사됩니다."
+          }
+        }
+      }
+    },
+    "While holding, press the toggle shortcut to latch on": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "While holding, press the toggle shortcut to latch on"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "길게 누른 상태에서 전환 단축키를 눌러 고정"
+          }
+        }
+      }
+    },
+    "With text selected, your normal shortcut transforms the selection": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "With text selected, your normal shortcut transforms the selection"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "텍스트를 선택하면 일반 단축키로 선택 영역을 변환"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -1,0 +1,18 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "Cancel" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Cancel" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "취소" } }
+      }
+    },
+    "Continue" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Continue" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "계속" } }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -8612,6 +8612,198 @@
           }
         }
       }
+    },
+    "Notch-side menu-bar overlay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notch-side menu-bar overlay"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노치 양옆 메뉴 막대 오버레이"
+          }
+        }
+      }
+    },
+    "Shows recording status beside the camera notch when supported, without covering app tabs or toolbars.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows recording status beside the camera notch when supported, without covering app tabs or toolbars."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지원되는 경우 앱 탭이나 도구 막대를 가리지 않고 카메라 노치 양옆에 녹음 상태를 표시합니다."
+          }
+        }
+      }
+    },
+    "Centered drop-down pill": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centered drop-down pill"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중앙 드롭다운 필"
+          }
+        }
+      }
+    },
+    "Shows a single centered pill below the menu bar. More visible, but it can cover a thin strip of the active app.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows a single centered pill below the menu bar. More visible, but it can cover a thin strip of the active app."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메뉴 막대 아래 중앙에 하나의 필을 표시합니다. 더 잘 보이지만 활성 앱의 얇은 영역을 가릴 수 있습니다."
+          }
+        }
+      }
+    },
+    "Waveform only": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waveform only"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "파형만 표시"
+          }
+        }
+      }
+    },
+    "Show the live audio waveform while recording.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show the live audio waveform while recording."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 중 실시간 오디오 파형을 표시합니다."
+          }
+        }
+      }
+    },
+    "Show elapsed time on hover": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show elapsed time on hover"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "포인터를 올리면 경과 시간 표시"
+          }
+        }
+      }
+    },
+    "Show the waveform; hover it to peek the elapsed recording time.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show the waveform; hover it to peek the elapsed recording time."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "파형을 표시하고 포인터를 올리면 녹음 경과 시간을 잠시 보여 줍니다."
+          }
+        }
+      }
+    },
+    "Show elapsed time instead of waveform": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show elapsed time instead of waveform"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "파형 대신 경과 시간 표시"
+          }
+        }
+      }
+    },
+    "Replace the waveform with a running elapsed-time counter.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Replace the waveform with a running elapsed-time counter."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "파형을 실행 중인 경과 시간 카운터로 바꿉니다."
+          }
+        }
+      }
+    },
+    "Selected": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selected"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택됨"
+          }
+        }
+      }
+    },
+    "Not selected": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not selected"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택되지 않음"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -8404,6 +8404,214 @@
           }
         }
       }
+    },
+    "Google Calendar needs reconnecting.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Calendar needs reconnecting."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Calendar를 다시 연결해야 합니다."
+          }
+        }
+      }
+    },
+    "Google Calendar needs reconnecting. Reconnect to restore meeting reminders and calendar-based note titles.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Calendar needs reconnecting. Reconnect to restore meeting reminders and calendar-based note titles."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Calendar를 다시 연결해야 합니다. 회의 알림과 캘린더 기반 노트 제목을 복원하려면 다시 연결하세요."
+          }
+        }
+      }
+    },
+    "Google Calendar needs reconnecting. Reconnect to restore meeting reminders.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Calendar needs reconnecting. Reconnect to restore meeting reminders."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Calendar를 다시 연결해야 합니다. 회의 알림을 복원하려면 다시 연결하세요."
+          }
+        }
+      }
+    },
+    "Google Calendar needs reconnecting. Calendar-based note titles may be unavailable.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Calendar needs reconnecting. Calendar-based note titles may be unavailable."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Calendar를 다시 연결해야 합니다. 캘린더 기반 노트 제목을 사용할 수 없을 수 있습니다."
+          }
+        }
+      }
+    },
+    "Unable to refresh Google Calendar reminders: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to refresh Google Calendar reminders: %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Calendar 알림을 새로 고치지 못했습니다: %@"
+          }
+        }
+      }
+    },
+    "Some Google calendars could not be refreshed. Reminders may be incomplete.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Some Google calendars could not be refreshed. Reminders may be incomplete."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일부 Google 캘린더를 새로 고치지 못했습니다. 알림이 누락될 수 있습니다."
+          }
+        }
+      }
+    },
+    "Unable to refresh Google Calendar: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to refresh Google Calendar: %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Calendar를 새로 고치지 못했습니다: %@"
+          }
+        }
+      }
+    },
+    "Some Google calendars could not be refreshed. Calendar-based note titles may be incomplete.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Some Google calendars could not be refreshed. Calendar-based note titles may be incomplete."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일부 Google 캘린더를 새로 고치지 못했습니다. 캘린더 기반 노트 제목이 불완전할 수 있습니다."
+          }
+        }
+      }
+    },
+    "Unable to refresh Google Calendar for note titles: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to refresh Google Calendar for note titles: %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노트 제목에 사용할 Google Calendar를 새로 고치지 못했습니다: %@"
+          }
+        }
+      }
+    },
+    "Quill can’t access Google Calendar. Reconnect to restore meeting reminders and calendar-based note titles.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill can’t access Google Calendar. Reconnect to restore meeting reminders and calendar-based note titles."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill에서 Google Calendar에 접근할 수 없습니다. 회의 알림과 캘린더 기반 노트 제목을 복원하려면 다시 연결하세요."
+          }
+        }
+      }
+    },
+    "Quill couldn’t refresh Google Calendar just now. Recording still works; reminders or note titles may be incomplete.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill couldn’t refresh Google Calendar just now. Recording still works; reminders or note titles may be incomplete."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 Quill에서 Google Calendar를 새로 고치지 못했습니다. 녹음은 계속 사용할 수 있지만 알림이나 노트 제목이 불완전할 수 있습니다."
+          }
+        }
+      }
+    },
+    "Reconnect Google Calendar to keep meeting recording reminders working.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconnect Google Calendar to keep meeting recording reminders working."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "회의 녹음 알림을 계속 사용하려면 Google Calendar를 다시 연결하세요."
+          }
+        }
+      }
+    },
+    "Calendar reminders may be incomplete until the next successful refresh.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calendar reminders may be incomplete until the next successful refresh."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다음 새로 고침에 성공할 때까지 캘린더 알림이 누락될 수 있습니다."
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -3004,7 +3004,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg restores the audio state it changed when dictation ends."
+            "value": "%arg은(는) 받아쓰기가 끝나면 변경한 오디오 상태를 복원합니다."
           }
         }
       }
@@ -4556,7 +4556,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Relaunching..."
+            "value": "다시 실행하는 중..."
           }
         }
       }
@@ -5532,7 +5532,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "When enabled, %arg retries or falls back to the literal transcript if post-processing looks like it answered the dictated text instead of cleaning it."
+            "value": "활성화하면 후처리가 받아쓴 텍스트를 정리하지 않고 답변한 것으로 보일 때 %arg이(가) 재시도하거나 원문 받아쓰기로 대체합니다."
           }
         }
       }
@@ -5548,7 +5548,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "When on, your clipboard manager (Paste, Raycast, Maccy, etc.) records each dictation so you can find it in your recent history. When off, %arg marks dictations transient and your clipboard manager skips them."
+            "value": "켜면 클립보드 관리자(Paste, Raycast, Maccy 등)가 각 받아쓰기를 기록하여 최근 기록에서 찾을 수 있습니다. 끄면 %arg이(가) 받아쓰기를 임시 항목으로 표시하고 클립보드 관리자가 건너뜁니다."
           }
         }
       }
@@ -6109,6 +6109,422 @@
           "stringUnit": {
             "state": "translated",
             "value": "%arg. 약 %arg."
+          }
+        }
+      }
+    },
+    "General": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일반"
+          }
+        }
+      }
+    },
+    "Appearance": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appearance"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모양"
+          }
+        }
+      }
+    },
+    "Models": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Models"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모델"
+          }
+        }
+      }
+    },
+    "Shortcuts": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shortcuts"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "단축키"
+          }
+        }
+      }
+    },
+    "Input": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Input"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "입력"
+          }
+        }
+      }
+    },
+    "About": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정보"
+          }
+        }
+      }
+    },
+    "My calendars": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "My calendars"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내 캘린더"
+          }
+        }
+      }
+    },
+    "Shared calendars": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shared calendars"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "공유 캘린더"
+          }
+        }
+      }
+    },
+    "Primary": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primary"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본"
+          }
+        }
+      }
+    },
+    "My calendar": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "My calendar"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내 캘린더"
+          }
+        }
+      }
+    },
+    "Shared": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shared"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "공유됨"
+          }
+        }
+      }
+    },
+    "Use API Provider transcription to choose a final output language.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use API Provider transcription to choose a final output language."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최종 출력 언어를 선택하려면 API 제공업체 받아쓰기를 사용하세요."
+          }
+        }
+      }
+    },
+    "Enable post-processing to choose a final output language.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable post-processing to choose a final output language."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최종 출력 언어를 선택하려면 후처리를 활성화하세요."
+          }
+        }
+      }
+    },
+    "Final transcript language for post-processing.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Final transcript language for post-processing."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후처리를 위한 최종 받아쓰기 언어입니다."
+          }
+        }
+      }
+    },
+    "About %arg.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About %arg."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "약 %arg."
+          }
+        }
+      }
+    },
+    "Automatic": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동"
+          }
+        }
+      }
+    },
+    "Manual": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manual"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "수동"
+          }
+        }
+      }
+    },
+    "Control": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Control"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Control"
+          }
+        }
+      }
+    },
+    "Option": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Option"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Option"
+          }
+        }
+      }
+    },
+    "Command": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command"
+          }
+        }
+      }
+    },
+    "Validating...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Validating..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인 중..."
+          }
+        }
+      }
+    },
+    "API key cleared": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API key cleared"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 키를 지웠습니다."
+          }
+        }
+      }
+    },
+    "API key saved": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API key saved"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 키를 저장했습니다."
+          }
+        }
+      }
+    },
+    "Edit Macro": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Macro"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "매크로 편집"
+          }
+        }
+      }
+    },
+    "Copy": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복사"
+          }
+        }
+      }
+    },
+    "Copied": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복사됨"
           }
         }
       }

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -2364,7 +2364,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "시작 중..."
+            "value": "시작하는 중..."
           }
         }
       }
@@ -4156,7 +4156,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "No audio recorded"
+            "value": "녹음된 오디오 없음"
           }
         }
       }
@@ -6541,6 +6541,998 @@
           "stringUnit": {
             "state": "translated",
             "value": "자동 감지"
+          }
+        }
+      }
+    },
+    "Hold %@ to dictate": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hold %@ to dictate"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@을(를) 길게 눌러 받아쓰기"
+          }
+        }
+      }
+    },
+    "Tap %@ to dictate": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap %@ to dictate"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@을(를) 눌러 받아쓰기"
+          }
+        }
+      }
+    },
+    "Hold %@ or tap %@ to dictate": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hold %@ or tap %@ to dictate"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@을(를) 길게 누르거나 %@을(를) 눌러 받아쓰기"
+          }
+        }
+      }
+    },
+    "Global shortcuts unavailable": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Global shortcuts unavailable"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전역 단축키를 사용할 수 없음"
+          }
+        }
+      }
+    },
+    "No dictation shortcut enabled": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No dictation shortcut enabled"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "활성화된 받아쓰기 단축키 없음"
+          }
+        }
+      }
+    },
+    "Select text to transform first.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select text to transform first."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "먼저 변환할 텍스트를 선택하세요."
+          }
+        }
+      }
+    },
+    "Select text to transform first": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select text to transform first"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "먼저 변환할 텍스트 선택"
+          }
+        }
+      }
+    },
+    "Fix Edit Mode modifier": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fix Edit Mode modifier"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집 모드 보조 키 수정"
+          }
+        }
+      }
+    },
+    "Accessibility permission required. Grant access in System Settings > Privacy & Security > Accessibility.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accessibility permission required. Grant access in System Settings > Privacy & Security > Accessibility."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "손쉬운 사용 권한이 필요합니다. 시스템 설정 > 개인정보 보호 및 보안 > 손쉬운 사용에서 권한을 부여하세요."
+          }
+        }
+      }
+    },
+    "No Accessibility": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Accessibility"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "손쉬운 사용 권한 없음"
+          }
+        }
+      }
+    },
+    "Quit while recording?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit while recording?"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 중에 종료할까요?"
+          }
+        }
+      }
+    },
+    "Quill will stop the current recording, finish transcription, and quit when transcription is complete.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill will stop the current recording, finish transcription, and quit when transcription is complete."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill이 현재 녹음을 중지하고 전사를 마친 뒤 종료합니다."
+          }
+        }
+      }
+    },
+    "Stop Recording and Quit": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop Recording and Quit"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 중지 후 종료"
+          }
+        }
+      }
+    },
+    "Cancel current recording?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel current recording?"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 녹음을 취소할까요?"
+          }
+        }
+      }
+    },
+    "Press Cancel to keep recording, or Stop Recording to discard the current recording session.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press Cancel to keep recording, or Stop Recording to discard the current recording session."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "계속 녹음하려면 취소를 누르고, 현재 녹음 세션을 버리려면 녹음 중지를 누르세요."
+          }
+        }
+      }
+    },
+    "Speech Recognition Permission Required": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speech Recognition Permission Required"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 인식 권한 필요"
+          }
+        }
+      }
+    },
+    "Quill cannot use Apple Live transcription without Speech Recognition access.\n\nGo to System Settings > Privacy & Security > Speech Recognition and enable Quill.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill cannot use Apple Live transcription without Speech Recognition access.\n\nGo to System Settings > Privacy & Security > Speech Recognition and enable Quill."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 인식 접근 권한 없이는 Quill에서 Apple 실시간 전사를 사용할 수 없습니다.\n\n시스템 설정 > 개인정보 보호 및 보안 > 음성 인식에서 Quill을 활성화하세요."
+          }
+        }
+      }
+    },
+    "Open System Settings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open System Settings"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 설정 열기"
+          }
+        }
+      }
+    },
+    "Dismiss": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dismiss"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "닫기"
+          }
+        }
+      }
+    },
+    "Error": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오류"
+          }
+        }
+      }
+    },
+    "Failed to start recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to start recording"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 시작 실패"
+          }
+        }
+      }
+    },
+    "%@: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@: %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@: %@"
+          }
+        }
+      }
+    },
+    "Failed to start recording: Audio input error. Verify microphone access is granted and a working mic is selected in System Settings > Sound > Input.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to start recording: Audio input error. Verify microphone access is granted and a working mic is selected in System Settings > Sound > Input."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음을 시작하지 못했습니다: 오디오 입력 오류입니다. 마이크 접근 권한이 부여되었고 시스템 설정 > 사운드 > 입력에서 작동하는 마이크가 선택되었는지 확인하세요."
+          }
+        }
+      }
+    },
+    "Failed to start recording (audio subsystem error %@). Check microphone permissions and selected input device.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to start recording (audio subsystem error %@). Check microphone permissions and selected input device."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 시작 실패(오디오 하위 시스템 오류 %@). 마이크 권한과 선택한 입력 장치를 확인하세요."
+          }
+        }
+      }
+    },
+    "No internet — check connection": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No internet — check connection"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "인터넷 연결 없음 — 연결을 확인하세요"
+          }
+        }
+      }
+    },
+    "Request timed out — try again": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Request timed out — try again"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요청 시간이 초과됨 — 다시 시도하세요"
+          }
+        }
+      }
+    },
+    "Microphone Permission Required": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Microphone Permission Required"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마이크 권한 필요"
+          }
+        }
+      }
+    },
+    "Quill cannot record audio without Microphone access.\n\nGo to System Settings > Privacy & Security > Microphone and enable Quill.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill cannot record audio without Microphone access.\n\nGo to System Settings > Privacy & Security > Microphone and enable Quill."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마이크 접근 권한 없이는 Quill에서 오디오를 녹음할 수 없습니다.\n\n시스템 설정 > 개인정보 보호 및 보안 > 마이크에서 Quill을 활성화하세요."
+          }
+        }
+      }
+    },
+    "Preparing audio...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing audio..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오 준비 중..."
+          }
+        }
+      }
+    },
+    "Screenshot Required": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screenshot Required"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스크린샷 필요"
+          }
+        }
+      }
+    },
+    "Screen Recording Permission Required": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screen Recording Permission Required"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "화면 기록 권한 필요"
+          }
+        }
+      }
+    },
+    "Screen Recording permission is required. %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screen Recording permission is required. %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "화면 기록 권한이 필요합니다. %@"
+          }
+        }
+      }
+    },
+    "Quill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill에서 맥락 인식 전사를 위한 스크린샷을 캡처하려면 화면 기록 권한이 필요합니다.\n\n시스템 설정 > 개인정보 보호 및 보안 > 화면 기록에서 Quill을 활성화하세요."
+          }
+        }
+      }
+    },
+    "Screenshot Capture Failed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screenshot Capture Failed"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스크린샷 캡처 실패"
+          }
+        }
+      }
+    },
+    "Failed to capture screenshot: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to capture screenshot: %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스크린샷을 캡처하지 못했습니다: %@"
+          }
+        }
+      }
+    },
+    "A screenshot is required for context-aware transcription. Recording has been stopped.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A screenshot is required for context-aware transcription. Recording has been stopped."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "맥락 인식 전사에는 스크린샷이 필요합니다. 녹음이 중지되었습니다."
+          }
+        }
+      }
+    },
+    "Ready": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ready"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "준비됨"
+          }
+        }
+      }
+    },
+    "You're Up to Date": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You're Up to Date"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최신 상태입니다"
+          }
+        }
+      }
+    },
+    "You're running the latest version of Quill.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You're running the latest version of Quill."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최신 버전의 Quill을 사용하고 있습니다."
+          }
+        }
+      }
+    },
+    "OK": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인"
+          }
+        }
+      }
+    },
+    "Updates Are Available in Release Builds": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updates Are Available in Release Builds"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "릴리스 빌드에서 업데이트를 사용할 수 있습니다"
+          }
+        }
+      }
+    },
+    "This local build of Quill does not use automatic updates. Download the latest release from GitHub when you want to update.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This local build of Quill does not use automatic updates. Download the latest release from GitHub when you want to update."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 로컬 Quill 빌드는 자동 업데이트를 사용하지 않습니다. 업데이트하려면 GitHub에서 최신 릴리스를 다운로드하세요."
+          }
+        }
+      }
+    },
+    "Open Releases": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Releases"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "릴리스 열기"
+          }
+        }
+      }
+    },
+    "Download failed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download failed"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다운로드 실패"
+          }
+        }
+      }
+    },
+    "Update failed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update failed"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트 실패"
+          }
+        }
+      }
+    },
+    "Meeting starts in %d minutes": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meeting starts in %d minutes"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "회의가 %d분 후 시작됩니다"
+          }
+        }
+      }
+    },
+    "Meeting starts in 1 minute": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meeting starts in 1 minute"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "회의가 1분 후 시작됩니다"
+          }
+        }
+      }
+    },
+    "Meeting starts soon": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meeting starts soon"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "회의가 곧 시작됩니다"
+          }
+        }
+      }
+    },
+    "Meeting is starting now": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meeting is starting now"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "회의가 지금 시작됩니다"
+          }
+        }
+      }
+    },
+    "Tap to start recording: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to start recording: %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "눌러서 녹음 시작: %@"
+          }
+        }
+      }
+    },
+    "Cancelled": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelled"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소됨"
+          }
+        }
+      }
+    },
+    "System Default + System Audio recording needs Microphone and Screen & System Audio Recording access. Enable both in System Settings > Privacy & Security.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Default + System Audio recording needs Microphone and Screen & System Audio Recording access. Enable both in System Settings > Privacy & Security."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 기본값 + 시스템 오디오 녹음에는 마이크 및 화면 및 시스템 오디오 녹음 접근 권한이 필요합니다. 시스템 설정 > 개인정보 보호 및 보안에서 두 권한을 모두 활성화하세요."
+          }
+        }
+      }
+    },
+    "System Default + System Audio Required": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Default + System Audio Required"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 기본값 + 시스템 오디오 필요"
+          }
+        }
+      }
+    },
+    "System Audio recording permission not granted. Enable Screen & System Audio Recording in System Settings > Privacy & Security.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Audio recording permission not granted. Enable Screen & System Audio Recording in System Settings > Privacy & Security."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 오디오 녹음 권한이 부여되지 않았습니다. 시스템 설정 > 개인정보 보호 및 보안에서 화면 및 시스템 오디오 녹음을 활성화하세요."
+          }
+        }
+      }
+    },
+    "System Audio Required": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Audio Required"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 오디오 필요"
+          }
+        }
+      }
+    },
+    "Microphone access granted. Press and hold again to record.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Microphone access granted. Press and hold again to record."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마이크 접근 권한이 부여되었습니다. 다시 길게 눌러 녹음하세요."
+          }
+        }
+      }
+    },
+    "Microphone permission denied. Grant access in System Settings > Privacy & Security > Microphone.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Microphone permission denied. Grant access in System Settings > Privacy & Security > Microphone."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마이크 권한이 거부되었습니다. 시스템 설정 > 개인정보 보호 및 보안 > 마이크에서 권한을 부여하세요."
+          }
+        }
+      }
+    },
+    "No Microphone": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Microphone"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마이크 권한 없음"
+          }
+        }
+      }
+    },
+    "Speech Recognition access granted. Press and hold again to record.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speech Recognition access granted. Press and hold again to record."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 인식 접근 권한이 부여되었습니다. 다시 길게 눌러 녹음하세요."
+          }
+        }
+      }
+    },
+    "Speech Recognition permission is required for Apple Live transcription. Enable it in System Settings > Privacy & Security > Speech Recognition.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speech Recognition permission is required for Apple Live transcription. Enable it in System Settings > Privacy & Security > Speech Recognition."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple 실시간 전사에는 음성 인식 권한이 필요합니다. 시스템 설정 > 개인정보 보호 및 보안 > 음성 인식에서 활성화하세요."
+          }
+        }
+      }
+    },
+    "No Speech Recognition": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Speech Recognition"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 인식 권한 없음"
+          }
+        }
+      }
+    },
+    "Screen recording permission not granted. Enable in System Settings > Privacy & Security > Screen Recording.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screen recording permission not granted. Enable in System Settings > Privacy & Security > Screen Recording."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "화면 기록 권한이 부여되지 않았습니다. 시스템 설정 > 개인정보 보호 및 보안 > 화면 기록에서 활성화하세요."
           }
         }
       }

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -7536,6 +7536,198 @@
           }
         }
       }
+    },
+    "Screen Recording permission is required. %@\n\nQuill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screen Recording permission is required. %@\n\nQuill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "화면 기록 권한이 필요합니다. %@\n\nQuill에서 맥락 인식 전사를 위한 스크린샷을 캡처하려면 화면 기록 권한이 필요합니다.\n\n시스템 설정 > 개인정보 보호 및 보안 > 화면 기록에서 Quill을 활성화하세요."
+          }
+        }
+      }
+    },
+    "Failed to capture screenshot: %@\n\nA screenshot is required for context-aware transcription. Recording has been stopped.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to capture screenshot: %@\n\nA screenshot is required for context-aware transcription. Recording has been stopped."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스크린샷을 캡처하지 못했습니다: %@\n\n맥락 인식 전사에는 스크린샷이 필요합니다. 녹음이 중지되었습니다."
+          }
+        }
+      }
+    },
+    "Unable to clear run history": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to clear run history"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 기록을 지울 수 없음"
+          }
+        }
+      }
+    },
+    "Unable to delete run history entry": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to delete run history entry"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 기록 항목을 삭제할 수 없음"
+          }
+        }
+      }
+    },
+    "Failed to save note title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to save note title"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노트 제목을 저장하지 못함"
+          }
+        }
+      }
+    },
+    "Failed to save transcript edit": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to save transcript edit"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사 편집을 저장하지 못함"
+          }
+        }
+      }
+    },
+    "Unable to save the audio file. Check disk space or file permissions and try again.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to save the audio file. Check disk space or file permissions and try again."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오 파일을 저장할 수 없습니다. 디스크 공간 또는 파일 권한을 확인한 후 다시 시도하세요."
+          }
+        }
+      }
+    },
+    "Unable to save imported audio note": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to save imported audio note"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가져온 오디오 노트를 저장할 수 없음"
+          }
+        }
+      }
+    },
+    "Unable to prepare retry": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to prepare retry"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다시 시도를 준비할 수 없음"
+          }
+        }
+      }
+    },
+    "Failed to save retry result": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to save retry result"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다시 시도 결과를 저장하지 못함"
+          }
+        }
+      }
+    },
+    "Unable to save recovery entry": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to save recovery entry"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복구 항목을 저장할 수 없음"
+          }
+        }
+      }
+    },
+    "Unable to save run history entry": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to save run history entry"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 기록 항목을 저장할 수 없음"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -2912,6 +2912,2918 @@
           }
         }
       }
+    },
+    "%arg": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg"
+          }
+        }
+      }
+    },
+    "%arg / %arg": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg / %arg"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg / %arg"
+          }
+        }
+      }
+    },
+    "%arg min before": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg min before"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg분 전"
+          }
+        }
+      }
+    },
+    "%arg ms": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg ms"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%argms"
+          }
+        }
+      }
+    },
+    "%arg px": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg px"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%argpx"
+          }
+        }
+      }
+    },
+    "%arg restores the audio state it changed when dictation ends.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg restores the audio state it changed when dictation ends."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg restores the audio state it changed when dictation ends."
+          }
+        }
+      }
+    },
+    "%arg%%": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg%%"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg%%"
+          }
+        }
+      }
+    },
+    "(empty transcript)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(empty transcript)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(빈 받아쓰기)"
+          }
+        }
+      }
+    },
+    "A newer default prompt is available.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A newer default prompt is available."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새 기본 프롬프트를 사용할 수 있습니다."
+          }
+        }
+      }
+    },
+    "API Base URL": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API Base URL"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 기본 URL"
+          }
+        }
+      }
+    },
+    "API Provider": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API Provider"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 제공업체"
+          }
+        }
+      }
+    },
+    "API Provider Options": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API Provider Options"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 제공업체 옵션"
+          }
+        }
+      }
+    },
+    "API key required to test": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API key required to test"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테스트하려면 API 키가 필요합니다."
+          }
+        }
+      }
+    },
+    "Active window (default)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active window (default)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "활성 창 (기본)"
+          }
+        }
+      }
+    },
+    "Add Macro": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Macro"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "매크로 추가"
+          }
+        }
+      }
+    },
+    "Advanced Legacy mlx-whisper": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advanced Legacy mlx-whisper"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고급 레거시 mlx-whisper"
+          }
+        }
+      }
+    },
+    "Applies before recording starts for both hold and tap shortcuts. Stopping still happens immediately.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applies before recording starts for both hold and tap shortcuts. Stopping still happens immediately."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "누르기와 탭 단축키 모두 녹음 시작 전에 적용됩니다. 중지는 즉시 실행됩니다."
+          }
+        }
+      }
+    },
+    "Automatically check for updates": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically check for updates"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트 자동 확인"
+          }
+        }
+      }
+    },
+    "Build number": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build number"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빌드 번호"
+          }
+        }
+      }
+    },
+    "Built-in": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Built-in"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내장됨"
+          }
+        }
+      }
+    },
+    "Bypass post-processing and immediately paste your predefined text.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bypass post-processing and immediately paste your predefined text."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후처리 없이 미리 정의한 텍스트를 바로 붙여넣습니다."
+          }
+        }
+      }
+    },
+    "Calendar": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calendar"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캘린더"
+          }
+        }
+      }
+    },
+    "Calendar refresh issue": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calendar refresh issue"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캘린더 새로 고침 문제"
+          }
+        }
+      }
+    },
+    "Calendars used for note title suggestions": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calendars used for note title suggestions"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노트 제목 제안에 사용할 캘린더"
+          }
+        }
+      }
+    },
+    "Cancel Local Whisper download": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel Local Whisper download"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로컬 Whisper 다운로드 취소"
+          }
+        }
+      }
+    },
+    "Captures a screenshot and metadata from the frontmost app, then runs the context prompt to infer activity.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Captures a screenshot and metadata from the frontmost app, then runs the context prompt to infer activity."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전면 앱의 스크린샷과 메타데이터를 캡처한 후 컨텍스트 프롬프트를 실행해 활동을 추론합니다."
+          }
+        }
+      }
+    },
+    "Change this to use a different OpenAI-compatible API provider.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change this to use a different OpenAI-compatible API provider."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다른 OpenAI 호환 API 제공업체를 사용하려면 변경하세요."
+          }
+        }
+      }
+    },
+    "Check Again": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check Again"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다시 확인"
+          }
+        }
+      }
+    },
+    "Check for Updates Now": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Updates Now"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지금 업데이트 확인"
+          }
+        }
+      }
+    },
+    "Checking...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인 중..."
+          }
+        }
+      }
+    },
+    "Clear": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지우기"
+          }
+        }
+      }
+    },
+    "Clear History": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear History"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기록 지우기"
+          }
+        }
+      }
+    },
+    "Click 'Add Macro' to define your first voice macro.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Click 'Add Macro' to define your first voice macro."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'매크로 추가'를 클릭해 첫 음성 매크로를 만드세요."
+          }
+        }
+      }
+    },
+    "Click the Dock icon to open Note Browser and browse your dictation history like notes.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Click the Dock icon to open Note Browser and browse your dictation history like notes."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dock 아이콘을 클릭하여 노트 브라우저를 열고 받아쓰기 기록을 노트처럼 살펴보세요."
+          }
+        }
+      }
+    },
+    "Connect Google Calendar first.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect Google Calendar first."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "먼저 Google 캘린더를 연결하세요."
+          }
+        }
+      }
+    },
+    "Connect your Google account to let Quill suggest note titles from matching calendar events.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect your Google account to let Quill suggest note titles from matching calendar events."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google 계정을 연결하면 Quill이 일치하는 캘린더 이벤트로 노트 제목을 제안합니다."
+          }
+        }
+      }
+    },
+    "Connected · Not checked yet": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connected · Not checked yet"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결됨 · 아직 확인하지 않음"
+          }
+        }
+      }
+    },
+    "Controls how Quill infers your current activity from app metadata and screenshots.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controls how Quill infers your current activity from app metadata and screenshots."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill이 앱 메타데이터와 스크린샷에서 현재 활동을 추론하는 방식을 설정합니다."
+          }
+        }
+      }
+    },
+    "Controls how raw transcriptions are cleaned up.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controls how raw transcriptions are cleaned up."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "원본 받아쓰기를 정리하는 방식을 설정합니다."
+          }
+        }
+      }
+    },
+    "Controls the maximum image dimension sent for context inference.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controls the maximum image dimension sent for context inference."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "컨텍스트 추론에 전송할 최대 이미지 크기를 설정합니다."
+          }
+        }
+      }
+    },
+    "Custom...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용자 지정..."
+          }
+        }
+      }
+    },
+    "Dark": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다크"
+          }
+        }
+      }
+    },
+    "Debug": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
+          }
+        }
+      }
+    },
+    "Default Context Prompt": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default Context Prompt"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 컨텍스트 프롬프트"
+          }
+        }
+      }
+    },
+    "Default System Prompt": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default System Prompt"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 시스템 프롬프트"
+          }
+        }
+      }
+    },
+    "Delete Model": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Model"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모델 삭제"
+          }
+        }
+      }
+    },
+    "Delete model?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete model?"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모델을 삭제할까요?"
+          }
+        }
+      }
+    },
+    "Disable Auto Paste": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable Auto Paste"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동 붙여넣기 비활성화"
+          }
+        }
+      }
+    },
+    "Disable Context Capture": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable Context Capture"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "컨텍스트 캡처 비활성화"
+          }
+        }
+      }
+    },
+    "Disable Post-Processing": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable Post-Processing"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후처리 비활성화"
+          }
+        }
+      }
+    },
+    "Disconnect": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnect"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결 해제"
+          }
+        }
+      }
+    },
+    "Display the update available overlay after dictation finishes.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Display the update available overlay after dictation finishes."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Display the update available overlay after dictation finishes."
+          }
+        }
+      }
+    },
+    "Download": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다운로드"
+          }
+        }
+      }
+    },
+    "Enable Note Browser": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Note Browser"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노트 브라우저 사용"
+          }
+        }
+      }
+    },
+    "Enter sample text to see how the current prompt cleans it up.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter sample text to see how the current prompt cleans it up."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 프롬프트가 텍스트를 어떻게 정리하는지 확인할 샘플 텍스트를 입력하세요."
+          }
+        }
+      }
+    },
+    "Enter your Groq API key": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter your Groq API key"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Groq API 키 입력"
+          }
+        }
+      }
+    },
+    "Fast local transcription. About %arg.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fast local transcription. About %arg."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빠른 로컬 받아쓰기. 약 %arg."
+          }
+        }
+      }
+    },
+    "Full prompt sent": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Full prompt sent"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전송된 전체 프롬프트"
+          }
+        }
+      }
+    },
+    "Google Calendar sign-in is not configured for this build.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Calendar sign-in is not configured for this build."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 빌드에서는 Google 캘린더 로그인이 구성되지 않았습니다."
+          }
+        }
+      }
+    },
+    "Hide": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "숨기기"
+          }
+        }
+      }
+    },
+    "Hint to the transcription model. Auto Detect works for most users. Pick a specific language if you see wrong-script characters appear in the output.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hint to the transcription model. Auto Detect works for most users. Pick a specific language if you see wrong-script characters appear in the output."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓰기 모델에 주는 힌트입니다. 대부분의 사용자에게 자동 감지가 적합합니다. 결과에 잘못된 문자 체계가 보이면 특정 언어를 선택하세요."
+          }
+        }
+      }
+    },
+    "Hold the extra modifier together with your normal dictation shortcut to transform selected text.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hold the extra modifier together with your normal dictation shortcut to transform selected text."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일반 받아쓰기 단축키와 함께 추가 보조 키를 눌러 선택한 텍스트를 변환하세요."
+          }
+        }
+      }
+    },
+    "If text is selected, your normal dictation shortcut transforms the selection instead of dictating over it.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If text is selected, your normal dictation shortcut transforms the selection instead of dictating over it."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "텍스트를 선택하면 일반 받아쓰기 단축키가 받아쓰기 대신 선택한 텍스트를 변환합니다."
+          }
+        }
+      }
+    },
+    "If you close Settings while the model is downloading, Quill cancels the download and removes the partial file.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If you close Settings while the model is downloading, Quill cancels the download and removes the partial file."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모델 다운로드 중 설정을 닫으면 Quill이 다운로드를 취소하고 부분 파일을 제거합니다."
+          }
+        }
+      }
+    },
+    "If you use another provider, enter that provider's model IDs here.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If you use another provider, enter that provider's model IDs here."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다른 제공업체를 사용한다면 여기에 해당 제공업체의 모델 ID를 입력하세요."
+          }
+        }
+      }
+    },
+    "Installed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installed"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설치됨"
+          }
+        }
+      }
+    },
+    "Keep dictations in clipboard history": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep dictations in clipboard history"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓰기를 클립보드 기록에 유지"
+          }
+        }
+      }
+    },
+    "Last checked: %arg": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last checked: %arg"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마지막 확인: %arg"
+          }
+        }
+      }
+    },
+    "Light": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Light"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "라이트"
+          }
+        }
+      }
+    },
+    "Loading...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "불러오는 중..."
+          }
+        }
+      }
+    },
+    "Local": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로컬"
+          }
+        }
+      }
+    },
+    "Local Options": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local Options"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로컬 옵션"
+          }
+        }
+      }
+    },
+    "Login item requires approval in System Settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Login item requires approval in System Settings."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인 항목은 시스템 설정에서 승인이 필요합니다."
+          }
+        }
+      }
+    },
+    "Mute audio when dictation starts": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mute audio when dictation starts"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓰기 시작 시 오디오 음소거"
+          }
+        }
+      }
+    },
+    "No Context": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Context"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Context"
+          }
+        }
+      }
+    },
+    "No LLM": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No LLM"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No LLM"
+          }
+        }
+      }
+    },
+    "No Voice Macros Yet": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Voice Macros Yet"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아직 음성 매크로가 없습니다."
+          }
+        }
+      }
+    },
+    "No audio recorded": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No audio recorded"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No audio recorded"
+          }
+        }
+      }
+    },
+    "No calendars are selected by default. Quill only reads events from calendars you explicitly select.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No calendars are selected by default. Quill only reads events from calendars you explicitly select."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본으로 선택된 캘린더는 없습니다. Quill은 명시적으로 선택한 캘린더의 이벤트만 읽습니다."
+          }
+        }
+      }
+    },
+    "No calendars loaded. Click Sync Now after connecting.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No calendars loaded. Click Sync Now after connecting."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "불러온 캘린더가 없습니다. 연결한 후 지금 동기화를 클릭하세요."
+          }
+        }
+      }
+    },
+    "No context captured": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No context captured"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No context captured"
+          }
+        }
+      }
+    },
+    "No runs yet. Use dictation to populate history.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No runs yet. Use dictation to populate history."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No runs yet. Use dictation to populate history."
+          }
+        }
+      }
+    },
+    "Not connected": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not connected"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결되지 않음"
+          }
+        }
+      }
+    },
+    "Notifications are disabled in System Settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications are disabled in System Settings."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 설정에서 알림이 비활성화되어 있습니다."
+          }
+        }
+      }
+    },
+    "Only enable this if you already manage mlx-whisper yourself.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Only enable this if you already manage mlx-whisper yourself."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mlx-whisper를 직접 관리하는 경우에만 활성화하세요."
+          }
+        }
+      }
+    },
+    "Open Login Items Settings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Login Items Settings"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인 항목 설정 열기"
+          }
+        }
+      }
+    },
+    "Output Language": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Output Language"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "출력 언어"
+          }
+        }
+      }
+    },
+    "Pipeline": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pipeline"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pipeline"
+          }
+        }
+      }
+    },
+    "Play alert sounds": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play alert sounds"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알림 소리 재생"
+          }
+        }
+      }
+    },
+    "Preserve Exact Wording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preserve Exact Wording"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정확한 표현 유지"
+          }
+        }
+      }
+    },
+    "Preserve clipboard after paste": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preserve clipboard after paste"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "붙여넣기 후 클립보드 유지"
+          }
+        }
+      }
+    },
+    "Prevent dictated prompts from being executed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prevent dictated prompts from being executed"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓴 프롬프트가 실행되지 않도록 방지"
+          }
+        }
+      }
+    },
+    "Preview": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preview"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "미리 보기"
+          }
+        }
+      }
+    },
+    "Primary display": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primary display"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "주 디스플레이"
+          }
+        }
+      }
+    },
+    "Quill re-reads selected Google Calendar events on this interval to keep meeting reminders and calendar-based note titles current.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill re-reads selected Google Calendar events on this interval to keep meeting reminders and calendar-based note titles current."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill이 이 간격으로 선택한 Google 캘린더 이벤트를 다시 읽어 회의 알림과 캘린더 기반 노트 제목을 최신 상태로 유지합니다."
+          }
+        }
+      }
+    },
+    "Quill schedules macOS notifications for events in your selected calendars. Clicking a reminder starts recording without toggling an active recording off.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill schedules macOS notifications for events in your selected calendars. Clicking a reminder starts recording without toggling an active recording off."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill은 선택한 캘린더 이벤트에 대해 macOS 알림을 예약합니다. 알림을 클릭하면 진행 중인 녹음을 끄지 않고 녹음을 시작합니다."
+          }
+        }
+      }
+    },
+    "Quill uses the configured transcription model with your selected OpenAI-compatible provider.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill uses the configured transcription model with your selected OpenAI-compatible provider."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill은 선택한 OpenAI 호환 제공업체와 구성된 받아쓰기 모델을 사용합니다."
+          }
+        }
+      }
+    },
+    "Quill will temporarily place the transcript on your clipboard to paste it, then restore whatever was there before. If you copy something else before the restore happens, Quill leaves it alone.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill will temporarily place the transcript on your clipboard to paste it, then restore whatever was there before. If you copy something else before the restore happens, Quill leaves it alone."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill은 붙여넣기 위해 받아쓰기 내용을 클립보드에 임시로 넣은 뒤 이전 내용을 복원합니다. 복원 전에 다른 항목을 복사하면 그대로 둡니다."
+          }
+        }
+      }
+    },
+    "Realtime Transcription Model": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Realtime Transcription Model"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실시간 받아쓰기 모델"
+          }
+        }
+      }
+    },
+    "Reconnect required": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconnect required"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다시 연결 필요"
+          }
+        }
+      }
+    },
+    "Refresh calendars": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh calendars"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캘린더 새로 고침"
+          }
+        }
+      }
+    },
+    "Refreshing": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refreshing"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새로 고치는 중"
+          }
+        }
+      }
+    },
+    "Relaunching...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relaunching..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relaunching..."
+          }
+        }
+      }
+    },
+    "Release tag": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Release tag"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "릴리스 태그"
+          }
+        }
+      }
+    },
+    "Remind me before meetings to record": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remind me before meetings to record"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "회의 전에 녹음 알림"
+          }
+        }
+      }
+    },
+    "Reminder times": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reminder times"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알림 시간"
+          }
+        }
+      }
+    },
+    "Required by some providers, e.g. gpt-4o-transcribe": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Required by some providers, e.g. gpt-4o-transcribe"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일부 제공업체에서 필요합니다. 예: gpt-4o-transcribe"
+          }
+        }
+      }
+    },
+    "Reset": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "재설정"
+          }
+        }
+      }
+    },
+    "Reset to Default": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset to Default"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값으로 재설정"
+          }
+        }
+      }
+    },
+    "Result:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Result:"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "결과:"
+          }
+        }
+      }
+    },
+    "Run Log": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run Log"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run Log"
+          }
+        }
+      }
+    },
+    "Running...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Running..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 중..."
+          }
+        }
+      }
+    },
+    "Save": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장"
+          }
+        }
+      }
+    },
+    "Say \"press enter\" to submit after paste": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Say \"press enter\" to submit after paste"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "붙여넣기 후 제출하려면 \"press enter\"라고 말하기"
+          }
+        }
+      }
+    },
+    "Screenshot Resolution": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screenshot Resolution"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스크린샷 해상도"
+          }
+        }
+      }
+    },
+    "Select at least one calendar above.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select at least one calendar above."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위에서 캘린더를 하나 이상 선택하세요."
+          }
+        }
+      }
+    },
+    "Select which audio input to use for recording.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select which audio input to use for recording."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음에 사용할 오디오 입력을 선택하세요."
+          }
+        }
+      }
+    },
+    "Shared Behaviors": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shared Behaviors"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "공통 동작"
+          }
+        }
+      }
+    },
+    "Shortcut Start Delay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shortcut Start Delay"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "단축키 시작 지연"
+          }
+        }
+      }
+    },
+    "Show Meeting Reminder": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Meeting Reminder"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Meeting Reminder"
+          }
+        }
+      }
+    },
+    "Show Update Overlay Now": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Update Overlay Now"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Update Overlay Now"
+          }
+        }
+      }
+    },
+    "Show a sample calendar reminder overlay. Turn on Debug Overlay first to preview the recording (wrapping) variant.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show a sample calendar reminder overlay. Turn on Debug Overlay first to preview the recording (wrapping) variant."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show a sample calendar reminder overlay. Turn on Debug Overlay first to preview the recording (wrapping) variant."
+          }
+        }
+      }
+    },
+    "Show after dictation": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show after dictation"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show after dictation"
+          }
+        }
+      }
+    },
+    "Show menu bar icon": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show menu bar icon"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메뉴 막대 아이콘 표시"
+          }
+        }
+      }
+    },
+    "Show on": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show on"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "표시 위치"
+          }
+        }
+      }
+    },
+    "Show the recording overlay with simulated audio levels.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show the recording overlay with simulated audio levels."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show the recording overlay with simulated audio levels."
+          }
+        }
+      }
+    },
+    "Skip LLM cleanup. Raw transcript is used as-is. No API call is made for post-processing.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip LLM cleanup. Raw transcript is used as-is. No API call is made for post-processing."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LLM 정리를 건너뜁니다. 원본 받아쓰기를 그대로 사용하며 후처리를 위한 API 호출을 하지 않습니다."
+          }
+        }
+      }
+    },
+    "Skip cleanup while post-processing is enabled. Without an Output Language, the raw transcript is used. With one, only a literal translation is performed.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip cleanup while post-processing is enabled. Without an Output Language, the raw transcript is used. With one, only a literal translation is performed."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후처리가 켜진 상태에서 정리를 건너뜁니다. 출력 언어가 없으면 원본 받아쓰기를 사용하고, 있으면 직역만 수행합니다."
+          }
+        }
+      }
+    },
+    "Skip screen recording and app context detection. Transcription will not adapt to the current app. Screen Recording permission is not required.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip screen recording and app context detection. Transcription will not adapt to the current app. Screen Recording permission is not required."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "화면 녹화와 앱 컨텍스트 감지를 건너뜁니다. 받아쓰기가 현재 앱에 맞춰지지 않으며 화면 녹화 권한이 필요하지 않습니다."
+          }
+        }
+      }
+    },
+    "Spoken language hint for speech recognition. Auto Detect works for most users.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spoken language hint for speech recognition. Auto Detect works for most users."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 인식을 위한 발화 언어 힌트입니다. 대부분의 사용자에게 자동 감지가 적합합니다."
+          }
+        }
+      }
+    },
+    "Stored locally. Only the %arg most recent runs are kept.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stored locally. Only the %arg most recent runs are kept."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stored locally. Only the %arg most recent runs are kept."
+          }
+        }
+      }
+    },
+    "Stream audio while recording (realtime)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stream audio while recording (realtime)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 중 오디오 스트리밍 (실시간)"
+          }
+        }
+      }
+    },
+    "Streams audio through the provider's OpenAI-compatible /v1/realtime WebSocket so transcription runs while you speak.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Streams audio through the provider's OpenAI-compatible /v1/realtime WebSocket so transcription runs while you speak."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제공업체의 OpenAI 호환 /v1/realtime WebSocket으로 오디오를 스트리밍해 말하는 동안 받아쓰기를 실행합니다."
+          }
+        }
+      }
+    },
+    "Switch to Default": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch to Default"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값으로 전환"
+          }
+        }
+      }
+    },
+    "Sync Now": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync Now"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지금 동기화"
+          }
+        }
+      }
+    },
+    "System Setting": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Setting"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 설정"
+          }
+        }
+      }
+    },
+    "System volume is muted or very low. Unmute to hear the preview.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System volume is muted or very low. Unmute to hear the preview."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 볼륨이 음소거되었거나 매우 낮습니다. 미리 보기를 들으려면 음소거를 해제하세요."
+          }
+        }
+      }
+    },
+    "Test Context Prompt": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test Context Prompt"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "컨텍스트 프롬프트 테스트"
+          }
+        }
+      }
+    },
+    "Test System Prompt": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test System Prompt"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 프롬프트 테스트"
+          }
+        }
+      }
+    },
+    "Text (What gets pasted)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text (What gets pasted)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "텍스트 (붙여넣을 내용)"
+          }
+        }
+      }
+    },
+    "Theme": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테마"
+          }
+        }
+      }
+    },
+    "This removes the downloaded Local Whisper model. You can download it again later.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This removes the downloaded Local Whisper model. You can download it again later."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다운로드한 로컬 Whisper 모델을 제거합니다. 나중에 다시 다운로드할 수 있습니다."
+          }
+        }
+      }
+    },
+    "This removes the downloaded local model cache. You can download it again later.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This removes the downloaded local model cache. You can download it again later."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다운로드한 로컬 모델 캐시를 제거합니다. 나중에 다시 다운로드할 수 있습니다."
+          }
+        }
+      }
+    },
+    "Transcription API Key": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcription API Key"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓰기 API 키"
+          }
+        }
+      }
+    },
+    "Transcription API URL": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcription API URL"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓰기 API URL"
+          }
+        }
+      }
+    },
+    "Transcription Language": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcription Language"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓰기 언어"
+          }
+        }
+      }
+    },
+    "Transcription Mode": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcription Mode"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓰기 모드"
+          }
+        }
+      }
+    },
+    "Transcription will be copied to clipboard only. Paste manually when needed.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcription will be copied to clipboard only. Paste manually when needed."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓰기는 클립보드에만 복사됩니다. 필요할 때 직접 붙여넣으세요."
+          }
+        }
+      }
+    },
+    "Transform highlighted text with a spoken instruction instead of dictating over it.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transform highlighted text with a spoken instruction instead of dictating over it."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓰기 대신 음성 명령으로 강조 표시한 텍스트를 변환합니다."
+          }
+        }
+      }
+    },
+    "Update Now": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update Now"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지금 업데이트"
+          }
+        }
+      }
+    },
+    "Updates are delivered by Sparkle and verified before installation.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updates are delivered by Sparkle and verified before installation."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트는 Sparkle로 제공되며 설치 전에 검증됩니다."
+          }
+        }
+      }
+    },
+    "Use legacy mlx-whisper": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use legacy mlx-whisper"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "레거시 mlx-whisper 사용"
+          }
+        }
+      }
+    },
+    "Used only for realtime streaming. Leave empty for providers that supply a server default.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Used only for realtime streaming. Leave empty for providers that supply a server default."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실시간 스트리밍에만 사용됩니다. 서버 기본값을 제공하는 업체는 비워 두세요."
+          }
+        }
+      }
+    },
+    "Uses API Base URL when empty": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uses API Base URL when empty"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "비어 있으면 API 기본 URL 사용"
+          }
+        }
+      }
+    },
+    "Uses API Key when empty": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uses API Key when empty"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "비어 있으면 API 키 사용"
+          }
+        }
+      }
+    },
+    "Using custom prompt": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Using custom prompt"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용자 지정 프롬프트 사용 중"
+          }
+        }
+      }
+    },
+    "Using custom value": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Using custom value"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용자 지정 값 사용 중"
+          }
+        }
+      }
+    },
+    "Using default": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Using default"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값 사용 중"
+          }
+        }
+      }
+    },
+    "Version": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버전"
+          }
+        }
+      }
+    },
+    "View Default": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View Default"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값 보기"
+          }
+        }
+      }
+    },
+    "Voice Command (What you say)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice Command (What you say)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 명령 (말할 내용)"
+          }
+        }
+      }
+    },
+    "Waveform display": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waveform display"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "파형 표시"
+          }
+        }
+      }
+    },
+    "What's New": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "What's New"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새로운 기능"
+          }
+        }
+      }
+    },
+    "When enabled, %arg retries or falls back to the literal transcript if post-processing looks like it answered the dictated text instead of cleaning it.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When enabled, %arg retries or falls back to the literal transcript if post-processing looks like it answered the dictated text instead of cleaning it."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When enabled, %arg retries or falls back to the literal transcript if post-processing looks like it answered the dictated text instead of cleaning it."
+          }
+        }
+      }
+    },
+    "When on, your clipboard manager (Paste, Raycast, Maccy, etc.) records each dictation so you can find it in your recent history. When off, %arg marks dictations transient and your clipboard manager skips them.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When on, your clipboard manager (Paste, Raycast, Maccy, etc.) records each dictation so you can find it in your recent history. When off, %arg marks dictations transient and your clipboard manager skips them."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When on, your clipboard manager (Paste, Raycast, Maccy, etc.) records each dictation so you can find it in your recent history. When off, %arg marks dictations transient and your clipboard manager skips them."
+          }
+        }
+      }
+    },
+    "When the transcription ends with \"press enter\", Quill removes those words before cleanup, pastes the remaining transcript, then presses Return.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When the transcription ends with \"press enter\", Quill removes those words before cleanup, pastes the remaining transcript, then presses Return."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓰기가 \"press enter\"로 끝나면 Quill이 정리 전에 해당 단어를 제거하고 나머지를 붙여넣은 후 Return 키를 누릅니다."
+          }
+        }
+      }
+    },
+    "Words and phrases to preserve during post-processing.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Words and phrases to preserve during post-processing."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후처리 중 유지할 단어와 구문입니다."
+          }
+        }
+      }
+    },
+    "e.g. debugging prompt": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "e.g. debugging prompt"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "예: 디버깅 프롬프트"
+          }
+        }
+      }
+    },
+    "v%arg": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%arg"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%arg"
+          }
+        }
+      }
+    },
+    "~/.local/bin/mlx_whisper": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "~/.local/bin/mlx_whisper"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "~/.local/bin/mlx_whisper"
+          }
+        }
+      }
+    },
+    "On-device · Fast": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "On-device · Fast"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "온디바이스 · 빠름"
+          }
+        }
+      }
+    },
+    "Fast · High accuracy (Recommended)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fast · High accuracy (Recommended)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빠름 · 정확도 높음 (추천)"
+          }
+        }
+      }
+    },
+    "Highest accuracy · Slow": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Highest accuracy · Slow"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최고 정확도 · 느림"
+          }
+        }
+      }
+    },
+    "Medium speed · Medium accuracy": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medium speed · Medium accuracy"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중간 속도 · 중간 정확도"
+          }
+        }
+      }
+    },
+    "Fast · Lower accuracy": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fast · Lower accuracy"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빠름 · 정확도 낮음"
+          }
+        }
+      }
+    },
+    "Fast local transcription with high accuracy. Recommended.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fast local transcription with high accuracy. Recommended."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빠르고 정확한 로컬 받아쓰기. 추천."
+          }
+        }
+      }
+    },
+    "Korean": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korean"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한국어"
+          }
+        }
+      }
+    },
+    "Japanese": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Japanese"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일본어"
+          }
+        }
+      }
+    },
+    "Chinese": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chinese"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중국어"
+          }
+        }
+      }
+    },
+    "Spanish": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spanish"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스페인어"
+          }
+        }
+      }
+    },
+    "French": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "French"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프랑스어"
+          }
+        }
+      }
+    },
+    "German": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "German"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "독일어"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -8113,6 +8113,54 @@
           }
         }
       }
+    },
+    "App": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앱"
+          }
+        }
+      }
+    },
+    "Updates": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updates"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트"
+          }
+        }
+      }
+    },
+    "Permissions": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permissions"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "권한"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -1,18 +1,998 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "Cancel" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Cancel" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "취소" } }
+  "sourceLanguage": "en",
+  "strings": {
+    "Cancel": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
+          }
+        }
       }
     },
-    "Continue" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Continue" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "계속" } }
+    "Continue": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "계속"
+          }
+        }
+      }
+    },
+    "Add title (optional)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add title (optional)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제목 추가 (선택)"
+          }
+        }
+      }
+    },
+    "Apply": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apply"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "적용"
+          }
+        }
+      }
+    },
+    "Calendar suggested title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calendar suggested title"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캘린더 추천 제목"
+          }
+        }
+      }
+    },
+    "Change": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "변경"
+          }
+        }
+      }
+    },
+    "Choose": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택"
+          }
+        }
+      }
+    },
+    "Choose an audio file. Supported formats: FLAC, MP3, MP4, MPEG, MPGA, M4A, OGG, WAV, WEBM": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose an audio file. Supported formats: FLAC, MP3, MP4, MPEG, MPGA, M4A, OGG, WAV, WEBM"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오 파일을 선택하세요. 지원 형식: FLAC, MP3, MP4, MPEG, MPGA, M4A, OGG, WAV, WEBM"
+          }
+        }
+      }
+    },
+    "Choose an Obsidian Vault folder": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose an Obsidian Vault folder"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obsidian Vault 폴더를 선택하세요"
+          }
+        }
+      }
+    },
+    "Choose audio input for the next recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose audio input for the next recording"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다음 녹음의 오디오 입력 선택"
+          }
+        }
+      }
+    },
+    "Cloud transcription": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud transcription"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클라우드 전사"
+          }
+        }
+      }
+    },
+    "Collapse": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collapse"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "접기"
+          }
+        }
+      }
+    },
+    "Context capture disabled": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Context capture disabled"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "컨텍스트 캡처 비활성화"
+          }
+        }
+      }
+    },
+    "Context capture enabled": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Context capture enabled"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "컨텍스트 캡처 사용"
+          }
+        }
+      }
+    },
+    "Copied to the same folder as the markdown file": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied to the same folder as the markdown file"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마크다운 파일과 같은 폴더에 복사됩니다"
+          }
+        }
+      }
+    },
+    "Copy content": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy content"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내용 복사"
+          }
+        }
+      }
+    },
+    "Delete": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "삭제"
+          }
+        }
+      }
+    },
+    "Delete note": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete note"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노트 삭제"
+          }
+        }
+      }
+    },
+    "Delete this note?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete this note?"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노트를 삭제할까요?"
+          }
+        }
+      }
+    },
+    "Deleted notes cannot be recovered.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deleted notes cannot be recovered."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "삭제한 노트는 복구할 수 없습니다."
+          }
+        }
+      }
+    },
+    "Edit": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집"
+          }
+        }
+      }
+    },
+    "Export": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내보내기"
+          }
+        }
+      }
+    },
+    "Export Complete": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export Complete"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내보내기 완료"
+          }
+        }
+      }
+    },
+    "Export Failed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export Failed"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내보내기 실패"
+          }
+        }
+      }
+    },
+    "Export in Background": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export in Background"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "백그라운드로 내보내기"
+          }
+        }
+      }
+    },
+    "Export to Obsidian": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export to Obsidian"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obsidian으로 내보내기"
+          }
+        }
+      }
+    },
+    "Exporting": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporting"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내보내는 중"
+          }
+        }
+      }
+    },
+    "File Title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File Title"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "파일 제목"
+          }
+        }
+      }
+    },
+    "Gemini CLI could not be found": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gemini CLI could not be found"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gemini CLI를 찾을 수 없습니다"
+          }
+        }
+      }
+    },
+    "Gemini CLI refines the transcript before export": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gemini CLI refines the transcript before export"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gemini CLI가 내보내기 전에 전사 내용을 정리합니다"
+          }
+        }
+      }
+    },
+    "Include Audio File": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Include Audio File"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오 파일 포함"
+          }
+        }
+      }
+    },
+    "LLM post-processing disabled": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LLM post-processing disabled"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LLM 후처리 미사용"
+          }
+        }
+      }
+    },
+    "LLM post-processing enabled": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LLM post-processing enabled"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LLM 후처리 사용"
+          }
+        }
+      }
+    },
+    "Live transcription in progress": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Live transcription in progress"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실시간 전사 중"
+          }
+        }
+      }
+    },
+    "Local transcription": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local transcription"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로컬 전사"
+          }
+        }
+      }
+    },
+    "No Recordings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Recordings"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음이 없습니다"
+          }
+        }
+      }
+    },
+    "No Search Results": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Search Results"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검색 결과 없음"
+          }
+        }
+      }
+    },
+    "Press the shortcut to start recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press the shortcut to start recording"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "단축키를 눌러 녹음을 시작하세요"
+          }
+        }
+      }
+    },
+    "Press the shortcut to start your first recording.\nYour transcript will appear here.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press the shortcut to start your first recording.\nYour transcript will appear here."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "단축키를 눌러 첫 번째 녹음을 시작하세요.\n전사된 내용이 여기에 나타납니다."
+          }
+        }
+      }
+    },
+    "Prompt": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프롬프트"
+          }
+        }
+      }
+    },
+    "Refine content with Gemini": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refine content with Gemini"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gemini로 내용 정리"
+          }
+        }
+      }
+    },
+    "Retry transcription": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry transcription"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사 재시도"
+          }
+        }
+      }
+    },
+    "Saved file name: %@.md": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saved file name: %@.md"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장될 파일명: %@.md"
+          }
+        }
+      }
+    },
+    "Search": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검색"
+          }
+        }
+      }
+    },
+    "Select a folder": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select a folder"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "폴더를 선택하세요"
+          }
+        }
+      }
+    },
+    "Select a Note": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select a Note"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노트를 선택하세요"
+          }
+        }
+      }
+    },
+    "Select a recording from the list to view its transcript": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select a recording from the list to view its transcript"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "목록에서 녹음을 선택하면 전사된 내용이 표시됩니다"
+          }
+        }
+      }
+    },
+    "Transcript": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcript"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사문"
+          }
+        }
+      }
+    },
+    "Transcription language": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcription language"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사 언어"
+          }
+        }
+      }
+    },
+    "Unknown error": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown error"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알 수 없는 오류"
+          }
+        }
+      }
+    },
+    "%@.md saved": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@.md saved"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@.md 저장됨"
+          }
+        }
+      }
+    },
+    "Import Audio File": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Audio File"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오 파일 가져오기"
+          }
+        }
+      }
+    },
+    "No transcription method is available. Configure an API key or install a Local Whisper model, then try again.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No transcription method is available. Configure an API key or install a Local Whisper model, then try again."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용 가능한 전사 방법이 없습니다. API 키를 설정하거나 Local Whisper 모델을 설치한 후 다시 시도하세요."
+          }
+        }
+      }
+    },
+    "Transcription Method": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcription Method"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사 방법"
+          }
+        }
+      }
+    },
+    "Transcribe": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcribe"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사하기"
+          }
+        }
+      }
+    },
+    "Recordings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recordings"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음"
+          }
+        }
+      }
+    },
+    "Import audio file": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import audio file"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오 파일 가져오기"
+          }
+        }
+      }
+    },
+    "Stop": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중지"
+          }
+        }
+      }
+    },
+    "Rec": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rec"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음"
+          }
+        }
+      }
+    },
+    "Transcription": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcription"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사"
+          }
+        }
+      }
+    },
+    "No content": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No content"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내용 없음"
+          }
+        }
+      }
+    },
+    "Transcription failed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcription failed"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사 실패"
+          }
+        }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -7744,6 +7744,214 @@
           }
         }
       }
+    },
+    "Centered": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centered"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중앙"
+          }
+        }
+      }
+    },
+    "Notch Sides": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notch Sides"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노치 양옆"
+          }
+        }
+      }
+    },
+    "Show the recording overlay centered below the notch.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show the recording overlay centered below the notch."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 오버레이를 노치 아래 중앙에 표시합니다."
+          }
+        }
+      }
+    },
+    "Show recording status beside the notch when supported. Update alerts stay centered.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show recording status beside the notch when supported. Update alerts stay centered."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지원되는 경우 노치 옆에 녹음 상태를 표시합니다. 업데이트 알림은 중앙에 표시됩니다."
+          }
+        }
+      }
+    },
+    "Elapsed time · click to switch audio input": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elapsed time · click to switch audio input"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경과 시간 · 클릭하여 오디오 입력 전환"
+          }
+        }
+      }
+    },
+    "Hover for elapsed time · click to switch audio input": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hover for elapsed time · click to switch audio input"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경과 시간을 보려면 가리키기 · 클릭하여 오디오 입력 전환"
+          }
+        }
+      }
+    },
+    "Switch audio input": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch audio input"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오 입력 전환"
+          }
+        }
+      }
+    },
+    "Starts at %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starts at %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@에 시작"
+          }
+        }
+      }
+    },
+    "Input changed to %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Input changed to %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "입력이 %@(으)로 변경됨"
+          }
+        }
+      }
+    },
+    "Update available: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update available: %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트 가능: %@"
+          }
+        }
+      }
+    },
+    "Start": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시작"
+          }
+        }
+      }
+    },
+    "Stop recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop recording"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 중지"
+          }
+        }
+      }
+    },
+    "Close": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "닫기"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -7537,22 +7537,6 @@
         }
       }
     },
-    "Screen Recording permission is required. %@\n\nQuill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Screen Recording permission is required. %@\n\nQuill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill."
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "화면 기록 권한이 필요합니다. %@\n\nQuill에서 맥락 인식 전사를 위한 스크린샷을 캡처하려면 화면 기록 권한이 필요합니다.\n\n시스템 설정 > 개인정보 보호 및 보안 > 화면 기록에서 Quill을 활성화하세요."
-          }
-        }
-      }
-    },
     "Failed to capture screenshot: %@\n\nA screenshot is required for context-aware transcription. Recording has been stopped.": {
       "localizations": {
         "en": {
@@ -7725,6 +7709,38 @@
           "stringUnit": {
             "state": "translated",
             "value": "실행 기록 항목을 저장할 수 없음"
+          }
+        }
+      }
+    },
+    "%@\n\nQuill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@\n\nQuill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@\n\nQuill에서 맥락 인식 전사를 위한 스크린샷을 캡처하려면 화면 기록 권한이 필요합니다.\n\n시스템 설정 > 개인정보 보호 및 보안 > 화면 기록에서 Quill을 활성화하세요."
+          }
+        }
+      }
+    },
+    "Screen Recording access was not granted.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screen Recording access was not granted."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "화면 기록 접근 권한이 부여되지 않았습니다."
           }
         }
       }

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -6528,6 +6528,22 @@
           }
         }
       }
+    },
+    "Auto Detect": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto Detect"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동 감지"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -1009,34 +1009,34 @@
         }
       }
     },
-    "  %arg": {
+    "  %@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "  %arg"
+            "value": "  %@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "  %arg"
+            "value": "  %@"
           }
         }
       }
     },
-    "  Custom: %arg": {
+    "  Custom: %@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "  Custom: %arg"
+            "value": "  Custom: %@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "  사용자 지정: %arg"
+            "value": "  사용자 지정: %@"
           }
         }
       }
@@ -1105,34 +1105,34 @@
         }
       }
     },
-    "%arg to try again": {
+    "%@ to try again": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg to try again"
+            "value": "%@ to try again"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg하여 다시 시도하세요"
+            "value": "%@하여 다시 시도하세요"
           }
         }
       }
     },
-    "%arg v%arg": {
+    "%@ v%@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg v%arg"
+            "value": "%@ v%@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg v%arg"
+            "value": "%@ v%@"
           }
         }
       }
@@ -1601,34 +1601,34 @@
         }
       }
     },
-    "Hold %arg": {
+    "Hold %@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hold %arg"
+            "value": "Hold %@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg 길게 누르기"
+            "value": "%@ 길게 누르기"
           }
         }
       }
     },
-    "Hold %arg or tap %arg": {
+    "Hold %@ or tap %@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hold %arg or tap %arg"
+            "value": "Hold %@ or tap %@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg 길게 누르기 또는 %arg 탭하기"
+            "value": "%@ 길게 누르기 또는 %@ 탭하기"
           }
         }
       }
@@ -1937,18 +1937,18 @@
         }
       }
     },
-    "Paste Again  (%arg)": {
+    "Paste Again  (%@)": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Paste Again  (%arg)"
+            "value": "Paste Again  (%@)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "다시 붙여넣기  (%arg)"
+            "value": "다시 붙여넣기  (%@)"
           }
         }
       }
@@ -2113,18 +2113,18 @@
         }
       }
     },
-    "Quit %arg": {
+    "Quit %@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Quit %arg"
+            "value": "Quit %@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg 종료"
+            "value": "%@ 종료"
           }
         }
       }
@@ -2433,18 +2433,18 @@
         }
       }
     },
-    "Tap %arg": {
+    "Tap %@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tap %arg"
+            "value": "Tap %@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg 탭하기"
+            "value": "%@ 탭하기"
           }
         }
       }
@@ -2657,18 +2657,18 @@
         }
       }
     },
-    "Welcome to %arg": {
+    "Welcome to %@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Welcome to %arg"
+            "value": "Welcome to %@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg에 오신 것을 환영합니다."
+            "value": "%@에 오신 것을 환영합니다."
           }
         }
       }
@@ -2705,50 +2705,50 @@
         }
       }
     },
-    "“%arg”": {
+    "“%@”": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "“%arg”"
+            "value": "“%@”"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "“%arg”"
+            "value": "“%@”"
           }
         }
       }
     },
-    "✓ %arg": {
+    "✓ %@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "✓ %arg"
+            "value": "✓ %@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "✓ %arg"
+            "value": "✓ %@"
           }
         }
       }
     },
-    "✓ Custom: %arg": {
+    "✓ Custom: %@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "✓ Custom: %arg"
+            "value": "✓ Custom: %@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "✓ 사용자 지정: %arg"
+            "value": "✓ 사용자 지정: %@"
           }
         }
       }
@@ -2817,50 +2817,50 @@
         }
       }
     },
-    "Hold %arg to record": {
+    "Hold %@ to record": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hold %arg to record"
+            "value": "Hold %@ to record"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg 길게 눌러 녹음"
+            "value": "%@ 길게 눌러 녹음"
           }
         }
       }
     },
-    "Hold %arg with your normal shortcut to transform selected text": {
+    "Hold %@ with your normal shortcut to transform selected text": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hold %arg with your normal shortcut to transform selected text"
+            "value": "Hold %@ with your normal shortcut to transform selected text"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "일반 단축키와 함께 %arg 길게 눌러 선택한 텍스트 변환"
+            "value": "일반 단축키와 함께 %@ 길게 눌러 선택한 텍스트 변환"
           }
         }
       }
     },
-    "Tap %arg to start and stop": {
+    "Tap %@ to start and stop": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tap %arg to start and stop"
+            "value": "Tap %@ to start and stop"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg 탭하여 시작 및 중지"
+            "value": "%@ 탭하여 시작 및 중지"
           }
         }
       }
@@ -2913,114 +2913,114 @@
         }
       }
     },
-    "%arg": {
+    "%@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg"
+            "value": "%@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg"
+            "value": "%@"
           }
         }
       }
     },
-    "%arg / %arg": {
+    "%@ / %@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg / %arg"
+            "value": "%@ / %@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg / %arg"
+            "value": "%@ / %@"
           }
         }
       }
     },
-    "%arg min before": {
+    "%@ min before": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg min before"
+            "value": "%@ min before"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg분 전"
+            "value": "%@분 전"
           }
         }
       }
     },
-    "%arg ms": {
+    "%@ ms": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg ms"
+            "value": "%@ ms"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%argms"
+            "value": "%@ms"
           }
         }
       }
     },
-    "%arg px": {
+    "%@ px": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg px"
+            "value": "%@ px"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%argpx"
+            "value": "%@px"
           }
         }
       }
     },
-    "%arg restores the audio state it changed when dictation ends.": {
+    "%@ restores the audio state it changed when dictation ends.": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg restores the audio state it changed when dictation ends."
+            "value": "%@ restores the audio state it changed when dictation ends."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg은(는) 받아쓰기가 끝나면 변경한 오디오 상태를 복원합니다."
+            "value": "%@은(는) 받아쓰기가 끝나면 변경한 오디오 상태를 복원합니다."
           }
         }
       }
     },
-    "%arg%%": {
+    "%@%%": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg%%"
+            "value": "%@%%"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg%%"
+            "value": "%@%%"
           }
         }
       }
@@ -3599,7 +3599,8 @@
             "value": "Debug"
           }
         }
-      }
+      },
+      "shouldTranslate": false
     },
     "Default Context Prompt": {
       "localizations": {
@@ -3743,7 +3744,8 @@
             "value": "Display the update available overlay after dictation finishes."
           }
         }
-      }
+      },
+      "shouldTranslate": false
     },
     "Download": {
       "localizations": {
@@ -3809,18 +3811,18 @@
         }
       }
     },
-    "Fast local transcription. About %arg.": {
+    "Fast local transcription. About %@.": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fast local transcription. About %arg."
+            "value": "Fast local transcription. About %@."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "빠른 로컬 받아쓰기. 약 %arg."
+            "value": "빠른 로컬 받아쓰기. 약 %@."
           }
         }
       }
@@ -3985,18 +3987,18 @@
         }
       }
     },
-    "Last checked: %arg": {
+    "Last checked: %@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Last checked: %arg"
+            "value": "Last checked: %@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "마지막 확인: %arg"
+            "value": "마지막 확인: %@"
           }
         }
       }
@@ -4111,7 +4113,8 @@
             "value": "No Context"
           }
         }
-      }
+      },
+      "shouldTranslate": false
     },
     "No LLM": {
       "localizations": {
@@ -4127,7 +4130,8 @@
             "value": "No LLM"
           }
         }
-      }
+      },
+      "shouldTranslate": false
     },
     "No Voice Macros Yet": {
       "localizations": {
@@ -4207,7 +4211,8 @@
             "value": "No context captured"
           }
         }
-      }
+      },
+      "shouldTranslate": false
     },
     "No runs yet. Use dictation to populate history.": {
       "localizations": {
@@ -4223,7 +4228,8 @@
             "value": "No runs yet. Use dictation to populate history."
           }
         }
-      }
+      },
+      "shouldTranslate": false
     },
     "Not connected": {
       "localizations": {
@@ -4319,7 +4325,8 @@
             "value": "Pipeline"
           }
         }
-      }
+      },
+      "shouldTranslate": false
     },
     "Play alert sounds": {
       "localizations": {
@@ -4687,7 +4694,8 @@
             "value": "Run Log"
           }
         }
-      }
+      },
+      "shouldTranslate": false
     },
     "Running...": {
       "localizations": {
@@ -4831,7 +4839,8 @@
             "value": "Show Meeting Reminder"
           }
         }
-      }
+      },
+      "shouldTranslate": false
     },
     "Show Update Overlay Now": {
       "localizations": {
@@ -4847,7 +4856,8 @@
             "value": "Show Update Overlay Now"
           }
         }
-      }
+      },
+      "shouldTranslate": false
     },
     "Show a sample calendar reminder overlay. Turn on Debug Overlay first to preview the recording (wrapping) variant.": {
       "localizations": {
@@ -4863,7 +4873,8 @@
             "value": "Show a sample calendar reminder overlay. Turn on Debug Overlay first to preview the recording (wrapping) variant."
           }
         }
-      }
+      },
+      "shouldTranslate": false
     },
     "Show after dictation": {
       "localizations": {
@@ -4879,7 +4890,8 @@
             "value": "Show after dictation"
           }
         }
-      }
+      },
+      "shouldTranslate": false
     },
     "Show menu bar icon": {
       "localizations": {
@@ -4927,7 +4939,8 @@
             "value": "Show the recording overlay with simulated audio levels."
           }
         }
-      }
+      },
+      "shouldTranslate": false
     },
     "Skip LLM cleanup. Raw transcript is used as-is. No API call is made for post-processing.": {
       "localizations": {
@@ -4993,21 +5006,22 @@
         }
       }
     },
-    "Stored locally. Only the %arg most recent runs are kept.": {
+    "Stored locally. Only the %@ most recent runs are kept.": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Stored locally. Only the %arg most recent runs are kept."
+            "value": "Stored locally. Only the %@ most recent runs are kept."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Stored locally. Only the %arg most recent runs are kept."
+            "value": "Stored locally. Only the %@ most recent runs are kept."
           }
         }
-      }
+      },
+      "shouldTranslate": false
     },
     "Stream audio while recording (realtime)": {
       "localizations": {
@@ -5521,34 +5535,34 @@
         }
       }
     },
-    "When enabled, %arg retries or falls back to the literal transcript if post-processing looks like it answered the dictated text instead of cleaning it.": {
+    "When enabled, %@ retries or falls back to the literal transcript if post-processing looks like it answered the dictated text instead of cleaning it.": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "When enabled, %arg retries or falls back to the literal transcript if post-processing looks like it answered the dictated text instead of cleaning it."
+            "value": "When enabled, %@ retries or falls back to the literal transcript if post-processing looks like it answered the dictated text instead of cleaning it."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "활성화하면 후처리가 받아쓴 텍스트를 정리하지 않고 답변한 것으로 보일 때 %arg이(가) 재시도하거나 원문 받아쓰기로 대체합니다."
+            "value": "활성화하면 후처리가 받아쓴 텍스트를 정리하지 않고 답변한 것으로 보일 때 %@이(가) 재시도하거나 원문 받아쓰기로 대체합니다."
           }
         }
       }
     },
-    "When on, your clipboard manager (Paste, Raycast, Maccy, etc.) records each dictation so you can find it in your recent history. When off, %arg marks dictations transient and your clipboard manager skips them.": {
+    "When on, your clipboard manager (Paste, Raycast, Maccy, etc.) records each dictation so you can find it in your recent history. When off, %@ marks dictations transient and your clipboard manager skips them.": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "When on, your clipboard manager (Paste, Raycast, Maccy, etc.) records each dictation so you can find it in your recent history. When off, %arg marks dictations transient and your clipboard manager skips them."
+            "value": "When on, your clipboard manager (Paste, Raycast, Maccy, etc.) records each dictation so you can find it in your recent history. When off, %@ marks dictations transient and your clipboard manager skips them."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "켜면 클립보드 관리자(Paste, Raycast, Maccy 등)가 각 받아쓰기를 기록하여 최근 기록에서 찾을 수 있습니다. 끄면 %arg이(가) 받아쓰기를 임시 항목으로 표시하고 클립보드 관리자가 건너뜁니다."
+            "value": "켜면 클립보드 관리자(Paste, Raycast, Maccy 등)가 각 받아쓰기를 기록하여 최근 기록에서 찾을 수 있습니다. 끄면 %@이(가) 받아쓰기를 임시 항목으로 표시하고 클립보드 관리자가 건너뜁니다."
           }
         }
       }
@@ -5601,18 +5615,18 @@
         }
       }
     },
-    "v%arg": {
+    "v%@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "v%arg"
+            "value": "v%@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "v%arg"
+            "value": "v%@"
           }
         }
       }
@@ -6097,18 +6111,18 @@
         }
       }
     },
-    "%arg. About %arg.": {
+    "%@. About %@.": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg. About %arg."
+            "value": "%@. About %@."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%arg. 약 %arg."
+            "value": "%@. 약 %@."
           }
         }
       }
@@ -6337,18 +6351,18 @@
         }
       }
     },
-    "About %arg.": {
+    "About %@.": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "About %arg."
+            "value": "About %@."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "약 %arg."
+            "value": "약 %@."
           }
         }
       }
@@ -7949,6 +7963,153 @@
           "stringUnit": {
             "state": "translated",
             "value": "닫기"
+          }
+        }
+      }
+    },
+    "API": {
+      "shouldTranslate": false,
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API"
+          }
+        }
+      }
+    },
+    "Legacy mlx-whisper": {
+      "shouldTranslate": false,
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legacy mlx-whisper"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legacy mlx-whisper"
+          }
+        }
+      }
+    },
+    "REC": {
+      "shouldTranslate": false,
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "REC"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "REC"
+          }
+        }
+      }
+    },
+    "Transcription method: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcription method: %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사 방법: %@"
+          }
+        }
+      }
+    },
+    "Both dictation shortcuts are disabled.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Both dictation shortcuts are disabled."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "두 받아쓰기 단축키가 모두 비활성화되어 있습니다."
+          }
+        }
+      }
+    },
+    "Custom shortcuts can use regular keys, modifier-only shortcuts, or modifier combinations.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom shortcuts can use regular keys, modifier-only shortcuts, or modifier combinations."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용자 지정 단축키에는 일반 키, 보조 키만으로 된 단축키 또는 보조 키 조합을 사용할 수 있습니다."
+          }
+        }
+      }
+    },
+    "Hold to record, tap to start and stop, and press the toggle shortcut while holding to latch into tap mode. You can disable either workflow or turn both shortcuts off.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hold to record, tap to start and stop, and press the toggle shortcut while holding to latch into tap mode. You can disable either workflow or turn both shortcuts off."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "길게 눌러 녹음하고, 탭하여 시작 및 중지하며, 길게 누르는 동안 전환 단축키를 눌러 탭 모드로 고정합니다. 각 방식을 비활성화하거나 두 단축키를 모두 끌 수 있습니다."
+          }
+        }
+      }
+    },
+    "Recording Cancel Shortcut": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording Cancel Shortcut"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 취소 단축키"
+          }
+        }
+      }
+    },
+    "While recording or transcribing, this shortcut opens the cancel confirmation dialog. Disable it if you want Esc to keep working in other apps.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "While recording or transcribing, this shortcut opens the cancel confirmation dialog. Disable it if you want Esc to keep working in other apps."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 또는 전사 중 이 단축키를 누르면 취소 확인 대화상자가 열립니다. 다른 앱에서 Esc 키를 계속 사용하려면 비활성화하세요."
           }
         }
       }

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -5824,6 +5824,294 @@
           }
         }
       }
+    },
+    "Standard": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "표준"
+          }
+        }
+      }
+    },
+    "API Standard": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API Standard"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 표준"
+          }
+        }
+      }
+    },
+    "Native Whisper": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Native Whisper"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "네이티브 Whisper"
+          }
+        }
+      }
+    },
+    "Legacy": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legacy"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "레거시"
+          }
+        }
+      }
+    },
+    "Realtime": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Realtime"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실시간"
+          }
+        }
+      }
+    },
+    "Apple Live": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Live"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple 라이브"
+          }
+        }
+      }
+    },
+    "Transcription Model": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcription Model"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓰기 모델"
+          }
+        }
+      }
+    },
+    "Used for speech-to-text transcription.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Used for speech-to-text transcription."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성을 텍스트로 변환하는 데 사용됩니다."
+          }
+        }
+      }
+    },
+    "Post-Processing Model": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Post-Processing Model"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후처리 모델"
+          }
+        }
+      }
+    },
+    "Cleans up transcripts and applies formatting.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cleans up transcripts and applies formatting."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓰기를 정리하고 서식을 적용합니다."
+          }
+        }
+      }
+    },
+    "Context Model": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Context Model"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "컨텍스트 모델"
+          }
+        }
+      }
+    },
+    "Uses active-window context to improve transcription.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uses active-window context to improve transcription."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "활성 창 컨텍스트를 사용해 받아쓰기를 개선합니다."
+          }
+        }
+      }
+    },
+    "Vision Model": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vision Model"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "비전 모델"
+          }
+        }
+      }
+    },
+    "Analyzes screenshots for visual context.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyzes screenshots for visual context."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시각적 컨텍스트를 위해 스크린샷을 분석합니다."
+          }
+        }
+      }
+    },
+    "Same as spoken language": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Same as spoken language"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "발화 언어와 동일"
+          }
+        }
+      }
+    },
+    "English": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "영어"
+          }
+        }
+      }
+    },
+    "Portuguese": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Portuguese"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "포르투갈어"
+          }
+        }
+      }
+    },
+    "%arg. About %arg.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg. About %arg."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%arg. 약 %arg."
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -992,6 +992,22 @@
           }
         }
       }
+    },
+    "Obsidian Vault Folder": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obsidian Vault Folder"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obsidian Vault 폴더"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -8161,6 +8161,249 @@
           }
         }
       }
+    },
+    "Note Browser": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note Browser"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note Browser"
+          }
+        }
+      },
+      "shouldTranslate": false
+    },
+    "Recording Overlay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording Overlay"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording Overlay"
+          }
+        }
+      },
+      "shouldTranslate": false
+    },
+    "Google Calendar": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Calendar"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Calendar"
+          }
+        }
+      },
+      "shouldTranslate": false
+    },
+    "App Appearance": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Appearance"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앱 외관"
+          }
+        }
+      }
+    },
+    "Meeting Recording Reminders": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meeting Recording Reminders"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "회의 녹음 알림"
+          }
+        }
+      }
+    },
+    "Language": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Language"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "언어"
+          }
+        }
+      }
+    },
+    "System Prompt": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Prompt"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 프롬프트"
+          }
+        }
+      }
+    },
+    "Instruction Guard": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instruction Guard"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "명령 보호"
+          }
+        }
+      }
+    },
+    "Context Prompt": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Context Prompt"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "컨텍스트 프롬프트"
+          }
+        }
+      }
+    },
+    "Dictation Shortcuts": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dictation Shortcuts"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓰기 단축키"
+          }
+        }
+      }
+    },
+    "Audio During Dictation": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio During Dictation"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "받아쓰기 중 오디오"
+          }
+        }
+      }
+    },
+    "Clipboard": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clipboard"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클립보드"
+          }
+        }
+      }
+    },
+    "Voice Macros": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice Macros"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 매크로"
+          }
+        }
+      }
+    },
+    "Sound Volume": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sound Volume"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소리 크기"
+          }
+        }
+      }
+    },
+    "Build": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빌드"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Resources/Localization/en.lproj/InfoPlist.strings
+++ b/Resources/Localization/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"NSMicrophoneUsageDescription" = "Quill needs microphone access to record dictation and meetings.";
+"NSSpeechRecognitionUsageDescription" = "Quill needs speech recognition access when Apple Live transcription is selected.";

--- a/Resources/Localization/ko.lproj/InfoPlist.strings
+++ b/Resources/Localization/ko.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"NSMicrophoneUsageDescription" = "Quill이 받아쓰기와 회의를 녹음하려면 마이크 접근 권한이 필요합니다.";
+"NSSpeechRecognitionUsageDescription" = "Apple Live 전사를 선택하면 Quill에 음성 인식 접근 권한이 필요합니다.";

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -20,7 +20,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             item.action = #selector(handleShowSettings)
         } else {
             let item = NSMenuItem(
-                title: "Settings...",
+                title: NSLocalizedString("Settings...", comment: "Settings menu action"),
                 action: #selector(handleShowSettings),
                 keyEquivalent: ","
             )

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12,7 +12,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func patchSettingsMenuItem() {
         guard let appMenu = NSApp.mainMenu?.items.first?.submenu else { return }
         if let item = appMenu.items.first(where: {
-            $0.title.contains("Settings") || $0.title.contains("Preferences")
+            Self.isSettingsMenuItemTitle($0.title, localizedSettingsTitle: String(localized: "Settings..."))
         }) {
             item.keyEquivalent = ","
             item.keyEquivalentModifierMask = .command
@@ -30,6 +30,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             appMenu.insertItem(NSMenuItem.separator(), at: insertIndex)
             appMenu.insertItem(item, at: insertIndex + 1)
         }
+    }
+
+    static func isSettingsMenuItemTitle(_ title: String, localizedSettingsTitle: String) -> Bool {
+        let recognizedTitles = [localizedSettingsTitle, "Settings...", "Settings", "Preferences...", "Preferences"]
+        return recognizedTitles.contains(title)
     }
 
     func updateActivationPolicy() {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1470,7 +1470,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var retryingItemIDs: Set<UUID> = []
     @Published var lastTranscript: String = ""
     @Published var errorMessage: String?
-    @Published var statusText: String = "Ready"
+    @Published var statusText: String = localizedCatalogString("Ready")
 
     // MCP interface
     var mcpAdditionalContext: String = ""
@@ -3558,18 +3558,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     var shortcutStatusText: String {
         if hotkeyMonitoringErrorMessage != nil {
-            return "Global shortcuts unavailable"
+            return localizedCatalogString("Global shortcuts unavailable")
         }
 
         switch (hasEnabledHoldShortcut, hasEnabledToggleShortcut) {
         case (true, true):
-            return "Hold \(holdShortcut.displayName) or tap \(toggleShortcut.displayName) to dictate"
+            return String(format: localizedCatalogString("Hold %@ or tap %@ to dictate"), holdShortcut.displayName, toggleShortcut.displayName)
         case (true, false):
-            return "Hold \(holdShortcut.displayName) to dictate"
+            return LocalizedUserMessage.shortcutStatus(shortcut: holdShortcut.displayName, isToggleMode: false)
         case (false, true):
-            return "Tap \(toggleShortcut.displayName) to dictate"
+            return LocalizedUserMessage.shortcutStatus(shortcut: toggleShortcut.displayName, isToggleMode: true)
         case (false, false):
-            return "No dictation shortcut enabled"
+            return localizedCatalogString("No dictation shortcut enabled")
         }
     }
 
@@ -4012,11 +4012,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         guard !isEscapeCancelAlertPresented else { return .terminateCancel }
 
         let alert = NSAlert()
-        alert.messageText = "Quit while recording?"
-        alert.informativeText = "Quill will stop the current recording, finish transcription, and quit when transcription is complete."
+        alert.messageText = localizedCatalogString("Quit while recording?")
+        alert.informativeText = localizedCatalogString("Quill will stop the current recording, finish transcription, and quit when transcription is complete.")
         alert.alertStyle = .warning
-        alert.addButton(withTitle: "Stop Recording and Quit")
-        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: localizedCatalogString("Stop Recording and Quit"))
+        alert.addButton(withTitle: localizedCatalogString("Cancel"))
         alert.icon = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: nil)
 
         isEscapeCancelAlertPresented = true
@@ -4060,11 +4060,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         isEscapeCancelAlertPresented = true
 
         let alert = NSAlert()
-        alert.messageText = "Cancel current recording?"
-        alert.informativeText = "Press Cancel to keep recording, or Stop Recording to discard the current recording session."
+        alert.messageText = localizedCatalogString("Cancel current recording?")
+        alert.informativeText = localizedCatalogString("Press Cancel to keep recording, or Stop Recording to discard the current recording session.")
         alert.alertStyle = .warning
-        alert.addButton(withTitle: "Stop Recording")
-        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: localizedCatalogString("Stop Recording"))
+        alert.addButton(withTitle: localizedCatalogString("Cancel"))
         alert.icon = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: nil)
 
         let response = alert.runModal()
@@ -4117,7 +4117,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         isRecording = false
         errorMessage = nil
         debugStatusMessage = "Cancelled"
-        statusText = "Cancelled"
+        statusText = localizedCatalogString("Cancelled")
         dismissTranscribingOverlay()
         tearDownRealtimeService()
         cancelActiveAudioRecorder()
@@ -4143,7 +4143,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         isRecording = false
         errorMessage = nil
         debugStatusMessage = "Cancelled"
-        statusText = "Cancelled"
+        statusText = localizedCatalogString("Cancelled")
         dismissTranscribingOverlay()
         cleanupActiveAudioRecordersIfIdle()
         if let audioFileName = job.audioFileName {
@@ -4256,15 +4256,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
         activeRecordingTriggerMode = nil
         pendingSelectionSnapshot = nil
         pendingManualCommandInvocation = false
-        errorMessage = "Select text to transform first."
-        statusText = "Select text to transform first"
+        errorMessage = localizedCatalogString("Select text to transform first.")
+        statusText = localizedCatalogString("Select text to transform first")
         debugStatusMessage = "Edit mode requires selected text"
         shortcutSessionController.reset()
         if triggerMode == .toggle {
             cancelPendingShortcutStart()
         }
         playAlertSound(named: "Basso")
-        scheduleReadyStatusReset(after: 2, matching: ["Select text to transform first"])
+        scheduleReadyStatusReset(after: 2, matching: [localizedCatalogString("Select text to transform first")])
     }
 
     private func rejectInvalidCommandModeModifier(triggerMode: RecordingTriggerMode, message: String) {
@@ -4273,14 +4273,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
         pendingSelectionSnapshot = nil
         pendingManualCommandInvocation = false
         errorMessage = message
-        statusText = "Fix Edit Mode modifier"
+        statusText = localizedCatalogString("Fix Edit Mode modifier")
         debugStatusMessage = "Edit mode modifier conflicts with dictation shortcuts"
         shortcutSessionController.reset()
         if triggerMode == .toggle {
             cancelPendingShortcutStart()
         }
         playAlertSound(named: "Basso")
-        scheduleReadyStatusReset(after: 2, matching: ["Fix Edit Mode modifier"])
+        scheduleReadyStatusReset(after: 2, matching: [localizedCatalogString("Fix Edit Mode modifier")])
     }
 
     @MainActor
@@ -4347,8 +4347,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let isAccessibilityTrusted = AXIsProcessTrusted()
         hasAccessibility = isAccessibilityTrusted
         guard isAccessibilityTrusted || !requiresAccessibility else {
-            errorMessage = "Accessibility permission required. Grant access in System Settings > Privacy & Security > Accessibility."
-            statusText = "No Accessibility"
+            errorMessage = localizedCatalogString("Accessibility permission required. Grant access in System Settings > Privacy & Security > Accessibility.")
+            statusText = localizedCatalogString("No Accessibility")
             activeRecordingTriggerMode = nil
             currentSessionIntent = .dictation
             shortcutSessionController.reset()
@@ -4432,11 +4432,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
     func showSpeechRecognitionPermissionAlert() {
 
         let alert = NSAlert()
-        alert.messageText = "Speech Recognition Permission Required"
-        alert.informativeText = "Quill cannot use Apple Live transcription without Speech Recognition access.\n\nGo to System Settings > Privacy & Security > Speech Recognition and enable Quill."
+        alert.messageText = localizedCatalogString("Speech Recognition Permission Required")
+        alert.informativeText = localizedCatalogString("Quill cannot use Apple Live transcription without Speech Recognition access.\n\nGo to System Settings > Privacy & Security > Speech Recognition and enable Quill.")
         alert.alertStyle = .critical
-        alert.addButton(withTitle: "Open System Settings")
-        alert.addButton(withTitle: "Dismiss")
+        alert.addButton(withTitle: localizedCatalogString("Open System Settings"))
+        alert.addButton(withTitle: localizedCatalogString("Dismiss"))
         alert.icon = NSImage(systemSymbolName: "waveform.badge.mic", accessibilityDescription: nil)
 
         let response = alert.runModal()
@@ -4469,9 +4469,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let granted = hasScreenCapturePermission()
         hasScreenRecordingPermission = granted
         guard granted else {
-            let message = "Screen recording permission not granted. Enable in System Settings > Privacy & Security > Screen Recording."
+            let message = localizedCatalogString("Screen recording permission not granted. Enable in System Settings > Privacy & Security > Screen Recording.")
             errorMessage = message
-            statusText = "Screenshot Required"
+            statusText = localizedCatalogString("Screenshot Required")
             activeRecordingTriggerMode = nil
             currentSessionIntent = .dictation
             shortcutSessionController.reset()
@@ -4521,9 +4521,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func showSystemDefaultAndSystemAudioAccessError() {
-        let message = "System Default + System Audio recording needs Microphone and Screen & System Audio Recording access. Enable both in System Settings > Privacy & Security."
+        let message = localizedCatalogString("System Default + System Audio recording needs Microphone and Screen & System Audio Recording access. Enable both in System Settings > Privacy & Security.")
         errorMessage = message
-        statusText = "System Default + System Audio Required"
+        statusText = localizedCatalogString("System Default + System Audio Required")
         activeRecordingTriggerMode = nil
         currentSessionIntent = .dictation
         shortcutSessionController.reset()
@@ -4535,9 +4535,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let granted = await requestScreenCapturePermissionForRecordingStart()
         hasScreenRecordingPermission = granted
         guard granted else {
-            let message = "System Audio recording permission not granted. Enable Screen & System Audio Recording in System Settings > Privacy & Security."
+            let message = localizedCatalogString("System Audio recording permission not granted. Enable Screen & System Audio Recording in System Settings > Privacy & Security.")
             errorMessage = message
-            statusText = "System Audio Required"
+            statusText = localizedCatalogString("System Audio Required")
             activeRecordingTriggerMode = nil
             currentSessionIntent = .dictation
             shortcutSessionController.reset()
@@ -4597,15 +4597,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             }
                         } else {
                             strongSelf.currentSessionIntent = .dictation
-                            strongSelf.statusText = "Microphone access granted. Press and hold again to record."
+                            strongSelf.statusText = localizedCatalogString("Microphone access granted. Press and hold again to record.")
                             strongSelf.scheduleReadyStatusReset(
                                 after: 2,
-                                matching: ["Microphone access granted. Press and hold again to record."]
+                                matching: [localizedCatalogString("Microphone access granted. Press and hold again to record.")]
                             )
                         }
                     } else {
-                        strongSelf.errorMessage = "Microphone permission denied. Grant access in System Settings > Privacy & Security > Microphone."
-                        strongSelf.statusText = "No Microphone"
+                        strongSelf.errorMessage = localizedCatalogString("Microphone permission denied. Grant access in System Settings > Privacy & Security > Microphone.")
+                        strongSelf.statusText = localizedCatalogString("No Microphone")
                         strongSelf.activeRecordingTriggerMode = nil
                         strongSelf.currentSessionIntent = .dictation
                         strongSelf.shortcutSessionController.reset()
@@ -4615,8 +4615,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
             return false
         default:
-            errorMessage = "Microphone permission denied. Grant access in System Settings > Privacy & Security > Microphone."
-            statusText = "No Microphone"
+            errorMessage = localizedCatalogString("Microphone permission denied. Grant access in System Settings > Privacy & Security > Microphone.")
+            statusText = localizedCatalogString("No Microphone")
             activeRecordingTriggerMode = nil
             currentSessionIntent = .dictation
             shortcutSessionController.reset()
@@ -4729,16 +4729,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         } else {
                             self.currentSessionIntent = .dictation
                             self.restoreAudioInterruptionIfNeeded()
-                            self.statusText = "Speech Recognition access granted. Press and hold again to record."
+                            self.statusText = localizedCatalogString("Speech Recognition access granted. Press and hold again to record.")
                             self.scheduleReadyStatusReset(
                                 after: 2,
-                                matching: ["Speech Recognition access granted. Press and hold again to record."]
+                                matching: [localizedCatalogString("Speech Recognition access granted. Press and hold again to record.")]
                             )
                         }
                     } else {
                         self.restoreAudioInterruptionIfNeeded()
-                        self.errorMessage = "Speech Recognition permission is required for Apple Live transcription. Enable it in System Settings > Privacy & Security > Speech Recognition."
-                        self.statusText = "No Speech Recognition"
+                        self.errorMessage = localizedCatalogString("Speech Recognition permission is required for Apple Live transcription. Enable it in System Settings > Privacy & Security > Speech Recognition.")
+                        self.statusText = localizedCatalogString("No Speech Recognition")
                         self.activeRecordingTriggerMode = nil
                         self.currentSessionIntent = .dictation
                         self.shortcutSessionController.reset()
@@ -4753,8 +4753,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 activeRecordingTriggerMode = nil
                 currentSessionIntent = .dictation
                 shortcutSessionController.reset()
-                errorMessage = "Speech Recognition permission is required for Apple Live transcription. Enable it in System Settings > Privacy & Security > Speech Recognition."
-                statusText = "No Speech Recognition"
+                errorMessage = localizedCatalogString("Speech Recognition permission is required for Apple Live transcription. Enable it in System Settings > Privacy & Security > Speech Recognition.")
+                statusText = localizedCatalogString("No Speech Recognition")
                 showSpeechRecognitionPermissionAlert()
                 return
             }
@@ -4763,7 +4763,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         isRecording = true
         syncCriticalDictationActivity()
         meetingReminderOverlayManager.refreshVisibleReminder()
-        statusText = "Starting..."
+        statusText = localizedCatalogString("Starting...")
         hasShownScreenshotPermissionAlert = false
 
         // Show initializing dots only if engine takes longer than 0.2s to start
@@ -4796,7 +4796,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     guard let self else { return }
                     self.cancelRecordingInitializationTimer()
                     os_log(.info, log: recordingLog, "first real audio — transitioning to waveform")
-                    self.statusText = "Recording..."
+                    self.statusText = localizedCatalogString("Recording...")
                     self.clearPendingOverlayDismissToken()
                     if overlayShown {
                         self.overlayManager.transitionToRecording(
@@ -4960,27 +4960,27 @@ final class AppState: ObservableObject, @unchecked Sendable {
         currentSessionIntent = .dictation
         shortcutSessionController.reset()
         errorMessage = formattedRecordingStartError(error)
-        statusText = "Error"
+        statusText = localizedCatalogString("Error")
         dismissTranscribingOverlay()
         refreshAvailableMicrophonesIfNeeded()
     }
 
     private func formattedRecordingStartError(_ error: Error) -> String {
         if let recorderError = error as? AudioRecorderError {
-            return "Failed to start recording: \(recorderError.localizedDescription)"
+            return LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Failed to start recording"), providerDetail: recorderError.localizedDescription)
         }
 
         let lower = error.localizedDescription.lowercased()
         if lower.contains("operation couldn't be completed") || lower.contains("operation could not be completed") {
-            return "Failed to start recording: Audio input error. Verify microphone access is granted and a working mic is selected in System Settings > Sound > Input."
+            return localizedCatalogString("Failed to start recording: Audio input error. Verify microphone access is granted and a working mic is selected in System Settings > Sound > Input.")
         }
 
         let nsError = error as NSError
         if nsError.domain == NSOSStatusErrorDomain {
-            return "Failed to start recording (audio subsystem error \(nsError.code)). Check microphone permissions and selected input device."
+            return String(format: localizedCatalogString("Failed to start recording (audio subsystem error %@). Check microphone permissions and selected input device."), String(nsError.code))
         }
 
-        return "Failed to start recording: \(error.localizedDescription)"
+        return LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Failed to start recording"), providerDetail: error.localizedDescription)
     }
 
     /// Turn a transcription failure into a concise, user-facing message,
@@ -4991,11 +4991,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
             switch code {
             case .notConnectedToInternet, .networkConnectionLost,
                  .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed:
-                return "No internet — check connection"
+                return localizedCatalogString("No internet — check connection")
             case .timedOut:
                 return NetworkMonitor.shared.isOnline
-                    ? "Request timed out — try again"
-                    : "No internet — check connection"
+                    ? localizedCatalogString("Request timed out — try again")
+                    : localizedCatalogString("No internet — check connection")
             default:
                 break
             }
@@ -5004,13 +5004,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let lower = error.localizedDescription.lowercased()
         if lower.contains("timed out") || lower.contains("timeout") {
             return NetworkMonitor.shared.isOnline
-                ? "Request timed out — try again"
-                : "No internet — check connection"
+                ? localizedCatalogString("Request timed out — try again")
+                : localizedCatalogString("No internet — check connection")
         }
         if lower.contains("offline") || lower.contains("internet connection")
             || lower.contains("not connected") || lower.contains("network")
             || lower.contains("cannot find host") {
-            return "No internet — check connection"
+            return localizedCatalogString("No internet — check connection")
         }
         return error.localizedDescription
     }
@@ -5043,11 +5043,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         let alert = NSAlert()
-        alert.messageText = "Microphone Permission Required"
-        alert.informativeText = "Quill cannot record audio without Microphone access.\n\nGo to System Settings > Privacy & Security > Microphone and enable Quill."
+        alert.messageText = localizedCatalogString("Microphone Permission Required")
+        alert.informativeText = localizedCatalogString("Quill cannot record audio without Microphone access.\n\nGo to System Settings > Privacy & Security > Microphone and enable Quill.")
         alert.alertStyle = .critical
-        alert.addButton(withTitle: "Open System Settings")
-        alert.addButton(withTitle: "Dismiss")
+        alert.addButton(withTitle: localizedCatalogString("Open System Settings"))
+        alert.addButton(withTitle: localizedCatalogString("Dismiss"))
         alert.icon = NSImage(systemSymbolName: "mic.fill", accessibilityDescription: nil)
 
         let response = alert.runModal()
@@ -5517,7 +5517,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         isRecording = false
         restoreAudioInterruptionIfNeeded()
         refreshTranscribingState()
-        statusText = "Preparing audio..."
+        statusText = localizedCatalogString("Preparing audio...")
         errorMessage = nil
         playAlertSound(named: "Pop")
         overlayManager.showTranscribing()
@@ -5557,7 +5557,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         if let transcriber = capturedLiveTranscriber, transcriber.handlesRecording {
             if overlayTranscriptionID == myOverlayID {
-                prepareTranscribingOverlay(for: myOverlayID, statusText: "Transcribing...", debugStatus: "Transcribing audio")
+                prepareTranscribingOverlay(for: myOverlayID, statusText: localizedCatalogString("Transcribing..."), debugStatus: "Transcribing audio")
             }
             let task = Task { [weak self] in
                 guard let self else { return }
@@ -5643,7 +5643,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         }
                         let userFacingErrorMessage = self.formattedTranscriptionError(error)
                         self.errorMessage = userFacingErrorMessage
-                        self.statusText = "Error"
+                        self.statusText = localizedCatalogString("Error")
                         self.overlayManager.showError(userFacingErrorMessage)
                         self.lastPostProcessedTranscript = ""
                         self.lastRawTranscript = ""
@@ -5665,8 +5665,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             guard let self else { return }
             guard let fileURL else {
                 if self.overlayTranscriptionID == myOverlayID {
-                    self.errorMessage = "No audio recorded"
-                    self.statusText = "Error"
+                    self.errorMessage = localizedCatalogString("No audio recorded")
+                    self.statusText = localizedCatalogString("Error")
                     self.dismissTranscribingOverlay()
                 }
                 self.mcpLastRecordingFailed = true
@@ -5802,7 +5802,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         }
                         let userFacingErrorMessage = self.formattedTranscriptionError(error)
                         self.errorMessage = userFacingErrorMessage
-                        self.statusText = "Error"
+                        self.statusText = localizedCatalogString("Error")
                         self.overlayManager.showError(userFacingErrorMessage)
                         self.lastPostProcessedTranscript = ""
                         self.lastRawTranscript = ""
@@ -6397,7 +6397,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             restoreAudioInterruptionIfNeeded()
             shortcutSessionController.reset()
             activeRecordingTriggerMode = nil
-            statusText = "Screenshot Required"
+            statusText = localizedCatalogString("Screenshot Required")
             dismissTranscribingOverlay()
 
             playAlertSound(named: "Basso")
@@ -6421,11 +6421,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         let alert = NSAlert()
-        alert.messageText = "Screen Recording Permission Required"
-        alert.informativeText = "\(message)\n\nQuill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill."
+        alert.messageText = localizedCatalogString("Screen Recording Permission Required")
+        alert.informativeText = LocalizedUserMessage.screenRecordingPermission(detail: message) + "\n\n" + localizedCatalogString("Quill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill.")
         alert.alertStyle = .critical
-        alert.addButton(withTitle: "Open System Settings")
-        alert.addButton(withTitle: "Dismiss")
+        alert.addButton(withTitle: localizedCatalogString("Open System Settings"))
+        alert.addButton(withTitle: localizedCatalogString("Dismiss"))
         alert.icon = NSImage(systemSymbolName: "camera.viewfinder", accessibilityDescription: nil)
 
         let response = alert.runModal()
@@ -6436,10 +6436,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func showScreenshotCaptureErrorAlert(message: String) {
         let alert = NSAlert()
-        alert.messageText = "Screenshot Capture Failed"
-        alert.informativeText = "\(message)\n\nA screenshot is required for context-aware transcription. Recording has been stopped."
+        alert.messageText = localizedCatalogString("Screenshot Capture Failed")
+        alert.informativeText = LocalizedUserMessage.screenshotFailure(detail: message) + "\n\n" + localizedCatalogString("A screenshot is required for context-aware transcription. Recording has been stopped.")
         alert.alertStyle = .critical
-        alert.addButton(withTitle: "Dismiss")
+        alert.addButton(withTitle: localizedCatalogString("Dismiss"))
         alert.icon = NSImage(systemSymbolName: "camera.viewfinder", accessibilityDescription: nil)
         _ = alert.runModal()
     }
@@ -6763,7 +6763,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             if let statuses, !statuses.contains(self.statusText) {
                 return
             }
-            self.statusText = "Ready"
+            self.statusText = localizedCatalogString("Ready")
         }
     }
 }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -810,12 +810,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     var noteBrowserTranscriptionChoiceLabel: String {
-        noteBrowserTranscriptionDisplay(for: currentNoteBrowserTranscriptionChoice).title
+        noteBrowserTranscriptionDisplay(for: currentNoteBrowserTranscriptionChoice).localizedTitle()
     }
 
     @MainActor
     var noteBrowserTranscriptionChoiceDetailLabel: String {
-        noteBrowserTranscriptionDisplay(for: currentNoteBrowserTranscriptionChoice).currentLabel
+        noteBrowserTranscriptionDisplay(for: currentNoteBrowserTranscriptionChoice).localizedCurrentLabel()
     }
 
     @MainActor
@@ -851,7 +851,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func label(for mode: NoteBrowserTranscriptionMode) -> String {
-        noteBrowserTranscriptionDisplay(for: preferredNoteBrowserTranscriptionChoice(for: mode)).currentLabel
+        noteBrowserTranscriptionDisplay(for: preferredNoteBrowserTranscriptionChoice(for: mode)).localizedCurrentLabel()
     }
 
     @MainActor

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -4117,7 +4117,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         isRecording = false
         errorMessage = nil
         debugStatusMessage = "Cancelled"
-        statusText = localizedCatalogString("Cancelled")
+        let cancelledStatus = localizedCatalogString("Cancelled")
+        statusText = cancelledStatus
         dismissTranscribingOverlay()
         tearDownRealtimeService()
         cancelActiveAudioRecorder()
@@ -4125,8 +4126,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         restoreAudioInterruptionIfNeeded()
         syncCriticalDictationActivity()
         refreshAvailableMicrophonesIfNeeded()
-        if !isRecording && !isTranscribing && statusText == "Cancelled" {
-            scheduleReadyStatusReset(after: 2, matching: ["Cancelled"])
+        if !isRecording && !isTranscribing && statusText == cancelledStatus {
+            scheduleReadyStatusReset(after: 2, matching: [cancelledStatus])
         }
     }
 
@@ -4143,7 +4144,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         isRecording = false
         errorMessage = nil
         debugStatusMessage = "Cancelled"
-        statusText = localizedCatalogString("Cancelled")
+        let cancelledStatus = localizedCatalogString("Cancelled")
+        statusText = cancelledStatus
         dismissTranscribingOverlay()
         cleanupActiveAudioRecordersIfIdle()
         if let audioFileName = job.audioFileName {
@@ -4157,8 +4159,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
         finishTranscriptionJob(job.id)
         refreshAvailableMicrophonesIfNeeded()
-        if !isRecording && !isTranscribing && statusText == "Cancelled" {
-            scheduleReadyStatusReset(after: 2, matching: ["Cancelled"])
+        if !isRecording && !isTranscribing && statusText == cancelledStatus {
+            scheduleReadyStatusReset(after: 2, matching: [cancelledStatus])
         }
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2166,13 +2166,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         var errorDescription: String? {
             switch self {
             case .needsReconnect:
-                return "Google Calendar needs reconnecting."
+                return localizedCatalogString("Google Calendar needs reconnecting.")
             }
         }
     }
 
     private static func googleCalendarReconnectMessage() -> String {
-        "Google Calendar needs reconnecting. Reconnect to restore meeting reminders and calendar-based note titles."
+        localizedCatalogString("Google Calendar needs reconnecting. Reconnect to restore meeting reminders and calendar-based note titles.")
     }
 
     static func isGoogleCalendarReconnectError(_ error: Error) -> Bool {
@@ -2214,7 +2214,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 await MainActor.run {
                     markGoogleCalendarNeedsReconnect(
                         feature: .recordingReminders,
-                        message: "Google Calendar needs reconnecting. Reconnect to restore meeting reminders."
+                        message: localizedCatalogString("Google Calendar needs reconnecting. Reconnect to restore meeting reminders.")
                     )
                 }
                 throw GoogleCalendarHealthError.needsReconnect
@@ -2225,12 +2225,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 if Self.isGoogleCalendarReconnectError(error) {
                     markGoogleCalendarNeedsReconnect(
                         feature: .recordingReminders,
-                        message: "Google Calendar needs reconnecting. Reconnect to restore meeting reminders."
+                        message: localizedCatalogString("Google Calendar needs reconnecting. Reconnect to restore meeting reminders.")
                     )
                 } else {
                     markGoogleCalendarTemporarilyUnavailable(
                         feature: .recordingReminders,
-                        message: "Unable to refresh Google Calendar reminders: \(error.localizedDescription)"
+                        message: localizedCatalogFormat("Unable to refresh Google Calendar reminders: %@", error.localizedDescription)
                     )
                 }
             }
@@ -2248,7 +2248,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             } else {
                 markGoogleCalendarTemporarilyUnavailable(
                     feature: .recordingReminders,
-                    message: "Some Google calendars could not be refreshed. Reminders may be incomplete."
+                    message: localizedCatalogString("Some Google calendars could not be refreshed. Reminders may be incomplete.")
                 )
             }
         }
@@ -2359,7 +2359,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             } else {
                 markGoogleCalendarTemporarilyUnavailable(
                     feature: .calendarList,
-                    message: "Unable to refresh Google Calendar: \(error.localizedDescription)"
+                    message: localizedCatalogFormat("Unable to refresh Google Calendar: %@", error.localizedDescription)
                 )
             }
         }
@@ -6037,7 +6037,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 await MainActor.run {
                     markGoogleCalendarNeedsReconnect(
                         feature: .recordingMatch,
-                        message: "Google Calendar needs reconnecting. Calendar-based note titles may be unavailable."
+                        message: localizedCatalogString("Google Calendar needs reconnecting. Calendar-based note titles may be unavailable.")
                     )
                 }
                 return nil
@@ -6061,7 +6061,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 await MainActor.run {
                     markGoogleCalendarTemporarilyUnavailable(
                         feature: .recordingMatch,
-                        message: "Some Google calendars could not be refreshed. Calendar-based note titles may be incomplete."
+                        message: localizedCatalogString("Some Google calendars could not be refreshed. Calendar-based note titles may be incomplete.")
                     )
                 }
                 os_log(
@@ -6127,12 +6127,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 if Self.isGoogleCalendarReconnectError(error) {
                     markGoogleCalendarNeedsReconnect(
                         feature: .recordingMatch,
-                        message: "Google Calendar needs reconnecting. Calendar-based note titles may be unavailable."
+                        message: localizedCatalogString("Google Calendar needs reconnecting. Calendar-based note titles may be unavailable.")
                     )
                 } else {
                     markGoogleCalendarTemporarilyUnavailable(
                         feature: .recordingMatch,
-                        message: "Unable to refresh Google Calendar for note titles: \(error.localizedDescription)"
+                        message: localizedCatalogFormat("Unable to refresh Google Calendar for note titles: %@", error.localizedDescription)
                     )
                 }
             }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2880,7 +2880,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
             pipelineHistory = []
         } catch {
-            errorMessage = "Unable to clear run history: \(error.localizedDescription)"
+            errorMessage = LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Unable to clear run history"), providerDetail: error.localizedDescription)
         }
     }
 
@@ -2892,7 +2892,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
             pipelineHistory.remove(at: index)
         } catch {
-            errorMessage = "Unable to delete run history entry: \(error.localizedDescription)"
+            errorMessage = LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Unable to delete run history entry"), providerDetail: error.localizedDescription)
         }
     }
 
@@ -2908,7 +2908,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             try pipelineHistoryStore.update(updated)
             pipelineHistory[index] = updated
         } catch {
-            errorMessage = "Failed to save note title: \(error.localizedDescription)"
+            errorMessage = LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Failed to save note title"), providerDetail: error.localizedDescription)
         }
     }
 
@@ -2956,7 +2956,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 pipelineHistory[index] = updated
             }
         } catch {
-            errorMessage = "Failed to save transcript edit: \(error.localizedDescription)"
+            errorMessage = LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Failed to save transcript edit"), providerDetail: error.localizedDescription)
         }
     }
 
@@ -2992,7 +2992,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         Task { [weak self] in
             guard let savedAudioFile = await Self.saveSecurityScopedAudioFileOffMain(from: fileURL) else {
-                self?.errorMessage = "Unable to save the audio file. Check disk space or file permissions and try again."
+                self?.errorMessage = localizedCatalogString("Unable to save the audio file. Check disk space or file permissions and try again.")
                 return
             }
             guard let self else {
@@ -3036,7 +3036,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 }
             } catch {
                 Self.deleteAudioFile(savedAudioFile.fileName)
-                self.errorMessage = "Unable to save imported audio note: \(error.localizedDescription)"
+                self.errorMessage = LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Unable to save imported audio note"), providerDetail: error.localizedDescription)
                 return
             }
 
@@ -3152,7 +3152,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         do {
             snapshot = try makeRetrySnapshot(for: item)
         } catch {
-            errorMessage = error.localizedDescription
+            errorMessage = LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Unable to prepare retry"), providerDetail: error.localizedDescription)
             return
         }
 
@@ -3231,7 +3231,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.copyRetryTranscriptToPasteboardIfNeeded(updatedItem.postProcessedTranscript)
                     }
                 } catch {
-                    self.errorMessage = "Failed to save retry result: \(error.localizedDescription)"
+                    self.errorMessage = LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Failed to save retry result"), providerDetail: error.localizedDescription)
                 }
                 self.retryingItemIDs.remove(snapshot.item.id)
             }
@@ -5984,7 +5984,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 $0.audioFileName = audioFileName
             }
         } catch {
-            errorMessage = "Unable to save recovery entry: \(error.localizedDescription)"
+            errorMessage = LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Unable to save recovery entry"), providerDetail: error.localizedDescription)
         }
     }
 
@@ -6222,7 +6222,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             updatePipelineHistoryItem(entry)
         } catch {
             Self.deleteStoredFiles(audioFileName: audioFileName, transcriptFileName: transcriptFileName)
-            errorMessage = "Unable to save run history entry: \(error.localizedDescription)"
+            errorMessage = LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Unable to save run history entry"), providerDetail: error.localizedDescription)
         }
 
         // MCP notification
@@ -6422,7 +6422,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         let alert = NSAlert()
         alert.messageText = localizedCatalogString("Screen Recording Permission Required")
-        alert.informativeText = LocalizedUserMessage.screenRecordingPermission(detail: message) + "\n\n" + localizedCatalogString("Quill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill.")
+        alert.informativeText = LocalizedUserMessage.screenRecordingPermission(detail: message)
         alert.alertStyle = .critical
         alert.addButton(withTitle: localizedCatalogString("Open System Settings"))
         alert.addButton(withTitle: localizedCatalogString("Dismiss"))
@@ -6437,7 +6437,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func showScreenshotCaptureErrorAlert(message: String) {
         let alert = NSAlert()
         alert.messageText = localizedCatalogString("Screenshot Capture Failed")
-        alert.informativeText = LocalizedUserMessage.screenshotFailure(detail: message) + "\n\n" + localizedCatalogString("A screenshot is required for context-aware transcription. Recording has been stopped.")
+        alert.informativeText = LocalizedUserMessage.screenshotFailure(detail: message)
         alert.alertStyle = .critical
         alert.addButton(withTitle: localizedCatalogString("Dismiss"))
         alert.icon = NSImage(systemSymbolName: "camera.viewfinder", accessibilityDescription: nil)

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2859,9 +2859,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
     /// than the full hardware microphone list.
     private func recordingOverlayInputOptions() -> [RecordingOverlayInputOption] {
         [
-            RecordingOverlayInputOption(id: AudioInputDevice.defaultMicrophoneID, name: "System Default"),
-            RecordingOverlayInputOption(id: AudioInputDevice.systemAudioID, name: "System Audio"),
-            RecordingOverlayInputOption(id: AudioInputDevice.systemDefaultAndSystemAudioID, name: "System Default + System Audio")
+            RecordingOverlayInputOption(id: AudioInputDevice.defaultMicrophoneID, name: "System Default", isStaticQuillName: true),
+            RecordingOverlayInputOption(id: AudioInputDevice.systemAudioID, name: "System Audio", isStaticQuillName: true),
+            RecordingOverlayInputOption(id: AudioInputDevice.systemDefaultAndSystemAudioID, name: "System Default + System Audio", isStaticQuillName: true)
         ]
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -4476,7 +4476,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             currentSessionIntent = .dictation
             shortcutSessionController.reset()
             playAlertSound(named: "Basso")
-            showScreenshotPermissionAlert(message: message)
+            showScreenshotPermissionAlert(message: localizedCatalogString("Screen Recording access was not granted."))
             return false
         }
 
@@ -4542,7 +4542,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             currentSessionIntent = .dictation
             shortcutSessionController.reset()
             playAlertSound(named: "Basso")
-            showScreenshotPermissionAlert(message: message)
+            showScreenshotPermissionAlert(message: localizedCatalogString("Screen Recording access was not granted."))
             return false
         }
         return true
@@ -6401,7 +6401,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             dismissTranscribingOverlay()
 
             playAlertSound(named: "Basso")
-            showScreenshotPermissionAlert(message: message)
+            showScreenshotPermissionAlert(message: localizedCatalogString("Screen Recording access was not granted."))
         }
         // Non-permission errors (transient failures) — continue recording without context
     }

--- a/Sources/AudioImportOptions.swift
+++ b/Sources/AudioImportOptions.swift
@@ -63,6 +63,43 @@ struct TranscriptionChoiceDisplay: Identifiable, Equatable {
     let unavailableReason: String?
 
     var id: String { choice.id }
+
+    /// Resolves only static UI labels; model IDs and persisted backend choices remain verbatim.
+    func localizedTitle(language: String = Locale.current.language.languageCode?.identifier ?? "en") -> String {
+        localizedStaticLabel(title, language: language)
+    }
+
+    func localizedCompactLabel(language: String = Locale.current.language.languageCode?.identifier ?? "en") -> String {
+        switch choice {
+        case .apiStandard(let modelID):
+            return "\(localizedStaticLabel("Standard", language: language)) · \(modelID)"
+        case .nativeWhisper:
+            return "\(localizedStaticLabel("Native Whisper", language: language)) · \(nativeModelName())"
+        case .legacyMlxWhisper(let model):
+            return "\(localizedStaticLabel("Legacy", language: language)) · \(model.displayName)"
+        case .apiRealtime(let modelID):
+            return "\(localizedStaticLabel("Realtime", language: language)) · \(modelID ?? "provider-default")"
+        case .appleLive:
+            return localizedStaticLabel("Apple Live", language: language)
+        }
+    }
+
+    private func nativeModelName() -> String {
+        subtitle ?? ""
+    }
+
+    private func localizedStaticLabel(_ value: String, language: String) -> String {
+        guard language.lowercased().hasPrefix("ko") else { return value }
+        switch value {
+        case "API Standard": return "API 표준"
+        case "Standard": return "표준"
+        case "Native Whisper": return "네이티브 Whisper"
+        case "Legacy": return "레거시"
+        case "Realtime": return "실시간"
+        case "Apple Live": return "Apple 라이브"
+        default: return value
+        }
+    }
 }
 
 struct AudioImportOptions {

--- a/Sources/AudioImportOptions.swift
+++ b/Sources/AudioImportOptions.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+private func audioImportLocalizedString(_ key: String, language: String, bundle: Bundle = .main) -> String {
+    let path = bundle.path(forResource: "Localizable", ofType: "strings", inDirectory: nil, forLocalization: language)
+        ?? URL(fileURLWithPath: bundle.bundlePath).appendingPathComponent("\(language).lproj/Localizable.strings").path
+    guard let strings = NSDictionary(contentsOfFile: path) as? [String: String] else { return key }
+    return strings[key] ?? key
+}
+
 enum NoteBrowserTranscriptionMode: CaseIterable, Equatable, Hashable {
     case apiStandard
     case apiRealtime
@@ -65,22 +72,28 @@ struct TranscriptionChoiceDisplay: Identifiable, Equatable {
     var id: String { choice.id }
 
     /// Resolves only static UI labels; model IDs and persisted backend choices remain verbatim.
-    func localizedTitle(language: String = Locale.current.language.languageCode?.identifier ?? "en") -> String {
-        localizedStaticLabel(title, language: language)
+    func localizedTitle(
+        language: String = Locale.current.language.languageCode?.identifier ?? "en",
+        bundle: Bundle = .main
+    ) -> String {
+        localizedStaticLabel(title, language: language, bundle: bundle)
     }
 
-    func localizedCompactLabel(language: String = Locale.current.language.languageCode?.identifier ?? "en") -> String {
+    func localizedCompactLabel(
+        language: String = Locale.current.language.languageCode?.identifier ?? "en",
+        bundle: Bundle = .main
+    ) -> String {
         switch choice {
         case .apiStandard(let modelID):
-            return "\(localizedStaticLabel("Standard", language: language)) · \(modelID)"
+            return "\(localizedStaticLabel("Standard", language: language, bundle: bundle)) · \(modelID)"
         case .nativeWhisper:
-            return "\(localizedStaticLabel("Native Whisper", language: language)) · \(nativeModelName())"
+            return "\(localizedStaticLabel("Native Whisper", language: language, bundle: bundle)) · \(nativeModelName())"
         case .legacyMlxWhisper(let model):
-            return "\(localizedStaticLabel("Legacy", language: language)) · \(model.displayName)"
+            return "\(localizedStaticLabel("Legacy", language: language, bundle: bundle)) · \(model.displayName)"
         case .apiRealtime(let modelID):
-            return "\(localizedStaticLabel("Realtime", language: language)) · \(modelID ?? "provider-default")"
+            return "\(localizedStaticLabel("Realtime", language: language, bundle: bundle)) · \(modelID ?? "provider-default")"
         case .appleLive:
-            return localizedStaticLabel("Apple Live", language: language)
+            return localizedStaticLabel("Apple Live", language: language, bundle: bundle)
         }
     }
 
@@ -88,17 +101,35 @@ struct TranscriptionChoiceDisplay: Identifiable, Equatable {
         subtitle ?? ""
     }
 
-    private func localizedStaticLabel(_ value: String, language: String) -> String {
-        guard language.lowercased().hasPrefix("ko") else { return value }
-        switch value {
-        case "API Standard": return "API 표준"
-        case "Standard": return "표준"
-        case "Native Whisper": return "네이티브 Whisper"
-        case "Legacy": return "레거시"
-        case "Realtime": return "실시간"
-        case "Apple Live": return "Apple 라이브"
-        default: return value
+    func localizedSubtitle(
+        language: String = Locale.current.language.languageCode?.identifier ?? "en",
+        bundle: Bundle = .main
+    ) -> String? {
+        subtitle.map { audioImportLocalizedString($0, language: language, bundle: bundle) }
+    }
+
+    func localizedCurrentLabel(
+        language: String = Locale.current.language.languageCode?.identifier ?? "en",
+        bundle: Bundle = .main
+    ) -> String {
+        switch choice {
+        case .apiStandard(let modelID): return "\(audioImportLocalizedString("API", language: language, bundle: bundle)) · \(localizedStaticLabel("Standard", language: language, bundle: bundle)) · \(modelID)"
+        case .apiRealtime(let modelID): return "\(audioImportLocalizedString("API", language: language, bundle: bundle)) · \(localizedStaticLabel("Realtime", language: language, bundle: bundle)) · \(modelID ?? "provider-default")"
+        case .nativeWhisper: return "\(audioImportLocalizedString("Local", language: language, bundle: bundle)) · \(localizedStaticLabel("Native Whisper", language: language, bundle: bundle)) · \(nativeModelName())"
+        case .legacyMlxWhisper(let model): return "\(audioImportLocalizedString("Local", language: language, bundle: bundle)) · \(localizedStaticLabel("Legacy", language: language, bundle: bundle)) · \(model.displayName)"
+        case .appleLive: return "\(audioImportLocalizedString("Local", language: language, bundle: bundle)) · \(localizedStaticLabel("Apple Live", language: language, bundle: bundle))"
         }
+    }
+
+    func localizedUnavailableReason(
+        language: String = Locale.current.language.languageCode?.identifier ?? "en",
+        bundle: Bundle = .main
+    ) -> String? {
+        unavailableReason.map { audioImportLocalizedString($0, language: language, bundle: bundle) }
+    }
+
+    private func localizedStaticLabel(_ value: String, language: String, bundle: Bundle) -> String {
+        audioImportLocalizedString(value, language: language, bundle: bundle)
     }
 }
 

--- a/Sources/AudioImportOptions.swift
+++ b/Sources/AudioImportOptions.swift
@@ -1,11 +1,5 @@
 import Foundation
 
-private func audioImportLocalizedString(_ key: String, language: String, bundle: Bundle = .main) -> String {
-    let path = bundle.path(forResource: "Localizable", ofType: "strings", inDirectory: nil, forLocalization: language)
-        ?? URL(fileURLWithPath: bundle.bundlePath).appendingPathComponent("\(language).lproj/Localizable.strings").path
-    guard let strings = NSDictionary(contentsOfFile: path) as? [String: String] else { return key }
-    return strings[key] ?? key
-}
 
 enum NoteBrowserTranscriptionMode: CaseIterable, Equatable, Hashable {
     case apiStandard
@@ -73,14 +67,14 @@ struct TranscriptionChoiceDisplay: Identifiable, Equatable {
 
     /// Resolves only static UI labels; model IDs and persisted backend choices remain verbatim.
     func localizedTitle(
-        language: String = Locale.current.language.languageCode?.identifier ?? "en",
+        language: String = preferredLocalizedStringLanguage(),
         bundle: Bundle = .main
     ) -> String {
         localizedStaticLabel(title, language: language, bundle: bundle)
     }
 
     func localizedCompactLabel(
-        language: String = Locale.current.language.languageCode?.identifier ?? "en",
+        language: String = preferredLocalizedStringLanguage(),
         bundle: Bundle = .main
     ) -> String {
         switch choice {
@@ -101,35 +95,28 @@ struct TranscriptionChoiceDisplay: Identifiable, Equatable {
         subtitle ?? ""
     }
 
-    func localizedSubtitle(
-        language: String = Locale.current.language.languageCode?.identifier ?? "en",
-        bundle: Bundle = .main
-    ) -> String? {
-        subtitle.map { audioImportLocalizedString($0, language: language, bundle: bundle) }
-    }
-
     func localizedCurrentLabel(
-        language: String = Locale.current.language.languageCode?.identifier ?? "en",
+        language: String = preferredLocalizedStringLanguage(),
         bundle: Bundle = .main
     ) -> String {
         switch choice {
-        case .apiStandard(let modelID): return "\(audioImportLocalizedString("API", language: language, bundle: bundle)) · \(localizedStaticLabel("Standard", language: language, bundle: bundle)) · \(modelID)"
-        case .apiRealtime(let modelID): return "\(audioImportLocalizedString("API", language: language, bundle: bundle)) · \(localizedStaticLabel("Realtime", language: language, bundle: bundle)) · \(modelID ?? "provider-default")"
-        case .nativeWhisper: return "\(audioImportLocalizedString("Local", language: language, bundle: bundle)) · \(localizedStaticLabel("Native Whisper", language: language, bundle: bundle)) · \(nativeModelName())"
-        case .legacyMlxWhisper(let model): return "\(audioImportLocalizedString("Local", language: language, bundle: bundle)) · \(localizedStaticLabel("Legacy", language: language, bundle: bundle)) · \(model.displayName)"
-        case .appleLive: return "\(audioImportLocalizedString("Local", language: language, bundle: bundle)) · \(localizedStaticLabel("Apple Live", language: language, bundle: bundle))"
+        case .apiStandard(let modelID): return "\(localizedCatalogString("API", language: language, bundle: bundle)) · \(localizedStaticLabel("Standard", language: language, bundle: bundle)) · \(modelID)"
+        case .apiRealtime(let modelID): return "\(localizedCatalogString("API", language: language, bundle: bundle)) · \(localizedStaticLabel("Realtime", language: language, bundle: bundle)) · \(modelID ?? "provider-default")"
+        case .nativeWhisper: return "\(localizedCatalogString("Local", language: language, bundle: bundle)) · \(localizedStaticLabel("Native Whisper", language: language, bundle: bundle)) · \(nativeModelName())"
+        case .legacyMlxWhisper(let model): return "\(localizedCatalogString("Local", language: language, bundle: bundle)) · \(localizedStaticLabel("Legacy", language: language, bundle: bundle)) · \(model.displayName)"
+        case .appleLive: return "\(localizedCatalogString("Local", language: language, bundle: bundle)) · \(localizedStaticLabel("Apple Live", language: language, bundle: bundle))"
         }
     }
 
     func localizedUnavailableReason(
-        language: String = Locale.current.language.languageCode?.identifier ?? "en",
+        language: String = preferredLocalizedStringLanguage(),
         bundle: Bundle = .main
     ) -> String? {
-        unavailableReason.map { audioImportLocalizedString($0, language: language, bundle: bundle) }
+        unavailableReason.map { localizedCatalogString($0, language: language, bundle: bundle) }
     }
 
     private func localizedStaticLabel(_ value: String, language: String, bundle: Bundle) -> String {
-        audioImportLocalizedString(value, language: language, bundle: bundle)
+        localizedCatalogString(value, language: language, bundle: bundle)
     }
 }
 

--- a/Sources/CalendarRecordingReminderScheduler.swift
+++ b/Sources/CalendarRecordingReminderScheduler.swift
@@ -407,19 +407,19 @@ final class CalendarRecordingReminderScheduler {
     nonisolated static func notificationTitle(for schedule: CalendarRecordingReminderSchedule, now: Date) -> String {
         let minutesUntilStart = Int(ceil(schedule.event.start.timeIntervalSince(now) / 60))
         if minutesUntilStart > 1 {
-            return "Meeting starts in \(minutesUntilStart) minutes"
+            return String(format: localizedCatalogString("Meeting starts in %d minutes"), minutesUntilStart)
         }
         if minutesUntilStart == 1 {
-            return "Meeting starts in 1 minute"
+            return localizedCatalogString("Meeting starts in 1 minute")
         }
         if schedule.event.start > now {
-            return "Meeting starts soon"
+            return localizedCatalogString("Meeting starts soon")
         }
-        return "Meeting is starting now"
+        return localizedCatalogString("Meeting is starting now")
     }
 
     nonisolated static func notificationBody(for event: GoogleCalendarEvent) -> String {
-        "Tap to start recording: \(event.title)"
+        String(format: localizedCatalogString("Tap to start recording: %@"), event.title)
     }
 
     nonisolated static func isReminderEligible(_ event: GoogleCalendarEvent) -> Bool {

--- a/Sources/CalendarRecordingReminderScheduler.swift
+++ b/Sources/CalendarRecordingReminderScheduler.swift
@@ -405,21 +405,29 @@ final class CalendarRecordingReminderScheduler {
     }
 
     nonisolated static func notificationTitle(for schedule: CalendarRecordingReminderSchedule, now: Date) -> String {
+        notificationTitle(for: schedule, now: now, language: preferredLocalizedStringLanguage(), bundle: .main)
+    }
+
+    nonisolated static func notificationTitle(for schedule: CalendarRecordingReminderSchedule, now: Date, language: String, bundle: Bundle) -> String {
         let minutesUntilStart = Int(ceil(schedule.event.start.timeIntervalSince(now) / 60))
         if minutesUntilStart > 1 {
-            return String(format: localizedCatalogString("Meeting starts in %d minutes"), minutesUntilStart)
+            return String(format: localizedCatalogString("Meeting starts in %d minutes", language: language, bundle: bundle), minutesUntilStart)
         }
         if minutesUntilStart == 1 {
-            return localizedCatalogString("Meeting starts in 1 minute")
+            return localizedCatalogString("Meeting starts in 1 minute", language: language, bundle: bundle)
         }
         if schedule.event.start > now {
-            return localizedCatalogString("Meeting starts soon")
+            return localizedCatalogString("Meeting starts soon", language: language, bundle: bundle)
         }
-        return localizedCatalogString("Meeting is starting now")
+        return localizedCatalogString("Meeting is starting now", language: language, bundle: bundle)
     }
 
     nonisolated static func notificationBody(for event: GoogleCalendarEvent) -> String {
-        String(format: localizedCatalogString("Tap to start recording: %@"), event.title)
+        notificationBody(for: event, language: preferredLocalizedStringLanguage(), bundle: .main)
+    }
+
+    nonisolated static func notificationBody(for event: GoogleCalendarEvent, language: String, bundle: Bundle) -> String {
+        String(format: localizedCatalogString("Tap to start recording: %@", language: language, bundle: bundle), event.title)
     }
 
     nonisolated static func isReminderEligible(_ event: GoogleCalendarEvent) -> Bool {

--- a/Sources/LocalizedStringLookup.swift
+++ b/Sources/LocalizedStringLookup.swift
@@ -17,3 +17,12 @@ func localizedCatalogString(
     }
     return strings[key] ?? key
 }
+
+func localizedCatalogFormat(
+    _ key: String,
+    _ arguments: CVarArg...,
+    language: String = preferredLocalizedStringLanguage(),
+    bundle: Bundle = .main
+) -> String {
+    String(format: localizedCatalogString(key, language: language, bundle: bundle), arguments: arguments)
+}

--- a/Sources/LocalizedStringLookup.swift
+++ b/Sources/LocalizedStringLookup.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Resolves stable UI catalog keys without changing persisted identifiers or dynamic values.
+func preferredLocalizedStringLanguage(bundle: Bundle = .main) -> String {
+    bundle.preferredLocalizations.first ?? "en"
+}
+
+func localizedCatalogString(
+    _ key: String,
+    language: String = preferredLocalizedStringLanguage(),
+    bundle: Bundle = .main
+) -> String {
+    let path = bundle.path(forResource: "Localizable", ofType: "strings", inDirectory: nil, forLocalization: language)
+        ?? URL(fileURLWithPath: bundle.bundlePath).appendingPathComponent("\(language).lproj/Localizable.strings").path
+    guard let strings = NSDictionary(contentsOfFile: path) as? [String: String] else {
+        return key
+    }
+    return strings[key] ?? key
+}

--- a/Sources/LocalizedStringLookup.swift
+++ b/Sources/LocalizedStringLookup.swift
@@ -10,12 +10,7 @@ func localizedCatalogString(
     language: String = preferredLocalizedStringLanguage(),
     bundle: Bundle = .main
 ) -> String {
-    let path = bundle.path(forResource: "Localizable", ofType: "strings", inDirectory: nil, forLocalization: language)
-        ?? URL(fileURLWithPath: bundle.bundlePath).appendingPathComponent("\(language).lproj/Localizable.strings").path
-    guard let strings = NSDictionary(contentsOfFile: path) as? [String: String] else {
-        return key
-    }
-    return strings[key] ?? key
+    localizedCatalogStrings(language: language, bundle: bundle)[key] ?? key
 }
 
 func localizedCatalogFormat(
@@ -24,5 +19,34 @@ func localizedCatalogFormat(
     language: String = preferredLocalizedStringLanguage(),
     bundle: Bundle = .main
 ) -> String {
-    String(format: localizedCatalogString(key, language: language, bundle: bundle), arguments: arguments)
+    String(
+        format: localizedCatalogString(key, language: language, bundle: bundle),
+        locale: Locale(identifier: language),
+        arguments: arguments
+    )
+}
+
+private let localizedCatalogCache = NSCache<NSString, NSDictionary>()
+private let localizedCatalogCacheLock = NSLock()
+
+private func localizedCatalogStrings(language: String, bundle: Bundle) -> [String: String] {
+    let cacheKey = "\(bundle.bundlePath)\u{0}\(language)" as NSString
+
+    localizedCatalogCacheLock.lock()
+    if let cached = localizedCatalogCache.object(forKey: cacheKey) as? [String: String] {
+        localizedCatalogCacheLock.unlock()
+        return cached
+    }
+    localizedCatalogCacheLock.unlock()
+
+    let path = bundle.path(forResource: "Localizable", ofType: "strings", inDirectory: nil, forLocalization: language)
+        ?? URL(fileURLWithPath: bundle.bundlePath).appendingPathComponent("\(language).lproj/Localizable.strings").path
+    guard let strings = NSDictionary(contentsOfFile: path) as? [String: String] else {
+        return [:]
+    }
+
+    localizedCatalogCacheLock.lock()
+    localizedCatalogCache.setObject(strings as NSDictionary, forKey: cacheKey)
+    localizedCatalogCacheLock.unlock()
+    return strings
 }

--- a/Sources/LocalizedUserMessage.swift
+++ b/Sources/LocalizedUserMessage.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum LocalizedUserMessage {
+    static func shortcutStatus(shortcut: String, isToggleMode: Bool) -> String {
+        formatted(isToggleMode ? "Tap %@ to dictate" : "Hold %@ to dictate", shortcut)
+    }
+
+    static func screenRecordingPermission(detail: String) -> String {
+        formatted("Screen Recording permission is required. %@", detail)
+    }
+
+    static func screenshotFailure(detail: String) -> String {
+        formatted("Failed to capture screenshot: %@", detail)
+    }
+
+    static func providerFailure(prefix: String, providerDetail: String) -> String {
+        String(format: localizedCatalogString("%@: %@"), prefix, providerDetail)
+    }
+
+    private static func formatted(_ key: String, _ value: String) -> String {
+        String(format: localizedCatalogString(key), value)
+    }
+}

--- a/Sources/LocalizedUserMessage.swift
+++ b/Sources/LocalizedUserMessage.swift
@@ -2,22 +2,38 @@ import Foundation
 
 enum LocalizedUserMessage {
     static func shortcutStatus(shortcut: String, isToggleMode: Bool) -> String {
-        formatted(isToggleMode ? "Tap %@ to dictate" : "Hold %@ to dictate", shortcut)
+        shortcutStatus(shortcut: shortcut, isToggleMode: isToggleMode, language: preferredLocalizedStringLanguage(), bundle: .main)
+    }
+
+    static func shortcutStatus(shortcut: String, isToggleMode: Bool, language: String, bundle: Bundle) -> String {
+        formatted(isToggleMode ? "Tap %@ to dictate" : "Hold %@ to dictate", shortcut, language: language, bundle: bundle)
     }
 
     static func screenRecordingPermission(detail: String) -> String {
-        formatted("Screen Recording permission is required. %@", detail)
+        screenRecordingPermission(detail: detail, language: preferredLocalizedStringLanguage(), bundle: .main)
+    }
+
+    static func screenRecordingPermission(detail: String, language: String, bundle: Bundle) -> String {
+        formatted("Screen Recording permission is required. %@\n\nQuill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill.", detail, language: language, bundle: bundle)
     }
 
     static func screenshotFailure(detail: String) -> String {
-        formatted("Failed to capture screenshot: %@", detail)
+        screenshotFailure(detail: detail, language: preferredLocalizedStringLanguage(), bundle: .main)
+    }
+
+    static func screenshotFailure(detail: String, language: String, bundle: Bundle) -> String {
+        formatted("Failed to capture screenshot: %@\n\nA screenshot is required for context-aware transcription. Recording has been stopped.", detail, language: language, bundle: bundle)
     }
 
     static func providerFailure(prefix: String, providerDetail: String) -> String {
-        String(format: localizedCatalogString("%@: %@"), prefix, providerDetail)
+        providerFailure(prefix: prefix, providerDetail: providerDetail, language: preferredLocalizedStringLanguage(), bundle: .main)
     }
 
-    private static func formatted(_ key: String, _ value: String) -> String {
-        String(format: localizedCatalogString(key), value)
+    static func providerFailure(prefix: String, providerDetail: String, language: String, bundle: Bundle) -> String {
+        String(format: localizedCatalogString("%@: %@", language: language, bundle: bundle), prefix, providerDetail)
+    }
+
+    private static func formatted(_ key: String, _ value: String, language: String, bundle: Bundle) -> String {
+        String(format: localizedCatalogString(key, language: language, bundle: bundle), value)
     }
 }

--- a/Sources/LocalizedUserMessage.swift
+++ b/Sources/LocalizedUserMessage.swift
@@ -14,7 +14,7 @@ enum LocalizedUserMessage {
     }
 
     static func screenRecordingPermission(detail: String, language: String, bundle: Bundle) -> String {
-        formatted("Screen Recording permission is required. %@\n\nQuill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill.", detail, language: language, bundle: bundle)
+        formatted("%@\n\nQuill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill.", detail, language: language, bundle: bundle)
     }
 
     static func screenshotFailure(detail: String) -> String {

--- a/Sources/MeetingReminderOverlay.swift
+++ b/Sources/MeetingReminderOverlay.swift
@@ -504,7 +504,7 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
     }
 
     private static func startText(for start: Date) -> String {
-        "Starts at \(startTimeText(for: start))"
+        OverlayDisplayCopy.meetingStarts(at: startTimeText(for: start))
     }
 
     private static func startTimeText(for start: Date) -> String {
@@ -615,7 +615,7 @@ private struct DefaultMeetingReminderOverlayView: View {
                         HStack(spacing: 6) {
                             AppIconView(size: 22, cornerRadius: 6)
                                 .matchedGeometryEffect(id: "appIcon", in: animationNamespace)
-                            Text("Quill")
+                            Text(verbatim: "Quill")
                                 .font(.system(size: 11, weight: .bold))
                                 .foregroundStyle(.white.opacity(0.72))
                                 .lineLimit(1)
@@ -699,7 +699,7 @@ private struct CenterMeetingReminderOverlayView: View {
                 HStack(spacing: 6) {
                     AppIconView(size: 22, cornerRadius: 6)
                         .matchedGeometryEffect(id: "appIcon", in: animationNamespace)
-                    Text("Quill")
+                    Text(verbatim: "Quill")
                         .font(.system(size: 11, weight: .bold))
                         .foregroundStyle(.white.opacity(0.72))
                         .lineLimit(1)
@@ -805,6 +805,7 @@ private struct CloseButton: View {
                 .background(Color.white.opacity(0.10), in: Circle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("Close")
     }
 }
 

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -31,7 +31,7 @@ struct MenuBarView: View {
         let text = transcriptText(for: item)
             .replacingOccurrences(of: "\n", with: " ")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty else { return "(no transcript)" }
+        guard !text.isEmpty else { return String(localized: "(no transcript)") }
         return text.count > 48 ? String(text.prefix(48)) + "..." : text
     }
 
@@ -113,7 +113,7 @@ struct MenuBarView: View {
             Divider()
 
             // Manual toggle
-            Button(appState.isRecording ? "Stop Recording" : "Start Dictating") {
+            Button(appState.isRecording ? String(localized: "Stop Recording") : String(localized: "Start Dictating")) {
                 appState.toggleRecording()
             }
             .disabled(appState.isTranscribing)
@@ -140,8 +140,8 @@ struct MenuBarView: View {
 
             if !appState.lastTranscript.isEmpty && !appState.isRecording && !appState.isTranscribing {
                 Button(appState.copyAgainShortcut.isDisabled
-                    ? "Paste Again"
-                    : "Paste Again  (\(appState.copyAgainShortcut.displayName))") {
+                    ? String(localized: "Paste Again")
+                    : String(localized: "Paste Again  (\(appState.copyAgainShortcut.displayName))")) {
                     appState.copyLastTranscriptToPasteboard()
                 }
 
@@ -384,7 +384,7 @@ struct MenuBarView: View {
                         ProgressView()
                             .controlSize(.small)
                     }
-                    Text(updateManager.isChecking ? "Checking for Updates..." : "Check for Updates")
+                    Text(updateManager.isChecking ? String(localized: "Checking for Updates...") : String(localized: "Check for Updates"))
                 }
             }
             .disabled(updateManager.isChecking)
@@ -451,7 +451,7 @@ struct MenuBarView: View {
 
             Divider()
 
-            Button("Quit \(AppName.displayName)") {
+            Button(String(localized: "Quit \(AppName.displayName)")) {
                 NSApplication.shared.terminate(nil)
             }
             .keyboardShortcut("q")

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -141,7 +141,7 @@ struct MenuBarView: View {
             if !appState.lastTranscript.isEmpty && !appState.isRecording && !appState.isTranscribing {
                 Button(appState.copyAgainShortcut.isDisabled
                     ? String(localized: "Paste Again")
-                    : String(localized: "Paste Again  (\(appState.copyAgainShortcut.displayName))")) {
+                    : localizedCatalogFormat("Paste Again  (%@)", appState.copyAgainShortcut.displayName)) {
                     appState.copyLastTranscriptToPasteboard()
                 }
 
@@ -451,7 +451,7 @@ struct MenuBarView: View {
 
             Divider()
 
-            Button(String(localized: "Quit \(AppName.displayName)")) {
+            Button(localizedCatalogFormat("Quit %@", AppName.displayName)) {
                 NSApplication.shared.terminate(nil)
             }
             .keyboardShortcut("q")

--- a/Sources/ModelDropdownView.swift
+++ b/Sources/ModelDropdownView.swift
@@ -3,8 +3,8 @@ import SwiftUI
 /// A reusable dropdown for selecting a model from predefined options,
 /// or providing a custom model string if "Custom..." is chosen.
 struct ModelDropdownView: View {
-    let title: String
-    let subtitle: String?
+    let title: LocalizedStringKey
+    let subtitle: LocalizedStringKey?
     let predefinedModels: [String]
     let defaultModel: String
     
@@ -47,7 +47,7 @@ struct ModelDropdownView: View {
             HStack(spacing: 8) {
                 Picker("", selection: effectiveSelection) {
                     ForEach(predefinedModels, id: \.self) { model in
-                        Text(model).tag(model)
+                        Text(verbatim: model).tag(model)
                     }
                     Divider()
                     Text("Custom...").tag("Custom...")

--- a/Sources/NativeWhisperModel.swift
+++ b/Sources/NativeWhisperModel.swift
@@ -1,12 +1,6 @@
 import CryptoKit
 import Foundation
 
-private func nativeLocalizedString(_ key: String, language: String, bundle: Bundle = .main) -> String {
-    let path = bundle.path(forResource: "Localizable", ofType: "strings", inDirectory: nil, forLocalization: language)
-        ?? URL(fileURLWithPath: bundle.bundlePath).appendingPathComponent("\(language).lproj/Localizable.strings").path
-    guard let strings = NSDictionary(contentsOfFile: path) as? [String: String] else { return key }
-    return strings[key] ?? key
-}
 
 struct NativeWhisperModel: Identifiable, Hashable, Codable {
     let id: String
@@ -21,11 +15,11 @@ struct NativeWhisperModel: Identifiable, Hashable, Codable {
 
     /// Resolves only user-facing copy. Download metadata and file identity stay unchanged.
     func localizedDescription(
-        language: String = Locale.current.language.languageCode?.identifier ?? "en",
+        language: String = preferredLocalizedStringLanguage(),
         bundle: Bundle = .main
     ) -> String {
         guard id == "whisper-large-v3-turbo" else { return description }
-        return nativeLocalizedString(
+        return localizedCatalogString(
             "Fast local transcription with high accuracy. Recommended.",
             language: language,
             bundle: bundle

--- a/Sources/NativeWhisperModel.swift
+++ b/Sources/NativeWhisperModel.swift
@@ -1,6 +1,13 @@
 import CryptoKit
 import Foundation
 
+private func nativeLocalizedString(_ key: String, language: String, bundle: Bundle = .main) -> String {
+    let path = bundle.path(forResource: "Localizable", ofType: "strings", inDirectory: nil, forLocalization: language)
+        ?? URL(fileURLWithPath: bundle.bundlePath).appendingPathComponent("\(language).lproj/Localizable.strings").path
+    guard let strings = NSDictionary(contentsOfFile: path) as? [String: String] else { return key }
+    return strings[key] ?? key
+}
+
 struct NativeWhisperModel: Identifiable, Hashable, Codable {
     let id: String
     let displayName: String
@@ -13,11 +20,16 @@ struct NativeWhisperModel: Identifiable, Hashable, Codable {
     static var recommended: NativeWhisperModel { NativeWhisperModelCatalog.recommended }
 
     /// Resolves only user-facing copy. Download metadata and file identity stay unchanged.
-    func localizedDescription(language: String = Locale.current.language.languageCode?.identifier ?? "en") -> String {
+    func localizedDescription(
+        language: String = Locale.current.language.languageCode?.identifier ?? "en",
+        bundle: Bundle = .main
+    ) -> String {
         guard id == "whisper-large-v3-turbo" else { return description }
-        return language.lowercased().hasPrefix("ko")
-            ? "빠르고 정확한 로컬 받아쓰기. 추천."
-            : "Fast local transcription with high accuracy. Recommended."
+        return nativeLocalizedString(
+            "Fast local transcription with high accuracy. Recommended.",
+            language: language,
+            bundle: bundle
+        )
     }
 }
 

--- a/Sources/NativeWhisperModel.swift
+++ b/Sources/NativeWhisperModel.swift
@@ -11,6 +11,14 @@ struct NativeWhisperModel: Identifiable, Hashable, Codable {
     let checksumSHA256: String
 
     static var recommended: NativeWhisperModel { NativeWhisperModelCatalog.recommended }
+
+    /// Resolves only user-facing copy. Download metadata and file identity stay unchanged.
+    func localizedDescription(language: String = Locale.current.language.languageCode?.identifier ?? "en") -> String {
+        guard id == "whisper-large-v3-turbo" else { return description }
+        return language.lowercased().hasPrefix("ko")
+            ? "빠르고 정확한 로컬 받아쓰기. 추천."
+            : "Fast local transcription with high accuracy. Recommended."
+    }
 }
 
 struct NativeWhisperModelCatalog {

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -1375,7 +1375,7 @@ private struct NoteDetailView: View {
             .foregroundStyle(.quaternary)
     }
 
-    private func metaTag(_ label: String, active: Bool, help tooltip: String) -> some View {
+    private func metaTag(_ label: String, active: Bool, help tooltip: LocalizedStringKey) -> some View {
         Button(action: {}) {
             Text(label)
                 .font(.system(size: 9, weight: .medium, design: .monospaced))
@@ -1542,7 +1542,7 @@ private struct NoteDetailView: View {
         action: @escaping () -> Void,
         @ViewBuilder label: @escaping () -> L,
         disabled: Bool,
-        help: String
+        help: LocalizedStringKey
     ) -> some View {
         ToolbarIconButton(
             action: action,
@@ -1914,7 +1914,7 @@ private struct ToolbarButtonStyle: ButtonStyle {
 private struct ToolbarIconButton<Label: View>: View {
     let action: () -> Void
     let disabled: Bool
-    let help: String
+    let help: LocalizedStringKey
     @ViewBuilder let label: () -> Label
 
     @State private var isHovered = false
@@ -1999,15 +1999,22 @@ private struct ObsidianExportSheet: View {
 
             fieldLabel("Obsidian Vault Folder")
             HStack(spacing: 8) {
-                Text(vaultPath.isEmpty ? "Select a folder" : vaultPath)
-                    .font(.callout)
-                    .foregroundStyle(vaultPath.isEmpty ? .tertiary : .primary)
-                    .lineLimit(1).truncationMode(.middle)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 10).padding(.vertical, 6)
-                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 7))
-                    .overlay(RoundedRectangle(cornerRadius: 7)
-                        .strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5))
+                Group {
+                    if vaultPath.isEmpty {
+                        Text("Select a folder")
+                            .foregroundStyle(.tertiary)
+                    } else {
+                        Text(vaultPath)
+                            .foregroundStyle(.primary)
+                    }
+                }
+                .font(.callout)
+                .lineLimit(1).truncationMode(.middle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 10).padding(.vertical, 6)
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 7))
+                .overlay(RoundedRectangle(cornerRadius: 7)
+                    .strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5))
                 Button("Change") { selectVaultFolder() }.controlSize(.small)
             }
             .padding(.bottom, 16)
@@ -2087,8 +2094,8 @@ private struct ObsidianExportSheet: View {
         .onAppear { titleInput = defaultTitleInput }
     }
 
-    private func fieldLabel(_ text: String) -> some View {
-        Text(text).font(.caption.weight(.semibold)).foregroundStyle(.secondary).padding(.bottom, 6)
+    private func fieldLabel(_ key: LocalizedStringKey) -> some View {
+        Text(key).font(.caption.weight(.semibold)).foregroundStyle(.secondary).padding(.bottom, 6)
     }
 
     private func selectVaultFolder() {

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -519,7 +519,7 @@ struct NoteBrowserView: View {
             // Title row
             HStack(spacing: 8) {
                 HStack(spacing: 6) {
-                    Text("Recordings")
+                    Text(verbatim: "Recordings")
                         .font(.system(size: 15, weight: .bold))
                         .foregroundStyle(.primary)
                         .lineLimit(1)
@@ -589,7 +589,7 @@ struct NoteBrowserView: View {
             .padding(.bottom, 10)
 
             HStack(spacing: 8) {
-                Text("Transcription")
+                Text(verbatim: "Transcription")
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundStyle(.tertiary)
                     .textCase(.uppercase)

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -152,7 +152,7 @@ source: Quill
 
 ---
 
-# 전사문
+# \(String(localized: "Transcript"))
 \(audioEmbed)
 \(content)
 """
@@ -164,7 +164,7 @@ date: \(iso.string(from: timestamp))
 source: Quill
 ---
 
-# 전사문
+# \(String(localized: "Transcript"))
 \(audioEmbed)
 \(content)
 """
@@ -182,9 +182,9 @@ source: Quill
                     try FileManager.default.copyItem(at: srcURL, to: dstURL)
                 }
 
-                await self.notify(title: "내보내기 완료", body: "\(fileName).md 저장됨", success: true)
+                await self.notify(title: String(localized: "Export Complete"), body: String(localized: "\(fileName).md saved"), success: true)
             } catch {
-                await self.notify(title: "내보내기 실패", body: error.localizedDescription, success: false)
+                await self.notify(title: String(localized: "Export Failed"), body: error.localizedDescription, success: false)
             }
         }
     }
@@ -205,7 +205,7 @@ source: Quill
         ]
         guard let geminiPath = candidates.first(where: { FileManager.default.fileExists(atPath: $0) }) else {
             throw NSError(domain: "GeminiCLI", code: 1,
-                          userInfo: [NSLocalizedDescriptionKey: "gemini CLI를 찾을 수 없습니다"])
+                          userInfo: [NSLocalizedDescriptionKey: String(localized: "Gemini CLI could not be found")])
         }
 
         return try await withCheckedThrowingContinuation { continuation in
@@ -236,7 +236,7 @@ source: Quill
                 let cleaned = raw.replacingOccurrences(of: #"\x1B\[[0-9;]*[mGKHF]"#, with: "", options: .regularExpression)
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 if cleaned.isEmpty {
-                    let err = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "알 수 없는 오류"
+                    let err = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? String(localized: "Unknown error")
                     continuation.resume(throwing: NSError(domain: "GeminiCLI", code: 2,
                         userInfo: [NSLocalizedDescriptionKey: err.trimmingCharacters(in: .whitespacesAndNewlines)]))
                 } else {
@@ -449,13 +449,13 @@ struct NoteBrowserView: View {
         }
         .onReceive(appState.$pipelineHistory) { newHistory in
             let ids = newHistory.map(\.id)
-            // 현재 선택이 사라진 경우 → 최신 항목 선택
+            // Select the latest item if the current selection disappears
             guard let current = selectedItemID, ids.contains(current) else {
                 selectedItemID = ids.first
                 knownHistoryIDs = Set(ids)
                 return
             }
-            // 진짜 새 항목이 추가된 경우에만 자동 선택 (기존 항목 수정은 무시)
+            // Auto-select only genuinely new items; ignore existing item edits
             if let newest = ids.first, newest != current, !knownHistoryIDs.contains(newest) {
                 selectedItemID = newest
             }
@@ -636,7 +636,7 @@ struct NoteBrowserView: View {
                 Image(systemName: "magnifyingglass")
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.tertiary)
-                TextField("검색", text: $searchText)
+                TextField("Search", text: $searchText)
                     .textFieldStyle(.plain)
                     .font(.system(size: 12))
                 if !searchText.isEmpty {
@@ -665,7 +665,7 @@ struct NoteBrowserView: View {
                     Image(systemName: "magnifyingglass")
                         .font(.system(size: 22, weight: .ultraLight))
                         .foregroundStyle(.tertiary)
-                    Text("검색 결과 없음")
+                    Text("No Search Results")
                         .font(.system(size: 12))
                         .foregroundStyle(.tertiary)
                     Spacer()
@@ -706,8 +706,8 @@ struct NoteBrowserView: View {
         panel.allowedContentTypes = Array(AudioImportOptions.broadlySupportedExtensions)
             .sorted()
             .compactMap { UTType(filenameExtension: $0) }
-        panel.prompt = "Choose"
-        panel.message = "Choose an audio file. Supported formats: FLAC, MP3, MP4, MPEG, MPGA, M4A, OGG, WAV, WEBM"
+        panel.prompt = String(localized: "Choose")
+        panel.message = String(localized: "Choose an audio file. Supported formats: FLAC, MP3, MP4, MPEG, MPGA, M4A, OGG, WAV, WEBM")
         panel.begin { response in
             guard response == .OK, let url = panel.url else { return }
             pendingAudioImport = PendingAudioImport(
@@ -732,10 +732,10 @@ struct NoteBrowserView: View {
                     .font(.system(size: 26, weight: .ultraLight))
                     .foregroundStyle(.tertiary)
             }
-            Text("녹음이 없습니다")
+            Text("No Recordings")
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(.secondary)
-            Text("단축키를 눌러 녹음을 시작하세요")
+            Text("Press the shortcut to start recording")
                 .font(.system(size: 11))
                 .foregroundStyle(.tertiary)
                 .multilineTextAlignment(.center)
@@ -773,10 +773,10 @@ struct NoteBrowserView: View {
                     .font(.system(size: 32, weight: .ultraLight))
                     .foregroundStyle(.tertiary)
             }
-            Text("노트를 선택하세요")
+            Text("Select a Note")
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(.secondary)
-            Text("왼쪽 목록에서 녹음을 선택하면\n전사된 내용이 표시됩니다")
+            Text("Select a recording from the list to view its transcript")
                 .font(.system(size: 12))
                 .foregroundStyle(.tertiary)
                 .multilineTextAlignment(.center)
@@ -798,10 +798,10 @@ struct NoteBrowserView: View {
                     .font(.system(size: 38, weight: .ultraLight))
                     .foregroundStyle(.tertiary)
             }
-            Text("녹음이 없습니다")
+            Text("No Recordings")
                 .font(.system(size: 18, weight: .semibold))
                 .foregroundStyle(.secondary)
-            Text("단축키를 눌러 첫 번째 녹음을 시작하세요.\n전사된 내용이 여기에 나타납니다.")
+            Text("Press the shortcut to start your first recording.\nYour transcript will appear here.")
                 .font(.system(size: 13))
                 .foregroundStyle(.tertiary)
                 .multilineTextAlignment(.center)
@@ -1030,7 +1030,7 @@ private struct NoteListRow: View {
                     if isExporting {
                         HStack(spacing: 2) {
                             ProgressView().controlSize(.mini).scaleEffect(0.6)
-                            Text("내보내는 중")
+                            Text("Exporting")
                                 .font(.system(size: 8, weight: .medium))
                                 .foregroundStyle(isSelected ? selectedMetaColor : .orange)
                         }
@@ -1186,11 +1186,11 @@ private struct NoteDetailView: View {
         .onReceive(appState.$retryingItemIDs) { ids in
             isRetrying = ids.contains(item.id)
         }
-        .confirmationDialog("노트를 삭제할까요?", isPresented: $showDeleteConfirmation, titleVisibility: .visible) {
-            Button("삭제", role: .destructive) { onDelete() }
-            Button("취소", role: .cancel) {}
+        .confirmationDialog("Delete this note?", isPresented: $showDeleteConfirmation, titleVisibility: .visible) {
+            Button("Delete", role: .destructive) { onDelete() }
+            Button("Cancel", role: .cancel) {}
         } message: {
-            Text("삭제한 노트는 복구할 수 없습니다.")
+            Text("Deleted notes cannot be recovered.")
         }
     }
 
@@ -1259,7 +1259,7 @@ private struct NoteDetailView: View {
                 .padding(.top, 2)
             }
 
-            // Audio player (오디오 파일이 있을 때만 표시)
+            // Show the audio player only when an audio file exists
             if let audioFileName = item.audioFileName {
                 let audioURL = AppState.audioStorageDirectory().appendingPathComponent(audioFileName)
                 if FileManager.default.fileExists(atPath: audioURL.path) {
@@ -1343,26 +1343,26 @@ private struct NoteDetailView: View {
             metaTag(
                 item.usedLocalTranscription ? "LOCAL" : "CLOUD",
                 active: item.usedLocalTranscription,
-                help: item.usedLocalTranscription ? "로컬 전사" : "클라우드 전사"
+                help: item.usedLocalTranscription ? "Local transcription" : "Cloud transcription"
             )
             metaDot
             metaTag(
                 item.usedContextCapture ? "CTX" : "NO CTX",
                 active: item.usedContextCapture,
-                help: item.usedContextCapture ? "컨텍스트 캡처 사용" : "컨텍스트 미사용"
+                help: item.usedContextCapture ? "Context capture enabled" : "Context capture disabled"
             )
             metaDot
             metaTag(
                 item.usedPostProcessing ? "LLM" : "NO LLM",
                 active: item.usedPostProcessing,
-                help: item.usedPostProcessing ? "LLM 후처리 사용" : "LLM 후처리 미사용"
+                help: item.usedPostProcessing ? "LLM post-processing enabled" : "LLM post-processing disabled"
             )
             if item.transcriptionLanguageCode != "auto" {
                 metaDot
                 metaTag(
                     item.transcriptionLanguageCode.uppercased(),
                     active: true,
-                    help: "전사 언어"
+                    help: "Transcription language"
                 )
             }
         }
@@ -1467,7 +1467,7 @@ private struct NoteDetailView: View {
                         }
                     },
                     disabled: isRetrying,
-                    help: "전사 재시도"
+                    help: "Retry transcription"
                 )
                 toolbarDivider
             }
@@ -1481,7 +1481,7 @@ private struct NoteDetailView: View {
                         .foregroundStyle(isCopied ? Color.accentColor : Color.primary)
                 },
                 disabled: displayContent.isEmpty,
-                help: "내용 복사"
+                help: "Copy content"
             )
 
             // Share (Obsidian export)
@@ -1493,7 +1493,7 @@ private struct NoteDetailView: View {
                         .foregroundStyle(Color.primary)
                 },
                 disabled: displayContent.isEmpty,
-                help: "Obsidian으로 내보내기"
+                help: "Export to Obsidian"
             )
 
             toolbarDivider
@@ -1507,7 +1507,7 @@ private struct NoteDetailView: View {
                         .foregroundStyle(Color.red.opacity(0.8))
                 },
                 disabled: false,
-                help: "노트 삭제"
+                help: "Delete note"
             )
         }
         .padding(.horizontal, 8)
@@ -1946,6 +1946,7 @@ private struct ObsidianExportSheet: View {
     let onDismiss: () -> Void
 
     @AppStorage("obsidian_vault_path") private var vaultPath: String = ""
+    // localization-allowlist: exact non-UI Gemini model prompt
     @AppStorage("obsidian_gemini_prompt") private var geminiPrompt: String = "다음은 음성 전사 내용입니다. 핵심 내용을 유지하면서 읽기 쉽게 정리해주세요. 마크다운 형식으로 작성하되, 불필요한 설명 없이 정리된 내용만 출력해주세요.\n옵시디언에 다른 회의록을 참고하여 컨텍스트와 작성 포맷을 통일하여 주세요."
     @State private var titleInput: String = ""
     @State private var includeAudio: Bool = true
@@ -1979,26 +1980,26 @@ private struct ObsidianExportSheet: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text("Obsidian으로 내보내기")
+            Text("Export to Obsidian")
                 .font(.headline)
                 .padding(.bottom, 20)
 
-            fieldLabel("파일 제목")
+            fieldLabel("File Title")
             HStack(spacing: 6) {
                 Text(datePrefix)
                     .font(.body).foregroundStyle(.secondary)
                     .padding(.horizontal, 10).padding(.vertical, 6)
                     .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 7))
-                TextField("제목 추가 (선택)", text: $titleInput)
+                TextField("Add title (optional)", text: $titleInput)
                     .textFieldStyle(.roundedBorder)
             }
-            Text("저장될 파일명: \(finalFileName).md")
+            Text("Saved file name: \(finalFileName).md")
                 .font(.caption).foregroundStyle(.tertiary)
                 .padding(.top, 4).padding(.bottom, 16)
 
-            fieldLabel("Obsidian Vault 폴더")
+            fieldLabel("Obsidian Vault Folder")
             HStack(spacing: 8) {
-                Text(vaultPath.isEmpty ? "폴더를 선택하세요" : vaultPath)
+                Text(vaultPath.isEmpty ? "Select a folder" : vaultPath)
                     .font(.callout)
                     .foregroundStyle(vaultPath.isEmpty ? .tertiary : .primary)
                     .lineLimit(1).truncationMode(.middle)
@@ -2007,15 +2008,15 @@ private struct ObsidianExportSheet: View {
                     .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 7))
                     .overlay(RoundedRectangle(cornerRadius: 7)
                         .strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5))
-                Button("변경") { selectVaultFolder() }.controlSize(.small)
+                Button("Change") { selectVaultFolder() }.controlSize(.small)
             }
             .padding(.bottom, 16)
 
             if hasAudio {
                 Toggle(isOn: $includeAudio) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("오디오 파일 포함").font(.callout)
-                        Text("md 파일과 같은 폴더에 복사됩니다")
+                        Text("Include Audio File").font(.callout)
+                        Text("Copied to the same folder as the markdown file")
                             .font(.caption).foregroundStyle(.secondary)
                     }
                 }
@@ -2025,8 +2026,8 @@ private struct ObsidianExportSheet: View {
             VStack(alignment: .leading, spacing: 8) {
                 Toggle(isOn: $useGemini) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Gemini로 내용 정리").font(.callout)
-                        Text("내보내기 전에 Gemini CLI로 전사 내용을 정리합니다")
+                        Text("Refine content with Gemini").font(.callout)
+                        Text("Gemini CLI refines the transcript before export")
                             .font(.caption).foregroundStyle(.secondary)
                     }
                 }
@@ -2035,9 +2036,9 @@ private struct ObsidianExportSheet: View {
                 if useGemini {
                     VStack(alignment: .leading, spacing: 4) {
                         HStack {
-                            Text("프롬프트").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                            Text("Prompt").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
                             Spacer()
-                            Button(showPromptEditor ? "접기" : "편집") { showPromptEditor.toggle() }
+                            Button(showPromptEditor ? "Collapse" : "Edit") { showPromptEditor.toggle() }
                                 .font(.caption).controlSize(.mini)
                         }
                         if showPromptEditor {
@@ -2072,9 +2073,9 @@ private struct ObsidianExportSheet: View {
             Divider().padding(.bottom, 16)
 
             HStack {
-                Button("취소") { onDismiss() }.keyboardShortcut(.cancelAction)
+                Button("Cancel") { onDismiss() }.keyboardShortcut(.cancelAction)
                 Spacer()
-                Button(useGemini ? "백그라운드로 내보내기" : "내보내기") { exportNote() }
+                Button(useGemini ? "Export in Background" : "Export") { exportNote() }
                     .keyboardShortcut(.defaultAction)
                     .disabled(vaultPath.isEmpty)
                     .buttonStyle(.borderedProminent)
@@ -2095,8 +2096,8 @@ private struct ObsidianExportSheet: View {
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
         panel.allowsMultipleSelection = false
-        panel.prompt = "선택"
-        panel.message = "Obsidian Vault 폴더를 선택하세요"
+        panel.prompt = String(localized: "Choose")
+        panel.message = String(localized: "Choose an Obsidian Vault folder")
         if panel.runModal() == .OK, let url = panel.url { vaultPath = url.path }
     }
 
@@ -2256,7 +2257,7 @@ private struct LiveRecordingBadge: View {
                 .font(.system(size: 9, weight: .semibold, design: .monospaced))
                 .foregroundStyle(.red.opacity(0.7))
         }
-        .help("실시간 전사 중")
+        .help("Live transcription in progress")
     }
 }
 

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -625,7 +625,7 @@ struct NoteBrowserView: View {
                         .background(Color.primary.opacity(0.06), in: Capsule())
                 }
                 .menuStyle(.borderlessButton)
-                .accessibilityLabel("Transcription method: \(appState.noteBrowserTranscriptionChoiceDetailLabel)")
+                .accessibilityLabel(String(localized: "Transcription method: \(appState.noteBrowserTranscriptionChoiceDetailLabel)"))
                 .disabled(appState.isRecording || appState.isTranscribing)
             }
             .padding(.horizontal, 12)
@@ -1278,9 +1278,10 @@ private struct NoteDetailView: View {
     }
 
     private var metadataLine: some View {
-        ViewThatFits(in: .horizontal) {
+        let detailTimestamp = NoteTimestampFormatter.detailTimestamp(for: item)
+        return ViewThatFits(in: .horizontal) {
             HStack(spacing: 8) {
-                detailTimestampLabel
+                detailTimestampLabel(detailTimestamp)
                 statusBadges
                 noteStateIndicator
                 contextSummaryLabel
@@ -1288,7 +1289,7 @@ private struct NoteDetailView: View {
             }
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 8) {
-                    detailTimestampLabel
+                    detailTimestampLabel(detailTimestamp)
                     noteStateIndicator
                     Spacer(minLength: 0)
                 }
@@ -1301,8 +1302,8 @@ private struct NoteDetailView: View {
         }
     }
 
-    private var detailTimestampLabel: some View {
-        Text(NoteTimestampFormatter.detailTimestamp(for: item))
+    private func detailTimestampLabel(_ detailTimestamp: String) -> some View {
+        Text(detailTimestamp)
             .font(.system(size: 10, design: .monospaced))
             .foregroundStyle(.tertiary)
             .textCase(.uppercase)

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -352,14 +352,14 @@ private struct AudioImportSheet: View {
                         HStack {
                             Image(systemName: selectedChoice == display.choice ? "largecircle.fill.circle" : "circle")
                             VStack(alignment: .leading, spacing: 2) {
-                                Text(display.title)
+                                Text(display.localizedTitle())
                                 if let subtitle = display.subtitle {
-                                    Text(subtitle)
+                                    Text(verbatim: subtitle)
                                         .font(.system(size: 10))
                                         .foregroundStyle(.secondary)
                                 }
                                 if let unavailableReason = display.unavailableReason {
-                                    Text(unavailableReason)
+                                    Text(display.localizedUnavailableReason() ?? unavailableReason)
                                         .font(.system(size: 10))
                                         .foregroundStyle(.tertiary)
                                 }
@@ -417,7 +417,7 @@ struct NoteBrowserView: View {
                 if isSelected { appState.setNoteBrowserTranscriptionChoice(display.choice) }
             }
         )) {
-            Text(display.compactLabel)
+            Text(display.localizedCompactLabel())
         }
         .disabled(!display.isAvailable)
     }

--- a/Sources/NoteListRowDisplayData.swift
+++ b/Sources/NoteListRowDisplayData.swift
@@ -55,7 +55,7 @@ struct NoteListRowDisplayData: Equatable {
     let displayTitle: String
     let preview: String
 
-    init(item: PipelineHistoryItem, retryingIDs: Set<UUID>) {
+    init(item: PipelineHistoryItem, retryingIDs: Set<UUID>, locale: Locale = .current) {
         let status = transcriptStatus(for: item, retrying: retryingIDs)
         let trimmedCustomTitle = item.customTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
         let customTitle = trimmedCustomTitle?.isEmpty == true ? nil : trimmedCustomTitle
@@ -67,7 +67,7 @@ struct NoteListRowDisplayData: Equatable {
 
         self.id = item.id
         self.status = status
-        self.rowDate = NoteTimestampFormatter.rowTimestamp(for: item)
+        self.rowDate = NoteTimestampFormatter.rowTimestamp(for: item, locale: locale)
         self.displayTitle = displayTitle
         self.preview = Self.preview(
             for: item,

--- a/Sources/NoteListRowDisplayData.swift
+++ b/Sources/NoteListRowDisplayData.swift
@@ -14,64 +14,48 @@ func transcriptStatus(for item: PipelineHistoryItem, retrying: Set<UUID>) -> Tra
 }
 
 enum NoteTimestampFormatter {
-    static func detailTimestamp(for item: PipelineHistoryItem) -> String {
-        intervalTimestamp(
-            for: item,
-            fallbackFormatter: fullDateTimeFormatter,
-            startFormatter: fullDateTimeFormatter,
-            crossDateEndFormatter: fullDateTimeFormatter
-        )
-    }
-
-    static func rowTimestamp(for item: PipelineHistoryItem) -> String {
-        guard let startedAt = item.recordingStartedAt else {
-            return rowSingleTimestampFormatter.string(from: item.timestamp)
-        }
-        return rowStartTimestampFormatter.string(from: startedAt)
-    }
-
-    private static func intervalTimestamp(
-        for item: PipelineHistoryItem,
-        fallbackFormatter: DateFormatter,
-        startFormatter: DateFormatter,
-        crossDateEndFormatter: DateFormatter
-    ) -> String {
+    static func detailTimestamp(for item: PipelineHistoryItem, locale: Locale = .current) -> String {
         guard let startedAt = item.recordingStartedAt,
               let endedAt = item.recordingEndedAt,
               endedAt >= startedAt else {
-            return fallbackFormatter.string(from: item.timestamp)
+            return normalized(dateTimeStyle(locale: locale).format(item.timestamp))
         }
 
-        let startText = startFormatter.string(from: startedAt)
-        guard calendar.isDate(startedAt, inSameDayAs: endedAt) else {
-            return "\(startText) - \(crossDateEndFormatter.string(from: endedAt))"
+        let start = normalized(dateTimeStyle(locale: locale).format(startedAt))
+        let end = normalized(timeStyle(locale: locale).format(endedAt))
+        guard Calendar.current.isDate(startedAt, inSameDayAs: endedAt) else {
+            return "\(start)\(intervalSeparator(for: locale, start: startedAt, end: endedAt))\(normalized(dateTimeStyle(locale: locale).format(endedAt)))"
         }
-
-        if periodFormatter.string(from: startedAt) == periodFormatter.string(from: endedAt) {
-            return "\(startText) - \(timeFormatter.string(from: endedAt))"
-        }
-        return "\(startText) - \(periodTimeFormatter.string(from: endedAt))"
+        return "\(start)\(intervalSeparator(for: locale, start: startedAt, end: endedAt))\(end)"
     }
 
-    private static let calendar: Calendar = {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.locale = Locale(identifier: "ko_KR")
-        return calendar
-    }()
+    static func rowTimestamp(for item: PipelineHistoryItem, locale: Locale = .current) -> String {
+        let timestamp = item.recordingStartedAt ?? item.timestamp
+        return normalized(rowTimestampStyle(locale: locale).format(timestamp))
+    }
 
-    private static let fullDateTimeFormatter = makeFormatter("yyyy년 M월 d일 a h:mm")
-    private static let rowSingleTimestampFormatter = makeFormatter("M월 d일 · HH:mm")
-    private static let rowStartTimestampFormatter = makeFormatter("M월 d일 a h:mm")
-    private static let periodTimeFormatter = makeFormatter("a h:mm")
-    private static let timeFormatter = makeFormatter("h:mm")
-    private static let periodFormatter = makeFormatter("a")
+    private static func dateTimeStyle(locale: Locale) -> Date.FormatStyle {
+        Date.FormatStyle(date: .long, time: .shortened).locale(locale)
+    }
 
-    private static func makeFormatter(_ dateFormat: String) -> DateFormatter {
-        let formatter = DateFormatter()
-        formatter.calendar = calendar
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = dateFormat
-        return formatter
+    private static func rowTimestampStyle(locale: Locale) -> Date.FormatStyle {
+        Date.FormatStyle().month(.wide).day().hour().minute().locale(locale)
+    }
+
+    private static func timeStyle(locale: Locale) -> Date.FormatStyle {
+        Date.FormatStyle().hour().minute().locale(locale)
+    }
+
+    private static func intervalSeparator(for locale: Locale, start: Date, end: Date) -> String {
+        let interval = Date.IntervalFormatStyle(date: .long, time: .shortened)
+            .locale(locale)
+            .format(start..<end)
+        return interval.contains("~") ? "~" : " – "
+    }
+
+    private static func normalized(_ value: String) -> String {
+        value.replacingOccurrences(of: "\u{202F}", with: " ")
+            .replacingOccurrences(of: "\u{00A0}", with: " ")
     }
 }
 

--- a/Sources/NoteListRowDisplayData.swift
+++ b/Sources/NoteListRowDisplayData.swift
@@ -21,12 +21,11 @@ enum NoteTimestampFormatter {
             return normalized(dateTimeStyle(locale: locale).format(item.timestamp))
         }
 
-        let start = normalized(dateTimeStyle(locale: locale).format(startedAt))
-        let end = normalized(timeStyle(locale: locale).format(endedAt))
-        guard Calendar.current.isDate(startedAt, inSameDayAs: endedAt) else {
-            return "\(start)\(intervalSeparator(for: locale, start: startedAt, end: endedAt))\(normalized(dateTimeStyle(locale: locale).format(endedAt)))"
-        }
-        return "\(start)\(intervalSeparator(for: locale, start: startedAt, end: endedAt))\(end)"
+        return normalized(
+            Date.IntervalFormatStyle(date: .long, time: .shortened)
+                .locale(locale)
+                .format(startedAt..<endedAt)
+        )
     }
 
     static func rowTimestamp(for item: PipelineHistoryItem, locale: Locale = .current) -> String {
@@ -42,20 +41,10 @@ enum NoteTimestampFormatter {
         Date.FormatStyle().month(.wide).day().hour().minute().locale(locale)
     }
 
-    private static func timeStyle(locale: Locale) -> Date.FormatStyle {
-        Date.FormatStyle().hour().minute().locale(locale)
-    }
-
-    private static func intervalSeparator(for locale: Locale, start: Date, end: Date) -> String {
-        let interval = Date.IntervalFormatStyle(date: .long, time: .shortened)
-            .locale(locale)
-            .format(start..<end)
-        return interval.contains("~") ? "~" : " – "
-    }
-
     private static func normalized(_ value: String) -> String {
         value.replacingOccurrences(of: "\u{202F}", with: " ")
             .replacingOccurrences(of: "\u{00A0}", with: " ")
+            .replacingOccurrences(of: "\u{2009}", with: " ")
     }
 }
 

--- a/Sources/OverlayDisplayCopy.swift
+++ b/Sources/OverlayDisplayCopy.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+enum OverlayDisplayCopy {
+    static func meetingStarts(
+        at time: String,
+        language: String = preferredLocalizedStringLanguage(),
+        bundle: Bundle = .main
+    ) -> String {
+        formatted("Starts at %@", value: time, language: language, bundle: bundle)
+    }
+
+    static func inputChanged(
+        to deviceName: String,
+        language: String = preferredLocalizedStringLanguage(),
+        bundle: Bundle = .main
+    ) -> String {
+        formatted("Input changed to %@", value: deviceName, language: language, bundle: bundle)
+    }
+
+    static func updateAvailable(
+        version: String,
+        language: String = preferredLocalizedStringLanguage(),
+        bundle: Bundle = .main
+    ) -> String {
+        formatted("Update available: %@", value: version, language: language, bundle: bundle)
+    }
+
+    private static func formatted(_ key: String, value: String, language: String, bundle: Bundle) -> String {
+        String(format: localizedCatalogString(key, language: language, bundle: bundle), value)
+    }
+}

--- a/Sources/OverlayDisplayCopy.swift
+++ b/Sources/OverlayDisplayCopy.swift
@@ -22,7 +22,10 @@ enum OverlayDisplayCopy {
         language: String = preferredLocalizedStringLanguage(),
         bundle: Bundle = .main
     ) -> String {
-        formatted("Update available: %@", value: version, language: language, bundle: bundle)
+        guard !version.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return localizedCatalogString("Update available", language: language, bundle: bundle)
+        }
+        return formatted("Update available: %@", value: version, language: language, bundle: bundle)
     }
 
     private static func formatted(_ key: String, value: String, language: String, bundle: Bundle) -> String {

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -5,7 +5,18 @@ import AppKit
 
 struct RecordingOverlayInputOption: Identifiable, Equatable {
     let id: String
-    let name: String
+    private let name: String
+    private let isStaticQuillName: Bool
+
+    init(id: String, name: String, isStaticQuillName: Bool = false) {
+        self.id = id
+        self.name = name
+        self.isStaticQuillName = isStaticQuillName
+    }
+
+    var displayName: String {
+        isStaticQuillName ? String(localized: String.LocalizationValue(name)) : name
+    }
 }
 
 final class RecordingOverlayState: ObservableObject {
@@ -60,14 +71,14 @@ enum RecordingOverlayLayout: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
-    var displayName: String {
+    var displayName: LocalizedStringKey {
         switch self {
         case .centered: return "Centered"
         case .notchSides: return "Notch Sides"
         }
     }
 
-    var helpText: String {
+    var helpText: LocalizedStringKey {
         switch self {
         case .centered:
             return "Show the recording overlay centered below the notch."
@@ -1049,6 +1060,7 @@ private struct NotchSideOverlayView: View {
                             .background(Circle().fill(Color.red.opacity(0.92)))
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Stop recording")
                     .transition(.move(edge: .trailing).combined(with: .opacity))
                 }
             case .feedback:
@@ -1091,7 +1103,7 @@ struct RecordingOverlayView: View {
             } else if state.phase == .feedback {
                 FailureIndicatorView()
             } else if state.phase == .updateAvailable {
-                UpdateAvailableOverlayView(onPress: onUpdateOverlayPressed)
+                UpdateAvailableOverlayView(version: state.updateVersion, onPress: onUpdateOverlayPressed)
             } else {
                 ZStack {
                     Group {
@@ -1188,7 +1200,7 @@ struct InputSwitchMenu<Content: View>: View {
         }
     }
 
-    private var helpText: String {
+    private var helpText: LocalizedStringKey {
         switch displayMode {
         case .timeOnly: return "Elapsed time · click to switch audio input"
         case .hoverTime: return "Hover for elapsed time · click to switch audio input"
@@ -1320,7 +1332,7 @@ private struct InputMenuClickCatcher: NSViewRepresentable {
             guard !options.isEmpty else { return }
             let menu = NSMenu()
             for option in options {
-                let item = NSMenuItem(title: option.name, action: #selector(selectOption(_:)), keyEquivalent: "")
+                let item = NSMenuItem(title: option.displayName, action: #selector(selectOption(_:)), keyEquivalent: "")
                 item.target = self
                 item.representedObject = option.id
                 item.state = AudioInputDevice.isSameInput(option.id, selectedID) ? .on : .off
@@ -1406,6 +1418,7 @@ struct RecordingNoticeToastView: View {
 }
 
 struct UpdateAvailableOverlayView: View {
+    let version: String
     let onPress: () -> Void
 
     var body: some View {
@@ -1415,7 +1428,7 @@ struct UpdateAvailableOverlayView: View {
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(.white)
 
-                Text("Update Available")
+                Text(verbatim: OverlayDisplayCopy.updateAvailable(version: version))
                     .font(.system(size: 11, weight: .semibold))
                     .lineLimit(1)
             }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1241,6 +1241,7 @@ struct GeneralSettingsView: View {
 
     var body: some View {
         ScrollView {
+            // localization-audit: settings-card-titles-start
             VStack(spacing: 20) {
                 SettingsCard("App", icon: "power") {
                     startupSection
@@ -1252,6 +1253,7 @@ struct GeneralSettingsView: View {
                     permissionsSection
                 }
             }
+            // localization-audit: settings-card-titles-end
             .padding(24)
         }
         .onAppear {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -892,9 +892,9 @@ struct CalendarSettingsView: View {
         case .unknown, .healthy:
             return nil
         case .needsReconnect:
-            return health.message ?? "Quill can’t access Google Calendar. Reconnect to restore meeting reminders and calendar-based note titles."
+            return health.message ?? localizedCatalogString("Quill can’t access Google Calendar. Reconnect to restore meeting reminders and calendar-based note titles.")
         case .temporaryFailure:
-            return health.message ?? "Quill couldn’t refresh Google Calendar just now. Recording still works; reminders or note titles may be incomplete."
+            return health.message ?? localizedCatalogString("Quill couldn’t refresh Google Calendar just now. Recording still works; reminders or note titles may be incomplete.")
         }
     }
 
@@ -904,9 +904,9 @@ struct CalendarSettingsView: View {
         guard health.affectedFeature == .recordingReminders else { return nil }
         switch health.status {
         case .needsReconnect:
-            return "Reconnect Google Calendar to keep meeting recording reminders working."
+            return localizedCatalogString("Reconnect Google Calendar to keep meeting recording reminders working.")
         case .temporaryFailure:
-            return "Calendar reminders may be incomplete until the next successful refresh."
+            return localizedCatalogString("Calendar reminders may be incomplete until the next successful refresh.")
         case .unknown, .healthy:
             return nil
         }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -5,12 +5,13 @@ import UserNotifications
 
 // MARK: - Shared Helpers
 
-private func settingsLocalizedString(_ key: String, language: String) -> String {
-    let bundle = Bundle.main
-    let path = bundle.path(forResource: "Localizable", ofType: "strings", inDirectory: nil, forLocalization: language)
-        ?? URL(fileURLWithPath: bundle.bundlePath).appendingPathComponent("\(language).lproj/Localizable.strings").path
-    return (NSDictionary(contentsOfFile: path) as? [String: String])?[key] ?? key
+private func localizedCatalogFormat(_ key: String, _ first: String, _ second: String) -> String {
+    var value = localizedCatalogString(key)
+    if let range = value.range(of: "%arg") { value.replaceSubrange(range, with: first) }
+    if let range = value.range(of: "%arg") { value.replaceSubrange(range, with: second) }
+    return value
 }
+
 
 private struct SettingsCard<Content: View>: View {
     let title: LocalizedStringKey
@@ -370,7 +371,7 @@ struct SettingsView: View {
                     Button {
                         appState.selectedSettingsTab = tab
                     } label: {
-                        SettingsSidebarRow(title: settingsLocalizedString(tab.title, language: Locale.current.language.languageCode?.identifier ?? "en"), icon: tab.icon)
+                        SettingsSidebarRow(title: localizedCatalogString(tab.title), icon: tab.icon)
                             .background(
                                 RoundedRectangle(cornerRadius: 6)
                                     .fill(appState.selectedSettingsTab == tab
@@ -1172,7 +1173,7 @@ struct CalendarSettingsView: View {
     private func calendarGroupSection(_ group: GoogleCalendarDisplayGroup) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
-                Text(settingsLocalizedString(group.title, language: Locale.current.language.languageCode?.identifier ?? "en"))
+                Text(localizedCatalogString(group.title))
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
                     .textCase(.uppercase)
@@ -1198,7 +1199,7 @@ struct CalendarSettingsView: View {
                         }
                         .toggleStyle(.checkbox)
 
-                        Text(settingsLocalizedString(calendarDisplayKind(calendar), language: Locale.current.language.languageCode?.identifier ?? "en"))
+                        Text(localizedCatalogString(calendarDisplayKind(calendar)))
                             .font(.caption2.weight(.semibold))
                             .foregroundStyle(.secondary)
                             .padding(.horizontal, 6)
@@ -1452,10 +1453,10 @@ struct GeneralSettingsView: View {
     }
 
     private func permissionRow(
-        title: String,
+        title: LocalizedStringKey,
         icon: String,
         granted: Bool,
-        actionTitle: String = "Grant Access",
+        actionTitle: LocalizedStringKey = "Grant Access",
         action: @escaping () -> Void
     ) -> some View {
         HStack {
@@ -1810,7 +1811,7 @@ struct ModelsSettingsView: View {
         if appState.useLocalTranscription { key = "Use API Provider transcription to choose a final output language." }
         else if appState.disablePostProcessing { key = "Enable post-processing to choose a final output language." }
         else { key = "Final transcript language for post-processing." }
-        return settingsLocalizedString(key, language: Locale.current.language.languageCode?.identifier ?? "en")
+        return localizedCatalogString(key)
     }
 
     private var sharedTranscriptionBehaviors: some View {
@@ -2454,7 +2455,7 @@ struct ShortcutsSettingsView: View {
                 set: { newValue in _ = appState.setCommandModeStyle(newValue) }
             )) {
                 ForEach(CommandModeStyle.allCases) { style in
-                    Text(style.title).tag(style)
+                    Text(localizedCatalogString(style.title)).tag(style)
                 }
             }
             .pickerStyle(.segmented)
@@ -2477,7 +2478,7 @@ struct ShortcutsSettingsView: View {
                             set: { newValue in _ = appState.setCommandModeManualModifier(newValue) }
                         )) {
                             ForEach(CommandModeManualModifier.allCases) { modifier in
-                                Text(modifier.title).tag(modifier)
+                                Text(localizedCatalogString(modifier.title)).tag(modifier)
                             }
                         }
                         .disabled(!appState.isCommandModeEnabled || appState.commandModeStyle != .manual)
@@ -3710,7 +3711,7 @@ struct NativeWhisperModelRowView: View {
                         VStack(alignment: .leading, spacing: 2) {
                             Text(verbatim: model.displayName)
                                 .font(.caption.weight(isSelected ? .semibold : .regular))
-                            Text("\(model.localizedDescription()). About \(ByteCountFormatter.string(fromByteCount: model.approximateBytes, countStyle: .file)).")
+                            Text(localizedCatalogFormat("%arg. About %arg.", model.localizedDescription(), ByteCountFormatter.string(fromByteCount: model.approximateBytes, countStyle: .file)))
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                         }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -5,6 +5,13 @@ import UserNotifications
 
 // MARK: - Shared Helpers
 
+private func settingsLocalizedString(_ key: String, language: String) -> String {
+    let bundle = Bundle.main
+    let path = bundle.path(forResource: "Localizable", ofType: "strings", inDirectory: nil, forLocalization: language)
+        ?? URL(fileURLWithPath: bundle.bundlePath).appendingPathComponent("\(language).lproj/Localizable.strings").path
+    return (NSDictionary(contentsOfFile: path) as? [String: String])?[key] ?? key
+}
+
 private struct SettingsCard<Content: View>: View {
     let title: LocalizedStringKey
     let icon: String
@@ -363,7 +370,7 @@ struct SettingsView: View {
                     Button {
                         appState.selectedSettingsTab = tab
                     } label: {
-                        SettingsSidebarRow(title: tab.title, icon: tab.icon)
+                        SettingsSidebarRow(title: settingsLocalizedString(tab.title, language: Locale.current.language.languageCode?.identifier ?? "en"), icon: tab.icon)
                             .background(
                                 RoundedRectangle(cornerRadius: 6)
                                     .fill(appState.selectedSettingsTab == tab
@@ -1165,7 +1172,7 @@ struct CalendarSettingsView: View {
     private func calendarGroupSection(_ group: GoogleCalendarDisplayGroup) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
-                Text(group.title)
+                Text(settingsLocalizedString(group.title, language: Locale.current.language.languageCode?.identifier ?? "en"))
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
                     .textCase(.uppercase)
@@ -1191,7 +1198,7 @@ struct CalendarSettingsView: View {
                         }
                         .toggleStyle(.checkbox)
 
-                        Text(verbatim: calendarDisplayKind(calendar))
+                        Text(settingsLocalizedString(calendarDisplayKind(calendar), language: Locale.current.language.languageCode?.identifier ?? "en"))
                             .font(.caption2.weight(.semibold))
                             .foregroundStyle(.secondary)
                             .padding(.horizontal, 6)
@@ -1799,13 +1806,11 @@ struct ModelsSettingsView: View {
     }
 
     private var outputLanguageHelpText: String {
-        if appState.useLocalTranscription {
-            return "Use API Provider transcription to choose a final output language."
-        }
-        if appState.disablePostProcessing {
-            return "Enable post-processing to choose a final output language."
-        }
-        return "Final transcript language for post-processing."
+        let key: String
+        if appState.useLocalTranscription { key = "Use API Provider transcription to choose a final output language." }
+        else if appState.disablePostProcessing { key = "Enable post-processing to choose a final output language." }
+        else { key = "Final transcript language for post-processing." }
+        return settingsLocalizedString(key, language: Locale.current.language.languageCode?.identifier ?? "en")
     }
 
     private var sharedTranscriptionBehaviors: some View {
@@ -3705,7 +3710,7 @@ struct NativeWhisperModelRowView: View {
                         VStack(alignment: .leading, spacing: 2) {
                             Text(verbatim: model.displayName)
                                 .font(.caption.weight(isSelected ? .semibold : .regular))
-                            Text("Fast local transcription. About \(ByteCountFormatter.string(fromByteCount: model.approximateBytes, countStyle: .file)).")
+                            Text("\(model.localizedDescription()). About \(ByteCountFormatter.string(fromByteCount: model.approximateBytes, countStyle: .file)).")
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                         }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -6,11 +6,11 @@ import UserNotifications
 // MARK: - Shared Helpers
 
 private struct SettingsCard<Content: View>: View {
-    let title: String
+    let title: LocalizedStringKey
     let icon: String
     let content: Content
 
-    init(_ title: String, icon: String, @ViewBuilder content: () -> Content) {
+    init(_ title: LocalizedStringKey, icon: String, @ViewBuilder content: () -> Content) {
         self.title = title
         self.icon = icon
         self.content = content()
@@ -215,7 +215,7 @@ struct ProviderSettingsFields: View {
                         .font(.caption.weight(.semibold))
                     Picker("", selection: $appState.transcriptionLanguage) {
                         ForEach(TranscriptionLanguage.all) { option in
-                            Text(option.displayName).tag(option)
+                            Text(option.localizedDisplayName()).tag(option)
                         }
                     }
                     .accessibilityLabel("Transcription Language")
@@ -437,6 +437,7 @@ private struct SettingsSidebarRow: View {
     }
 }
 
+// localization-exclusion: developer-diagnostics-start
 // MARK: - Debug Settings
 
 struct DebugSettingsView: View {
@@ -491,6 +492,8 @@ struct DebugSettingsView: View {
         }
     }
 }
+
+// localization-exclusion: developer-diagnostics-end
 
 // MARK: - Appearance Settings
 
@@ -592,7 +595,7 @@ struct AppearanceSettingsView: View {
                 Text("Active window (default)").tag(0)
                 Text("Primary display").tag(-1)
                 ForEach(connectedScreenEntries, id: \.tag) { entry in
-                    Text(entry.name).tag(entry.tag)
+                    Text(verbatim: entry.name).tag(entry.tag)
                 }
             }
             .labelsHidden()
@@ -623,8 +626,8 @@ struct AppearanceSettingsView: View {
 }
 
 struct OverlayLayoutOptionRow: View {
-    let title: String
-    let subtitle: String
+    let title: LocalizedStringKey
+    let subtitle: LocalizedStringKey
     let layout: RecordingOverlayLayout
     @Binding var selection: RecordingOverlayLayout
 
@@ -673,8 +676,8 @@ struct OverlayLayoutOptionRow: View {
 }
 
 struct OverlayWaveformModeOptionRow: View {
-    let title: String
-    let subtitle: String
+    let title: LocalizedStringKey
+    let subtitle: LocalizedStringKey
     let mode: OverlayWaveformDisplayMode
     @Binding var selection: OverlayWaveformDisplayMode
 
@@ -953,7 +956,7 @@ struct CalendarSettingsView: View {
                 if appState.googleCalendarConnection.isConnected,
                    let email = appState.googleCalendarConnection.accountEmail,
                    !email.isEmpty {
-                    Text(email)
+                    Text(verbatim: email)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -1019,7 +1022,7 @@ struct CalendarSettingsView: View {
             if googleCalendarHealthMessage == nil,
                let error = appState.googleCalendarConnection.lastErrorMessage,
                !error.isEmpty {
-                Text(error)
+                Text(verbatim: error)
                     .font(.caption)
                     .foregroundStyle(.red)
                     .fixedSize(horizontal: false, vertical: true)
@@ -1179,15 +1182,16 @@ struct CalendarSettingsView: View {
                 ForEach(group.calendars) { calendar in
                     HStack(alignment: .firstTextBaseline, spacing: 8) {
                         Toggle(
-                            calendar.displayName,
                             isOn: Binding(
                                 get: { appState.googleCalendarConnection.selectedCalendarIDs.contains(calendar.id) },
                                 set: { appState.setGoogleCalendarSelected(calendar.id, isSelected: $0) }
                             )
-                        )
+                        ) {
+                            Text(verbatim: calendar.displayName)
+                        }
                         .toggleStyle(.checkbox)
 
-                        Text(calendarDisplayKind(calendar))
+                        Text(verbatim: calendarDisplayKind(calendar))
                             .font(.caption2.weight(.semibold))
                             .foregroundStyle(.secondary)
                             .padding(.horizontal, 6)
@@ -1529,16 +1533,21 @@ struct ModelsSettingsView: View {
     @State private var contextTestError: String? = nil
     @State private var contextTestPrompt: String? = nil
 
-    private static let outputLanguageOptions: [(label: String, value: String)] = [
-        ("Same as spoken language", ""),
-        ("English", "English"),
-        ("한국어", "Korean"),
-        ("日本語", "Japanese"),
-        ("中文", "Chinese"),
-        ("Español", "Spanish"),
-        ("Français", "French"),
-        ("Deutsch", "German"),
-        ("Português", "Portuguese"),
+    private struct OutputLanguageOption {
+        let label: LocalizedStringKey
+        let value: String // Persisted prompt/API value; never localize.
+    }
+
+    private static let outputLanguageOptions: [OutputLanguageOption] = [
+        .init(label: "Same as spoken language", value: ""),
+        .init(label: "English", value: "English"),
+        .init(label: "Korean", value: "Korean"),
+        .init(label: "Japanese", value: "Japanese"),
+        .init(label: "Chinese", value: "Chinese"),
+        .init(label: "Spanish", value: "Spanish"),
+        .init(label: "French", value: "French"),
+        .init(label: "German", value: "German"),
+        .init(label: "Portuguese", value: "Portuguese"),
     ]
 
     var body: some View {
@@ -1759,7 +1768,7 @@ struct ModelsSettingsView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Picker("Transcription Language", selection: $appState.transcriptionLanguage) {
                     ForEach(TranscriptionLanguage.all) { lang in
-                        Text(lang.displayName).tag(lang)
+                        Text(lang.localizedDisplayName()).tag(lang)
                     }
                 }
                 .pickerStyle(.menu)
@@ -1954,7 +1963,7 @@ struct ModelsSettingsView: View {
                         Button("Hide") { showDefaultSystemPrompt = false }
                             .font(.caption)
                     }
-                    Text(PostProcessingService.defaultSystemPrompt)
+                    Text(verbatim: PostProcessingService.defaultSystemPrompt)
                         .font(.system(.caption, design: .monospaced))
                         .foregroundStyle(.secondary)
                 }
@@ -2167,7 +2176,7 @@ struct ModelsSettingsView: View {
                         Button("Hide") { showDefaultContextPrompt = false }
                             .font(.caption)
                     }
-                    Text(AppContextService.defaultContextPrompt)
+                    Text(verbatim: AppContextService.defaultContextPrompt)
                         .font(.system(.caption, design: .monospaced))
                         .foregroundStyle(.secondary)
                 }
@@ -2541,7 +2550,7 @@ struct ShortcutsSettingsView: View {
                     ForEach(Array(appState.voiceMacros.enumerated()), id: \.element.id) { index, macro in
                         VStack(alignment: .leading, spacing: 4) {
                             HStack {
-                                Text(macro.command)
+                                Text(verbatim: macro.command)
                                     .font(.headline)
                                 Spacer()
                                 Button("Edit") {
@@ -2557,7 +2566,7 @@ struct ShortcutsSettingsView: View {
                                 .font(.caption)
                                 .foregroundStyle(.red)
                             }
-                            Text(macro.payload)
+                            Text(verbatim: macro.payload)
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                                 .lineLimit(2)
@@ -2731,7 +2740,7 @@ struct AboutSettingsView: View {
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 64, height: 64)
-                    Text(appDisplayName)
+                    Text(verbatim: appDisplayName)
                         .font(.system(size: 20, weight: .bold, design: .rounded))
                     Text("v\(appVersion)")
                         .font(.caption)
@@ -2782,7 +2791,7 @@ struct AboutSettingsView: View {
             }
 
             HStack(alignment: .top, spacing: 12) {
-                Text(buildDiagnosticsText)
+                Text(verbatim: buildDiagnosticsText)
                     .font(.system(.caption, design: .monospaced))
                     .foregroundStyle(.secondary)
                     .textSelection(.enabled)
@@ -2827,7 +2836,7 @@ struct MicrophoneOptionRow: View {
             HStack {
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                     .foregroundStyle(isSelected ? .blue : .secondary)
-                Text(name)
+                Text(verbatim: name)
                     .foregroundStyle(.primary)
                 Spacer()
             }
@@ -2843,6 +2852,7 @@ struct MicrophoneOptionRow: View {
     }
 }
 
+// localization-exclusion: developer-diagnostics-start
 // MARK: - Run Log
 
 struct RunLogView: View {
@@ -3573,6 +3583,8 @@ struct FlowLayout: Layout {
     }
 }
 
+// localization-exclusion: developer-diagnostics-end
+
 // MARK: - Voice Macro Editor
 
 struct VoiceMacroEditorView: View {
@@ -3691,7 +3703,7 @@ struct NativeWhisperModelRowView: View {
                         Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
                             .foregroundStyle(isInstalled ? Color.accentColor : .secondary)
                         VStack(alignment: .leading, spacing: 2) {
-                            Text(model.displayName)
+                            Text(verbatim: model.displayName)
                                 .font(.caption.weight(isSelected ? .semibold : .regular))
                             Text("Fast local transcription. About \(ByteCountFormatter.string(fromByteCount: model.approximateBytes, countStyle: .file)).")
                                 .font(.caption2)
@@ -3722,7 +3734,7 @@ struct NativeWhisperModelRowView: View {
                 .stroke(isSelected ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
         )
         .confirmationDialog(
-            "Delete \(model.displayName)?",
+            "Delete model?",
             isPresented: $showDeleteConfirmation,
             titleVisibility: .visible
         ) {
@@ -3858,9 +3870,9 @@ struct ModelRowView: View {
                         Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
                             .foregroundStyle(isInstalled ? Color.accentColor : .secondary)
                         VStack(alignment: .leading, spacing: 2) {
-                            Text(model.displayName)
+                            Text(verbatim: model.displayName)
                                 .font(.caption.weight(isSelected ? .semibold : .regular))
-                            Text(model.description)
+                            Text(model.localizedDescription())
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                         }
@@ -3889,7 +3901,7 @@ struct ModelRowView: View {
                 .stroke(isSelected ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
         )
         .confirmationDialog(
-            "Delete \(model.displayName)?",
+            "Delete model?",
             isPresented: $showDeleteConfirmation,
             titleVisibility: .visible
         ) {
@@ -3898,7 +3910,7 @@ struct ModelRowView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This removes the downloaded local model cache for \(model.displayName). You can download it again later.")
+            Text("This removes the downloaded local model cache. You can download it again later.")
         }
         .onAppear {
             refreshInstallState()

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -2616,23 +2616,23 @@ struct InputSettingsView: View {
 
             VStack(spacing: 6) {
                 MicrophoneOptionRow(
-                    name: "System Default",
+                    title: "System Default",
                     isSelected: appState.selectedMicrophoneID == AudioInputDevice.defaultMicrophoneID || appState.selectedMicrophoneID.isEmpty,
                     action: { appState.selectedMicrophoneID = AudioInputDevice.defaultMicrophoneID }
                 )
                 MicrophoneOptionRow(
-                    name: "System Audio",
+                    title: "System Audio",
                     isSelected: appState.selectedMicrophoneID == AudioInputDevice.systemAudioID,
                     action: { appState.selectedMicrophoneID = AudioInputDevice.systemAudioID }
                 )
                 MicrophoneOptionRow(
-                    name: "System Default + System Audio",
+                    title: "System Default + System Audio",
                     isSelected: appState.selectedMicrophoneID == AudioInputDevice.systemDefaultAndSystemAudioID,
                     action: { appState.selectedMicrophoneID = AudioInputDevice.systemDefaultAndSystemAudioID }
                 )
                 ForEach(appState.availableMicrophones) { device in
                     MicrophoneOptionRow(
-                        name: device.name,
+                        verbatimName: device.name,
                         isSelected: appState.selectedMicrophoneID == device.uid,
                         action: { appState.selectedMicrophoneID = device.uid }
                     )
@@ -2833,17 +2833,37 @@ struct AboutSettingsView: View {
 // MARK: - Microphone Option Row
 
 struct MicrophoneOptionRow: View {
-    let name: String
+    private let title: LocalizedStringKey?
+    private let verbatimName: String?
     let isSelected: Bool
     let action: () -> Void
+
+    init(title: LocalizedStringKey, isSelected: Bool, action: @escaping () -> Void) {
+        self.title = title
+        self.verbatimName = nil
+        self.isSelected = isSelected
+        self.action = action
+    }
+
+    init(verbatimName: String, isSelected: Bool, action: @escaping () -> Void) {
+        self.title = nil
+        self.verbatimName = verbatimName
+        self.isSelected = isSelected
+        self.action = action
+    }
 
     var body: some View {
         Button(action: action) {
             HStack {
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                     .foregroundStyle(isSelected ? .blue : .secondary)
-                Text(verbatim: name)
-                    .foregroundStyle(.primary)
+                if let title {
+                    Text(title)
+                        .foregroundStyle(.primary)
+                } else if let verbatimName {
+                    Text(verbatim: verbatimName)
+                        .foregroundStyle(.primary)
+                }
                 Spacer()
             }
             .padding(12)

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -5,14 +5,6 @@ import UserNotifications
 
 // MARK: - Shared Helpers
 
-private func localizedCatalogFormat(_ key: String, _ first: String, _ second: String) -> String {
-    var value = localizedCatalogString(key)
-    if let range = value.range(of: "%arg") { value.replaceSubrange(range, with: first) }
-    if let range = value.range(of: "%arg") { value.replaceSubrange(range, with: second) }
-    return value
-}
-
-
 private struct SettingsCard<Content: View>: View {
     let title: LocalizedStringKey
     let icon: String
@@ -3731,7 +3723,7 @@ struct NativeWhisperModelRowView: View {
                         VStack(alignment: .leading, spacing: 2) {
                             Text(verbatim: model.displayName)
                                 .font(.caption.weight(isSelected ? .semibold : .regular))
-                            Text(localizedCatalogFormat("%arg. About %arg.", model.localizedDescription(), ByteCountFormatter.string(fromByteCount: model.approximateBytes, countStyle: .file)))
+                            Text(localizedCatalogFormat("%@. About %@.", model.localizedDescription(), ByteCountFormatter.string(fromByteCount: model.approximateBytes, countStyle: .file)))
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                         }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -671,7 +671,7 @@ struct OverlayLayoutOptionRow: View {
         .buttonStyle(.plain)
         // Combine so VoiceOver reads the subtitle too, not just the title.
         .accessibilityElement(children: .combine)
-        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityValue(localizedCatalogString(isSelected ? "Selected" : "Not selected"))
     }
 }
 
@@ -719,7 +719,7 @@ struct OverlayWaveformModeOptionRow: View {
         .buttonStyle(.plain)
         // Combine so VoiceOver reads the subtitle too, not just the title.
         .accessibilityElement(children: .combine)
-        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityValue(localizedCatalogString(isSelected ? "Selected" : "Not selected"))
     }
 }
 

--- a/Sources/SetupFlow.swift
+++ b/Sources/SetupFlow.swift
@@ -1,7 +1,7 @@
 import UserNotifications
 
 enum SetupFlow {
-    static let localOnlySkipButtonTitle = "Skip"
+    static let localOnlySkipButtonTitle = String(localized: "Skip")
 
     struct LocalOnlySkipState: Equatable {
         let useLocalTranscription: Bool
@@ -34,6 +34,6 @@ enum SetupFlow {
     }
 
     static func notificationPermissionActionTitle(for status: UNAuthorizationStatus) -> String {
-        status == .denied ? "Open Settings" : "Grant Access"
+        status == .denied ? String(localized: "Open Settings") : String(localized: "Grant Access")
     }
 }

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -1089,10 +1089,10 @@ struct SetupView: View {
 
             VStack(alignment: .leading, spacing: 12) {
                 if appState.hasEnabledHoldShortcut {
-                    HowToRow(icon: "keyboard", text: String(localized: "Hold \(appState.holdShortcut.displayName) to record"))
+                    HowToRow(icon: "keyboard", text: localizedCatalogFormat("Hold %@ to record", appState.holdShortcut.displayName))
                 }
                 if appState.hasEnabledToggleShortcut {
-                    HowToRow(icon: "switch.2", text: String(localized: "Tap \(appState.toggleShortcut.displayName) to start and stop"))
+                    HowToRow(icon: "switch.2", text: localizedCatalogFormat("Tap %@ to start and stop", appState.toggleShortcut.displayName))
                 }
                 if appState.hasEnabledHoldShortcut && appState.hasEnabledToggleShortcut {
                     HowToRow(icon: "arrow.triangle.branch", text: String(localized: "While holding, press the toggle shortcut to latch on"))
@@ -1104,7 +1104,7 @@ struct SetupView: View {
                     case .manual:
                         HowToRow(
                             icon: "wand.and.stars",
-                            text: String(localized: "Hold \(appState.commandModeManualModifier.title) with your normal shortcut to transform selected text")
+                            text: localizedCatalogFormat("Hold %@ with your normal shortcut to transform selected text", appState.commandModeManualModifier.title)
                         )
                     }
                 }
@@ -1145,18 +1145,18 @@ struct SetupView: View {
     private var testShortcutPrompt: String {
         switch (appState.hasEnabledHoldShortcut, appState.hasEnabledToggleShortcut) {
         case (true, true):
-            return String(localized: "Hold \(appState.holdShortcut.displayName) or tap \(appState.toggleShortcut.displayName)")
+            return localizedCatalogFormat("Hold %@ or tap %@", appState.holdShortcut.displayName, appState.toggleShortcut.displayName)
         case (true, false):
-            return String(localized: "Hold \(appState.holdShortcut.displayName)")
+            return localizedCatalogFormat("Hold %@", appState.holdShortcut.displayName)
         case (false, true):
-            return String(localized: "Tap \(appState.toggleShortcut.displayName)")
+            return localizedCatalogFormat("Tap %@", appState.toggleShortcut.displayName)
         case (false, false):
             return String(localized: "Use Start Dictating from the menu bar")
         }
     }
 
     private var retryShortcutPrompt: String {
-        String(localized: "\(testShortcutPrompt) to try again")
+        localizedCatalogFormat("%@ to try again", testShortcutPrompt)
     }
 
     // MARK: - Helpers

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -1089,26 +1089,26 @@ struct SetupView: View {
 
             VStack(alignment: .leading, spacing: 12) {
                 if appState.hasEnabledHoldShortcut {
-                    HowToRow(icon: "keyboard", text: "Hold \(appState.holdShortcut.displayName) to record")
+                    HowToRow(icon: "keyboard", text: String(localized: "Hold \(appState.holdShortcut.displayName) to record"))
                 }
                 if appState.hasEnabledToggleShortcut {
-                    HowToRow(icon: "switch.2", text: "Tap \(appState.toggleShortcut.displayName) to start and stop")
+                    HowToRow(icon: "switch.2", text: String(localized: "Tap \(appState.toggleShortcut.displayName) to start and stop"))
                 }
                 if appState.hasEnabledHoldShortcut && appState.hasEnabledToggleShortcut {
-                    HowToRow(icon: "arrow.triangle.branch", text: "While holding, press the toggle shortcut to latch on")
+                    HowToRow(icon: "arrow.triangle.branch", text: String(localized: "While holding, press the toggle shortcut to latch on"))
                 }
                 if appState.isCommandModeEnabled {
                     switch appState.commandModeStyle {
                     case .automatic:
-                        HowToRow(icon: "wand.and.stars", text: "With text selected, your normal shortcut transforms the selection")
+                        HowToRow(icon: "wand.and.stars", text: String(localized: "With text selected, your normal shortcut transforms the selection"))
                     case .manual:
                         HowToRow(
                             icon: "wand.and.stars",
-                            text: "Hold \(appState.commandModeManualModifier.title) with your normal shortcut to transform selected text"
+                            text: String(localized: "Hold \(appState.commandModeManualModifier.title) with your normal shortcut to transform selected text")
                         )
                     }
                 }
-                HowToRow(icon: "doc.on.clipboard", text: "Text is typed at your cursor & copied")
+                HowToRow(icon: "doc.on.clipboard", text: String(localized: "Text is typed at your cursor & copied"))
             }
             .padding(.top, 10)
 
@@ -1145,18 +1145,18 @@ struct SetupView: View {
     private var testShortcutPrompt: String {
         switch (appState.hasEnabledHoldShortcut, appState.hasEnabledToggleShortcut) {
         case (true, true):
-            return "Hold \(appState.holdShortcut.displayName) or tap \(appState.toggleShortcut.displayName)"
+            return String(localized: "Hold \(appState.holdShortcut.displayName) or tap \(appState.toggleShortcut.displayName)")
         case (true, false):
-            return "Hold \(appState.holdShortcut.displayName)"
+            return String(localized: "Hold \(appState.holdShortcut.displayName)")
         case (false, true):
-            return "Tap \(appState.toggleShortcut.displayName)"
+            return String(localized: "Tap \(appState.toggleShortcut.displayName)")
         case (false, false):
-            return "Use Start Dictating from the menu bar"
+            return String(localized: "Use Start Dictating from the menu bar")
         }
     }
 
     private var retryShortcutPrompt: String {
-        "\(testShortcutPrompt) to try again"
+        String(localized: "\(testShortcutPrompt) to try again")
     }
 
     // MARK: - Helpers
@@ -1193,7 +1193,7 @@ struct SetupView: View {
                         currentStep = nextStep(currentStep)
                     }
                 } else {
-                    keyValidationError = "Validation failed. Please check your API key and provider settings, then try again."
+                    keyValidationError = String(localized: "Validation failed. Please check your API key and provider settings, then try again.")
                 }
             }
         }
@@ -1524,7 +1524,7 @@ struct SetupView: View {
                 testSystemAudioRecorder = nil
                 testSystemDefaultAndSystemAudioRecorder = nil
                 if testError == nil {
-                    testError = "No audio file was created."
+                    testError = String(localized: "No audio file was created.")
                 }
                 withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
                     testPhase = .done

--- a/Sources/TranscriptionLanguage.swift
+++ b/Sources/TranscriptionLanguage.swift
@@ -1,15 +1,6 @@
 import Foundation
 import Speech
 
-private func languageLocalizedString(_ key: String, language: String, bundle: Bundle = .main) -> String {
-    let path = bundle.path(forResource: "Localizable", ofType: "strings", inDirectory: nil, forLocalization: language)
-        ?? URL(fileURLWithPath: bundle.bundlePath).appendingPathComponent("\(language).lproj/Localizable.strings").path
-    guard let strings = NSDictionary(contentsOfFile: path) as? [String: String] else {
-        return key
-    }
-    return strings[key] ?? key
-}
-
 struct TranscriptionLanguage: Identifiable, Hashable, Codable {
     let code: String      // mlx-whisper에 넘기는 언어 코드 (e.g. "ko")
     let displayName: String  // Stable fallback display name; `code` remains the persisted/API value.
@@ -17,7 +8,7 @@ struct TranscriptionLanguage: Identifiable, Hashable, Codable {
     var id: String { code }
 
     func localizedDisplayName(
-        language: String = Locale.current.language.languageCode?.identifier ?? "en",
+        language: String = preferredLocalizedStringLanguage(),
         bundle: Bundle = .main
     ) -> String {
         let key: String
@@ -32,7 +23,7 @@ struct TranscriptionLanguage: Identifiable, Hashable, Codable {
         case "de": key = "German"
         default: return displayName
         }
-        return languageLocalizedString(key, language: language, bundle: bundle)
+        return localizedCatalogString(key, language: language, bundle: bundle)
     }
 
     // 자동 감지 옵션

--- a/Sources/TranscriptionLanguage.swift
+++ b/Sources/TranscriptionLanguage.swift
@@ -3,9 +3,24 @@ import Speech
 
 struct TranscriptionLanguage: Identifiable, Hashable, Codable {
     let code: String      // mlx-whisper에 넘기는 언어 코드 (e.g. "ko")
-    let displayName: String  // UI에 표시되는 이름 (e.g. "한국어")
+    let displayName: String  // Stable fallback display name; `code` remains the persisted/API value.
 
     var id: String { code }
+
+    func localizedDisplayName(language: String = Locale.current.language.languageCode?.identifier ?? "en") -> String {
+        let korean = language.lowercased().hasPrefix("ko")
+        switch code {
+        case "auto": return korean ? "자동 감지" : "Auto Detect"
+        case "ko": return korean ? "한국어" : "Korean"
+        case "en": return korean ? "영어" : "English"
+        case "ja": return korean ? "일본어" : "Japanese"
+        case "zh": return korean ? "중국어" : "Chinese"
+        case "es": return korean ? "스페인어" : "Spanish"
+        case "fr": return korean ? "프랑스어" : "French"
+        case "de": return korean ? "독일어" : "German"
+        default: return displayName
+        }
+    }
 
     // 자동 감지 옵션
     static let auto = TranscriptionLanguage(code: "auto", displayName: "Auto Detect")

--- a/Sources/TranscriptionLanguage.swift
+++ b/Sources/TranscriptionLanguage.swift
@@ -1,25 +1,38 @@
 import Foundation
 import Speech
 
+private func languageLocalizedString(_ key: String, language: String, bundle: Bundle = .main) -> String {
+    let path = bundle.path(forResource: "Localizable", ofType: "strings", inDirectory: nil, forLocalization: language)
+        ?? URL(fileURLWithPath: bundle.bundlePath).appendingPathComponent("\(language).lproj/Localizable.strings").path
+    guard let strings = NSDictionary(contentsOfFile: path) as? [String: String] else {
+        return key
+    }
+    return strings[key] ?? key
+}
+
 struct TranscriptionLanguage: Identifiable, Hashable, Codable {
     let code: String      // mlx-whisper에 넘기는 언어 코드 (e.g. "ko")
     let displayName: String  // Stable fallback display name; `code` remains the persisted/API value.
 
     var id: String { code }
 
-    func localizedDisplayName(language: String = Locale.current.language.languageCode?.identifier ?? "en") -> String {
-        let korean = language.lowercased().hasPrefix("ko")
+    func localizedDisplayName(
+        language: String = Locale.current.language.languageCode?.identifier ?? "en",
+        bundle: Bundle = .main
+    ) -> String {
+        let key: String
         switch code {
-        case "auto": return korean ? "자동 감지" : "Auto Detect"
-        case "ko": return korean ? "한국어" : "Korean"
-        case "en": return korean ? "영어" : "English"
-        case "ja": return korean ? "일본어" : "Japanese"
-        case "zh": return korean ? "중국어" : "Chinese"
-        case "es": return korean ? "스페인어" : "Spanish"
-        case "fr": return korean ? "프랑스어" : "French"
-        case "de": return korean ? "독일어" : "German"
+        case "auto": key = "Auto Detect"
+        case "ko": key = "Korean"
+        case "en": key = "English"
+        case "ja": key = "Japanese"
+        case "zh": key = "Chinese"
+        case "es": key = "Spanish"
+        case "fr": key = "French"
+        case "de": key = "German"
         default: return displayName
         }
+        return languageLocalizedString(key, language: language, bundle: bundle)
     }
 
     // 자동 감지 옵션

--- a/Sources/TranscriptionModel.swift
+++ b/Sources/TranscriptionModel.swift
@@ -122,6 +122,19 @@ struct TranscriptionModel: Identifiable, Hashable, Codable {
         ),
     ]
 
+    /// Resolves only user-facing copy. The stored model ID and cache identity stay unchanged.
+    func localizedDescription(language: String = Locale.current.language.languageCode?.identifier ?? "en") -> String {
+        let korean = language.lowercased().hasPrefix("ko")
+        switch id {
+        case "apple-speech": return korean ? "온디바이스 · 빠름" : "On-device · Fast"
+        case "mlx-community/whisper-large-v3-turbo": return korean ? "빠름 · 정확도 높음 (추천)" : "Fast · High accuracy (Recommended)"
+        case "mlx-community/whisper-large-v3-mlx": return korean ? "최고 정확도 · 느림" : "Highest accuracy · Slow"
+        case "mlx-community/whisper-medium-mlx": return korean ? "중간 속도 · 중간 정확도" : "Medium speed · Medium accuracy"
+        case "mlx-community/whisper-small-mlx": return korean ? "빠름 · 정확도 낮음" : "Fast · Lower accuracy"
+        default: return description
+        }
+    }
+
     var isAppleSpeech: Bool { id == "apple-speech" }
 
     var estimatedDownloadBytes: Int64? {

--- a/Sources/TranscriptionModel.swift
+++ b/Sources/TranscriptionModel.swift
@@ -1,11 +1,5 @@
 import Foundation
 
-private func modelLocalizedString(_ key: String, language: String, bundle: Bundle = .main) -> String {
-    let path = bundle.path(forResource: "Localizable", ofType: "strings", inDirectory: nil, forLocalization: language)
-        ?? URL(fileURLWithPath: bundle.bundlePath).appendingPathComponent("\(language).lproj/Localizable.strings").path
-    guard let strings = NSDictionary(contentsOfFile: path) as? [String: String] else { return key }
-    return strings[key] ?? key
-}
 
 enum TranscriptionModelCacheError: LocalizedError {
     case builtInModelCannotBeDownloaded
@@ -131,7 +125,7 @@ struct TranscriptionModel: Identifiable, Hashable, Codable {
 
     /// Resolves only user-facing copy. The stored model ID and cache identity stay unchanged.
     func localizedDescription(
-        language: String = Locale.current.language.languageCode?.identifier ?? "en",
+        language: String = preferredLocalizedStringLanguage(),
         bundle: Bundle = .main
     ) -> String {
         let key: String
@@ -143,7 +137,7 @@ struct TranscriptionModel: Identifiable, Hashable, Codable {
         case "mlx-community/whisper-small-mlx": key = "Fast · Lower accuracy"
         default: return description
         }
-        return modelLocalizedString(key, language: language, bundle: bundle)
+        return localizedCatalogString(key, language: language, bundle: bundle)
     }
 
     var isAppleSpeech: Bool { id == "apple-speech" }

--- a/Sources/TranscriptionModel.swift
+++ b/Sources/TranscriptionModel.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+private func modelLocalizedString(_ key: String, language: String, bundle: Bundle = .main) -> String {
+    let path = bundle.path(forResource: "Localizable", ofType: "strings", inDirectory: nil, forLocalization: language)
+        ?? URL(fileURLWithPath: bundle.bundlePath).appendingPathComponent("\(language).lproj/Localizable.strings").path
+    guard let strings = NSDictionary(contentsOfFile: path) as? [String: String] else { return key }
+    return strings[key] ?? key
+}
+
 enum TranscriptionModelCacheError: LocalizedError {
     case builtInModelCannotBeDownloaded
     case builtInModelCannotBeDeleted
@@ -123,16 +130,20 @@ struct TranscriptionModel: Identifiable, Hashable, Codable {
     ]
 
     /// Resolves only user-facing copy. The stored model ID and cache identity stay unchanged.
-    func localizedDescription(language: String = Locale.current.language.languageCode?.identifier ?? "en") -> String {
-        let korean = language.lowercased().hasPrefix("ko")
+    func localizedDescription(
+        language: String = Locale.current.language.languageCode?.identifier ?? "en",
+        bundle: Bundle = .main
+    ) -> String {
+        let key: String
         switch id {
-        case "apple-speech": return korean ? "온디바이스 · 빠름" : "On-device · Fast"
-        case "mlx-community/whisper-large-v3-turbo": return korean ? "빠름 · 정확도 높음 (추천)" : "Fast · High accuracy (Recommended)"
-        case "mlx-community/whisper-large-v3-mlx": return korean ? "최고 정확도 · 느림" : "Highest accuracy · Slow"
-        case "mlx-community/whisper-medium-mlx": return korean ? "중간 속도 · 중간 정확도" : "Medium speed · Medium accuracy"
-        case "mlx-community/whisper-small-mlx": return korean ? "빠름 · 정확도 낮음" : "Fast · Lower accuracy"
+        case "apple-speech": key = "On-device · Fast"
+        case "mlx-community/whisper-large-v3-turbo": key = "Fast · High accuracy (Recommended)"
+        case "mlx-community/whisper-large-v3-mlx": key = "Highest accuracy · Slow"
+        case "mlx-community/whisper-medium-mlx": key = "Medium speed · Medium accuracy"
+        case "mlx-community/whisper-small-mlx": key = "Fast · Lower accuracy"
         default: return description
         }
+        return modelLocalizedString(key, language: language, bundle: bundle)
     }
 
     var isAppleSpeech: Bool { id == "apple-speech" }

--- a/Sources/UpdateManager.swift
+++ b/Sources/UpdateManager.swift
@@ -165,11 +165,11 @@ final class UpdateManager: NSObject, ObservableObject {
 
     func showUpToDateAlert() {
         let alert = NSAlert()
-        alert.messageText = "You're Up to Date"
-        alert.informativeText = "You're running the latest version of Quill."
+        alert.messageText = localizedCatalogString("You're Up to Date")
+        alert.informativeText = localizedCatalogString("You're running the latest version of Quill.")
         alert.alertStyle = .informational
         alert.icon = NSApp.applicationIconImage
-        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: localizedCatalogString("OK"))
         alert.runModal()
     }
 
@@ -263,12 +263,12 @@ final class UpdateManager: NSObject, ObservableObject {
 
     private func showReleaseBuildRequiredAlert() {
         let alert = NSAlert()
-        alert.messageText = "Updates Are Available in Release Builds"
-        alert.informativeText = "This local build of Quill does not use automatic updates. Download the latest release from GitHub when you want to update."
+        alert.messageText = localizedCatalogString("Updates Are Available in Release Builds")
+        alert.informativeText = localizedCatalogString("This local build of Quill does not use automatic updates. Download the latest release from GitHub when you want to update.")
         alert.alertStyle = .informational
         alert.icon = NSApp.applicationIconImage
-        alert.addButton(withTitle: "Open Releases")
-        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: localizedCatalogString("Open Releases"))
+        alert.addButton(withTitle: localizedCatalogString("OK"))
 
         if alert.runModal() == .alertFirstButtonReturn,
            let url = URL(string: "https://github.com/woosublee/quill/releases/latest") {
@@ -310,7 +310,7 @@ extension UpdateManager: SPUUpdaterDelegate {
 
     func updater(_ updater: SPUUpdater, failedToDownloadUpdate item: SUAppcastItem, error: Error) {
         applyAvailableUpdate(item)
-        updateStatus = .error("Download failed: \(error.localizedDescription)")
+        updateStatus = .error(LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Download failed"), providerDetail: error.localizedDescription))
     }
 
     func userDidCancelDownload(_ updater: SPUUpdater) {
@@ -338,7 +338,7 @@ extension UpdateManager: SPUUpdaterDelegate {
     }
 
     func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
-        updateStatus = .error(error.localizedDescription)
+        updateStatus = .error(LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Update failed"), providerDetail: error.localizedDescription))
         isChecking = false
     }
 
@@ -350,7 +350,7 @@ extension UpdateManager: SPUUpdaterDelegate {
             if nsError.domain == SUSparkleErrorDomain, nsError.code == SUError.noUpdateError.rawValue {
                 clearAvailableUpdate()
             } else if updateStatus == .idle {
-                updateStatus = .error(error.localizedDescription)
+                updateStatus = .error(LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Update failed"), providerDetail: error.localizedDescription))
             }
         }
     }

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -789,8 +789,8 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(sheetBody.contains("ForEach(options.displayRows)"))
         precondition(sheetBody.contains("@State private var selectedChoice: TranscriptionBackendChoice"))
         precondition(sheetBody.contains("onImport: (TranscriptionBackendChoice) -> Void"))
-        precondition(sheetBody.contains("Text(display.title)"))
-        precondition(sheetBody.contains("Text(unavailableReason)"))
+        precondition(sheetBody.contains("Text(display.localizedTitle())"))
+        precondition(sheetBody.contains("Text(display.localizedUnavailableReason() ?? unavailableReason)"))
         precondition(!sheetBody.contains("[NoteBrowserTranscriptionMode.apiStandard, .localWhisper]"))
         precondition(!sheetBody.contains("appState.audioImportLabel(for:"))
     }

--- a/Tests/BuildMetadataTests.swift
+++ b/Tests/BuildMetadataTests.swift
@@ -8,6 +8,7 @@ struct BuildMetadataTests {
         try testBuildSettingsTrackCodesignIdentity()
         try testMakefileSeparatesDevRunFromInstallBuild()
         try testMakefileCopiesSelectedIconToBundleIconName()
+        try testMakefileBundlesLocalizationResources()
         try testMakefileStripsExtendedAttributesDuringCodesignStaging()
         try testMakefileStripsExtendedAttributesDuringDmgStaging()
         try testMakefileCreatesDmgWithoutFinderMetadata()
@@ -85,6 +86,16 @@ struct BuildMetadataTests {
         assertContains(infoPlist, "<key>CFBundleIconFile</key>\n    <string>AppIcon</string>")
         assertContains(makefile, "ICON_ICNS = Resources/AppIcon-Dev.icns")
         assertContains(makefile, "@cp $(ICON_ICNS) \"$(RESOURCES)/AppIcon.icns\"")
+    }
+
+    private static func testMakefileBundlesLocalizationResources() throws {
+        let makefile = try String(contentsOfFile: "Makefile", encoding: .utf8)
+
+        assertContains(makefile, "LOCALIZATION_CATALOG = Resources/Localization/Localizable.xcstrings")
+        assertContains(makefile, "xcrun xcstringstool compile")
+        assertContains(makefile, "-l en -l ko")
+        assertContains(makefile, "$(RESOURCES)/en.lproj")
+        assertContains(makefile, "$(RESOURCES)/ko.lproj")
     }
 
     private static func testMakefileStripsExtendedAttributesDuringCodesignStaging() throws {

--- a/Tests/BuildMetadataTests.swift
+++ b/Tests/BuildMetadataTests.swift
@@ -9,7 +9,7 @@ struct BuildMetadataTests {
         try testMakefileSeparatesDevRunFromInstallBuild()
         try testMakefileCopiesSelectedIconToBundleIconName()
         try testMakefileBundlesLocalizationResources()
-        try testMakefileBuildsAdHocLocalizationBundleForValidation()
+        try testMakefileBuildsAppBundleForLocalizationValidation()
         try testTestsWorkflowValidatesLocalizationBundle()
         try testMakefileStripsExtendedAttributesDuringCodesignStaging()
         try testMakefileStripsExtendedAttributesDuringDmgStaging()
@@ -100,22 +100,19 @@ struct BuildMetadataTests {
         assertContains(makefile, "$(RESOURCES)/ko.lproj")
     }
 
-    private static func testMakefileBuildsAdHocLocalizationBundleForValidation() throws {
+    private static func testMakefileBuildsAppBundleForLocalizationValidation() throws {
         let makefile = try String(contentsOfFile: "Makefile", encoding: .utf8)
 
-        assertContains(makefile, "localization-bundle-test: /tmp/LocalizationResourceTests $(LOCALIZATION_STAMP)")
-        assertContains(makefile, #"bundle="$(BUILD_DIR)/Quill Localization Test.app""#)
-        assertContains(makefile, #"ditto --norsrc --noextattr "$(LOCALIZATION_BUILD_DIR)/en.lproj""#)
-        assertContains(makefile, #"ditto --norsrc --noextattr "$(LOCALIZATION_BUILD_DIR)/ko.lproj""#)
-        assertContains(makefile, "PlaceholderFixtures.strings")
-        assertContains(makefile, #"/tmp/LocalizationResourceTests --bundle "$$bundle""#)
-        assertDoesNotContain(makefile, "localization-bundle-test: /tmp/LocalizationResourceTests\n\t@$(MAKE) all")
+        assertContains(makefile, "localization-bundle-test: /tmp/LocalizationResourceTests $(APP_EXECUTABLE_TARGET)")
+        assertContains(makefile, #"/tmp/LocalizationResourceTests --bundle "$(APP_BUNDLE)""#)
+        assertDoesNotContain(makefile, "Quill Localization Test.app")
+        assertDoesNotContain(makefile, "PlaceholderFixtures.strings")
     }
 
     private static func testTestsWorkflowValidatesLocalizationBundle() throws {
         let workflow = try String(contentsOfFile: ".github/workflows/tests.yml", encoding: .utf8)
 
-        assertContains(workflow, "make localization-bundle-test")
+        assertContains(workflow, "make localization-bundle-test CODESIGN_IDENTITY=-")
     }
 
     private static func testMakefileStripsExtendedAttributesDuringCodesignStaging() throws {

--- a/Tests/BuildMetadataTests.swift
+++ b/Tests/BuildMetadataTests.swift
@@ -9,6 +9,8 @@ struct BuildMetadataTests {
         try testMakefileSeparatesDevRunFromInstallBuild()
         try testMakefileCopiesSelectedIconToBundleIconName()
         try testMakefileBundlesLocalizationResources()
+        try testMakefileBuildsAdHocLocalizationBundleForValidation()
+        try testTestsWorkflowValidatesLocalizationBundle()
         try testMakefileStripsExtendedAttributesDuringCodesignStaging()
         try testMakefileStripsExtendedAttributesDuringDmgStaging()
         try testMakefileCreatesDmgWithoutFinderMetadata()
@@ -47,7 +49,7 @@ struct BuildMetadataTests {
     private static func testMakefilePrintsVersionMetadata() throws {
         let makefile = try String(contentsOfFile: "Makefile", encoding: .utf8)
 
-        assertContains(makefile, ".PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run check-test-wiring test print-app-version print-build-number print-build-tag print-version-metadata FORCE")
+        assertContains(makefile, ".PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run check-test-wiring test localization-bundle-test print-app-version print-build-number print-build-tag print-version-metadata FORCE /tmp/LocalizationResourceTests")
         assertContains(makefile, "print-app-version:")
         assertContains(makefile, "print-build-number:")
         assertContains(makefile, "print-build-tag:")
@@ -96,6 +98,24 @@ struct BuildMetadataTests {
         assertContains(makefile, "-l en -l ko")
         assertContains(makefile, "$(RESOURCES)/en.lproj")
         assertContains(makefile, "$(RESOURCES)/ko.lproj")
+    }
+
+    private static func testMakefileBuildsAdHocLocalizationBundleForValidation() throws {
+        let makefile = try String(contentsOfFile: "Makefile", encoding: .utf8)
+
+        assertContains(makefile, "localization-bundle-test: /tmp/LocalizationResourceTests $(LOCALIZATION_STAMP)")
+        assertContains(makefile, #"bundle="$(BUILD_DIR)/Quill Localization Test.app""#)
+        assertContains(makefile, #"ditto --norsrc --noextattr "$(LOCALIZATION_BUILD_DIR)/en.lproj""#)
+        assertContains(makefile, #"ditto --norsrc --noextattr "$(LOCALIZATION_BUILD_DIR)/ko.lproj""#)
+        assertContains(makefile, "PlaceholderFixtures.strings")
+        assertContains(makefile, #"/tmp/LocalizationResourceTests --bundle "$$bundle""#)
+        assertDoesNotContain(makefile, "localization-bundle-test: /tmp/LocalizationResourceTests\n\t@$(MAKE) all")
+    }
+
+    private static func testTestsWorkflowValidatesLocalizationBundle() throws {
+        let workflow = try String(contentsOfFile: ".github/workflows/tests.yml", encoding: .utf8)
+
+        assertContains(workflow, "make localization-bundle-test")
     }
 
     private static func testMakefileStripsExtendedAttributesDuringCodesignStaging() throws {

--- a/Tests/CalendarRecordingReminderSchedulerTests.swift
+++ b/Tests/CalendarRecordingReminderSchedulerTests.swift
@@ -3,7 +3,7 @@ import UserNotifications
 
 @main
 struct CalendarRecordingReminderSchedulerTests {
-    static func main() async {
+    static func main() async throws {
         testLeadMinutesAffectFireDate()
         testMultipleLeadMinutesCreateMultipleSchedules()
         testPastReminderTimeForUpcomingMeetingBecomesImmediate()
@@ -16,6 +16,7 @@ struct CalendarRecordingReminderSchedulerTests {
         testReminderGroupIdentifierIgnoresLeadMinutes()
         testCalendarReminderIdentifierFilteringUsesPrefix()
         testNotificationTitleDescribesRelativeStartTime()
+        try testNotificationCopyLocalizesWrapperAndPreservesEventTitle()
         testNormalizesLeadMinutes()
         testNormalizesLeadMinuteSelections()
         testNormalizesRefreshIntervalMinutesToSupportedOptions()
@@ -221,6 +222,25 @@ struct CalendarRecordingReminderSchedulerTests {
         assert(CalendarRecordingReminderScheduler.notificationTitle(for: future, now: now) == "Meeting starts in 10 minutes")
         assert(CalendarRecordingReminderScheduler.notificationTitle(for: soon, now: now) == "Meeting starts in 1 minute")
         assert(CalendarRecordingReminderScheduler.notificationTitle(for: started, now: now) == "Meeting is starting now")
+    }
+
+    private static func testNotificationCopyLocalizesWrapperAndPreservesEventTitle() throws {
+        let bundle = try compiledLocalizationBundle()
+        let now = Date(timeIntervalSince1970: 1_000)
+        let event = calendarEvent(id: "localized", title: "Quarterly Review: Q3", start: 1_600, end: 1_900)
+        let schedule = CalendarRecordingReminderSchedule(identifier: "localized", fireDate: now, event: event, delivery: .scheduled)
+
+        assert(CalendarRecordingReminderScheduler.notificationTitle(for: schedule, now: now, language: "en", bundle: bundle) == "Meeting starts in 10 minutes")
+        assert(CalendarRecordingReminderScheduler.notificationTitle(for: schedule, now: now, language: "ko", bundle: bundle) == "회의가 10분 후 시작됩니다")
+        assert(CalendarRecordingReminderScheduler.notificationBody(for: event, language: "ko", bundle: bundle) == "눌러서 녹음 시작: Quarterly Review: Q3")
+    }
+
+    private static func compiledLocalizationBundle() throws -> Bundle {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        guard let bundle = Bundle(path: root.appendingPathComponent("build/localization").path) else {
+            throw NSError(domain: "CalendarRecordingReminderSchedulerTests", code: 1)
+        }
+        return bundle
     }
 
     private static func testNormalizesLeadMinutes() {

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -40,6 +40,7 @@ struct LocalizationResourceTests {
 
         try assertTask3ExtractionCoverage(root: root, catalogStrings: strings)
         try assertTask3ReviewCoverage(root: root)
+        try assertTask4SettingsExtractionCoverage(root: root, catalogStrings: strings)
 
         let noteBrowserSource = try String(
             contentsOf: root.appendingPathComponent("Sources/NoteBrowserView.swift"),
@@ -121,6 +122,56 @@ struct LocalizationResourceTests {
         let arguments = String(testSource[argumentsStart.lowerBound..<argumentsEnd.lowerBound])
         assert(arguments.contains("Sources/AppDelegate.swift"))
         assert(arguments.contains("Sources/SetupFlow.swift"))
+    }
+
+
+    private static func assertTask4SettingsExtractionCoverage(root: URL, catalogStrings: [String: Any]) throws {
+        let settingsURL = root.appendingPathComponent("Sources/SettingsView.swift")
+        let source = try String(contentsOf: settingsURL, encoding: .utf8)
+        let startMarker = "// localization-exclusion: developer-diagnostics-start"
+        let endMarker = "// localization-exclusion: developer-diagnostics-end"
+        assert(source.components(separatedBy: startMarker).count == 3, "Expected exactly two developer diagnostic start markers")
+        assert(source.components(separatedBy: endMarker).count == 3, "Expected exactly two developer diagnostic end markers")
+
+        var remaining = source
+        var excluded = ""
+        while let start = remaining.range(of: startMarker), let end = remaining.range(of: endMarker, range: start.upperBound..<remaining.endIndex) {
+            excluded += String(remaining[start.lowerBound..<end.upperBound])
+            remaining.removeSubrange(start.lowerBound..<end.upperBound)
+        }
+        assert(excluded.contains("struct DebugSettingsView"))
+        assert(excluded.contains("struct RunLogView"))
+        assert(excluded.contains("struct RunLogEntryView"))
+        assert(excluded.contains("struct PipelineStepView"))
+        assert(remaining.contains("struct AppearanceSettingsView"))
+        assert(remaining.contains("struct ModelsSettingsView"))
+        assert(remaining.contains("struct VoiceMacroEditorView"))
+        assert(remaining.contains("struct ModelRowView"))
+
+        let temporaryDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        let filteredSettingsURL = temporaryDirectory.appendingPathComponent("SettingsView.swift")
+        try remaining.write(to: filteredSettingsURL, atomically: true, encoding: .utf8)
+
+        let process = Process()
+        process.currentDirectoryURL = root
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        process.arguments = ["xcstringstool", "extract", "--SwiftUI", "--modern-localizable-strings", "--output-format", "xcstrings", "-o", temporaryDirectory.path, filteredSettingsURL.path, "Sources/ModelDropdownView.swift"]
+        try process.run()
+        process.waitUntilExit()
+        assert(process.terminationStatus == 0, "Task 4 localization extraction failed")
+
+        let extractedData = try Data(contentsOf: temporaryDirectory.appendingPathComponent("Localizable.xcstrings"))
+        let extracted = try JSONSerialization.jsonObject(with: extractedData) as! [String: Any]
+        for key in (extracted["strings"] as! [String: Any]).keys where !key.isEmpty {
+            let entry = catalogStrings[key] as? [String: Any]
+            let localizations = entry?["localizations"] as? [String: Any]
+            for language in ["en", "ko"] {
+                let unit = (localizations?[language] as? [String: Any])?["stringUnit"] as? [String: Any]
+                assert(!(unit?["value"] as? String ?? "").isEmpty, "Missing Task 4 \(language) translation for \(key)")
+            }
+        }
     }
 
     private static func localizedValue(

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -4,6 +4,15 @@ import Foundation
 struct LocalizationResourceTests {
     static func main() throws {
         let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        if CommandLine.arguments.count > 1 {
+            guard CommandLine.arguments.count == 3, CommandLine.arguments[1] == "--bundle" else {
+                throw TestFailure("Usage: LocalizationResourceTests [--bundle <app-bundle>]")
+            }
+            try validateBundle(at: URL(fileURLWithPath: CommandLine.arguments[2], isDirectory: true))
+            print("LocalizationResourceTests bundle validation passed")
+            return
+        }
+
         let catalogURL = root.appendingPathComponent("Resources/Localization/Localizable.xcstrings")
         let catalogData = try Data(contentsOf: catalogURL)
         let catalog = try JSONSerialization.jsonObject(with: catalogData) as! [String: Any]
@@ -43,6 +52,13 @@ struct LocalizationResourceTests {
         try assertTask4SettingsExtractionCoverage(root: root, catalogStrings: strings)
         try assertTask5ApplicationMessageCoverage(root: root, catalogStrings: strings)
         try assertTask6OverlayCoverage(root: root, catalogStrings: strings)
+
+        try assertFinalManagedSourceAudit(root: root, catalogStrings: strings)
+        try assertCatalogPlaceholderCompatibility(catalogStrings: strings)
+        try assertDeveloperDiagnosticsAreExcluded(catalogStrings: strings)
+        try assertRepresentativeProductionKoreanTranslations(catalogStrings: strings)
+        try assertInfoPlistTranslations(root: root)
+
         let settingsSource = try String(contentsOf: root.appendingPathComponent("Sources/SettingsView.swift"), encoding: .utf8)
         assert(settingsSource.contains("MicrophoneOptionRow(\n                    title: \"System Default\""))
         assert(settingsSource.contains("verbatimName: device.name,"))
@@ -59,7 +75,7 @@ struct LocalizationResourceTests {
             assert(!(((localizations?["en"] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String ?? "").isEmpty)
             assert(!(((localizations?["ko"] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String ?? "").isEmpty)
         }
-        for key in ["Relaunching...", "%arg restores the audio state it changed when dictation ends.", "When enabled, %arg retries or falls back to the literal transcript if post-processing looks like it answered the dictated text instead of cleaning it.", "When on, your clipboard manager (Paste, Raycast, Maccy, etc.) records each dictation so you can find it in your recent history. When off, %arg marks dictations transient and your clipboard manager skips them."] {
+        for key in ["Relaunching...", "%@ restores the audio state it changed when dictation ends.", "When enabled, %@ retries or falls back to the literal transcript if post-processing looks like it answered the dictated text instead of cleaning it.", "When on, your clipboard manager (Paste, Raycast, Maccy, etc.) records each dictation so you can find it in your recent history. When off, %@ marks dictations transient and your clipboard manager skips them."] {
             let localizations = (strings[key] as? [String: Any])?["localizations"] as? [String: Any]
             let en = (((localizations?["en"] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String)
             let ko = (((localizations?["ko"] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String)
@@ -123,7 +139,8 @@ struct LocalizationResourceTests {
         let extractedCatalog = try JSONSerialization.jsonObject(with: extractedData) as! [String: Any]
         let extractedStrings = extractedCatalog["strings"] as! [String: Any]
         let exclusions: Set<String> = ["Open Run Log"]
-        for key in extractedStrings.keys where !exclusions.contains(key) {
+        for extractedKey in extractedStrings.keys where !exclusions.contains(extractedKey) {
+            let key = catalogKey(forExtractedKey: extractedKey)
             let entry = catalogStrings[key] as? [String: Any]
             let localizations = entry?["localizations"] as? [String: Any]
             for language in ["en", "ko"] {
@@ -178,7 +195,7 @@ struct LocalizationResourceTests {
         assert(remaining.contains("struct VoiceMacroEditorView"))
         assert(remaining.contains("struct ModelRowView"))
 
-        let temporaryDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let temporaryDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("quill-localization-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
         try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
         let filteredSettingsURL = temporaryDirectory.appendingPathComponent("SettingsView.swift")
@@ -194,7 +211,8 @@ struct LocalizationResourceTests {
 
         let extractedData = try Data(contentsOf: temporaryDirectory.appendingPathComponent("Localizable.xcstrings"))
         let extracted = try JSONSerialization.jsonObject(with: extractedData) as! [String: Any]
-        for key in (extracted["strings"] as! [String: Any]).keys where !key.isEmpty {
+        for extractedKey in (extracted["strings"] as! [String: Any]).keys where !extractedKey.isEmpty {
+            let key = catalogKey(forExtractedKey: extractedKey)
             let entry = catalogStrings[key] as? [String: Any]
             let localizations = entry?["localizations"] as? [String: Any]
             for language in ["en", "ko"] {
@@ -264,8 +282,311 @@ struct LocalizationResourceTests {
         }
     }
 
-    private static func assertCatalogTranslations(for key: String, catalogStrings: [String: Any]) {
-        let localizations = (catalogStrings[key] as? [String: Any])?["localizations"] as? [String: Any]
+
+    private struct TestFailure: Error, CustomStringConvertible {
+        let description: String
+        init(_ description: String) { self.description = description }
+    }
+
+    private static func validateBundle(at appURL: URL) throws {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: appURL.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+            throw TestFailure("App bundle does not exist: \(appURL.path)")
+        }
+
+        let resourcesURL = appURL.appendingPathComponent("Contents/Resources", isDirectory: true)
+        let requiredInfoKeys = ["NSMicrophoneUsageDescription", "NSSpeechRecognitionUsageDescription"]
+        var languageBundles: [String: Bundle] = [:]
+        for language in ["en", "ko"] {
+            let localizationURL = resourcesURL.appendingPathComponent("\(language).lproj", isDirectory: true)
+            for fileName in ["Localizable.strings", "InfoPlist.strings"] {
+                let fileURL = localizationURL.appendingPathComponent(fileName)
+                guard FileManager.default.fileExists(atPath: fileURL.path) else {
+                    throw TestFailure("Missing bundled localization resource: \(fileURL.path)")
+                }
+            }
+            guard let bundle = Bundle(url: localizationURL) else {
+                throw TestFailure("Unable to load language bundle: \(localizationURL.path)")
+            }
+            languageBundles[language] = bundle
+
+            let infoValues = NSDictionary(contentsOf: localizationURL.appendingPathComponent("InfoPlist.strings")) as? [String: String] ?? [:]
+            guard Set(infoValues.keys) == Set(requiredInfoKeys) else {
+                throw TestFailure("Unexpected bundled InfoPlist.strings keys for \(language)")
+            }
+            for key in requiredInfoKeys where infoValues[key]?.isEmpty != false {
+                throw TestFailure("Missing bundled \(language) InfoPlist value for \(key)")
+            }
+        }
+
+        let representativeStatic: [String: [String: String]] = [
+            "en": ["Continue": "Continue", "Settings...": "Settings...", "Start Dictating": "Start Dictating"],
+            "ko": ["Continue": "계속", "Settings...": "설정...", "Start Dictating": "받아쓰기 시작"]
+        ]
+        for language in ["en", "ko"] {
+            guard let bundle = languageBundles[language] else { continue }
+            for (key, expected) in representativeStatic[language] ?? [:] {
+                let value = bundle.localizedString(forKey: key, value: nil, table: "Localizable")
+                guard value == expected else {
+                    throw TestFailure("Unexpected bundled \(language) value for \(key): \(value)")
+                }
+            }
+        }
+
+        try assertBundledDynamicString(
+            key: "Input changed to %@",
+            arguments: ["Studio Display"],
+            expected: ["en": "Input changed to Studio Display", "ko": "입력이 Studio Display(으)로 변경됨"],
+            languageBundles: languageBundles
+        )
+        try assertBundledDynamicString(
+            key: "Meeting starts in %d minutes",
+            arguments: [3],
+            expected: ["en": "Meeting starts in 3 minutes", "ko": "회의가 3분 후 시작됩니다"],
+            languageBundles: languageBundles
+        )
+        try assertBundledDynamicString(
+            key: "Welcome to %@",
+            arguments: ["Quill"],
+            expected: ["en": "Welcome to Quill", "ko": "Quill에 오신 것을 환영합니다."],
+            languageBundles: languageBundles
+        )
+
+
+        let fixtureURL = resourcesURL.appendingPathComponent("PlaceholderFixtures.strings")
+        let fixtureContents = try String(contentsOf: fixtureURL, encoding: .utf8)
+        for placeholder in ["%@", "%d", "%lld", "%arg"] {
+            guard fixtureContents.contains(#"= "\#(placeholder)";"#) else {
+                throw TestFailure("Missing bundled placeholder serialization fixture for \(placeholder)")
+            }
+        }
+
+        let placeholderPattern = try NSRegularExpression(pattern: #"%(?:@|d|lld|arg)"#)
+        for key in ["Input changed to %@", "Meeting starts in %d minutes", "Welcome to %@"] {
+            let expectedPlaceholders = placeholders(in: key, pattern: placeholderPattern)
+            for language in ["en", "ko"] {
+                guard let bundle = languageBundles[language] else { continue }
+                let localized = bundle.localizedString(forKey: key, value: nil, table: "Localizable")
+                guard placeholders(in: localized, pattern: placeholderPattern) == expectedPlaceholders else {
+                    throw TestFailure("Bundled \(language) placeholder mismatch for \(key)")
+                }
+            }
+        }
+    }
+
+    private static func assertBundledDynamicString(
+        key: String,
+        arguments: [CVarArg],
+        expected: [String: String],
+        languageBundles: [String: Bundle]
+    ) throws {
+        for language in ["en", "ko"] {
+            guard let bundle = languageBundles[language], let expectedValue = expected[language] else { continue }
+            let localized = bundle.localizedString(forKey: key, value: nil, table: "Localizable")
+            let value = String(format: localized, locale: Locale(identifier: language), arguments: arguments)
+            guard value == expectedValue else {
+                throw TestFailure("Unexpected bundled \(language) dynamic value for \(key): \(value)")
+            }
+        }
+    }
+
+    private static func assertFinalManagedSourceAudit(root: URL, catalogStrings: [String: Any]) throws {
+        let managedSourceFiles = [
+            "Sources/NoteBrowserView.swift", "Sources/NoteListRowDisplayData.swift",
+            "Sources/SetupView.swift", "Sources/MenuBarView.swift", "Sources/ShortcutComponents.swift",
+            "Sources/App.swift",
+            "Sources/AppDelegate.swift", "Sources/SetupFlow.swift", "Sources/SettingsView.swift",
+            "Sources/ModelDropdownView.swift", "Sources/AppState.swift", "Sources/AudioImportOptions.swift",
+            "Sources/CalendarRecordingReminderScheduler.swift", "Sources/LocalizedUserMessage.swift",
+            "Sources/UpdateManager.swift", "Sources/NativeWhisperModel.swift",
+            "Sources/TranscriptionLanguage.swift", "Sources/TranscriptionModel.swift",
+            "Sources/RecordingOverlay.swift", "Sources/MeetingReminderOverlay.swift",
+            "Sources/OverlayDisplayCopy.swift"
+        ]
+        for sourceFile in managedSourceFiles {
+            assert(FileManager.default.fileExists(atPath: root.appendingPathComponent(sourceFile).path), "Missing managed source file: \(sourceFile)")
+        }
+
+        let extractedKeys = try extractManagedKeys(root: root, sourceFiles: managedSourceFiles)
+        let exactNonCatalogSwiftUIKeys: Set<String> = [
+            "Open Run Log", "·", "API", "Legacy mlx-whisper", "REC",
+            "%arg.md saved", "Saved file name: %arg.md"
+        ]
+        for extractedKey in extractedKeys where !extractedKey.isEmpty && !exactNonCatalogSwiftUIKeys.contains(extractedKey) {
+            assertCatalogTranslations(
+                for: catalogKey(forExtractedKey: extractedKey),
+                catalogStrings: catalogStrings,
+                requiresTranslation: true
+            )
+        }
+
+        let customLookupPattern = try NSRegularExpression(pattern: #"localizedCatalogString\(\s*\"((?:\\.|[^\"\\])*)\""#)
+        for sourceFile in managedSourceFiles {
+            let source = try managedSource(sourceFile, root: root)
+            let range = NSRange(source.startIndex..., in: source)
+            for match in customLookupPattern.matches(in: source, range: range) {
+                guard let keyRange = Range(match.range(at: 1), in: source) else { continue }
+                let key = String(source[keyRange])
+                    .replacingOccurrences(of: #"\n"#, with: "\n")
+                    .replacingOccurrences(of: #"\""#, with: #"""#)
+                    .replacingOccurrences(of: #"\\"#, with: #"\"#)
+                assertCatalogTranslations(for: key, catalogStrings: catalogStrings)
+            }
+        }
+
+        let hangulPattern = try NSRegularExpression(pattern: "[가-힣]")
+        let exactHangulExceptions: Set<String> = [
+            #"@AppStorage("obsidian_gemini_prompt") private var geminiPrompt: String = "다음은 음성 전사 내용입니다. 핵심 내용을 유지하면서 읽기 쉽게 정리해주세요. 마크다운 형식으로 작성하되, 불필요한 설명 없이 정리된 내용만 출력해주세요.\n옵시디언에 다른 회의록을 참고하여 컨텍스트와 작성 포맷을 통일하여 주세요.""#,
+            #"TranscriptionLanguage(code: "ko", displayName: "한국어"),"#,
+            #"description: "시스템 내장 · 온디바이스 · 빠름""#,
+            #"description: "빠름 · 정확도 높음 (추천)""#,
+            #"description: "최고 정확도 · 느림""#,
+            #"description: "중간 속도 · 중간 정확도""#,
+            #"description: "빠름 · 정확도 낮음""#
+        ]
+        for sourceFile in managedSourceFiles {
+            let source = try managedSource(sourceFile, root: root)
+            for (index, line) in source.components(separatedBy: .newlines).enumerated() {
+                guard hangulPattern.firstMatch(in: line, range: NSRange(line.startIndex..., in: line)) != nil else { continue }
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                let isComment = trimmed.hasPrefix("//") || trimmed.hasPrefix("///")
+                let containsOnlyCommentHangul = line.split(separator: "//", maxSplits: 1).first.map {
+                    hangulPattern.firstMatch(in: String($0), range: NSRange($0.startIndex..., in: $0)) == nil
+                } ?? false
+                assert(isComment || containsOnlyCommentHangul || exactHangulExceptions.contains(trimmed), "Unexpected Hangul literal in \(sourceFile):\(index + 1): \(trimmed)")
+            }
+        }
+    }
+
+    private static func extractManagedKeys(root: URL, sourceFiles: [String]) throws -> Set<String> {
+        let temporaryDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("quill-localization-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+
+        var extractionFiles: [String] = []
+        for sourceFile in sourceFiles {
+            var source = try managedSource(sourceFile, root: root)
+            if sourceFile == "Sources/RecordingOverlay.swift" {
+                source = source.replacingOccurrences(
+                    of: "isStaticQuillName ? String(localized: String.LocalizationValue(name)) : name",
+                    with: "isStaticQuillName ? localizedCatalogString(name) : name"
+                )
+            }
+            let outputURL = temporaryDirectory.appendingPathComponent(URL(fileURLWithPath: sourceFile).lastPathComponent)
+            try source.write(to: outputURL, atomically: true, encoding: .utf8)
+            extractionFiles.append(outputURL.path)
+        }
+
+        let process = Process()
+        process.currentDirectoryURL = root
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        process.arguments = [
+            "xcstringstool", "extract", "--SwiftUI", "--modern-localizable-strings",
+            "--output-format", "xcstrings", "-o", temporaryDirectory.path
+        ] + extractionFiles
+        try process.run()
+        process.waitUntilExit()
+        assert(process.terminationStatus == 0, "Final managed localization extraction failed")
+
+        let extractedData = try Data(contentsOf: temporaryDirectory.appendingPathComponent("Localizable.xcstrings"))
+        let extracted = try JSONSerialization.jsonObject(with: extractedData) as! [String: Any]
+        return Set((extracted["strings"] as? [String: Any] ?? [:]).keys)
+    }
+
+    private static func managedSource(_ sourceFile: String, root: URL) throws -> String {
+        var source = try String(contentsOf: root.appendingPathComponent(sourceFile), encoding: .utf8)
+        guard sourceFile == "Sources/SettingsView.swift" else { return source }
+
+        let startMarker = "// localization-exclusion: developer-diagnostics-start"
+        let endMarker = "// localization-exclusion: developer-diagnostics-end"
+        while let start = source.range(of: startMarker),
+              let end = source.range(of: endMarker, range: start.upperBound..<source.endIndex) {
+            source.removeSubrange(start.lowerBound..<end.upperBound)
+        }
+        return source
+    }
+
+    private static func catalogKey(forExtractedKey key: String) -> String {
+        key.replacingOccurrences(of: "%arg", with: "%@")
+    }
+
+    private static func assertCatalogPlaceholderCompatibility(catalogStrings: [String: Any]) throws {
+        let placeholderPattern = try NSRegularExpression(pattern: #"%(?:@|d|lld|arg)"#)
+        for (key, rawEntry) in catalogStrings {
+            let entry = rawEntry as? [String: Any] ?? [:]
+            guard entry["shouldTranslate"] as? Bool != false else { continue }
+            let localizations = entry["localizations"] as? [String: Any] ?? [:]
+            let en = (((localizations["en"] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String) ?? ""
+            let ko = (((localizations["ko"] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String) ?? ""
+            let keyPlaceholders = placeholders(in: key, pattern: placeholderPattern)
+            assert(placeholders(in: en, pattern: placeholderPattern) == keyPlaceholders, "English placeholder mismatch for \(key)")
+            assert(placeholders(in: ko, pattern: placeholderPattern) == keyPlaceholders, "Korean placeholder mismatch for \(key)")
+        }
+    }
+
+    private static func placeholders(in value: String, pattern: NSRegularExpression) -> [String] {
+        pattern.matches(in: value, range: NSRange(value.startIndex..., in: value)).compactMap {
+            Range($0.range, in: value).map { String(value[$0]) }
+        }
+    }
+
+    private static func assertDeveloperDiagnosticsAreExcluded(catalogStrings: [String: Any]) throws {
+        let diagnosticOnlyKeys = [
+            "Debug", "Display the update available overlay after dictation finishes.",
+            "No Context", "No LLM", "No context captured",
+            "No runs yet. Use dictation to populate history.", "Pipeline", "Run Log",
+            "Show Meeting Reminder", "Show Update Overlay Now",
+            "Show a sample calendar reminder overlay. Turn on Debug Overlay first to preview the recording (wrapping) variant.",
+            "Show after dictation", "Show the recording overlay with simulated audio levels.",
+            "Stored locally. Only the %@ most recent runs are kept."
+        ]
+        for key in diagnosticOnlyKeys {
+            let entry = catalogStrings[key] as? [String: Any]
+            assert(entry == nil || entry?["shouldTranslate"] as? Bool == false, "Developer diagnostic key must not require translations: \(key)")
+        }
+    }
+
+    private static func assertRepresentativeProductionKoreanTranslations(catalogStrings: [String: Any]) throws {
+        for key in [
+            "No audio recorded",
+            "When enabled, %@ retries or falls back to the literal transcript if post-processing looks like it answered the dictated text instead of cleaning it.",
+            "When on, your clipboard manager (Paste, Raycast, Maccy, etc.) records each dictation so you can find it in your recent history. When off, %@ marks dictations transient and your clipboard manager skips them."
+        ] {
+            guard let entry = catalogStrings[key] as? [String: Any], entry["shouldTranslate"] as? Bool != false else { continue }
+            let localizations = entry["localizations"] as? [String: Any]
+            let en = (((localizations?["en"] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String)
+            let ko = (((localizations?["ko"] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String)
+            assert(en != ko, "Expected Korean production translation for \(key)")
+        }
+    }
+
+    private static func assertInfoPlistTranslations(root: URL) throws {
+        let requiredKeys = ["NSMicrophoneUsageDescription", "NSSpeechRecognitionUsageDescription"]
+        var valuesByLanguage: [String: [String: String]] = [:]
+        for language in ["en", "ko"] {
+            let url = root.appendingPathComponent("Resources/Localization/\(language).lproj/InfoPlist.strings")
+            let values = NSDictionary(contentsOf: url) as? [String: String] ?? [:]
+            valuesByLanguage[language] = values
+            assert(Set(values.keys) == Set(requiredKeys), "Unexpected InfoPlist.strings keys for \(language)")
+            for key in requiredKeys {
+                assert(values[key]?.isEmpty == false, "Missing \(language) InfoPlist translation for \(key)")
+            }
+        }
+        for key in requiredKeys {
+            assert(valuesByLanguage["en"]?[key] != valuesByLanguage["ko"]?[key], "Expected distinct Korean InfoPlist translation for \(key)")
+        }
+    }
+
+    private static func assertCatalogTranslations(
+        for key: String,
+        catalogStrings: [String: Any],
+        requiresTranslation: Bool = false
+    ) {
+        let entry = catalogStrings[key] as? [String: Any]
+        if requiresTranslation {
+            assert(entry?["shouldTranslate"] as? Bool != false, "Managed production key is marked non-translatable: \(key)")
+        }
+        let localizations = entry?["localizations"] as? [String: Any]
         for language in ["en", "ko"] {
             let value = (((localizations?[language] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String)
             assert(!(value ?? "").isEmpty, "Missing Task 5 \(language) translation for \(key)")

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+@main
+struct LocalizationResourceTests {
+    static func main() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let catalogURL = root.appendingPathComponent("Resources/Localization/Localizable.xcstrings")
+        let catalogData = try Data(contentsOf: catalogURL)
+        let catalog = try JSONSerialization.jsonObject(with: catalogData) as! [String: Any]
+
+        assert(catalog["sourceLanguage"] as? String == "en")
+        let strings = catalog["strings"] as! [String: Any]
+        assert(!strings.isEmpty)
+
+        for (key, rawEntry) in strings {
+            let entry = rawEntry as? [String: Any] ?? [:]
+            guard entry["shouldTranslate"] as? Bool != false else { continue }
+            let localizations = entry["localizations"] as? [String: Any] ?? [:]
+            for language in ["en", "ko"] {
+                let localization = localizations[language] as? [String: Any]
+                let unit = localization?["stringUnit"] as? [String: Any]
+                let value = unit?["value"] as? String
+                assert(value?.isEmpty == false, "Missing \(language) translation for \(key)")
+            }
+        }
+
+        for language in ["en", "ko"] {
+            let infoURL = root.appendingPathComponent("Resources/Localization/\(language).lproj/InfoPlist.strings")
+            let info = try String(contentsOf: infoURL, encoding: .utf8)
+            assert(info.contains("NSMicrophoneUsageDescription"))
+            assert(info.contains("NSSpeechRecognitionUsageDescription"))
+        }
+
+        print("LocalizationResourceTests passed")
+    }
+}

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -31,6 +31,20 @@ struct LocalizationResourceTests {
             assert(info.contains("NSSpeechRecognitionUsageDescription"))
         }
 
+        let hangulPattern = try NSRegularExpression(pattern: "[가-힣]")
+        let sourceFiles = ["Sources/NoteBrowserView.swift", "Sources/NoteListRowDisplayData.swift"]
+        for sourceFile in sourceFiles {
+            let source = try String(contentsOf: root.appendingPathComponent(sourceFile), encoding: .utf8)
+            let lines = source.components(separatedBy: .newlines)
+            for (index, line) in lines.enumerated() {
+                guard hangulPattern.firstMatch(in: line, range: NSRange(line.startIndex..., in: line)) != nil else { continue }
+                let previousLine = index > 0 ? lines[index - 1] : ""
+                let isAllowlistedGeminiPrompt = previousLine.contains("localization-allowlist: exact non-UI Gemini model prompt")
+                    && line.contains("@AppStorage(\"obsidian_gemini_prompt\")")
+                assert(isAllowlistedGeminiPrompt, "Unexpected Hangul literal in \(sourceFile):\(index + 1)")
+            }
+        }
+
         print("LocalizationResourceTests passed")
     }
 }

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -24,12 +24,21 @@ struct LocalizationResourceTests {
             }
         }
 
+        let continueKorean = try localizedValue(key: "Continue", language: "ko", root: root)
+        let settingsKorean = try localizedValue(key: "Settings...", language: "ko", root: root)
+        let startDictatingKorean = try localizedValue(key: "Start Dictating", language: "ko", root: root)
+        assert(continueKorean == "계속")
+        assert(settingsKorean == "설정...")
+        assert(startDictatingKorean == "받아쓰기 시작")
+
         for language in ["en", "ko"] {
             let infoURL = root.appendingPathComponent("Resources/Localization/\(language).lproj/InfoPlist.strings")
             let info = try String(contentsOf: infoURL, encoding: .utf8)
             assert(info.contains("NSMicrophoneUsageDescription"))
             assert(info.contains("NSSpeechRecognitionUsageDescription"))
         }
+
+        try assertTask3ExtractionCoverage(root: root, catalogStrings: strings)
 
         let noteBrowserSource = try String(
             contentsOf: root.appendingPathComponent("Sources/NoteBrowserView.swift"),
@@ -57,5 +66,49 @@ struct LocalizationResourceTests {
         }
 
         print("LocalizationResourceTests passed")
+    }
+
+    private static func assertTask3ExtractionCoverage(root: URL, catalogStrings: [String: Any]) throws {
+        let temporaryDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let process = Process()
+        process.currentDirectoryURL = root
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        process.arguments = [
+            "xcstringstool", "extract", "--SwiftUI", "--modern-localizable-strings",
+            "--output-format", "xcstrings", "-o", temporaryDirectory.path,
+            "Sources/SetupView.swift", "Sources/MenuBarView.swift", "Sources/App.swift"
+        ]
+        try process.run()
+        process.waitUntilExit()
+        assert(process.terminationStatus == 0, "Task 3 localization extraction failed")
+
+        let extractedURL = temporaryDirectory.appendingPathComponent("Localizable.xcstrings")
+        let extractedData = try Data(contentsOf: extractedURL)
+        let extractedCatalog = try JSONSerialization.jsonObject(with: extractedData) as! [String: Any]
+        let extractedStrings = extractedCatalog["strings"] as! [String: Any]
+        let exclusions: Set<String> = ["Open Run Log"]
+        for key in extractedStrings.keys where !exclusions.contains(key) {
+            let entry = catalogStrings[key] as? [String: Any]
+            let localizations = entry?["localizations"] as? [String: Any]
+            for language in ["en", "ko"] {
+                let unit = (localizations?[language] as? [String: Any])?["stringUnit"] as? [String: Any]
+                assert(!(unit?["value"] as? String ?? "").isEmpty, "Missing Task 3 \(language) translation for \(key)")
+            }
+        }
+    }
+
+    private static func localizedValue(
+        key: String,
+        language: String,
+        root: URL
+    ) throws -> String {
+        let url = root
+            .appendingPathComponent("build/localization")
+            .appendingPathComponent("\(language).lproj/Localizable.strings")
+        let dictionary = NSDictionary(contentsOf: url) as? [String: String] ?? [:]
+        return dictionary[key] ?? key
     }
 }

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -41,6 +41,17 @@ struct LocalizationResourceTests {
         try assertTask3ExtractionCoverage(root: root, catalogStrings: strings)
         try assertTask3ReviewCoverage(root: root)
         try assertTask4SettingsExtractionCoverage(root: root, catalogStrings: strings)
+        let settingsSource = try String(contentsOf: root.appendingPathComponent("Sources/SettingsView.swift"), encoding: .utf8)
+        assert(settingsSource.contains("MicrophoneOptionRow(\n                    title: \"System Default\""))
+        assert(settingsSource.contains("verbatimName: device.name,"))
+        assert(settingsSource.contains("init(title: LocalizedStringKey"))
+        assert(settingsSource.contains("init(verbatimName: String"))
+        for key in ["Auto Detect", "System Default", "System Audio", "System Default + System Audio"] {
+            let localizations = (strings[key] as? [String: Any])?["localizations"] as? [String: Any]
+            for language in ["en", "ko"] {
+                assert(!(((localizations?[language] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String ?? "").isEmpty, "Missing \(language) input localization for \(key)")
+            }
+        }
         for key in ["General", "Appearance", "Models", "Shortcuts", "Input", "About", "My calendars", "Shared calendars", "Primary", "My calendar", "Shared", "Use API Provider transcription to choose a final output language.", "Enable post-processing to choose a final output language.", "Final transcript language for post-processing."] {
             let localizations = (strings[key] as? [String: Any])?["localizations"] as? [String: Any]
             assert(!(((localizations?["en"] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String ?? "").isEmpty)

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -322,6 +322,28 @@ struct LocalizationResourceTests {
         ] {
             assertCatalogTranslations(for: key, catalogStrings: catalogStrings)
         }
+
+        assertCatalogTranslations(for: "Recording Overlay", catalogStrings: catalogStrings)
+        for key in [
+            "Notch-side menu-bar overlay",
+            "Shows recording status beside the camera notch when supported, without covering app tabs or toolbars.",
+            "Centered drop-down pill",
+            "Shows a single centered pill below the menu bar. More visible, but it can cover a thin strip of the active app.",
+            "Waveform display",
+            "Waveform only",
+            "Show the live audio waveform while recording.",
+            "Show elapsed time on hover",
+            "Show the waveform; hover it to peek the elapsed recording time.",
+            "Show elapsed time instead of waveform",
+            "Replace the waveform with a running elapsed-time counter.",
+            "Show on", "Active window (default)", "Primary display",
+            "Selected", "Not selected"
+        ] {
+            assertCatalogTranslations(for: key, catalogStrings: catalogStrings, requiresTranslation: true)
+        }
+
+        let settings = try managedSource("Sources/SettingsView.swift", root: root)
+        assert(settings.components(separatedBy: "localizedCatalogString(isSelected ? \"Selected\" : \"Not selected\")").count == 3)
     }
 
     private static func assertLocalizedCancellationStatusReset(root: URL) throws {

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -51,6 +51,7 @@ struct LocalizationResourceTests {
         try assertTask3ReviewCoverage(root: root)
         try assertTask4SettingsExtractionCoverage(root: root, catalogStrings: strings)
         try assertTask5ApplicationMessageCoverage(root: root, catalogStrings: strings)
+        try assertGoogleCalendarHealthMessageCoverage(root: root, catalogStrings: strings)
         try assertTask6OverlayCoverage(root: root, catalogStrings: strings)
         try assertLocalizedCancellationStatusReset(root: root)
 
@@ -253,6 +254,44 @@ struct LocalizationResourceTests {
         assert(appState.contains("alert.informativeText = LocalizedUserMessage.screenshotFailure(detail: message)"))
         assert(!appState.contains("LocalizedUserMessage.screenRecordingPermission(detail: message) +"))
         assert(!appState.contains("LocalizedUserMessage.screenshotFailure(detail: message) +"))
+    }
+
+    private static func assertGoogleCalendarHealthMessageCoverage(
+        root: URL,
+        catalogStrings: [String: Any]
+    ) throws {
+        let appState = try managedSource("Sources/AppState.swift", root: root)
+        let settings = try managedSource("Sources/SettingsView.swift", root: root)
+        let fixedKeys = [
+            "Google Calendar needs reconnecting.",
+            "Google Calendar needs reconnecting. Reconnect to restore meeting reminders and calendar-based note titles.",
+            "Google Calendar needs reconnecting. Reconnect to restore meeting reminders.",
+            "Google Calendar needs reconnecting. Calendar-based note titles may be unavailable.",
+            "Some Google calendars could not be refreshed. Reminders may be incomplete.",
+            "Some Google calendars could not be refreshed. Calendar-based note titles may be incomplete.",
+            "Quill can’t access Google Calendar. Reconnect to restore meeting reminders and calendar-based note titles.",
+            "Quill couldn’t refresh Google Calendar just now. Recording still works; reminders or note titles may be incomplete.",
+            "Reconnect Google Calendar to keep meeting recording reminders working.",
+            "Calendar reminders may be incomplete until the next successful refresh."
+        ]
+        let formattedKeys = [
+            "Unable to refresh Google Calendar reminders: %@",
+            "Unable to refresh Google Calendar: %@",
+            "Unable to refresh Google Calendar for note titles: %@"
+        ]
+
+        for key in fixedKeys + formattedKeys {
+            assertCatalogTranslations(for: key, catalogStrings: catalogStrings, requiresTranslation: true)
+        }
+        for key in fixedKeys where appState.contains(key) {
+            assert(appState.contains("localizedCatalogString(\"\(key)\")"), "Calendar message bypasses the catalog: \(key)")
+        }
+        for key in fixedKeys where settings.contains(key) {
+            assert(settings.contains("localizedCatalogString(\"\(key)\")"), "Settings fallback bypasses the catalog: \(key)")
+        }
+        for key in formattedKeys {
+            assert(appState.contains("localizedCatalogFormat(\"\(key)\", error.localizedDescription)"), "Calendar detail must stay a verbatim format argument: \(key)")
+        }
     }
 
     private static func assertTask6OverlayCoverage(root: URL, catalogStrings: [String: Any]) throws {

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -42,6 +42,7 @@ struct LocalizationResourceTests {
         try assertTask3ReviewCoverage(root: root)
         try assertTask4SettingsExtractionCoverage(root: root, catalogStrings: strings)
         try assertTask5ApplicationMessageCoverage(root: root, catalogStrings: strings)
+        try assertTask6OverlayCoverage(root: root, catalogStrings: strings)
         let settingsSource = try String(contentsOf: root.appendingPathComponent("Sources/SettingsView.swift"), encoding: .utf8)
         assert(settingsSource.contains("MicrophoneOptionRow(\n                    title: \"System Default\""))
         assert(settingsSource.contains("verbatimName: device.name,"))
@@ -231,6 +232,36 @@ struct LocalizationResourceTests {
         assert(appState.contains("alert.informativeText = LocalizedUserMessage.screenshotFailure(detail: message)"))
         assert(!appState.contains("LocalizedUserMessage.screenRecordingPermission(detail: message) +"))
         assert(!appState.contains("LocalizedUserMessage.screenshotFailure(detail: message) +"))
+    }
+
+    private static func assertTask6OverlayCoverage(root: URL, catalogStrings: [String: Any]) throws {
+        let recordingOverlay = try String(contentsOf: root.appendingPathComponent("Sources/RecordingOverlay.swift"), encoding: .utf8)
+        let meetingOverlay = try String(contentsOf: root.appendingPathComponent("Sources/MeetingReminderOverlay.swift"), encoding: .utf8)
+        let helper = try String(contentsOf: root.appendingPathComponent("Sources/OverlayDisplayCopy.swift"), encoding: .utf8)
+
+        assert(helper.contains("static func meetingStarts("))
+        assert(helper.contains("static func inputChanged("))
+        assert(helper.contains("static func updateAvailable("))
+        assert(meetingOverlay.contains("OverlayDisplayCopy.meetingStarts(at: startTimeText(for: start))"))
+        assert(meetingOverlay.contains("Text(displayData.title)"))
+        assert(recordingOverlay.contains("UpdateAvailableOverlayView(version: state.updateVersion"))
+        assert(recordingOverlay.contains("Text(verbatim: OverlayDisplayCopy.updateAvailable(version: version))"))
+        assert(recordingOverlay.contains("var helpText: LocalizedStringKey"))
+        assert(recordingOverlay.contains("var displayName: LocalizedStringKey"))
+        assert(recordingOverlay.contains("isStaticQuillName"))
+
+        for key in [
+            "Centered", "Notch Sides",
+            "Show the recording overlay centered below the notch.",
+            "Show recording status beside the notch when supported. Update alerts stay centered.",
+            "Elapsed time · click to switch audio input",
+            "Hover for elapsed time · click to switch audio input",
+            "Switch audio input",
+            "Starts at %@", "Input changed to %@", "Update available: %@",
+            "Start", "Close"
+        ] {
+            assertCatalogTranslations(for: key, catalogStrings: catalogStrings)
+        }
     }
 
     private static func assertCatalogTranslations(for key: String, catalogStrings: [String: Any]) {

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -41,6 +41,17 @@ struct LocalizationResourceTests {
         try assertTask3ExtractionCoverage(root: root, catalogStrings: strings)
         try assertTask3ReviewCoverage(root: root)
         try assertTask4SettingsExtractionCoverage(root: root, catalogStrings: strings)
+        for key in ["General", "Appearance", "Models", "Shortcuts", "Input", "About", "My calendars", "Shared calendars", "Primary", "My calendar", "Shared", "Use API Provider transcription to choose a final output language.", "Enable post-processing to choose a final output language.", "Final transcript language for post-processing."] {
+            let localizations = (strings[key] as? [String: Any])?["localizations"] as? [String: Any]
+            assert(!(((localizations?["en"] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String ?? "").isEmpty)
+            assert(!(((localizations?["ko"] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String ?? "").isEmpty)
+        }
+        for key in ["Relaunching...", "%arg restores the audio state it changed when dictation ends.", "When enabled, %arg retries or falls back to the literal transcript if post-processing looks like it answered the dictated text instead of cleaning it.", "When on, your clipboard manager (Paste, Raycast, Maccy, etc.) records each dictation so you can find it in your recent history. When off, %arg marks dictations transient and your clipboard manager skips them."] {
+            let localizations = (strings[key] as? [String: Any])?["localizations"] as? [String: Any]
+            let en = (((localizations?["en"] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String)
+            let ko = (((localizations?["ko"] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String)
+            assert(en != ko, "Expected Korean regular Settings translation for \(key)")
+        }
         for key in ["Transcription Model", "Used for speech-to-text transcription.", "Post-Processing Model", "Cleans up transcripts and applies formatting.", "Context Model", "Uses active-window context to improve transcription.", "Vision Model", "Analyzes screenshots for visual context.", "Same as spoken language", "English", "Portuguese"] {
             let localizations = (strings[key] as? [String: Any])?["localizations"] as? [String: Any]
             for language in ["en", "ko"] {

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -41,6 +41,7 @@ struct LocalizationResourceTests {
         try assertTask3ExtractionCoverage(root: root, catalogStrings: strings)
         try assertTask3ReviewCoverage(root: root)
         try assertTask4SettingsExtractionCoverage(root: root, catalogStrings: strings)
+        try assertTask5ApplicationMessageCoverage(root: root, catalogStrings: strings)
         let settingsSource = try String(contentsOf: root.appendingPathComponent("Sources/SettingsView.swift"), encoding: .utf8)
         assert(settingsSource.contains("MicrophoneOptionRow(\n                    title: \"System Default\""))
         assert(settingsSource.contains("verbatimName: device.name,"))
@@ -199,6 +200,41 @@ struct LocalizationResourceTests {
                 let unit = (localizations?[language] as? [String: Any])?["stringUnit"] as? [String: Any]
                 assert(!(unit?["value"] as? String ?? "").isEmpty, "Missing Task 4 \(language) translation for \(key)")
             }
+        }
+    }
+
+    private static func assertTask5ApplicationMessageCoverage(root: URL, catalogStrings: [String: Any]) throws {
+        let appState = try String(contentsOf: root.appendingPathComponent("Sources/AppState.swift"), encoding: .utf8)
+        let helper = try String(contentsOf: root.appendingPathComponent("Sources/LocalizedUserMessage.swift"), encoding: .utf8)
+        let requiredPrefixes = [
+            "Unable to clear run history", "Unable to delete run history entry", "Failed to save note title",
+            "Failed to save transcript edit", "Unable to save imported audio note", "Unable to prepare retry",
+            "Failed to save retry result", "Unable to save recovery entry", "Unable to save run history entry"
+        ]
+        for key in requiredPrefixes {
+            assert(appState.contains("localizedCatalogString(\"\(key)\")"), "Missing Task 5 localized error prefix: \(key)")
+            assertCatalogTranslations(for: key, catalogStrings: catalogStrings)
+        }
+        let guidance = "Unable to save the audio file. Check disk space or file permissions and try again."
+        assert(appState.contains("localizedCatalogString(\"\(guidance)\")"))
+        assertCatalogTranslations(for: guidance, catalogStrings: catalogStrings)
+        let screenPermissionKey = "Screen Recording permission is required. %@\n\nQuill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill."
+        let screenshotFailureKey = "Failed to capture screenshot: %@\n\nA screenshot is required for context-aware transcription. Recording has been stopped."
+        assertCatalogTranslations(for: screenPermissionKey, catalogStrings: catalogStrings)
+        assertCatalogTranslations(for: screenshotFailureKey, catalogStrings: catalogStrings)
+        assert(helper.contains("static func screenRecordingPermission(detail: String, language: String, bundle: Bundle)"))
+        assert(helper.contains("static func screenshotFailure(detail: String, language: String, bundle: Bundle)"))
+        assert(appState.contains("alert.informativeText = LocalizedUserMessage.screenRecordingPermission(detail: message)"))
+        assert(appState.contains("alert.informativeText = LocalizedUserMessage.screenshotFailure(detail: message)"))
+        assert(!appState.contains("LocalizedUserMessage.screenRecordingPermission(detail: message) +"))
+        assert(!appState.contains("LocalizedUserMessage.screenshotFailure(detail: message) +"))
+    }
+
+    private static func assertCatalogTranslations(for key: String, catalogStrings: [String: Any]) {
+        let localizations = (catalogStrings[key] as? [String: Any])?["localizations"] as? [String: Any]
+        for language in ["en", "ko"] {
+            let value = (((localizations?[language] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String)
+            assert(!(value ?? "").isEmpty, "Missing Task 5 \(language) translation for \(key)")
         }
     }
 

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -55,7 +55,8 @@ struct LocalizationResourceTests {
         try assertLocalizedCancellationStatusReset(root: root)
 
         try assertFinalManagedSourceAudit(root: root, catalogStrings: strings)
-        try assertLocalizedStringKeyHelperLiteralCoverage(root: root, catalogStrings: strings)
+        try assertIntentionalEnglishProductCopy(root: root, catalogStrings: strings)
+        try assertRegularSettingsCardTitleCoverage(root: root, catalogStrings: strings)
         try assertCatalogPlaceholderCompatibility(catalogStrings: strings)
         try assertDeveloperDiagnosticsAreExcluded(catalogStrings: strings)
         try assertRepresentativeProductionKoreanTranslations(catalogStrings: strings)
@@ -462,39 +463,44 @@ struct LocalizationResourceTests {
         }
     }
 
-    private static func assertLocalizedStringKeyHelperLiteralCoverage(
+    private static func assertIntentionalEnglishProductCopy(
         root: URL,
         catalogStrings: [String: Any]
     ) throws {
-        let helperCallSites = [
-            (sourceFile: "Sources/SettingsView.swift", helperName: "SettingsCard")
-        ]
+        let noteBrowser = try managedSource("Sources/NoteBrowserView.swift", root: root)
+        assert(noteBrowser.contains("Text(verbatim: \"Recordings\")"))
+        assert(noteBrowser.contains("Text(verbatim: \"Transcription\")"))
+        assert(!noteBrowser.contains("Text(\"Recordings\")"))
+        assert(!noteBrowser.contains("Text(\"Transcription\")"))
 
-        for callSite in helperCallSites {
-            let source = try managedSource(callSite.sourceFile, root: root)
-            let startMarker = "// localization-audit: settings-card-titles-start"
-            let endMarker = "// localization-audit: settings-card-titles-end"
-            let auditedSource: String
-            if let start = source.range(of: startMarker),
-               let end = source.range(of: endMarker, range: start.upperBound..<source.endIndex) {
-                auditedSource = String(source[start.upperBound..<end.lowerBound])
-            } else {
-                assertionFailure("Missing exact helper literal audit range in \(callSite.sourceFile)")
-                continue
+        for key in ["Note Browser", "Recording Overlay", "Google Calendar"] {
+            let entry = catalogStrings[key] as? [String: Any]
+            assert(entry?["shouldTranslate"] as? Bool == false, "Feature name must be an explicit English exception: \(key)")
+            let localizations = entry?["localizations"] as? [String: Any]
+            for language in ["en", "ko"] {
+                let value = (((localizations?[language] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String)
+                assert(value == key, "Feature name must stay English for \(language): \(key)")
             }
+        }
+    }
 
-            let escapedHelperName = NSRegularExpression.escapedPattern(for: callSite.helperName)
-            let pattern = try NSRegularExpression(
-                pattern: #"\b"# + escapedHelperName + #"\(\s*\"((?:\\.|[^\"\\])*)\""#
+    private static func assertRegularSettingsCardTitleCoverage(
+        root: URL,
+        catalogStrings: [String: Any]
+    ) throws {
+        let settings = try managedSource("Sources/SettingsView.swift", root: root)
+        let pattern = try NSRegularExpression(pattern: #"SettingsCard\(\"((?:\\.|[^\"\\])*)\""#)
+        let range = NSRange(settings.startIndex..., in: settings)
+        let englishFeatureNames: Set<String> = ["Note Browser", "Recording Overlay", "Google Calendar"]
+
+        for match in pattern.matches(in: settings, range: range) {
+            guard let titleRange = Range(match.range(at: 1), in: settings) else { continue }
+            let key = String(settings[titleRange])
+            assertCatalogTranslations(
+                for: key,
+                catalogStrings: catalogStrings,
+                requiresTranslation: !englishFeatureNames.contains(key)
             )
-            let matches = pattern.matches(in: auditedSource, range: NSRange(auditedSource.startIndex..., in: auditedSource))
-            assert(!matches.isEmpty, "No literal call sites found for localized helper \(callSite.helperName)")
-
-            for match in matches {
-                guard let keyRange = Range(match.range(at: 1), in: auditedSource) else { continue }
-                let key = String(auditedSource[keyRange])
-                assertCatalogTranslations(for: key, catalogStrings: catalogStrings, requiresTranslation: true)
-            }
         }
     }
 

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -54,6 +54,7 @@ struct LocalizationResourceTests {
         try assertTask6OverlayCoverage(root: root, catalogStrings: strings)
 
         try assertFinalManagedSourceAudit(root: root, catalogStrings: strings)
+        try assertLocalizedStringKeyHelperLiteralCoverage(root: root, catalogStrings: strings)
         try assertCatalogPlaceholderCompatibility(catalogStrings: strings)
         try assertDeveloperDiagnosticsAreExcluded(catalogStrings: strings)
         try assertRepresentativeProductionKoreanTranslations(catalogStrings: strings)
@@ -454,6 +455,42 @@ struct LocalizationResourceTests {
                     hangulPattern.firstMatch(in: String($0), range: NSRange($0.startIndex..., in: $0)) == nil
                 } ?? false
                 assert(isComment || containsOnlyCommentHangul || exactHangulExceptions.contains(trimmed), "Unexpected Hangul literal in \(sourceFile):\(index + 1): \(trimmed)")
+            }
+        }
+    }
+
+    private static func assertLocalizedStringKeyHelperLiteralCoverage(
+        root: URL,
+        catalogStrings: [String: Any]
+    ) throws {
+        let helperCallSites = [
+            (sourceFile: "Sources/SettingsView.swift", helperName: "SettingsCard")
+        ]
+
+        for callSite in helperCallSites {
+            let source = try managedSource(callSite.sourceFile, root: root)
+            let startMarker = "// localization-audit: settings-card-titles-start"
+            let endMarker = "// localization-audit: settings-card-titles-end"
+            let auditedSource: String
+            if let start = source.range(of: startMarker),
+               let end = source.range(of: endMarker, range: start.upperBound..<source.endIndex) {
+                auditedSource = String(source[start.upperBound..<end.lowerBound])
+            } else {
+                assertionFailure("Missing exact helper literal audit range in \(callSite.sourceFile)")
+                continue
+            }
+
+            let escapedHelperName = NSRegularExpression.escapedPattern(for: callSite.helperName)
+            let pattern = try NSRegularExpression(
+                pattern: #"\b"# + escapedHelperName + #"\(\s*\"((?:\\.|[^\"\\])*)\""#
+            )
+            let matches = pattern.matches(in: auditedSource, range: NSRange(auditedSource.startIndex..., in: auditedSource))
+            assert(!matches.isEmpty, "No literal call sites found for localized helper \(callSite.helperName)")
+
+            for match in matches {
+                guard let keyRange = Range(match.range(at: 1), in: auditedSource) else { continue }
+                let key = String(auditedSource[keyRange])
+                assertCatalogTranslations(for: key, catalogStrings: catalogStrings, requiresTranslation: true)
             }
         }
     }

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -257,7 +257,7 @@ struct LocalizationResourceTests {
             "Elapsed time · click to switch audio input",
             "Hover for elapsed time · click to switch audio input",
             "Switch audio input",
-            "Starts at %@", "Input changed to %@", "Update available: %@",
+            "Starts at %@", "Input changed to %@", "Update available", "Update available: %@",
             "Start", "Close"
         ] {
             assertCatalogTranslations(for: key, catalogStrings: catalogStrings)

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -218,12 +218,15 @@ struct LocalizationResourceTests {
         let guidance = "Unable to save the audio file. Check disk space or file permissions and try again."
         assert(appState.contains("localizedCatalogString(\"\(guidance)\")"))
         assertCatalogTranslations(for: guidance, catalogStrings: catalogStrings)
-        let screenPermissionKey = "Screen Recording permission is required. %@\n\nQuill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill."
+        let screenPermissionDetail = "Screen Recording access was not granted."
+        let screenPermissionKey = "%@\n\nQuill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill."
         let screenshotFailureKey = "Failed to capture screenshot: %@\n\nA screenshot is required for context-aware transcription. Recording has been stopped."
+        assertCatalogTranslations(for: screenPermissionDetail, catalogStrings: catalogStrings)
         assertCatalogTranslations(for: screenPermissionKey, catalogStrings: catalogStrings)
         assertCatalogTranslations(for: screenshotFailureKey, catalogStrings: catalogStrings)
         assert(helper.contains("static func screenRecordingPermission(detail: String, language: String, bundle: Bundle)"))
         assert(helper.contains("static func screenshotFailure(detail: String, language: String, bundle: Bundle)"))
+        assert(appState.contains("showScreenshotPermissionAlert(message: localizedCatalogString(\"Screen Recording access was not granted.\"))"))
         assert(appState.contains("alert.informativeText = LocalizedUserMessage.screenRecordingPermission(detail: message)"))
         assert(appState.contains("alert.informativeText = LocalizedUserMessage.screenshotFailure(detail: message)"))
         assert(!appState.contains("LocalizedUserMessage.screenRecordingPermission(detail: message) +"))

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -31,6 +31,17 @@ struct LocalizationResourceTests {
             assert(info.contains("NSSpeechRecognitionUsageDescription"))
         }
 
+        let noteBrowserSource = try String(
+            contentsOf: root.appendingPathComponent("Sources/NoteBrowserView.swift"),
+            encoding: .utf8
+        )
+        assert(noteBrowserSource.contains("help: LocalizedStringKey"))
+        assert(noteBrowserSource.contains("let help: LocalizedStringKey"))
+        assert(noteBrowserSource.contains("fieldLabel(_ key: LocalizedStringKey)"))
+        assert(noteBrowserSource.contains("if vaultPath.isEmpty {\n                        Text(\"Select a folder\")"))
+        assert(noteBrowserSource.contains("} else {\n                        Text(vaultPath)"))
+        assert(strings["Obsidian Vault Folder"] != nil)
+
         let hangulPattern = try NSRegularExpression(pattern: "[가-힣]")
         let sourceFiles = ["Sources/NoteBrowserView.swift", "Sources/NoteListRowDisplayData.swift"]
         for sourceFile in sourceFiles {

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -41,6 +41,12 @@ struct LocalizationResourceTests {
         try assertTask3ExtractionCoverage(root: root, catalogStrings: strings)
         try assertTask3ReviewCoverage(root: root)
         try assertTask4SettingsExtractionCoverage(root: root, catalogStrings: strings)
+        for key in ["Transcription Model", "Used for speech-to-text transcription.", "Post-Processing Model", "Cleans up transcripts and applies formatting.", "Context Model", "Uses active-window context to improve transcription.", "Vision Model", "Analyzes screenshots for visual context.", "Same as spoken language", "English", "Portuguese"] {
+            let localizations = (strings[key] as? [String: Any])?["localizations"] as? [String: Any]
+            for language in ["en", "ko"] {
+                assert(!(((localizations?[language] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String ?? "").isEmpty, "Missing required Task 4 \(language) key: \(key)")
+            }
+        }
 
         let noteBrowserSource = try String(
             contentsOf: root.appendingPathComponent("Sources/NoteBrowserView.swift"),

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -39,6 +39,7 @@ struct LocalizationResourceTests {
         }
 
         try assertTask3ExtractionCoverage(root: root, catalogStrings: strings)
+        try assertTask3ReviewCoverage(root: root)
 
         let noteBrowserSource = try String(
             contentsOf: root.appendingPathComponent("Sources/NoteBrowserView.swift"),
@@ -79,7 +80,8 @@ struct LocalizationResourceTests {
         process.arguments = [
             "xcstringstool", "extract", "--SwiftUI", "--modern-localizable-strings",
             "--output-format", "xcstrings", "-o", temporaryDirectory.path,
-            "Sources/SetupView.swift", "Sources/MenuBarView.swift", "Sources/App.swift"
+            "Sources/SetupView.swift", "Sources/MenuBarView.swift", "Sources/App.swift",
+            "Sources/AppDelegate.swift", "Sources/SetupFlow.swift"
         ]
         try process.run()
         process.waitUntilExit()
@@ -98,6 +100,27 @@ struct LocalizationResourceTests {
                 assert(!(unit?["value"] as? String ?? "").isEmpty, "Missing Task 3 \(language) translation for \(key)")
             }
         }
+    }
+
+    private static func assertTask3ReviewCoverage(root: URL) throws {
+        let appDelegateSource = try String(
+            contentsOf: root.appendingPathComponent("Sources/AppDelegate.swift"),
+            encoding: .utf8
+        )
+        assert(appDelegateSource.contains("isSettingsMenuItemTitle($0.title, localizedSettingsTitle: String(localized: \"Settings...\"))"))
+
+        let testSource = try String(
+            contentsOf: root.appendingPathComponent("Tests/LocalizationResourceTests.swift"),
+            encoding: .utf8
+        )
+        guard let argumentsStart = testSource.range(of: "process.arguments = ["),
+              let argumentsEnd = testSource.range(of: "        ]", range: argumentsStart.upperBound..<testSource.endIndex) else {
+            assertionFailure("Task 3 extraction arguments are missing")
+            return
+        }
+        let arguments = String(testSource[argumentsStart.lowerBound..<argumentsEnd.lowerBound])
+        assert(arguments.contains("Sources/AppDelegate.swift"))
+        assert(arguments.contains("Sources/SetupFlow.swift"))
     }
 
     private static func localizedValue(

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -52,6 +52,7 @@ struct LocalizationResourceTests {
         try assertTask4SettingsExtractionCoverage(root: root, catalogStrings: strings)
         try assertTask5ApplicationMessageCoverage(root: root, catalogStrings: strings)
         try assertTask6OverlayCoverage(root: root, catalogStrings: strings)
+        try assertLocalizedCancellationStatusReset(root: root)
 
         try assertFinalManagedSourceAudit(root: root, catalogStrings: strings)
         try assertLocalizedStringKeyHelperLiteralCoverage(root: root, catalogStrings: strings)
@@ -283,6 +284,16 @@ struct LocalizationResourceTests {
         }
     }
 
+    private static func assertLocalizedCancellationStatusReset(root: URL) throws {
+        let appState = try String(contentsOf: root.appendingPathComponent("Sources/AppState.swift"), encoding: .utf8)
+        assert(appState.components(separatedBy: "let cancelledStatus = localizedCatalogString(\"Cancelled\")").count == 3)
+        assert(appState.components(separatedBy: "statusText = cancelledStatus").count == 3)
+        assert(appState.components(separatedBy: "statusText == cancelledStatus").count == 3)
+        assert(appState.components(separatedBy: "matching: [cancelledStatus]").count == 3)
+        assert(!appState.contains("statusText == \"Cancelled\""))
+        assert(!appState.contains("matching: [\"Cancelled\"]"))
+    }
+
 
     private struct TestFailure: Error, CustomStringConvertible {
         let description: String
@@ -353,14 +364,6 @@ struct LocalizationResourceTests {
             languageBundles: languageBundles
         )
 
-
-        let fixtureURL = resourcesURL.appendingPathComponent("PlaceholderFixtures.strings")
-        let fixtureContents = try String(contentsOf: fixtureURL, encoding: .utf8)
-        for placeholder in ["%@", "%d", "%lld", "%arg"] {
-            guard fixtureContents.contains(#"= "\#(placeholder)";"#) else {
-                throw TestFailure("Missing bundled placeholder serialization fixture for \(placeholder)")
-            }
-        }
 
         let placeholderPattern = try NSRegularExpression(pattern: #"%(?:@|d|lld|arg)"#)
         for key in ["Input changed to %@", "Meeting starts in %d minutes", "Welcome to %@"] {

--- a/Tests/LocalizedStringLookupTests.swift
+++ b/Tests/LocalizedStringLookupTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+@main
+struct LocalizedStringLookupTests {
+    static func main() throws {
+        try testFormattingUsesRequestedLanguageLocale()
+        try testRepeatedLookupUsesCachedDictionary()
+        print("LocalizedStringLookupTests passed")
+    }
+
+    private static func testRepeatedLookupUsesCachedDictionary() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-localized-string-cache-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let localizationDirectory = root.appendingPathComponent("en.lproj", isDirectory: true)
+        try FileManager.default.createDirectory(at: localizationDirectory, withIntermediateDirectories: true)
+        let stringsURL = localizationDirectory.appendingPathComponent("Localizable.strings")
+        try #""Greeting" = "First";"#.write(to: stringsURL, atomically: true, encoding: .utf8)
+        guard let bundle = Bundle(path: root.path) else {
+            throw TestFailure("Unable to create localization test bundle")
+        }
+
+        assert(localizedCatalogString("Greeting", language: "en", bundle: bundle) == "First")
+        try #""Greeting" = "Second";"#.write(to: stringsURL, atomically: true, encoding: .utf8)
+        assert(localizedCatalogString("Greeting", language: "en", bundle: bundle) == "First")
+    }
+
+    private static func testFormattingUsesRequestedLanguageLocale() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-localized-format-locale-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let localizationDirectory = root.appendingPathComponent("fr_FR.lproj", isDirectory: true)
+        try FileManager.default.createDirectory(at: localizationDirectory, withIntermediateDirectories: true)
+        let stringsURL = localizationDirectory.appendingPathComponent("Localizable.strings")
+        try #""Amount: %.1f" = "Montant : %.1f";"#.write(to: stringsURL, atomically: true, encoding: .utf8)
+        guard let bundle = Bundle(path: root.path) else {
+            throw TestFailure("Unable to create format locale test bundle")
+        }
+
+        let formatted = localizedCatalogFormat(
+            "Amount: %.1f",
+            1234.5,
+            language: "fr_FR",
+            bundle: bundle
+        )
+        assert(formatted.contains("1\u{202F}234,5"), "Unexpected French number formatting: \(formatted)")
+    }
+
+    private struct TestFailure: Error {
+        let message: String
+        init(_ message: String) { self.message = message }
+    }
+}

--- a/Tests/LocalizedUserMessageTests.swift
+++ b/Tests/LocalizedUserMessageTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+@main
+struct LocalizedUserMessageTests {
+    static func main() {
+        testShortcutStatusUsesCompleteEnglishSentence()
+        testPermissionAndScreenshotMessagesKeepDetailOrdering()
+        testProviderFailurePreservesProviderDetailVerbatim()
+        print("LocalizedUserMessageTests passed")
+    }
+
+    private static func testShortcutStatusUsesCompleteEnglishSentence() {
+        assert(LocalizedUserMessage.shortcutStatus(shortcut: "⌥ Space", isToggleMode: false) == "Hold ⌥ Space to dictate")
+        assert(LocalizedUserMessage.shortcutStatus(shortcut: "⌥ Space", isToggleMode: true) == "Tap ⌥ Space to dictate")
+    }
+
+    private static func testPermissionAndScreenshotMessagesKeepDetailOrdering() {
+        let permissionDetail = "System Settings is unavailable"
+        let screenshotDetail = "Unsupported MIME type: image/heic"
+
+        assert(LocalizedUserMessage.screenRecordingPermission(detail: permissionDetail) == "Screen Recording permission is required. \(permissionDetail)")
+        assert(LocalizedUserMessage.screenshotFailure(detail: screenshotDetail) == "Failed to capture screenshot: \(screenshotDetail)")
+    }
+
+    private static func testProviderFailurePreservesProviderDetailVerbatim() {
+        let detail = "HTTP 429: rate limited"
+        let result = LocalizedUserMessage.providerFailure(
+            prefix: "Transcription failed",
+            providerDetail: detail
+        )
+
+        assert(result == "Transcription failed: \(detail)")
+        assert(result.contains(detail))
+    }
+}

--- a/Tests/LocalizedUserMessageTests.swift
+++ b/Tests/LocalizedUserMessageTests.swift
@@ -2,34 +2,49 @@ import Foundation
 
 @main
 struct LocalizedUserMessageTests {
-    static func main() {
-        testShortcutStatusUsesCompleteEnglishSentence()
-        testPermissionAndScreenshotMessagesKeepDetailOrdering()
-        testProviderFailurePreservesProviderDetailVerbatim()
+    static func main() throws {
+        let bundle = try compiledLocalizationBundle()
+        testShortcutStatusUsesLocalizedCompleteSentence(bundle: bundle)
+        testPermissionAndScreenshotMessagesKeepOneVerbatimDetail(bundle: bundle)
+        testProviderFailurePreservesProviderDetailVerbatim(bundle: bundle)
         print("LocalizedUserMessageTests passed")
     }
 
-    private static func testShortcutStatusUsesCompleteEnglishSentence() {
-        assert(LocalizedUserMessage.shortcutStatus(shortcut: "⌥ Space", isToggleMode: false) == "Hold ⌥ Space to dictate")
-        assert(LocalizedUserMessage.shortcutStatus(shortcut: "⌥ Space", isToggleMode: true) == "Tap ⌥ Space to dictate")
+    private static func testShortcutStatusUsesLocalizedCompleteSentence(bundle: Bundle) {
+        assert(LocalizedUserMessage.shortcutStatus(shortcut: "⌥ Space", isToggleMode: false, language: "en", bundle: bundle) == "Hold ⌥ Space to dictate")
+        assert(LocalizedUserMessage.shortcutStatus(shortcut: "⌥ Space", isToggleMode: true, language: "ko", bundle: bundle) == "⌥ Space을(를) 눌러 받아쓰기")
     }
 
-    private static func testPermissionAndScreenshotMessagesKeepDetailOrdering() {
+    private static func testPermissionAndScreenshotMessagesKeepOneVerbatimDetail(bundle: Bundle) {
         let permissionDetail = "System Settings is unavailable"
         let screenshotDetail = "Unsupported MIME type: image/heic"
+        let permission = LocalizedUserMessage.screenRecordingPermission(detail: permissionDetail, language: "ko", bundle: bundle)
+        let screenshot = LocalizedUserMessage.screenshotFailure(detail: screenshotDetail, language: "ko", bundle: bundle)
 
-        assert(LocalizedUserMessage.screenRecordingPermission(detail: permissionDetail) == "Screen Recording permission is required. \(permissionDetail)")
-        assert(LocalizedUserMessage.screenshotFailure(detail: screenshotDetail) == "Failed to capture screenshot: \(screenshotDetail)")
+        assert(permission == "화면 기록 권한이 필요합니다. \(permissionDetail)\n\nQuill에서 맥락 인식 전사를 위한 스크린샷을 캡처하려면 화면 기록 권한이 필요합니다.\n\n시스템 설정 > 개인정보 보호 및 보안 > 화면 기록에서 Quill을 활성화하세요.")
+        assert(screenshot == "스크린샷을 캡처하지 못했습니다: \(screenshotDetail)\n\n맥락 인식 전사에는 스크린샷이 필요합니다. 녹음이 중지되었습니다.")
+        assert(permission.components(separatedBy: permissionDetail).count == 2)
+        assert(screenshot.components(separatedBy: screenshotDetail).count == 2)
     }
 
-    private static func testProviderFailurePreservesProviderDetailVerbatim() {
+    private static func testProviderFailurePreservesProviderDetailVerbatim(bundle: Bundle) {
         let detail = "HTTP 429: rate limited"
         let result = LocalizedUserMessage.providerFailure(
-            prefix: "Transcription failed",
-            providerDetail: detail
+            prefix: localizedCatalogString("Transcription failed", language: "ko", bundle: bundle),
+            providerDetail: detail,
+            language: "ko",
+            bundle: bundle
         )
 
-        assert(result == "Transcription failed: \(detail)")
+        assert(result == "전사 실패: \(detail)")
         assert(result.contains(detail))
+    }
+
+    private static func compiledLocalizationBundle() throws -> Bundle {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        guard let bundle = Bundle(path: root.appendingPathComponent("build/localization").path) else {
+            throw NSError(domain: "LocalizedUserMessageTests", code: 1)
+        }
+        return bundle
     }
 }

--- a/Tests/LocalizedUserMessageTests.swift
+++ b/Tests/LocalizedUserMessageTests.swift
@@ -16,14 +16,19 @@ struct LocalizedUserMessageTests {
     }
 
     private static func testPermissionAndScreenshotMessagesKeepOneVerbatimDetail(bundle: Bundle) {
-        let permissionDetail = "System Settings is unavailable"
+        let permissionDetail = "Screen Recording access was not granted."
         let screenshotDetail = "Unsupported MIME type: image/heic"
-        let permission = LocalizedUserMessage.screenRecordingPermission(detail: permissionDetail, language: "ko", bundle: bundle)
+        let englishPermission = LocalizedUserMessage.screenRecordingPermission(detail: permissionDetail, language: "en", bundle: bundle)
+        let koreanPermission = LocalizedUserMessage.screenRecordingPermission(detail: permissionDetail, language: "ko", bundle: bundle)
         let screenshot = LocalizedUserMessage.screenshotFailure(detail: screenshotDetail, language: "ko", bundle: bundle)
 
-        assert(permission == "화면 기록 권한이 필요합니다. \(permissionDetail)\n\nQuill에서 맥락 인식 전사를 위한 스크린샷을 캡처하려면 화면 기록 권한이 필요합니다.\n\n시스템 설정 > 개인정보 보호 및 보안 > 화면 기록에서 Quill을 활성화하세요.")
+        assert(englishPermission == "\(permissionDetail)\n\nQuill requires Screen Recording permission to capture screenshots for context-aware transcription.\n\nGo to System Settings > Privacy & Security > Screen Recording and enable Quill.")
+        assert(koreanPermission == "\(permissionDetail)\n\nQuill에서 맥락 인식 전사를 위한 스크린샷을 캡처하려면 화면 기록 권한이 필요합니다.\n\n시스템 설정 > 개인정보 보호 및 보안 > 화면 기록에서 Quill을 활성화하세요.")
         assert(screenshot == "스크린샷을 캡처하지 못했습니다: \(screenshotDetail)\n\n맥락 인식 전사에는 스크린샷이 필요합니다. 녹음이 중지되었습니다.")
-        assert(permission.components(separatedBy: permissionDetail).count == 2)
+        assert(englishPermission.components(separatedBy: permissionDetail).count == 2)
+        assert(koreanPermission.components(separatedBy: permissionDetail).count == 2)
+        assert(englishPermission.components(separatedBy: "System Settings > Privacy & Security > Screen Recording").count == 2)
+        assert(koreanPermission.components(separatedBy: "시스템 설정 > 개인정보 보호 및 보안 > 화면 기록").count == 2)
         assert(screenshot.components(separatedBy: screenshotDetail).count == 2)
     }
 

--- a/Tests/NoteListRowDisplayDataTests.swift
+++ b/Tests/NoteListRowDisplayDataTests.swift
@@ -87,7 +87,11 @@ struct NoteListRowDisplayDataTests {
             transcript: "Morning notes"
         )
 
-        let data = NoteListRowDisplayData(item: item, retryingIDs: [])
+        let data = NoteListRowDisplayData(
+            item: item,
+            retryingIDs: [],
+            locale: Locale(identifier: "ko_KR")
+        )
 
         assert(data.rowDate == "5월 15일 오전 10:38", "Unexpected row date: \(data.rowDate)")
     }
@@ -100,7 +104,11 @@ struct NoteListRowDisplayDataTests {
             transcript: "Noon notes"
         )
 
-        let data = NoteListRowDisplayData(item: item, retryingIDs: [])
+        let data = NoteListRowDisplayData(
+            item: item,
+            retryingIDs: [],
+            locale: Locale(identifier: "ko_KR")
+        )
 
         assert(data.rowDate == "5월 15일 오전 10:38", "Unexpected row date: \(data.rowDate)")
     }
@@ -113,7 +121,11 @@ struct NoteListRowDisplayDataTests {
             transcript: "Late notes"
         )
 
-        let data = NoteListRowDisplayData(item: item, retryingIDs: [])
+        let data = NoteListRowDisplayData(
+            item: item,
+            retryingIDs: [],
+            locale: Locale(identifier: "ko_KR")
+        )
 
         assert(data.rowDate == "5월 15일 오후 11:40", "Unexpected row date: \(data.rowDate)")
     }
@@ -126,7 +138,7 @@ struct NoteListRowDisplayDataTests {
             transcript: "Morning notes"
         )
 
-        let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
+        let formatted = NoteTimestampFormatter.detailTimestamp(for: item, locale: Locale(identifier: "ko_KR"))
 
         assert(formatted == "2026년 5월 15일 오전 10:38~11:12", "Unexpected interval: \(formatted)")
     }
@@ -139,7 +151,7 @@ struct NoteListRowDisplayDataTests {
             transcript: "Noon notes"
         )
 
-        let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
+        let formatted = NoteTimestampFormatter.detailTimestamp(for: item, locale: Locale(identifier: "ko_KR"))
 
         assert(formatted == "2026년 5월 15일 오전 10:38 ~ 오후 12:12", "Unexpected interval: \(formatted)")
     }
@@ -152,7 +164,7 @@ struct NoteListRowDisplayDataTests {
             transcript: "Afternoon notes"
         )
 
-        let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
+        let formatted = NoteTimestampFormatter.detailTimestamp(for: item, locale: Locale(identifier: "ko_KR"))
 
         assert(formatted == "2026년 5월 15일 오후 1:05~2:22", "Unexpected interval: \(formatted)")
     }
@@ -165,7 +177,7 @@ struct NoteListRowDisplayDataTests {
             transcript: "Late notes"
         )
 
-        let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
+        let formatted = NoteTimestampFormatter.detailTimestamp(for: item, locale: Locale(identifier: "ko_KR"))
 
         assert(formatted == "2026년 5월 15일 오후 11:40 ~ 2026년 5월 16일 오전 12:10", "Unexpected interval: \(formatted)")
     }
@@ -176,7 +188,7 @@ struct NoteListRowDisplayDataTests {
             transcript: "Imported notes"
         )
 
-        let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
+        let formatted = NoteTimestampFormatter.detailTimestamp(for: item, locale: Locale(identifier: "ko_KR"))
 
         assert(formatted == "2026년 5월 15일 오전 10:38", "Unexpected timestamp: \(formatted)")
     }

--- a/Tests/NoteListRowDisplayDataTests.swift
+++ b/Tests/NoteListRowDisplayDataTests.swift
@@ -4,6 +4,8 @@ import Foundation
 struct NoteListRowDisplayDataTests {
     static func main() {
         testFormatsRowDate()
+        testFormatsExplicitLocaleRowDates()
+        testFormatsExplicitLocaleDetailTimestamps()
         testFormatsSameMorningRowDateStartTime()
         testFormatsMorningToAfternoonRowDateStartTime()
         testFormatsCrossDateRowDateStartTime()
@@ -28,9 +30,39 @@ struct NoteListRowDisplayDataTests {
             transcript: "Team sync notes"
         )
 
-        let data = NoteListRowDisplayData(item: item, retryingIDs: [])
+        let rowDate = NoteTimestampFormatter.rowTimestamp(for: item, locale: Locale(identifier: "ko_KR"))
 
-        assert(data.rowDate == "5월 5일 · 09:00", "Unexpected row date: \(data.rowDate)")
+        assert(rowDate == "5월 5일 오전 9:00", "Unexpected row date: \(rowDate)")
+    }
+
+    private static func testFormatsExplicitLocaleRowDates() {
+        let item = historyItem(
+            timestamp: date(year: 2026, month: 5, day: 15, hour: 11, minute: 12),
+            recordingStartedAt: date(year: 2026, month: 5, day: 15, hour: 10, minute: 38),
+            recordingEndedAt: date(year: 2026, month: 5, day: 15, hour: 11, minute: 12),
+            transcript: "Morning notes"
+        )
+
+        let english = NoteTimestampFormatter.rowTimestamp(for: item, locale: Locale(identifier: "en_US"))
+        let korean = NoteTimestampFormatter.rowTimestamp(for: item, locale: Locale(identifier: "ko_KR"))
+
+        assert(english == "May 15 at 10:38 AM", "Unexpected English row date: \(english)")
+        assert(korean == "5월 15일 오전 10:38", "Unexpected Korean row date: \(korean)")
+    }
+
+    private static func testFormatsExplicitLocaleDetailTimestamps() {
+        let item = historyItem(
+            timestamp: date(year: 2026, month: 5, day: 15, hour: 11, minute: 12),
+            recordingStartedAt: date(year: 2026, month: 5, day: 15, hour: 10, minute: 38),
+            recordingEndedAt: date(year: 2026, month: 5, day: 15, hour: 11, minute: 12),
+            transcript: "Morning notes"
+        )
+
+        let english = NoteTimestampFormatter.detailTimestamp(for: item, locale: Locale(identifier: "en_US"))
+        let korean = NoteTimestampFormatter.detailTimestamp(for: item, locale: Locale(identifier: "ko_KR"))
+
+        assert(english == "May 15, 2026 at 10:38 AM – 11:12 AM", "Unexpected English interval: \(english)")
+        assert(korean == "2026년 5월 15일 오전 10:38~오전 11:12", "Unexpected Korean interval: \(korean)")
     }
 
     private static func testFormatsSameMorningRowDateStartTime() {
@@ -82,7 +114,7 @@ struct NoteListRowDisplayDataTests {
 
         let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
 
-        assert(formatted == "2026년 5월 15일 오전 10:38 - 11:12", "Unexpected interval: \(formatted)")
+        assert(formatted == "2026년 5월 15일 오전 10:38~오전 11:12", "Unexpected interval: \(formatted)")
     }
 
     private static func testFormatsMorningToAfternoonRecordingInterval() {
@@ -95,7 +127,7 @@ struct NoteListRowDisplayDataTests {
 
         let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
 
-        assert(formatted == "2026년 5월 15일 오전 10:38 - 오후 12:12", "Unexpected interval: \(formatted)")
+        assert(formatted == "2026년 5월 15일 오전 10:38~오후 12:12", "Unexpected interval: \(formatted)")
     }
 
     private static func testFormatsSameAfternoonRecordingInterval() {
@@ -108,7 +140,7 @@ struct NoteListRowDisplayDataTests {
 
         let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
 
-        assert(formatted == "2026년 5월 15일 오후 1:05 - 2:22", "Unexpected interval: \(formatted)")
+        assert(formatted == "2026년 5월 15일 오후 1:05~오후 2:22", "Unexpected interval: \(formatted)")
     }
 
     private static func testFormatsCrossDateRecordingInterval() {
@@ -121,7 +153,7 @@ struct NoteListRowDisplayDataTests {
 
         let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
 
-        assert(formatted == "2026년 5월 15일 오후 11:40 - 2026년 5월 16일 오전 12:10", "Unexpected interval: \(formatted)")
+        assert(formatted == "2026년 5월 15일 오후 11:40~2026년 5월 16일 오전 12:10", "Unexpected interval: \(formatted)")
     }
 
     private static func testUsesSingleTimestampWhenRecordingIntervalIsMissing() {

--- a/Tests/NoteListRowDisplayDataTests.swift
+++ b/Tests/NoteListRowDisplayDataTests.swift
@@ -6,6 +6,7 @@ struct NoteListRowDisplayDataTests {
         testFormatsRowDate()
         testFormatsExplicitLocaleRowDates()
         testFormatsExplicitLocaleDetailTimestamps()
+        testFormatsJapaneseDetailTimestamp()
         testFormatsSameMorningRowDateStartTime()
         testFormatsMorningToAfternoonRowDateStartTime()
         testFormatsCrossDateRowDateStartTime()
@@ -61,8 +62,21 @@ struct NoteListRowDisplayDataTests {
         let english = NoteTimestampFormatter.detailTimestamp(for: item, locale: Locale(identifier: "en_US"))
         let korean = NoteTimestampFormatter.detailTimestamp(for: item, locale: Locale(identifier: "ko_KR"))
 
-        assert(english == "May 15, 2026 at 10:38 AM – 11:12 AM", "Unexpected English interval: \(english)")
-        assert(korean == "2026년 5월 15일 오전 10:38~오전 11:12", "Unexpected Korean interval: \(korean)")
+        assert(english == "May 15, 2026, 10:38 – 11:12 AM", "Unexpected English interval: \(english)")
+        assert(korean == "2026년 5월 15일 오전 10:38~11:12", "Unexpected Korean interval: \(korean)")
+    }
+
+    private static func testFormatsJapaneseDetailTimestamp() {
+        let item = historyItem(
+            timestamp: date(year: 2026, month: 5, day: 15, hour: 11, minute: 12),
+            recordingStartedAt: date(year: 2026, month: 5, day: 15, hour: 10, minute: 38),
+            recordingEndedAt: date(year: 2026, month: 5, day: 15, hour: 11, minute: 12),
+            transcript: "Morning notes"
+        )
+
+        let japanese = NoteTimestampFormatter.detailTimestamp(for: item, locale: Locale(identifier: "ja_JP"))
+
+        assert(japanese == "2026年5月15日 10時38分～11時12分", "Unexpected Japanese interval: \(japanese)")
     }
 
     private static func testFormatsSameMorningRowDateStartTime() {
@@ -114,7 +128,7 @@ struct NoteListRowDisplayDataTests {
 
         let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
 
-        assert(formatted == "2026년 5월 15일 오전 10:38~오전 11:12", "Unexpected interval: \(formatted)")
+        assert(formatted == "2026년 5월 15일 오전 10:38~11:12", "Unexpected interval: \(formatted)")
     }
 
     private static func testFormatsMorningToAfternoonRecordingInterval() {
@@ -127,7 +141,7 @@ struct NoteListRowDisplayDataTests {
 
         let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
 
-        assert(formatted == "2026년 5월 15일 오전 10:38~오후 12:12", "Unexpected interval: \(formatted)")
+        assert(formatted == "2026년 5월 15일 오전 10:38 ~ 오후 12:12", "Unexpected interval: \(formatted)")
     }
 
     private static func testFormatsSameAfternoonRecordingInterval() {
@@ -140,7 +154,7 @@ struct NoteListRowDisplayDataTests {
 
         let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
 
-        assert(formatted == "2026년 5월 15일 오후 1:05~오후 2:22", "Unexpected interval: \(formatted)")
+        assert(formatted == "2026년 5월 15일 오후 1:05~2:22", "Unexpected interval: \(formatted)")
     }
 
     private static func testFormatsCrossDateRecordingInterval() {
@@ -153,7 +167,7 @@ struct NoteListRowDisplayDataTests {
 
         let formatted = NoteTimestampFormatter.detailTimestamp(for: item)
 
-        assert(formatted == "2026년 5월 15일 오후 11:40~2026년 5월 16일 오전 12:10", "Unexpected interval: \(formatted)")
+        assert(formatted == "2026년 5월 15일 오후 11:40 ~ 2026년 5월 16일 오전 12:10", "Unexpected interval: \(formatted)")
     }
 
     private static func testUsesSingleTimestampWhenRecordingIntervalIsMissing() {

--- a/Tests/OverlayDisplayCopyTests.swift
+++ b/Tests/OverlayDisplayCopyTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+@main
+struct OverlayDisplayCopyTests {
+    static func main() throws {
+        let bundle = try compiledLocalizationBundle()
+        testMeetingStartKeepsFormattedTimeVerbatim(bundle: bundle)
+        testInputChangeKeepsDeviceNameVerbatim(bundle: bundle)
+        testUpdateAvailabilityKeepsVersionVerbatim(bundle: bundle)
+        print("OverlayDisplayCopyTests passed")
+    }
+
+    private static func testMeetingStartKeepsFormattedTimeVerbatim(bundle: Bundle) {
+        let time = "9:30 AM"
+        assert(OverlayDisplayCopy.meetingStarts(at: time, language: "en", bundle: bundle) == "Starts at 9:30 AM")
+        assert(OverlayDisplayCopy.meetingStarts(at: time, language: "ko", bundle: bundle) == "9:30 AM에 시작")
+    }
+
+    private static func testInputChangeKeepsDeviceNameVerbatim(bundle: Bundle) {
+        let deviceName = "Studio Mic"
+        assert(OverlayDisplayCopy.inputChanged(to: deviceName, language: "en", bundle: bundle) == "Input changed to Studio Mic")
+        assert(OverlayDisplayCopy.inputChanged(to: deviceName, language: "ko", bundle: bundle) == "입력이 Studio Mic(으)로 변경됨")
+    }
+
+    private static func testUpdateAvailabilityKeepsVersionVerbatim(bundle: Bundle) {
+        let version = "9.9.9"
+        assert(OverlayDisplayCopy.updateAvailable(version: version, language: "en", bundle: bundle) == "Update available: 9.9.9")
+        assert(OverlayDisplayCopy.updateAvailable(version: version, language: "ko", bundle: bundle) == "업데이트 가능: 9.9.9")
+    }
+
+    private static func compiledLocalizationBundle() throws -> Bundle {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        guard let bundle = Bundle(path: root.appendingPathComponent("build/localization").path) else {
+            throw NSError(domain: "OverlayDisplayCopyTests", code: 1)
+        }
+        return bundle
+    }
+}

--- a/Tests/OverlayDisplayCopyTests.swift
+++ b/Tests/OverlayDisplayCopyTests.swift
@@ -7,6 +7,7 @@ struct OverlayDisplayCopyTests {
         testMeetingStartKeepsFormattedTimeVerbatim(bundle: bundle)
         testInputChangeKeepsDeviceNameVerbatim(bundle: bundle)
         testUpdateAvailabilityKeepsVersionVerbatim(bundle: bundle)
+        testUpdateAvailabilityWithoutVersionUsesNonVersionedCopy(bundle: bundle)
         print("OverlayDisplayCopyTests passed")
     }
 
@@ -26,6 +27,11 @@ struct OverlayDisplayCopyTests {
         let version = "9.9.9"
         assert(OverlayDisplayCopy.updateAvailable(version: version, language: "en", bundle: bundle) == "Update available: 9.9.9")
         assert(OverlayDisplayCopy.updateAvailable(version: version, language: "ko", bundle: bundle) == "업데이트 가능: 9.9.9")
+    }
+
+    private static func testUpdateAvailabilityWithoutVersionUsesNonVersionedCopy(bundle: Bundle) {
+        assert(OverlayDisplayCopy.updateAvailable(version: " \n ", language: "en", bundle: bundle) == "Update available")
+        assert(OverlayDisplayCopy.updateAvailable(version: "", language: "ko", bundle: bundle) == "업데이트 사용 가능")
     }
 
     private static func compiledLocalizationBundle() throws -> Bundle {

--- a/Tests/SettingsLocalizationTests.swift
+++ b/Tests/SettingsLocalizationTests.swift
@@ -9,6 +9,7 @@ struct SettingsLocalizationTests {
         try testAudioImportDisplayKeepsModelIDAndLocalizesStaticLabels()
         try testSettingsSectionTitlePolicy()
         try testGoogleCalendarHealthMessagesLocalizeWithoutChangingDetail()
+        try testRecordingOverlaySettingsCopyLocalizes()
         print("SettingsLocalizationTests passed")
     }
 
@@ -108,6 +109,23 @@ struct SettingsLocalizationTests {
                 bundle: bundle
             ) == "Google Calendar를 새로 고치지 못했습니다: \(detail)"
         )
+    }
+
+    private static func testRecordingOverlaySettingsCopyLocalizes() throws {
+        let bundle = try compiledLocalizationBundle()
+        let expected: [String: String] = [
+            "Notch-side menu-bar overlay": "노치 양옆 메뉴 막대 오버레이",
+            "Centered drop-down pill": "중앙 드롭다운 필",
+            "Waveform display": "파형 표시",
+            "Waveform only": "파형만 표시",
+            "Show elapsed time on hover": "포인터를 올리면 경과 시간 표시",
+            "Show elapsed time instead of waveform": "파형 대신 경과 시간 표시",
+            "Selected": "선택됨",
+            "Not selected": "선택되지 않음"
+        ]
+        for (key, value) in expected {
+            assert(localizedCatalogString(key, language: "ko", bundle: bundle) == value)
+        }
     }
 
     private static func compiledLocalizationBundle() throws -> Bundle {

--- a/Tests/SettingsLocalizationTests.swift
+++ b/Tests/SettingsLocalizationTests.swift
@@ -12,30 +12,33 @@ struct SettingsLocalizationTests {
 
     private static func testTranscriptionLanguageKeepsCodeAndLocalizesDisplayName() throws {
         let korean = TranscriptionLanguage.find(code: "ko")
+        let localizationBundle = try compiledLocalizationBundle()
 
         assert(korean.code == "ko")
-        assert(korean.localizedDisplayName(language: "en") == "Korean")
-        assert(korean.localizedDisplayName(language: "ko") == "한국어")
+        assert(korean.localizedDisplayName(language: "en", bundle: localizationBundle) == "Korean")
+        assert(korean.localizedDisplayName(language: "ko", bundle: localizationBundle) == "한국어")
         assert(korean.whisperArgument == "ko")
     }
 
     private static func testTranscriptionModelKeepsIdentityAndLocalizesDescription() throws {
         let appleSpeech = TranscriptionModel.find(id: "apple-speech")
+        let localizationBundle = try compiledLocalizationBundle()
 
         assert(appleSpeech.id == "apple-speech")
         assert(appleSpeech.cacheDirectoryName == "models--apple-speech")
-        assert(appleSpeech.localizedDescription(language: "en") == "On-device · Fast")
-        assert(appleSpeech.localizedDescription(language: "ko") == "온디바이스 · 빠름")
+        assert(appleSpeech.localizedDescription(language: "en", bundle: localizationBundle) == "On-device · Fast")
+        assert(appleSpeech.localizedDescription(language: "ko", bundle: localizationBundle) == "온디바이스 · 빠름")
     }
 
     private static func testNativeWhisperModelKeepsIdentityAndLocalizesDescription() throws {
         let model = NativeWhisperModelCatalog.recommended
+        let localizationBundle = try compiledLocalizationBundle()
 
         assert(model.id == "whisper-large-v3-turbo")
         assert(model.expectedFileName == "ggml-large-v3-turbo.bin")
         assert(model.downloadURL.absoluteString == "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin")
-        assert(model.localizedDescription(language: "en") == "Fast local transcription with high accuracy. Recommended.")
-        assert(model.localizedDescription(language: "ko") == "빠르고 정확한 로컬 받아쓰기. 추천.")
+        assert(model.localizedDescription(language: "en", bundle: localizationBundle) == "Fast local transcription with high accuracy. Recommended.")
+        assert(model.localizedDescription(language: "ko", bundle: localizationBundle) == "빠르고 정확한 로컬 받아쓰기. 추천.")
     }
 
     private static func testAudioImportDisplayKeepsModelIDAndLocalizesStaticLabels() throws {
@@ -45,10 +48,20 @@ struct SettingsLocalizationTests {
             apiStandardModelID: "whisper-large-v3"
         )
         let display = options.displayRows.first { $0.choice == .apiStandard(modelID: "whisper-large-v3") }!
+        let localizationBundle = try compiledLocalizationBundle()
 
         assert(display.choice.id == "api-standard:whisper-large-v3")
-        assert(display.localizedTitle(language: "en") == "API Standard")
-        assert(display.localizedTitle(language: "ko") == "API 표준")
-        assert(display.localizedCompactLabel(language: "ko") == "표준 · whisper-large-v3")
+        assert(display.localizedTitle(language: "en", bundle: localizationBundle) == "API Standard")
+        assert(display.localizedTitle(language: "ko", bundle: localizationBundle) == "API 표준")
+        assert(display.localizedCompactLabel(language: "ko", bundle: localizationBundle) == "표준 · whisper-large-v3")
+    }
+
+    private static func compiledLocalizationBundle() throws -> Bundle {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let localizationRoot = root.appendingPathComponent("build/localization")
+        guard let bundle = Bundle(path: localizationRoot.path) else {
+            throw NSError(domain: "SettingsLocalizationTests", code: 1, userInfo: [NSLocalizedDescriptionKey: "Missing compiled localization bundle"])
+        }
+        return bundle
     }
 }

--- a/Tests/SettingsLocalizationTests.swift
+++ b/Tests/SettingsLocalizationTests.swift
@@ -12,8 +12,12 @@ struct SettingsLocalizationTests {
 
     private static func testTranscriptionLanguageKeepsCodeAndLocalizesDisplayName() throws {
         let korean = TranscriptionLanguage.find(code: "ko")
+        let auto = TranscriptionLanguage.auto
         let localizationBundle = try compiledLocalizationBundle()
 
+        assert(auto.code == "auto")
+        assert(auto.localizedDisplayName(language: "en", bundle: localizationBundle) == "Auto Detect")
+        assert(auto.localizedDisplayName(language: "ko", bundle: localizationBundle) == "자동 감지")
         assert(korean.code == "ko")
         assert(korean.localizedDisplayName(language: "en", bundle: localizationBundle) == "Korean")
         assert(korean.localizedDisplayName(language: "ko", bundle: localizationBundle) == "한국어")

--- a/Tests/SettingsLocalizationTests.swift
+++ b/Tests/SettingsLocalizationTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+@main
+struct SettingsLocalizationTests {
+    static func main() throws {
+        try testTranscriptionLanguageKeepsCodeAndLocalizesDisplayName()
+        try testTranscriptionModelKeepsIdentityAndLocalizesDescription()
+        try testNativeWhisperModelKeepsIdentityAndLocalizesDescription()
+        try testAudioImportDisplayKeepsModelIDAndLocalizesStaticLabels()
+        print("SettingsLocalizationTests passed")
+    }
+
+    private static func testTranscriptionLanguageKeepsCodeAndLocalizesDisplayName() throws {
+        let korean = TranscriptionLanguage.find(code: "ko")
+
+        assert(korean.code == "ko")
+        assert(korean.localizedDisplayName(language: "en") == "Korean")
+        assert(korean.localizedDisplayName(language: "ko") == "한국어")
+        assert(korean.whisperArgument == "ko")
+    }
+
+    private static func testTranscriptionModelKeepsIdentityAndLocalizesDescription() throws {
+        let appleSpeech = TranscriptionModel.find(id: "apple-speech")
+
+        assert(appleSpeech.id == "apple-speech")
+        assert(appleSpeech.cacheDirectoryName == "models--apple-speech")
+        assert(appleSpeech.localizedDescription(language: "en") == "On-device · Fast")
+        assert(appleSpeech.localizedDescription(language: "ko") == "온디바이스 · 빠름")
+    }
+
+    private static func testNativeWhisperModelKeepsIdentityAndLocalizesDescription() throws {
+        let model = NativeWhisperModelCatalog.recommended
+
+        assert(model.id == "whisper-large-v3-turbo")
+        assert(model.expectedFileName == "ggml-large-v3-turbo.bin")
+        assert(model.downloadURL.absoluteString == "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin")
+        assert(model.localizedDescription(language: "en") == "Fast local transcription with high accuracy. Recommended.")
+        assert(model.localizedDescription(language: "ko") == "빠르고 정확한 로컬 받아쓰기. 추천.")
+    }
+
+    private static func testAudioImportDisplayKeepsModelIDAndLocalizesStaticLabels() throws {
+        let options = AudioImportOptions(
+            fileExtension: "wav",
+            currentChoice: .apiStandard(modelID: "whisper-large-v3"),
+            apiStandardModelID: "whisper-large-v3"
+        )
+        let display = options.displayRows.first { $0.choice == .apiStandard(modelID: "whisper-large-v3") }!
+
+        assert(display.choice.id == "api-standard:whisper-large-v3")
+        assert(display.localizedTitle(language: "en") == "API Standard")
+        assert(display.localizedTitle(language: "ko") == "API 표준")
+        assert(display.localizedCompactLabel(language: "ko") == "표준 · whisper-large-v3")
+    }
+}

--- a/Tests/SettingsLocalizationTests.swift
+++ b/Tests/SettingsLocalizationTests.swift
@@ -8,6 +8,7 @@ struct SettingsLocalizationTests {
         try testNativeWhisperModelKeepsIdentityAndLocalizesDescription()
         try testAudioImportDisplayKeepsModelIDAndLocalizesStaticLabels()
         try testSettingsSectionTitlePolicy()
+        try testGoogleCalendarHealthMessagesLocalizeWithoutChangingDetail()
         print("SettingsLocalizationTests passed")
     }
 
@@ -86,6 +87,27 @@ struct SettingsLocalizationTests {
         for (key, expected) in ordinaryKoreanTitles {
             assert(localizedCatalogString(key, language: "ko", bundle: bundle) == expected)
         }
+    }
+
+    private static func testGoogleCalendarHealthMessagesLocalizeWithoutChangingDetail() throws {
+        let bundle = try compiledLocalizationBundle()
+        let detail = "HTTP 503: upstream unavailable"
+
+        assert(
+            localizedCatalogString(
+                "Google Calendar needs reconnecting. Reconnect to restore meeting reminders and calendar-based note titles.",
+                language: "ko",
+                bundle: bundle
+            ) == "Google Calendar를 다시 연결해야 합니다. 회의 알림과 캘린더 기반 노트 제목을 복원하려면 다시 연결하세요."
+        )
+        assert(
+            localizedCatalogFormat(
+                "Unable to refresh Google Calendar: %@",
+                detail,
+                language: "ko",
+                bundle: bundle
+            ) == "Google Calendar를 새로 고치지 못했습니다: \(detail)"
+        )
     }
 
     private static func compiledLocalizationBundle() throws -> Bundle {

--- a/Tests/SettingsLocalizationTests.swift
+++ b/Tests/SettingsLocalizationTests.swift
@@ -7,6 +7,7 @@ struct SettingsLocalizationTests {
         try testTranscriptionModelKeepsIdentityAndLocalizesDescription()
         try testNativeWhisperModelKeepsIdentityAndLocalizesDescription()
         try testAudioImportDisplayKeepsModelIDAndLocalizesStaticLabels()
+        try testSettingsSectionTitlePolicy()
         print("SettingsLocalizationTests passed")
     }
 
@@ -58,6 +59,33 @@ struct SettingsLocalizationTests {
         assert(display.localizedTitle(language: "en", bundle: localizationBundle) == "API Standard")
         assert(display.localizedTitle(language: "ko", bundle: localizationBundle) == "API 표준")
         assert(display.localizedCompactLabel(language: "ko", bundle: localizationBundle) == "표준 · whisper-large-v3")
+    }
+
+    private static func testSettingsSectionTitlePolicy() throws {
+        let bundle = try compiledLocalizationBundle()
+
+        for key in ["Note Browser", "Recording Overlay", "Google Calendar"] {
+            assert(localizedCatalogString(key, language: "en", bundle: bundle) == key)
+            assert(localizedCatalogString(key, language: "ko", bundle: bundle) == key)
+        }
+
+        let ordinaryKoreanTitles: [String: String] = [
+            "App Appearance": "앱 외관",
+            "Meeting Recording Reminders": "회의 녹음 알림",
+            "Language": "언어",
+            "System Prompt": "시스템 프롬프트",
+            "Instruction Guard": "명령 보호",
+            "Context Prompt": "컨텍스트 프롬프트",
+            "Dictation Shortcuts": "받아쓰기 단축키",
+            "Audio During Dictation": "받아쓰기 중 오디오",
+            "Clipboard": "클립보드",
+            "Voice Macros": "음성 매크로",
+            "Sound Volume": "소리 크기",
+            "Build": "빌드"
+        ]
+        for (key, expected) in ordinaryKoreanTitles {
+            assert(localizedCatalogString(key, language: "ko", bundle: bundle) == expected)
+        }
     }
 
     private static func compiledLocalizationBundle() throws -> Bundle {

--- a/Tests/SystemAudioInputSelectionTests.swift
+++ b/Tests/SystemAudioInputSelectionTests.swift
@@ -48,8 +48,8 @@ struct SystemAudioInputSelectionTests {
         let source = try sourceFile("Sources/SettingsView.swift")
         assertOrder(
             source: source,
-            first: "name: \"System Default\"",
-            second: "name: \"System Audio\"",
+            first: "title: \"System Default\"",
+            second: "title: \"System Audio\"",
             file: "Sources/SettingsView.swift"
         )
     }
@@ -83,7 +83,7 @@ struct SystemAudioInputSelectionTests {
 
     private static func testSettingsPickerIncludesSystemDefaultAndSystemAudio() throws {
         let source = try sourceFile("Sources/SettingsView.swift")
-        assertContains(source, "name: \"System Default + System Audio\"")
+        assertContains(source, "title: \"System Default + System Audio\"")
         assertContains(source, "AudioInputDevice.systemDefaultAndSystemAudioID")
     }
 

--- a/docs/superpowers/plans/2026-07-17-localization-follow-up.md
+++ b/docs/superpowers/plans/2026-07-17-localization-follow-up.md
@@ -1,0 +1,658 @@
+# Localization Follow-up Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Quill's English/Korean UI terminology intentional by keeping selected feature names in English, localizing Google Calendar health messages, and completing the regular-user Recording Overlay settings translations.
+
+**Architecture:** Preserve the existing String Catalog and `localizedCatalogString`/`localizedCatalogFormat` helpers. Explicit English exceptions render verbatim or use catalog entries marked non-translatable, while ordinary UI and complete Calendar health sentences remain catalog-backed; persisted values, provider details, device names, and display names never change.
+
+**Tech Stack:** Swift 5.10, SwiftUI, AppKit, Foundation localization, `Localizable.xcstrings`, `xcstringstool`, Make, macOS 13 deployment target.
+
+## Global Constraints
+
+- Supported application locales remain exactly `en` and `ko`.
+- Keep `Note Browser`, `Recording Overlay`, and `Google Calendar` in English as product or feature names.
+- Keep the Note Browser headings `Recordings` and `Transcription` in English as explicit user-approved exceptions.
+- Translate ordinary section names, option labels, explanatory copy, and accessibility values into Korean.
+- Keep developer-only Debug and Run Log surfaces in English.
+- Do not translate provider error details, device names, display names, model IDs, URLs, checksums, enum raw values, or persisted identifiers.
+- Do not change overlay layout behavior, Calendar health state transitions, token handling, persistence, geometry, or animation.
+- Preserve the Makefile + direct `swiftc` build, the `CODESIGN_IDENTITY=Quill` development build policy, Sparkle integration, and macOS 13 minimum.
+- Do not modify or install `/Applications/Quill.app`; runtime verification uses `build/Quill Dev.app` with bundle ID `com.woosublee.quill.dev`.
+
+## File Structure
+
+- `Sources/NoteBrowserView.swift` — render the two approved English headings verbatim.
+- `Sources/SettingsView.swift` — keep approved feature card titles in English, localize ordinary Settings card titles, Calendar health fallbacks, Recording Overlay options, and accessibility values.
+- `Sources/AppState.swift` — generate localized Calendar health messages at the point where health state is recorded while preserving external error details.
+- `Resources/Localization/Localizable.xcstrings` — remain the source of truth for English/Korean values and intentional non-translatable feature names.
+- `Tests/LocalizationResourceTests.swift` — audit verbatim exceptions, all regular-user `SettingsCard` titles, Calendar health call sites, and Recording Overlay catalog coverage.
+- `Tests/SettingsLocalizationTests.swift` — validate representative English/Korean Calendar and Recording Overlay strings from compiled resources.
+
+---
+
+### Task 1: Make section-title language policy explicit
+
+**Files:**
+- Modify: `Sources/NoteBrowserView.swift:517-597`
+- Modify: `Resources/Localization/Localizable.xcstrings`
+- Modify: `Tests/LocalizationResourceTests.swift:56-58, 462-496`
+- Modify: `Tests/SettingsLocalizationTests.swift:5-10, 63-70`
+
+**Interfaces:**
+- Consumes: `SettingsCard.init(_ title: LocalizedStringKey, icon: String, @ViewBuilder content: () -> Content)`.
+- Produces: two explicit `Text(verbatim:)` Note Browser headings; catalog-backed ordinary Settings card titles; intentional English feature-name entries with `shouldTranslate: false`.
+
+- [ ] **Step 1: Write failing audits for the Note Browser exceptions and all regular Settings cards**
+
+In `Tests/LocalizationResourceTests.swift`, call a new audit after the existing task-specific coverage:
+
+```swift
+try assertIntentionalEnglishProductCopy(root: root, catalogStrings: strings)
+try assertRegularSettingsCardTitleCoverage(root: root, catalogStrings: strings)
+```
+
+Add these functions:
+
+```swift
+private static func assertIntentionalEnglishProductCopy(
+    root: URL,
+    catalogStrings: [String: Any]
+) throws {
+    let noteBrowser = try managedSource("Sources/NoteBrowserView.swift", root: root)
+    assert(noteBrowser.contains("Text(verbatim: \"Recordings\")"))
+    assert(noteBrowser.contains("Text(verbatim: \"Transcription\")"))
+    assert(!noteBrowser.contains("Text(\"Recordings\")"))
+    assert(!noteBrowser.contains("Text(\"Transcription\")"))
+
+    for key in ["Note Browser", "Recording Overlay", "Google Calendar"] {
+        let entry = catalogStrings[key] as? [String: Any]
+        assert(entry?["shouldTranslate"] as? Bool == false, "Feature name must be an explicit English exception: \(key)")
+        let localizations = entry?["localizations"] as? [String: Any]
+        for language in ["en", "ko"] {
+            let value = (((localizations?[language] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String)
+            assert(value == key, "Feature name must stay English for \(language): \(key)")
+        }
+    }
+}
+
+private static func assertRegularSettingsCardTitleCoverage(
+    root: URL,
+    catalogStrings: [String: Any]
+) throws {
+    let settings = try managedSource("Sources/SettingsView.swift", root: root)
+    let pattern = try NSRegularExpression(pattern: #"SettingsCard\(\"((?:\\.|[^\"\\])*)\""#)
+    let range = NSRange(settings.startIndex..., in: settings)
+    let englishFeatureNames: Set<String> = ["Note Browser", "Recording Overlay", "Google Calendar"]
+
+    for match in pattern.matches(in: settings, range: range) {
+        guard let titleRange = Range(match.range(at: 1), in: settings) else { continue }
+        let key = String(settings[titleRange])
+        assertCatalogTranslations(
+            for: key,
+            catalogStrings: catalogStrings,
+            requiresTranslation: !englishFeatureNames.contains(key)
+        )
+    }
+}
+```
+
+Remove the marker-limited implementation of `assertLocalizedStringKeyHelperLiteralCoverage` and its call, because the new regular-card audit scans the entire non-debug `SettingsView` returned by `managedSource`.
+
+- [ ] **Step 2: Add failing compiled-resource expectations for title policy**
+
+In `Tests/SettingsLocalizationTests.swift`, invoke and add:
+
+```swift
+try testSettingsSectionTitlePolicy()
+
+private static func testSettingsSectionTitlePolicy() throws {
+    let bundle = try compiledLocalizationBundle()
+
+    for key in ["Note Browser", "Recording Overlay", "Google Calendar"] {
+        assert(localizedCatalogString(key, language: "en", bundle: bundle) == key)
+        assert(localizedCatalogString(key, language: "ko", bundle: bundle) == key)
+    }
+
+    let ordinaryKoreanTitles: [String: String] = [
+        "App Appearance": "앱 외관",
+        "Meeting Recording Reminders": "회의 녹음 알림",
+        "Language": "언어",
+        "System Prompt": "시스템 프롬프트",
+        "Instruction Guard": "명령 보호",
+        "Context Prompt": "컨텍스트 프롬프트",
+        "Dictation Shortcuts": "받아쓰기 단축키",
+        "Audio During Dictation": "받아쓰기 중 오디오",
+        "Clipboard": "클립보드",
+        "Voice Macros": "음성 매크로",
+        "Sound Volume": "소리 크기",
+        "Build": "빌드"
+    ]
+    for (key, expected) in ordinaryKoreanTitles {
+        assert(localizedCatalogString(key, language: "ko", bundle: bundle) == expected)
+    }
+}
+```
+
+- [ ] **Step 3: Run focused tests and verify RED**
+
+Run:
+
+```bash
+make /tmp/LocalizationResourceTests
+/tmp/LocalizationResourceTests
+swiftc -parse-as-library \
+  Sources/LocalizedStringLookup.swift \
+  Sources/TranscriptionLanguage.swift \
+  Sources/TranscriptionModel.swift \
+  Sources/NativeWhisperModel.swift \
+  Sources/AudioImportOptions.swift \
+  Tests/SettingsLocalizationTests.swift \
+  -o /tmp/SettingsLocalizationTests
+/tmp/SettingsLocalizationTests
+```
+
+Expected: `LocalizationResourceTests` fails because the two headings are localized literals and feature-name catalog entries are missing; `SettingsLocalizationTests` fails on missing ordinary card-title translations.
+
+- [ ] **Step 4: Render the two approved headings verbatim**
+
+In `Sources/NoteBrowserView.swift`, replace only the two heading initializers:
+
+```swift
+Text(verbatim: "Recordings")
+```
+
+```swift
+Text(verbatim: "Transcription")
+```
+
+Do not change the nearby record button, transcription picker, search field, or empty-state copy.
+
+- [ ] **Step 5: Add explicit feature-name and ordinary-card catalog entries**
+
+Update `Resources/Localization/Localizable.xcstrings` without changing unrelated entries. Add `Note Browser`, `Recording Overlay`, and `Google Calendar` with English and Korean values equal to the English key and `shouldTranslate: false`.
+
+Add or complete ordinary card-title translations using this exact mapping:
+
+```python
+ordinary_titles = {
+    "App Appearance": ("App Appearance", "앱 외관"),
+    "Meeting Recording Reminders": ("Meeting Recording Reminders", "회의 녹음 알림"),
+    "Language": ("Language", "언어"),
+    "System Prompt": ("System Prompt", "시스템 프롬프트"),
+    "Instruction Guard": ("Instruction Guard", "명령 보호"),
+    "Context Prompt": ("Context Prompt", "컨텍스트 프롬프트"),
+    "Dictation Shortcuts": ("Dictation Shortcuts", "받아쓰기 단축키"),
+    "Audio During Dictation": ("Audio During Dictation", "받아쓰기 중 오디오"),
+    "Clipboard": ("Clipboard", "클립보드"),
+    "Voice Macros": ("Voice Macros", "음성 매크로"),
+    "Sound Volume": ("Sound Volume", "소리 크기"),
+    "Build": ("Build", "빌드"),
+}
+```
+
+Retain existing translations such as `App`, `Updates`, `Permissions`, `Transcription`, `Custom Vocabulary`, `Edit Mode`, and `Microphone`; the full-card audit must validate those too.
+
+- [ ] **Step 6: Recompile resources and verify GREEN**
+
+Run:
+
+```bash
+rm -rf build/localization
+make build/localization/.compiled
+make /tmp/LocalizationResourceTests
+/tmp/LocalizationResourceTests
+swiftc -parse-as-library \
+  Sources/LocalizedStringLookup.swift \
+  Sources/TranscriptionLanguage.swift \
+  Sources/TranscriptionModel.swift \
+  Sources/NativeWhisperModel.swift \
+  Sources/AudioImportOptions.swift \
+  Tests/SettingsLocalizationTests.swift \
+  -o /tmp/SettingsLocalizationTests
+/tmp/SettingsLocalizationTests
+```
+
+Expected: both binaries print their `passed` message.
+
+- [ ] **Step 7: Commit the title-policy change**
+
+```bash
+git add Sources/NoteBrowserView.swift Resources/Localization/Localizable.xcstrings \
+  Tests/LocalizationResourceTests.swift Tests/SettingsLocalizationTests.swift
+git commit -m "Clarify localized section titles" -m "Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Localize Google Calendar health messages
+
+**Files:**
+- Modify: `Sources/AppState.swift:2163-2176, 2213-2252, 2338-2363, 6035-6136`
+- Modify: `Sources/SettingsView.swift:888-910`
+- Modify: `Resources/Localization/Localizable.xcstrings`
+- Modify: `Tests/LocalizationResourceTests.swift:227-255`
+- Modify: `Tests/SettingsLocalizationTests.swift:5-11, 63-70`
+
+**Interfaces:**
+- Consumes: `localizedCatalogString(_:language:bundle:)` and `localizedCatalogFormat(_:_:language:bundle:)` from `Sources/LocalizedStringLookup.swift`.
+- Produces: localized `GoogleCalendarHealth.message` values while preserving `error.localizedDescription` as a verbatim `%@` argument.
+
+- [ ] **Step 1: Write failing Calendar health source and catalog audits**
+
+Invoke a new function from `LocalizationResourceTests.main()`:
+
+```swift
+try assertGoogleCalendarHealthMessageCoverage(root: root, catalogStrings: strings)
+```
+
+Add:
+
+```swift
+private static func assertGoogleCalendarHealthMessageCoverage(
+    root: URL,
+    catalogStrings: [String: Any]
+) throws {
+    let appState = try managedSource("Sources/AppState.swift", root: root)
+    let settings = try managedSource("Sources/SettingsView.swift", root: root)
+    let fixedKeys = [
+        "Google Calendar needs reconnecting.",
+        "Google Calendar needs reconnecting. Reconnect to restore meeting reminders and calendar-based note titles.",
+        "Google Calendar needs reconnecting. Reconnect to restore meeting reminders.",
+        "Google Calendar needs reconnecting. Calendar-based note titles may be unavailable.",
+        "Some Google calendars could not be refreshed. Reminders may be incomplete.",
+        "Some Google calendars could not be refreshed. Calendar-based note titles may be incomplete.",
+        "Quill can’t access Google Calendar. Reconnect to restore meeting reminders and calendar-based note titles.",
+        "Quill couldn’t refresh Google Calendar just now. Recording still works; reminders or note titles may be incomplete.",
+        "Reconnect Google Calendar to keep meeting recording reminders working.",
+        "Calendar reminders may be incomplete until the next successful refresh."
+    ]
+    let formattedKeys = [
+        "Unable to refresh Google Calendar reminders: %@",
+        "Unable to refresh Google Calendar: %@",
+        "Unable to refresh Google Calendar for note titles: %@"
+    ]
+
+    for key in fixedKeys + formattedKeys {
+        assertCatalogTranslations(for: key, catalogStrings: catalogStrings, requiresTranslation: true)
+    }
+    for key in fixedKeys where appState.contains(key) {
+        assert(appState.contains("localizedCatalogString(\"\(key)\")"), "Calendar message bypasses the catalog: \(key)")
+    }
+    for key in fixedKeys where settings.contains(key) {
+        assert(settings.contains("localizedCatalogString(\"\(key)\")"), "Settings fallback bypasses the catalog: \(key)")
+    }
+    for key in formattedKeys {
+        assert(appState.contains("localizedCatalogFormat(\"\(key)\", error.localizedDescription)"), "Calendar detail must stay a verbatim format argument: \(key)")
+    }
+}
+```
+
+- [ ] **Step 2: Add failing English/Korean Calendar copy assertions**
+
+In `SettingsLocalizationTests.swift`, invoke and add:
+
+```swift
+try testGoogleCalendarHealthMessagesLocalizeWithoutChangingDetail()
+
+private static func testGoogleCalendarHealthMessagesLocalizeWithoutChangingDetail() throws {
+    let bundle = try compiledLocalizationBundle()
+    let detail = "HTTP 503: upstream unavailable"
+
+    assert(
+        localizedCatalogString(
+            "Google Calendar needs reconnecting. Reconnect to restore meeting reminders and calendar-based note titles.",
+            language: "ko",
+            bundle: bundle
+        ) == "Google Calendar를 다시 연결해야 합니다. 회의 알림과 캘린더 기반 노트 제목을 복원하려면 다시 연결하세요."
+    )
+    assert(
+        localizedCatalogFormat(
+            "Unable to refresh Google Calendar: %@",
+            detail,
+            language: "ko",
+            bundle: bundle
+        ) == "Google Calendar를 새로 고치지 못했습니다: \(detail)"
+    )
+}
+```
+
+- [ ] **Step 3: Run focused tests and verify RED**
+
+Run the same two binaries from Task 1.
+
+Expected: failures report missing Calendar keys and raw English call sites.
+
+- [ ] **Step 4: Route fixed and formatted Calendar messages through catalog helpers**
+
+Apply these patterns in `Sources/AppState.swift`:
+
+```swift
+private static func googleCalendarReconnectMessage() -> String {
+    localizedCatalogString("Google Calendar needs reconnecting. Reconnect to restore meeting reminders and calendar-based note titles.")
+}
+```
+
+```swift
+message: localizedCatalogString("Google Calendar needs reconnecting. Reconnect to restore meeting reminders.")
+```
+
+```swift
+message: localizedCatalogFormat(
+    "Unable to refresh Google Calendar reminders: %@",
+    error.localizedDescription
+)
+```
+
+```swift
+message: localizedCatalogString("Google Calendar needs reconnecting. Calendar-based note titles may be unavailable.")
+```
+
+Use the equivalent catalog helper for every fixed or formatted message listed in Step 1. In `GoogleCalendarHealthError.errorDescription`, return:
+
+```swift
+localizedCatalogString("Google Calendar needs reconnecting.")
+```
+
+In `Sources/SettingsView.swift`, change all four fallback branches to `localizedCatalogString(...)` while leaving status enums and icons unchanged.
+
+- [ ] **Step 5: Add exact Calendar translations to the catalog**
+
+Add English values equal to each key and these Korean values:
+
+```python
+calendar_messages = {
+    "Google Calendar needs reconnecting.": "Google Calendar를 다시 연결해야 합니다.",
+    "Google Calendar needs reconnecting. Reconnect to restore meeting reminders and calendar-based note titles.": "Google Calendar를 다시 연결해야 합니다. 회의 알림과 캘린더 기반 노트 제목을 복원하려면 다시 연결하세요.",
+    "Google Calendar needs reconnecting. Reconnect to restore meeting reminders.": "Google Calendar를 다시 연결해야 합니다. 회의 알림을 복원하려면 다시 연결하세요.",
+    "Google Calendar needs reconnecting. Calendar-based note titles may be unavailable.": "Google Calendar를 다시 연결해야 합니다. 캘린더 기반 노트 제목을 사용할 수 없을 수 있습니다.",
+    "Unable to refresh Google Calendar reminders: %@": "Google Calendar 알림을 새로 고치지 못했습니다: %@",
+    "Some Google calendars could not be refreshed. Reminders may be incomplete.": "일부 Google 캘린더를 새로 고치지 못했습니다. 알림이 누락될 수 있습니다.",
+    "Unable to refresh Google Calendar: %@": "Google Calendar를 새로 고치지 못했습니다: %@",
+    "Some Google calendars could not be refreshed. Calendar-based note titles may be incomplete.": "일부 Google 캘린더를 새로 고치지 못했습니다. 캘린더 기반 노트 제목이 불완전할 수 있습니다.",
+    "Unable to refresh Google Calendar for note titles: %@": "노트 제목에 사용할 Google Calendar를 새로 고치지 못했습니다: %@",
+    "Quill can’t access Google Calendar. Reconnect to restore meeting reminders and calendar-based note titles.": "Quill에서 Google Calendar에 접근할 수 없습니다. 회의 알림과 캘린더 기반 노트 제목을 복원하려면 다시 연결하세요.",
+    "Quill couldn’t refresh Google Calendar just now. Recording still works; reminders or note titles may be incomplete.": "현재 Quill에서 Google Calendar를 새로 고치지 못했습니다. 녹음은 계속 사용할 수 있지만 알림이나 노트 제목이 불완전할 수 있습니다.",
+    "Reconnect Google Calendar to keep meeting recording reminders working.": "회의 녹음 알림을 계속 사용하려면 Google Calendar를 다시 연결하세요.",
+    "Calendar reminders may be incomplete until the next successful refresh.": "다음 새로 고침에 성공할 때까지 캘린더 알림이 누락될 수 있습니다."
+}
+```
+
+Keep the `%@` placeholder exactly once and in the same order in both locales.
+
+- [ ] **Step 6: Recompile resources and verify GREEN**
+
+Run:
+
+```bash
+rm -rf build/localization
+make build/localization/.compiled
+make /tmp/LocalizationResourceTests
+/tmp/LocalizationResourceTests
+swiftc -parse-as-library \
+  Sources/LocalizedStringLookup.swift \
+  Sources/TranscriptionLanguage.swift \
+  Sources/TranscriptionModel.swift \
+  Sources/NativeWhisperModel.swift \
+  Sources/AudioImportOptions.swift \
+  Tests/SettingsLocalizationTests.swift \
+  -o /tmp/SettingsLocalizationTests
+/tmp/SettingsLocalizationTests
+```
+
+Expected: both pass, and the test detail remains byte-for-byte `HTTP 503: upstream unavailable` inside the Korean sentence.
+
+- [ ] **Step 7: Commit Calendar message localization**
+
+```bash
+git add Sources/AppState.swift Sources/SettingsView.swift \
+  Resources/Localization/Localizable.xcstrings \
+  Tests/LocalizationResourceTests.swift Tests/SettingsLocalizationTests.swift
+git commit -m "Localize Calendar health messages" -m "Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Complete Recording Overlay settings localization
+
+**Files:**
+- Modify: `Sources/SettingsView.swift:536-605, 628-723`
+- Modify: `Resources/Localization/Localizable.xcstrings`
+- Modify: `Tests/LocalizationResourceTests.swift:257-285`
+- Modify: `Tests/SettingsLocalizationTests.swift:5-11, 63-70`
+
+**Interfaces:**
+- Consumes: existing `LocalizedStringKey` option-row title and subtitle properties.
+- Produces: catalog-backed layout/waveform options and localized VoiceOver selection values; no changes to `RecordingOverlayLayout` or `OverlayWaveformDisplayMode`.
+
+- [ ] **Step 1: Extend the overlay resource audit with all regular-user option keys**
+
+Add these keys to the regular-user overlay array in `assertTask6OverlayCoverage`:
+
+```swift
+"Recording Overlay",
+"Notch-side menu-bar overlay",
+"Shows recording status beside the camera notch when supported, without covering app tabs or toolbars.",
+"Centered drop-down pill",
+"Shows a single centered pill below the menu bar. More visible, but it can cover a thin strip of the active app.",
+"Waveform display",
+"Waveform only",
+"Show the live audio waveform while recording.",
+"Show elapsed time on hover",
+"Show the waveform; hover it to peek the elapsed recording time.",
+"Show elapsed time instead of waveform",
+"Replace the waveform with a running elapsed-time counter.",
+"Show on",
+"Active window (default)",
+"Primary display",
+"Selected",
+"Not selected"
+```
+
+For `Recording Overlay`, call `assertCatalogTranslations` without `requiresTranslation` and separately rely on Task 1's English-feature exception audit. Require translation for every other key.
+
+Also assert:
+
+```swift
+let settings = try managedSource("Sources/SettingsView.swift", root: root)
+assert(settings.components(separatedBy: "localizedCatalogString(isSelected ? \"Selected\" : \"Not selected\")").count == 3)
+```
+
+- [ ] **Step 2: Add failing representative Korean overlay assertions**
+
+In `SettingsLocalizationTests.swift`, invoke and add:
+
+```swift
+try testRecordingOverlaySettingsCopyLocalizes()
+
+private static func testRecordingOverlaySettingsCopyLocalizes() throws {
+    let bundle = try compiledLocalizationBundle()
+    let expected: [String: String] = [
+        "Notch-side menu-bar overlay": "노치 양옆 메뉴 막대 오버레이",
+        "Centered drop-down pill": "중앙 드롭다운 필",
+        "Waveform display": "파형 표시",
+        "Waveform only": "파형만 표시",
+        "Show elapsed time on hover": "포인터를 올리면 경과 시간 표시",
+        "Show elapsed time instead of waveform": "파형 대신 경과 시간 표시",
+        "Selected": "선택됨",
+        "Not selected": "선택되지 않음"
+    ]
+    for (key, value) in expected {
+        assert(localizedCatalogString(key, language: "ko", bundle: bundle) == value)
+    }
+}
+```
+
+- [ ] **Step 3: Run focused tests and verify RED**
+
+Run the two focused test binaries from Task 1.
+
+Expected: missing overlay keys fail the catalog audit and compiled-resource expectations.
+
+- [ ] **Step 4: Localize the dynamic accessibility values explicitly**
+
+In both `OverlayLayoutOptionRow` and `OverlayWaveformModeOptionRow`, replace:
+
+```swift
+.accessibilityValue(isSelected ? "Selected" : "Not selected")
+```
+
+with:
+
+```swift
+.accessibilityValue(localizedCatalogString(isSelected ? "Selected" : "Not selected"))
+```
+
+This is required because the ternary expression produces a dynamic `String` rather than a `LocalizedStringKey`.
+
+- [ ] **Step 5: Add exact Recording Overlay translations**
+
+Add English values equal to each key and these Korean values:
+
+```python
+overlay_messages = {
+    "Notch-side menu-bar overlay": "노치 양옆 메뉴 막대 오버레이",
+    "Shows recording status beside the camera notch when supported, without covering app tabs or toolbars.": "지원되는 경우 앱 탭이나 도구 막대를 가리지 않고 카메라 노치 양옆에 녹음 상태를 표시합니다.",
+    "Centered drop-down pill": "중앙 드롭다운 필",
+    "Shows a single centered pill below the menu bar. More visible, but it can cover a thin strip of the active app.": "메뉴 막대 아래 중앙에 하나의 필을 표시합니다. 더 잘 보이지만 활성 앱의 얇은 영역을 가릴 수 있습니다.",
+    "Waveform display": "파형 표시",
+    "Waveform only": "파형만 표시",
+    "Show the live audio waveform while recording.": "녹음 중 실시간 오디오 파형을 표시합니다.",
+    "Show elapsed time on hover": "포인터를 올리면 경과 시간 표시",
+    "Show the waveform; hover it to peek the elapsed recording time.": "파형을 표시하고 포인터를 올리면 녹음 경과 시간을 잠시 보여 줍니다.",
+    "Show elapsed time instead of waveform": "파형 대신 경과 시간 표시",
+    "Replace the waveform with a running elapsed-time counter.": "파형을 실행 중인 경과 시간 카운터로 바꿉니다.",
+    "Selected": "선택됨",
+    "Not selected": "선택되지 않음"
+}
+```
+
+Retain the existing Korean values for `Show on`, `Active window (default)`, and `Primary display`. Keep physical `NSScreen.localizedName` values rendered with `Text(verbatim:)`.
+
+- [ ] **Step 6: Recompile resources and verify GREEN**
+
+Run:
+
+```bash
+rm -rf build/localization
+make build/localization/.compiled
+make /tmp/LocalizationResourceTests
+/tmp/LocalizationResourceTests
+swiftc -parse-as-library \
+  Sources/LocalizedStringLookup.swift \
+  Sources/TranscriptionLanguage.swift \
+  Sources/TranscriptionModel.swift \
+  Sources/NativeWhisperModel.swift \
+  Sources/AudioImportOptions.swift \
+  Tests/SettingsLocalizationTests.swift \
+  -o /tmp/SettingsLocalizationTests
+/tmp/SettingsLocalizationTests
+```
+
+Expected: both pass with Korean overlay option values.
+
+- [ ] **Step 7: Commit Recording Overlay copy**
+
+```bash
+git add Sources/SettingsView.swift Resources/Localization/Localizable.xcstrings \
+  Tests/LocalizationResourceTests.swift Tests/SettingsLocalizationTests.swift
+git commit -m "Localize Recording Overlay settings" -m "Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Run full regression and Quill Dev runtime verification
+
+**Files:**
+- Verify only: all files changed in Tasks 1-3
+- Do not modify: `/Applications/Quill.app`
+
+**Interfaces:**
+- Consumes: committed outputs from Tasks 1-3.
+- Produces: fresh full-test, packaged-bundle, and Korean GUI evidence.
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+make test
+```
+
+Expected: every test binary prints `passed`; no test exits nonzero.
+
+- [ ] **Step 2: Validate the actual packaged app localization resources**
+
+```bash
+make localization-bundle-test CODESIGN_IDENTITY="Quill"
+codesign --verify --deep --strict build/Quill.app
+```
+
+Expected: `LocalizationResourceTests bundle validation passed` and `codesign` exits 0. Do not install the app.
+
+- [ ] **Step 3: Rebuild and open the development app in Korean**
+
+```bash
+pkill -f '/Quill Dev.app/Contents/MacOS/Quill Dev' 2>/dev/null || true
+make run CODESIGN_IDENTITY="Quill"
+```
+
+If the current per-app language is not Korean, relaunch only the built development executable:
+
+```bash
+pkill -f '/Quill Dev.app/Contents/MacOS/Quill Dev' 2>/dev/null || true
+'build/Quill Dev.app/Contents/MacOS/Quill Dev' -AppleLanguages '(ko)' -AppleLocale ko_KR
+```
+
+Expected: process path is under `build/Quill Dev.app`, bundle ID is `com.woosublee.quill.dev`, and the production app remains untouched.
+
+- [ ] **Step 4: Inspect the Note Browser title policy**
+
+Open the Note Browser and verify:
+
+- `Recordings` remains English.
+- `Transcription` remains English.
+- record actions, search, and empty-state copy remain Korean.
+
+Capture the Note Browser window as evidence.
+
+- [ ] **Step 5: Inspect ordinary Settings titles and Recording Overlay options**
+
+Open Settings → Appearance and verify:
+
+- `Note Browser` and `Recording Overlay` remain English.
+- ordinary card title `앱 외관` is Korean.
+- both overlay layout titles and descriptions are Korean.
+- all waveform option titles and descriptions are Korean.
+- display names remain unchanged/verbatim.
+
+Capture the Settings window as evidence.
+
+- [ ] **Step 6: Exercise the Calendar reconnect state**
+
+Use only the development bundle's preferences and token state to produce a connected-metadata/no-valid-token health check. Open Settings → Calendar and verify:
+
+- `Google Calendar` remains English.
+- the reconnect status and explanatory health message are Korean.
+- no provider/OAuth detail is translated or altered when one is present.
+
+Do not reset or alter the production `com.woosublee.quill` bundle's preferences or permissions. Capture the Calendar settings window.
+
+- [ ] **Step 7: Run final diff and repository checks**
+
+```bash
+git diff --check
+git status --short --branch
+git log --oneline -6
+```
+
+Expected: no whitespace errors; only intentional follow-up commits exist; working tree is clean.
+
+- [ ] **Step 8: Request one final focused code review**
+
+Review the range from commit `4f4df48` to `HEAD` for only:
+
+- intentional English exceptions versus missing translations
+- Calendar external-detail preservation
+- complete regular-user Recording Overlay coverage
+- Debug/Run Log exclusion preservation
+
+Fix only verified Critical or Important issues, rerun Steps 1-7 after any fix, and avoid repeated review loops.

--- a/docs/superpowers/specs/2026-07-17-en-ko-localization-design.md
+++ b/docs/superpowers/specs/2026-07-17-en-ko-localization-design.md
@@ -1,0 +1,162 @@
+# Quill English/Korean Localization Design
+
+## Goal
+
+Make Quill's primary user experience consistently available in English and Korean using Apple's localization system, while preserving the current Makefile + direct `swiftc` build and avoiding a separate in-app language selector.
+
+## Product decisions
+
+- Quill supports English (`en`) and Korean (`ko`).
+- English is the development and fallback language.
+- Quill follows macOS system language and macOS per-app language settings.
+- Language changes take effect after Quill is relaunched.
+- Quill does not add its own language picker in this work.
+- Developer-only Debug and Run Log surfaces remain English.
+
+## Localization resources
+
+`Resources/Localization/Localizable.xcstrings` is the source of truth for managed UI translations. The catalog contains an English value and a Korean value for every managed key.
+
+The Makefile compiles the catalog with `xcstringstool` before code signing and copies the generated resources into the application bundle:
+
+```text
+Quill.app/Contents/Resources/
+├── en.lproj/
+│   ├── Localizable.strings
+│   └── InfoPlist.strings
+└── ko.lproj/
+    ├── Localizable.strings
+    └── InfoPlist.strings
+```
+
+`InfoPlist.strings` is maintained explicitly for the macOS privacy-purpose strings used by system permission dialogs. `Info.plist` declares English as `CFBundleDevelopmentRegion` and lists `en` and `ko` as supported localizations.
+
+Catalog compilation is a required build step. Invalid catalog content or missing localization output fails the build. Changes to localization sources invalidate the app executable target so a normal `make` rebuild includes them.
+
+## Source-code conventions
+
+### SwiftUI literals
+
+SwiftUI APIs that accept `LocalizedStringKey` keep direct English literals:
+
+```swift
+Text("Continue")
+Button("Cancel") { ... }
+Label("Settings", systemImage: "gearshape")
+```
+
+The English literal is the catalog key. Direct `Text("...")` literals are not prohibited because they are Apple's standard localizable SwiftUI form.
+
+### Plain String and AppKit text
+
+User-visible text created as `String` before it reaches a view uses `String(localized:)`. This includes:
+
+- `AppState` status and error messages;
+- `NSAlert` titles, descriptions, and buttons;
+- notification titles and bodies;
+- `NSOpenPanel` titles, messages, and prompts;
+- model display descriptions;
+- dynamic meeting and recording status text.
+
+Example:
+
+```swift
+let message = String(localized: "Microphone access is required.")
+```
+
+Dynamic sentences use a localized interpolation as one complete key so translations can change word order:
+
+```swift
+String(localized: "Starts at \(time)")
+```
+
+### Verbatim and non-localized content
+
+The following remain verbatim and are not catalog keys:
+
+- provider and model identifiers;
+- API field names, HTTP values, and MCP protocol text;
+- SF Symbol names and asset identifiers;
+- user transcripts, calendar event titles, custom vocabulary, macros, and custom prompts;
+- default LLM prompt content whose language affects model behavior;
+- external provider error text;
+- `InstructionExecutionDetector` language-specific regex tokens;
+- developer logs, debug panels, and Run Log text.
+
+Where a plain `String` must appear verbatim in SwiftUI, the code uses `Text(verbatim:)` or another explicitly non-localized path.
+
+## Included product surfaces
+
+The first localization pass covers primary user-facing behavior:
+
+- Setup and first-run permission guidance;
+- regular Settings sections, excluding developer-only Debug and Run Log surfaces;
+- menu-bar commands, status, and update actions;
+- Note Browser empty states, actions, confirmation dialogs, playback controls, and Obsidian export;
+- recording and meeting-reminder overlays;
+- permission, confirmation, cancellation, and update alerts;
+- Quill-owned error and recovery guidance;
+- notification and file-picker copy;
+- transcription model names and descriptions intended for users;
+- macOS privacy-purpose strings;
+- user-facing date and time labels.
+
+## Date, time, and language labels
+
+Hard-coded `ko_KR` locale and Korean date patterns are removed from Note Browser presentation. Date and time labels use `Date.FormatStyle` or a formatter configured from the current locale.
+
+Transcription language and output language are independent product settings, not application-language controls. Their stored identifiers remain unchanged. Their user-visible display names are localized, so the Korean language option appears as `Korean` in the English UI and `한국어` in the Korean UI.
+
+## Fallback and failure behavior
+
+- English is the fallback for a missing Korean translation.
+- A malformed String Catalog or failed `xcstringstool` compilation fails the build.
+- A missing expected `en.lproj` or `ko.lproj` output fails the bundle verification test.
+- Quill-owned wrapper text around an external provider error is localized; the provider's original error remains verbatim for diagnosis.
+- Existing settings, persisted language codes, transcript content, and user prompts are not migrated or rewritten.
+
+## Validation strategy
+
+### Automated checks
+
+1. Compile `Localizable.xcstrings` during the normal Makefile build.
+2. Assert that the built app contains:
+   - `en.lproj/Localizable.strings`;
+   - `ko.lproj/Localizable.strings`;
+   - `en.lproj/InfoPlist.strings`;
+   - `ko.lproj/InfoPlist.strings`.
+3. Parse the String Catalog and require English and Korean values for every managed key.
+4. Protect the source from new unmanaged Korean UI literals using a narrow lint and explicit allowlist. Valid non-UI Korean content such as detector regexes, language self-names, and LLM prompt content is permitted.
+5. Test representative plain-String lookups and dynamic interpolation in English and Korean.
+6. Test that Note Browser date presentation uses the selected/current locale instead of forcing `ko_KR`.
+7. Run the complete existing `make test` suite.
+
+The lint does not ban all `Text("literal")` calls. Such a ban would reject correctly localizable SwiftUI code and miss AppKit, notification, and dynamic-string paths.
+
+### Runtime checks
+
+1. Build and launch Quill with English as the preferred app language.
+2. Verify representative copy in Setup, regular Settings, menu bar, Note Browser, recording/meeting overlays, alerts, and date labels.
+3. Set Quill's macOS per-app language to Korean and relaunch.
+4. Verify the same representative flows in Korean, including dynamic values and date/time ordering.
+5. Confirm Debug and Run Log surfaces remain usable in English and that user-generated content remains unchanged.
+
+## Scope exclusions
+
+This work does not add:
+
+- an in-app language selector;
+- live language switching without relaunch;
+- translation of developer Debug or Run Log surfaces;
+- translation of user content or LLM prompt defaults;
+- translation or rewriting of external provider error payloads;
+- broad restructuring of Settings, Setup, or AppState unrelated to localization.
+
+## Completion criteria
+
+- The normal Makefile build bundles valid English and Korean localization resources.
+- Primary product surfaces render consistently in English and Korean after relaunch under the corresponding macOS app language.
+- Managed SwiftUI and non-SwiftUI user-facing text uses localization lookup.
+- Note Browser dates are locale-aware and no longer forced to Korean formatting.
+- Explicit non-UI exceptions are documented and protected from accidental translation.
+- All localization checks and the full test suite pass.

--- a/docs/superpowers/specs/2026-07-17-localization-follow-up-design.md
+++ b/docs/superpowers/specs/2026-07-17-localization-follow-up-design.md
@@ -1,0 +1,76 @@
+# Localization Follow-up Design
+
+## Context
+
+The English/Korean localization implementation for issue #177 is complete, but runtime review found three consistency gaps:
+
+1. The Note Browser headings `Recordings` and `Transcription` should remain English by explicit product preference.
+2. Google Calendar reconnect and refresh-health messages are stored as raw English strings and therefore bypass localization.
+3. The regular-user `Recording Overlay` settings card contains layout and waveform option copy that is missing from the String Catalog.
+
+This follow-up keeps the existing localization architecture and makes only targeted copy and catalog changes.
+
+## Display Language Policy
+
+Use Korean for ordinary section names and explanatory UI when Korean is the preferred app language. Keep product and feature names in English, including `Note Browser`, `Recording Overlay`, and `Google Calendar`.
+
+`Recordings` and `Transcription` are explicit exceptions: the two Note Browser headings remain English even though they are ordinary terms. Their rendering must make the verbatim intent visible in source code and localization audits.
+
+Device and display names, persisted IDs, enum raw values, URLs, checksums, and provider error details remain unchanged.
+
+## Note Browser
+
+Change only the two headings at the top of the Note Browser sidebar:
+
+- `Recordings`
+- `Transcription`
+
+Render them verbatim rather than through `LocalizedStringKey`. The record button, search field, empty states, actions, and other Note Browser copy continue to follow the selected language.
+
+## Google Calendar Health Messages
+
+Localize fixed user-facing health messages generated in `AppState` and fallback messages rendered by `SettingsView`, including:
+
+- reconnect required for reminders and note titles
+- reconnect required for reminders only
+- reconnect required for calendar-based note titles
+- temporary refresh failure messages
+- partial calendar refresh messages
+
+Use catalog-backed complete sentences for fixed messages. For messages containing `error.localizedDescription`, localize the surrounding prefix or sentence template and interpolate the original detail verbatim. Keep `Google Calendar` in English inside Korean translations.
+
+Do not change health status enums, affected-feature values, token handling, or persistence.
+
+## Recording Overlay Settings
+
+Keep the card title `Recording Overlay` in English. Add English and Korean catalog entries for its ordinary option copy:
+
+- notch-side and centered layout option titles
+- both layout descriptions
+- waveform section title
+- waveform-only, hover-time, and time-only option titles
+- all waveform option descriptions
+- VoiceOver selection states `Selected` and `Not selected`
+
+The existing display selector (`Show on`, `Active window (default)`, `Primary display`) remains catalog-backed. Physical display names remain verbatim.
+
+Do not change overlay layout behavior, previews, persisted enum values, geometry, or animation.
+
+## Validation
+
+Extend localization resource tests to verify:
+
+- the two Note Browser headings use explicit verbatim rendering and are allowlisted as intentional English exceptions
+- `Note Browser`, `Recording Overlay`, and `Google Calendar` remain English product/feature names where required
+- all Calendar health message keys have English and Korean values with compatible placeholders
+- all regular-user Recording Overlay option and accessibility keys have English and Korean values
+- Debug/Run Log-only overlay controls remain non-translatable
+
+Run the full test suite and actual app-bundle localization validation. Rebuild and launch `Quill Dev` in Korean, then inspect the Note Browser, Calendar settings health state, and Appearance → Recording Overlay options. Production `/Applications/Quill.app` is not modified.
+
+## Out of Scope
+
+- a general terminology framework or centralized product-name registry
+- changes to Debug/Run Log localization policy
+- new UI, layout, behavior, or language picker
+- translation of external provider details, device names, or display names


### PR DESCRIPTION
## Summary

- add an Apple String Catalog localization pipeline for English and Korean while preserving the direct `swiftc` Makefile build
- localize Setup, menu bar, Note Browser, Settings, model copy, application messages, Calendar health messages, and recording/meeting/update overlays
- keep Debug/Run Log and approved product names or headings in English, while preserving stable identifiers and external details verbatim
- add source/catalog audits, placeholder checks, focused resource tests, and CI validation against the actual built app bundle

## Language behavior

- follows the macOS system or per-app language setting after relaunch
- supports `en` and `ko`; no in-app language picker
- keeps `Note Browser`, `Recording Overlay`, `Google Calendar`, `Recordings`, and `Transcription` in English by design

## Verification

- `make test`
- `make localization-bundle-test CODESIGN_IDENTITY=-`
- `codesign --verify --deep --strict build/Quill.app`
- isolated English and Korean runtime smoke tests
- Korean `Quill Dev` checks for Note Browser headings, Calendar reconnect copy, and Recording Overlay settings/options

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

