### PR TITLE
Redesign model-first settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,6 +338,8 @@ test: check-test-wiring $(SPARKLE_STAMP) $(LOCALIZATION_STAMP)
 	@/tmp/LocalizationResourceTests
 	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Sources/TranscriptionLanguage.swift Sources/TranscriptionModel.swift Sources/NativeWhisperModel.swift Sources/AudioImportOptions.swift Tests/SettingsLocalizationTests.swift -o /tmp/SettingsLocalizationTests
 	@/tmp/SettingsLocalizationTests
+	@swiftc -parse-as-library Tests/ModelsSettingsUIContractTests.swift -o /tmp/ModelsSettingsUIContractTests
+	@/tmp/ModelsSettingsUIContractTests
 	@swiftc -parse-as-library Sources/InstructionExecutionDetector.swift Tests/InstructionExecutionDetectorTests.swift -o /tmp/InstructionExecutionDetectorTests
 	@/tmp/InstructionExecutionDetectorTests
 	@swiftc -parse-as-library Tests/ReleaseSDKCompatibilityTests.swift -o /tmp/ReleaseSDKCompatibilityTests

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -1,6 +1,38 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "Add a custom model ID when it is not listed in the main Model menu.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add a custom model ID when it is not listed in the main Model menu."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 모델 메뉴에 없는 사용자 지정 모델 ID를 추가합니다."
+          }
+        }
+      }
+    },
+    "Custom Standard API Model": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom Standard API Model"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용자 지정 표준 API 모델"
+          }
+        }
+      }
+    },
     "Cancel": {
       "localizations": {
         "en": {
@@ -3923,6 +3955,22 @@
         }
       }
     },
+    "Closing Settings will cancel the model download and remove the partial file.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Closing Settings will cancel the model download and remove the partial file."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings를 닫으면 모델 다운로드가 취소되고 완료되지 않은 파일이 제거됩니다."
+          }
+        }
+      }
+    },
     "If you close Settings while the model is downloading, Quill cancels the download and removes the partial file.": {
       "localizations": {
         "en": {
@@ -4499,7 +4547,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "실시간 받아쓰기 모델"
+            "value": "실시간 전사 모델"
           }
         }
       }
@@ -5001,7 +5049,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "음성 인식을 위한 발화 언어 힌트입니다. 대부분의 사용자에게 자동 감지가 적합합니다."
+            "value": "음성 인식을 위한 발화 언어 힌트입니다. 대부분의 사용자는 자동 감지를 사용하면 됩니다."
           }
         }
       }
@@ -5034,7 +5082,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "녹음 중 오디오 스트리밍 (실시간)"
+            "value": "녹음 중 오디오 스트리밍(실시간)"
           }
         }
       }
@@ -5050,7 +5098,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "제공업체의 OpenAI 호환 /v1/realtime WebSocket으로 오디오를 스트리밍해 말하는 동안 받아쓰기를 실행합니다."
+            "value": "제공자의 OpenAI-compatible /v1/realtime WebSocket으로 오디오를 스트리밍하여 말하는 동안 전사를 실행합니다."
           }
         }
       }
@@ -5370,7 +5418,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "실시간 스트리밍에만 사용됩니다. 서버 기본값을 제공하는 업체는 비워 두세요."
+            "value": "실시간 스트리밍에만 사용합니다. 서버 기본값을 제공하는 공급자에서는 비워 두세요."
           }
         }
       }
@@ -6491,6 +6539,102 @@
           "stringUnit": {
             "state": "translated",
             "value": "API 키를 저장했습니다."
+          }
+        }
+      }
+    },
+    "API Key configured": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API Key configured"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API Key가 설정됨"
+          }
+        }
+      }
+    },
+    "Cloud transcription requires an API key. Add one in Cloud Provider or use the transcription override in Details.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud transcription requires an API key. Add one in Cloud Provider or use the transcription override in Details."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클라우드 전사를 사용하려면 API Key가 필요합니다. 클라우드 공급자에서 추가하거나 세부 설정의 전사 전용 설정을 사용하세요."
+          }
+        }
+      }
+    },
+    "Add an API key in Cloud Provider to enable Post-processing.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add an API key in Cloud Provider to enable Post-processing."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후처리를 활성화하려면 클라우드 공급자에서 API Key를 추가하세요."
+          }
+        }
+      }
+    },
+    "Post-processing is on, but cloud processing is unavailable until an API key is configured.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Post-processing is on, but cloud processing is unavailable until an API key is configured."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후처리가 켜져 있지만 API Key를 설정하기 전에는 클라우드 처리를 사용할 수 없습니다."
+          }
+        }
+      }
+    },
+    "Add an API key in Cloud Provider to enable Context.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add an API key in Cloud Provider to enable Context."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "컨텍스트를 활성화하려면 클라우드 공급자에서 API Key를 추가하세요."
+          }
+        }
+      }
+    },
+    "Context is on, but AI context analysis is unavailable until an API key is configured.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Context is on, but AI context analysis is unavailable until an API key is configured."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "컨텍스트가 켜져 있지만 API Key를 설정하기 전에는 AI 컨텍스트 분석을 사용할 수 없습니다."
           }
         }
       }
@@ -8801,6 +8945,534 @@
           "stringUnit": {
             "state": "translated",
             "value": "선택되지 않음"
+          }
+        }
+      }
+    },
+    "Cloud Provider": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud Provider"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클라우드 공급자"
+          }
+        }
+      }
+    },
+    "Cloud models use this shared OpenAI-compatible provider.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud models use this shared OpenAI-compatible provider."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클라우드 모델은 이 공통 OpenAI-compatible 공급자를 사용합니다."
+          }
+        }
+      }
+    },
+    "AI Models": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI Models"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 모델"
+          }
+        }
+      }
+    },
+    "Convert speech to text.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Convert speech to text."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성을 텍스트로 변환합니다."
+          }
+        }
+      }
+    },
+    "Required · Always On": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Required · Always On"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "필수 · 항상 켜짐"
+          }
+        }
+      }
+    },
+    "Details": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Details"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "세부 설정"
+          }
+        }
+      }
+    },
+    "Model": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모델"
+          }
+        }
+      }
+    },
+    "Standard API Model": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard API Model"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "표준 API 모델"
+          }
+        }
+      }
+    },
+    "On": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "On"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "켬"
+          }
+        }
+      }
+    },
+    "Off": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "끔"
+          }
+        }
+      }
+    },
+    "Post-processing": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Post-processing"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후처리"
+          }
+        }
+      }
+    },
+    "Clean up wording, formatting, and language.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clean up wording, formatting, and language."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문장 표현, 형식, 언어를 정리합니다."
+          }
+        }
+      }
+    },
+    "Normal dictation uses the raw transcript while Post-processing is off. Edit Mode still uses this model configuration.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Normal dictation uses the raw transcript while Post-processing is off. Edit Mode still uses this model configuration."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후처리가 꺼져 있으면 일반 받아쓰기는 원본 전사문을 사용합니다. Edit Mode는 계속 이 모델 설정을 사용합니다."
+          }
+        }
+      }
+    },
+    "Context": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Context"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "컨텍스트"
+          }
+        }
+      }
+    },
+    "Use the current app and screen to improve context.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use the current app and screen to improve context."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 앱과 화면을 사용해 맥락을 보완합니다."
+          }
+        }
+      }
+    },
+    "Context capture is off. Quill skips app context and screenshots for normal dictation.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Context capture is off. Quill skips app context and screenshots for normal dictation."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "컨텍스트 캡처가 꺼져 있습니다. Quill은 일반 받아쓰기에서 앱 맥락과 스크린샷을 건너뜁니다."
+          }
+        }
+      }
+    },
+    "After Transcription": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "After Transcription"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사 후"
+          }
+        }
+      }
+    },
+    "Paste Automatically": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paste Automatically"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동으로 붙여넣기"
+          }
+        }
+      }
+    },
+    "When off, Quill copies the transcript to the clipboard so you can paste it manually.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When off, Quill copies the transcript to the clipboard so you can paste it manually."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "끄면 Quill이 전사문을 클립보드에 복사하며, 필요할 때 직접 붙여넣을 수 있습니다."
+          }
+        }
+      }
+    },
+    "Used for transcript cleanup and Edit Mode transforms.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Used for transcript cleanup and Edit Mode transforms."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사문 정리와 Edit Mode 변환에 사용합니다."
+          }
+        }
+      }
+    },
+    "Used for context inference, with a text-only retry when screenshot analysis fails.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Used for context inference, with a text-only retry when screenshot analysis fails."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "컨텍스트 추론에 사용하며, 스크린샷 분석에 실패하면 텍스트 전용으로 다시 시도합니다."
+          }
+        }
+      }
+    },
+    "Post-Processing Fallback Model": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Post-Processing Fallback Model"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후처리 대체 모델"
+          }
+        }
+      }
+    },
+    "Used as the explicit retry model for transcript cleanup and Edit Mode transforms.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Used as the explicit retry model for transcript cleanup and Edit Mode transforms."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사문 정리와 Edit Mode 변환을 다시 시도할 때 사용할 모델입니다."
+          }
+        }
+      }
+    },
+    "Edit Mode uses this model, fallback model, Output Language, and Custom Vocabulary. Invocation Style and Extra Modifier remain in Shortcuts.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Mode uses this model, fallback model, Output Language, and Custom Vocabulary. Invocation Style and Extra Modifier remain in Shortcuts."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Mode는 이 모델, 대체 모델, 출력 언어 및 사용자 지정 어휘를 사용합니다. 실행 방식과 추가 보조 키는 단축키에 그대로 있습니다."
+          }
+        }
+      }
+    },
+    "Output Language remains available for Edit Mode transforms.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Output Language remains available for Edit Mode transforms."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "출력 언어는 Edit Mode 변환에서도 계속 사용할 수 있습니다."
+          }
+        }
+      }
+    },
+    "Final transcript language for post-processing and Edit Mode transforms.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Final transcript language for post-processing and Edit Mode transforms."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후처리와 Edit Mode 변환에 사용할 최종 전사문 언어입니다."
+          }
+        }
+      }
+    },
+    "e.g. custom-transcription-model": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "e.g. custom-transcription-model"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "예: custom-transcription-model"
+          }
+        }
+      }
+    },
+    "Show Realtime transcription option": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Realtime transcription option"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실시간 전사 옵션 표시"
+          }
+        }
+      }
+    },
+    "Download required": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download required"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다운로드 필요"
+          }
+        }
+      }
+    },
+    "Downloading...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloading..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다운로드 중..."
+          }
+        }
+      }
+    },
+    "Local Whisper Download in Progress": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local Whisper Download in Progress"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local Whisper 다운로드 진행 중"
+          }
+        }
+      }
+    },
+    "Keep Settings Open": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep Settings Open"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings 열어 두기"
+          }
+        }
+      }
+    },
+    "Close and Cancel Download": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close and Cancel Download"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "닫고 다운로드 취소"
           }
         }
       }

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -9349,6 +9349,22 @@
         }
       }
     },
+    "Output Language is unavailable while Post-processing and Edit Mode are off.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Output Language is unavailable while Post-processing and Edit Mode are off."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후처리와 Edit Mode가 모두 꺼져 있으면 출력 언어를 사용할 수 없습니다."
+          }
+        }
+      }
+    },
     "Final transcript language for post-processing and Edit Mode transforms.": {
       "localizations": {
         "en": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5,6 +5,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let appState = AppState()
     var setupWindow: NSWindow?
     private var settingsWindow: NSWindow?
+    private lazy var settingsWindowDelegate = SettingsWindowDelegate(appState: appState)
     private var noteBrowserWindow: NSWindow?
     private var mcpServer: MCPServer?
     private var shouldRestoreAfterSetupWindowClose = false
@@ -266,6 +267,7 @@ private func showNoteBrowserWindow() {
         window.title = AppName.displayName
         window.contentView = hostingView
         window.isReleasedWhenClosed = false
+        window.delegate = settingsWindowDelegate
         window.center()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
@@ -342,5 +344,32 @@ private func showNoteBrowserWindow() {
         } catch {
             print("[MCP] Failed to start server: \(error)")
         }
+    }
+}
+
+private final class SettingsWindowDelegate: NSObject, NSWindowDelegate {
+    private let appState: AppState
+
+    init(appState: AppState) {
+        self.appState = appState
+    }
+
+    @MainActor
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        guard appState.isInstallingNativeWhisper else { return true }
+
+        let alert = NSAlert()
+        alert.messageText = localizedCatalogString("Local Whisper Download in Progress")
+        alert.informativeText = localizedCatalogString(
+            "Closing Settings will cancel the model download and remove the partial file."
+        )
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: localizedCatalogString("Keep Settings Open"))
+        alert.addButton(withTitle: localizedCatalogString("Close and Cancel Download"))
+        alert.buttons.last?.hasDestructiveAction = true
+
+        guard alert.runModal() == .alertSecondButtonReturn else { return false }
+        appState.cancelNativeWhisperInstallForSettingsClose()
+        return true
     }
 }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1730,7 +1730,7 @@ struct ModelsSettingsView: View {
             case .apiRealtime:
                 return showRealtimeTranscriptionOption || appState.realtimeStreamingEnabled
             case .legacyMlxWhisper:
-                return appState.showLegacyMlxWhisperOptions
+                return display.isAvailable
             case .appleLive:
                 return true
             }
@@ -1827,7 +1827,7 @@ struct ModelsSettingsView: View {
         Toggle(isOn: Binding(
             get: { appState.currentNoteBrowserTranscriptionChoice == display.choice },
             set: { isSelected in
-                if isSelected { appState.setNoteBrowserTranscriptionChoice(display.choice) }
+                if isSelected { handleTranscriptionChoiceSelection(display.choice) }
             }
         )) {
             Text(transcriptionChoiceMenuLabel(display))
@@ -2228,6 +2228,8 @@ struct ModelsSettingsView: View {
             }
             .pickerStyle(.menu)
             .frame(minWidth: 280, maxWidth: 320, alignment: .leading)
+            .disabled(!isOutputLanguageAvailable)
+            .opacity(isOutputLanguageAvailable ? 1 : 0.55)
 
             Text(outputLanguageHelpText)
                 .font(.caption)
@@ -2235,10 +2237,19 @@ struct ModelsSettingsView: View {
         }
     }
 
+    private var isOutputLanguageAvailable: Bool {
+        !appState.disablePostProcessing || appState.isCommandModeEnabled
+    }
+
     private var outputLanguageHelpText: String {
-        let key = appState.disablePostProcessing
-            ? "Output Language remains available for Edit Mode transforms."
-            : "Final transcript language for post-processing and Edit Mode transforms."
+        let key: String
+        if !isOutputLanguageAvailable {
+            key = "Output Language is unavailable while Post-processing and Edit Mode are off."
+        } else if appState.disablePostProcessing {
+            key = "Output Language remains available for Edit Mode transforms."
+        } else {
+            key = "Final transcript language for post-processing and Edit Mode transforms."
+        }
         return localizedCatalogString(key)
     }
 
@@ -2368,9 +2379,6 @@ struct ModelsSettingsView: View {
                 isValidatingKey = false
                 if valid {
                     appState.apiKey = key
-                    if !appState.useLocalTranscription {
-                        appState.setNoteBrowserTranscriptionMode(.apiStandard)
-                    }
                 } else {
                     keyValidationError = "Validation failed. Please check your API key and provider settings, then try again."
                 }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1514,10 +1514,21 @@ struct ModelsSettingsView: View {
     @State private var apiBaseURLInput: String = ""
     @State private var transcriptionAPIURLInput: String = ""
     @State private var transcriptionAPIKeyInput: String = ""
-    @State private var showingLocalTranscriptionSettings = true
+    @State private var transcriptionModelDraft = ""
+    @State private var pendingNativeModelID: String?
+    @State private var nativeInstallAutoSelectModelID: String?
+    @State private var showRealtimeTranscriptionOption = false
+    @State private var realtimeStreamingModelDraft = ""
+    @State private var postProcessingModelDraft = ""
+    @State private var postProcessingFallbackModelDraft = ""
+    @State private var contextModelDraft = ""
+    @FocusState private var isEditingAPIBaseURL: Bool
+    @FocusState private var isEditingTranscriptionModel: Bool
+    @FocusState private var isEditingRealtimeStreamingModel: Bool
+    @FocusState private var transcriptionAPIURLFocused: Bool
+    @FocusState private var transcriptionAPIKeyFocused: Bool
     @State private var isValidatingKey = false
     @State private var keyValidationError: String?
-    @State private var keyValidationSuccess = false
     @State private var customVocabularyInput: String = ""
     @State private var advancedProviderSettingsExpanded = false
 
@@ -1555,23 +1566,17 @@ struct ModelsSettingsView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 20) {
-                SettingsCard("Transcription", icon: "waveform.badge.magnifyingglass") {
-                    transcriptionSection
+                SettingsCard("Cloud Provider", icon: "cloud.fill") {
+                    cloudProviderSection
                 }
-                SettingsCard("Language", icon: "globe") {
-                    languageSettings
+                SettingsCard("Transcription", icon: "waveform") {
+                    transcriptionFeatureSection
                 }
-                SettingsCard("Custom Vocabulary", icon: "text.book.closed.fill") {
-                    vocabularySection
+                SettingsCard("Post-processing", icon: "wand.and.stars") {
+                    postProcessingFeatureSection
                 }
-                SettingsCard("System Prompt", icon: "text.bubble.fill") {
-                    systemPromptSection
-                }
-                SettingsCard("Instruction Guard", icon: "shield.lefthalf.filled") {
-                    instructionGuardSection
-                }
-                SettingsCard("Context Prompt", icon: "eye.fill") {
-                    contextPromptSection
+                SettingsCard("Context", icon: "rectangle.and.text.magnifyingglass") {
+                    contextFeatureSection
                 }
             }
             .padding(24)
@@ -1581,7 +1586,12 @@ struct ModelsSettingsView: View {
             apiBaseURLInput = appState.apiBaseURL
             transcriptionAPIURLInput = appState.transcriptionAPIURL
             transcriptionAPIKeyInput = appState.transcriptionAPIKey
-            showingLocalTranscriptionSettings = appState.useLocalTranscription
+            transcriptionModelDraft = customStandardAPIModelDraft(for: appState.transcriptionModel)
+            showRealtimeTranscriptionOption = appState.realtimeStreamingEnabled
+            realtimeStreamingModelDraft = appState.realtimeStreamingModel
+            postProcessingModelDraft = appState.postProcessingModel
+            postProcessingFallbackModelDraft = appState.postProcessingFallbackModel
+            contextModelDraft = appState.contextModel
             customVocabularyInput = appState.customVocabulary
             customSystemPromptInput = appState.customSystemPrompt.isEmpty
                 ? PostProcessingService.defaultSystemPrompt
@@ -1589,6 +1599,7 @@ struct ModelsSettingsView: View {
             customContextPromptInput = appState.customContextPrompt.isEmpty
                 ? AppContextService.defaultContextPrompt
                 : appState.customContextPrompt
+            initializeManagedNativeModel()
         }
         .onChange(of: appState.transcriptionAPIURL) { value in
             if transcriptionAPIURLInput != value { transcriptionAPIURLInput = value }
@@ -1596,78 +1607,581 @@ struct ModelsSettingsView: View {
         .onChange(of: appState.transcriptionAPIKey) { value in
             if transcriptionAPIKeyInput != value { transcriptionAPIKeyInput = value }
         }
-    }
-
-    private var transcriptionSection: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Transcription Mode")
-                    .font(.caption.weight(.semibold))
-
-                Picker("Transcription Mode", selection: $showingLocalTranscriptionSettings) {
-                    Text("Local").tag(true)
-                    Text("API Provider").tag(false)
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .onChange(of: showingLocalTranscriptionSettings) { showsLocal in
-                    if showsLocal {
-                        appState.useLocalTranscription = true
-                    } else if appState.hasTranscriptionAPIKey {
-                        appState.setNoteBrowserTranscriptionMode(.apiStandard)
-                    }
-                }
-
-                Text(showingLocalTranscriptionSettings
-                    ? "Run speech recognition on this Mac and configure only local transcription options."
-                    : "Use your configured OpenAI-compatible provider and configure only provider-specific options.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Divider()
-
-            if showingLocalTranscriptionSettings {
-                localTranscriptionSettings
-            } else {
-                apiProviderTranscriptionSettings
-            }
-
-            Divider()
-
-            sharedTranscriptionBehaviors
+        .onChange(of: appState.transcriptionModel) { value in
+            guard !isEditingTranscriptionModel else { return }
+            let draft = customStandardAPIModelDraft(for: value)
+            if transcriptionModelDraft != draft { transcriptionModelDraft = draft }
+        }
+        .onChange(of: appState.nativeWhisperInstallStatus) { status in
+            guard status == .ready,
+                  let modelID = nativeInstallAutoSelectModelID,
+                  pendingNativeModelID == modelID,
+                  appState.selectedSettingsTab == .models else { return }
+            appState.setNoteBrowserTranscriptionChoice(.nativeWhisper(modelID: modelID))
+            nativeInstallAutoSelectModelID = nil
         }
     }
 
-    private var localTranscriptionSettings: some View {
+    private var hasConfiguredCloudAPIKey: Bool {
+        !appState.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var cloudProviderSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Local Options")
-                    .font(.caption.weight(.semibold))
+            Text("Cloud models use this shared OpenAI-compatible provider.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
 
-                ModelRowView(
-                    model: TranscriptionModel.find(id: "apple-speech"),
-                    isSelected: appState.localTranscriptionModel.isAppleSpeech,
-                    whisperBin: "",
-                    onSelect: {
-                        appState.setNoteBrowserTranscriptionChoice(.appleLive)
-                    },
-                    onDeleted: {}
-                )
+            HStack(spacing: 8) {
+                SecureField("Enter your Groq API key", text: $apiKeyInput)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(.body, design: .monospaced))
+                    .disabled(isValidatingKey)
+                    .onChange(of: apiKeyInput) { _ in
+                        keyValidationError = nil
+                    }
 
+                Button(isValidatingKey ? "Validating..." : "Save") {
+                    validateAndSaveKey()
+                }
+                .disabled(isValidatingKey)
+            }
+
+            providerValidationStatus
+
+            DisclosureGroup(isExpanded: $advancedProviderSettingsExpanded) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("API Base URL")
+                        .font(.caption.weight(.semibold))
+                    HStack(spacing: 8) {
+                        TextField(AppState.defaultAPIBaseURL, text: $apiBaseURLInput)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(.body, design: .monospaced))
+                            .focused($isEditingAPIBaseURL)
+                            .onSubmit { commitAPIBaseURL() }
+                            .onChange(of: isEditingAPIBaseURL) { editing in
+                                if !editing { commitAPIBaseURL() }
+                            }
+                        Button("Reset to Default") {
+                            apiBaseURLInput = AppState.defaultAPIBaseURL
+                            appState.apiBaseURL = AppState.defaultAPIBaseURL
+                        }
+                        .font(.caption)
+                    }
+                }
+                .padding(.top, 8)
+            } label: {
+                Text("Advanced Provider Settings")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var providerValidationStatus: some View {
+        if isValidatingKey {
+            Label("Validating...", systemImage: "arrow.triangle.2.circlepath")
+                .foregroundStyle(.secondary)
+                .font(.caption)
+        } else {
+            if hasConfiguredCloudAPIKey {
+                Label("API Key configured", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .font(.caption)
+            }
+
+            if let error = keyValidationError {
+                Label(error, systemImage: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+                    .font(.caption)
+            }
+        }
+    }
+
+    private var currentTranscriptionDisplay: TranscriptionChoiceDisplay {
+        appState.noteBrowserTranscriptionDisplay(
+            for: appState.currentNoteBrowserTranscriptionChoice
+        )
+    }
+
+    private var standardAPIModelIDs: [String] {
+        var modelIDs: [String] = []
+        for modelID in ModelConfiguration.transcriptionModels where !modelIDs.contains(modelID) {
+            modelIDs.append(modelID)
+        }
+
+        let currentModelID = appState.transcriptionModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !currentModelID.isEmpty && !modelIDs.contains(currentModelID) {
+            modelIDs.append(currentModelID)
+        }
+        return modelIDs
+    }
+
+    private var transcriptionChoiceDisplays: [TranscriptionChoiceDisplay] {
+        let standardDisplays = standardAPIModelIDs.map { modelID in
+            appState.noteBrowserTranscriptionDisplay(for: .apiStandard(modelID: modelID))
+        }
+        let nativeDisplays = NativeWhisperModelCatalog.all.map { model in
+            appState.noteBrowserTranscriptionDisplay(for: .nativeWhisper(modelID: model.id))
+        }
+        let otherDisplays = appState.noteBrowserTranscriptionChoiceDisplays.filter { display in
+            switch display.choice {
+            case .apiStandard, .nativeWhisper:
+                return false
+            case .apiRealtime:
+                return showRealtimeTranscriptionOption || appState.realtimeStreamingEnabled
+            case .legacyMlxWhisper:
+                return appState.showLegacyMlxWhisperOptions
+            case .appleLive:
+                return true
+            }
+        }
+        return standardDisplays + nativeDisplays + otherDisplays
+    }
+
+    private var transcriptionChoice: Binding<TranscriptionBackendChoice> {
+        Binding(
+            get: { appState.currentNoteBrowserTranscriptionChoice },
+            set: { handleTranscriptionChoiceSelection($0) }
+        )
+    }
+
+    private var managedNativeModel: NativeWhisperModel? {
+        guard let pendingNativeModelID else { return nil }
+        return NativeWhisperModelCatalog.all.first { $0.id == pendingNativeModelID }
+    }
+
+    private func initializeManagedNativeModel() {
+        guard case .nativeWhisper(let modelID) =
+            appState.currentNoteBrowserTranscriptionChoice else { return }
+        pendingNativeModelID = modelID
+    }
+
+    private func handleTranscriptionChoiceSelection(_ choice: TranscriptionBackendChoice) {
+        switch choice {
+        case .nativeWhisper(let modelID):
+            pendingNativeModelID = modelID
+            if appState.isNoteBrowserTranscriptionChoiceAvailable(choice) {
+                nativeInstallAutoSelectModelID = nil
+                appState.setNoteBrowserTranscriptionChoice(choice)
+            }
+        case .apiStandard, .apiRealtime, .legacyMlxWhisper, .appleLive:
+            pendingNativeModelID = nil
+            nativeInstallAutoSelectModelID = nil
+            appState.setNoteBrowserTranscriptionChoice(choice)
+        }
+    }
+
+    private func canSelectTranscriptionDisplay(_ display: TranscriptionChoiceDisplay) -> Bool {
+        if case .nativeWhisper = display.choice { return true }
+        return display.isAvailable
+    }
+
+    private func transcriptionChoiceMenuLabel(_ display: TranscriptionChoiceDisplay) -> String {
+        guard case .nativeWhisper = display.choice, !display.isAvailable else {
+            return display.localizedCompactLabel()
+        }
+        let status = appState.isInstallingNativeWhisper ? "Downloading..." : "Download required"
+        return "\(display.localizedCompactLabel()) — \(localizedCatalogString(status))"
+    }
+
+    @ViewBuilder
+    private var transcriptionChoicePickerControl: some View {
+        if #available(macOS 14.0, *) {
+            Picker("Model", selection: transcriptionChoice) {
+                ForEach(["API", "Local", "Legacy mlx-whisper"], id: \.self) { section in
+                    let displays = transcriptionChoiceDisplays.filter { $0.section == section }
+                    if !displays.isEmpty {
+                        Section(section) {
+                            ForEach(displays) { display in
+                                Text(transcriptionChoiceMenuLabel(display))
+                                    .tag(display.choice)
+                                    .selectionDisabled(!canSelectTranscriptionDisplay(display))
+                            }
+                        }
+                    }
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+        } else {
+            Menu {
+                ForEach(["API", "Local", "Legacy mlx-whisper"], id: \.self) { section in
+                    let displays = transcriptionChoiceDisplays.filter { $0.section == section }
+                    if !displays.isEmpty {
+                        Section(section) {
+                            ForEach(displays) { display in
+                                transcriptionChoiceMenuItem(display)
+                            }
+                        }
+                    }
+                }
+            } label: {
+                Text(currentTranscriptionDisplay.localizedCompactLabel())
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .menuStyle(.borderlessButton)
+        }
+    }
+
+    private func transcriptionChoiceMenuItem(_ display: TranscriptionChoiceDisplay) -> some View {
+        Toggle(isOn: Binding(
+            get: { appState.currentNoteBrowserTranscriptionChoice == display.choice },
+            set: { isSelected in
+                if isSelected { appState.setNoteBrowserTranscriptionChoice(display.choice) }
+            }
+        )) {
+            Text(transcriptionChoiceMenuLabel(display))
+        }
+        .disabled(!canSelectTranscriptionDisplay(display))
+    }
+
+    private var transcriptionChoicePicker: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Model")
+                .font(.caption.weight(.semibold))
+
+            transcriptionChoicePickerControl
+                .frame(minWidth: 280, maxWidth: 320, alignment: .leading)
+        }
+    }
+
+    private var currentTranscriptionUsesAPI: Bool {
+        switch appState.currentNoteBrowserTranscriptionChoice {
+        case .apiStandard, .apiRealtime:
+            true
+        case .nativeWhisper, .legacyMlxWhisper, .appleLive:
+            false
+        }
+    }
+
+    private var transcriptionFeatureSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Convert speech to text.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            transcriptionChoicePicker
+
+            if let model = managedNativeModel {
                 NativeWhisperModelRowView(
-                    isSelected: !appState.localTranscriptionModel.isAppleSpeech && !appState.useLegacyMlxWhisper,
+                    model: model,
+                    isSelected: appState.currentNoteBrowserTranscriptionChoice == .nativeWhisper(modelID: model.id),
                     onSelect: {
-                        appState.setNoteBrowserTranscriptionChoice(
-                            .nativeWhisper(modelID: NativeWhisperModelCatalog.recommended.id)
-                        )
+                        handleTranscriptionChoiceSelection(.nativeWhisper(modelID: model.id))
+                    },
+                    showsSelectionControl: false,
+                    onDownloadStarted: {
+                        nativeInstallAutoSelectModelID = model.id
                     }
                 )
+
                 Text("If you close Settings while the model is downloading, Quill cancels the download and removes the partial file.")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
 
+            if currentTranscriptionUsesAPI && !appState.hasTranscriptionAPIKey {
+                Label(
+                    "Cloud transcription requires an API key. Add one in Cloud Provider or use the transcription override in Details.",
+                    systemImage: "exclamationmark.triangle"
+                )
+                .font(.caption)
+                .foregroundStyle(.orange)
+            } else if let reason = currentTranscriptionDisplay.localizedUnavailableReason() {
+                Label(reason, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
+            DisclosureGroup("Details") {
+                VStack(alignment: .leading, spacing: 14) {
+                    transcriptionLanguageSetting
+                    Divider()
+                    standardAPITranscriptionSetting
+                    realtimeTranscriptionSetting
+                    transcriptionProviderOverrideSetting
+                    Divider()
+                    legacyTranscriptionSettings
+                }
+                .padding(.top, 8)
+            }
+        }
+    }
+
+    private var postProcessingEnabled: Binding<Bool> {
+        Binding(
+            get: { !appState.disablePostProcessing },
+            set: { appState.disablePostProcessing = !$0 }
+        )
+    }
+
+    private var postProcessingFeatureSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Clean up wording, formatting, and language.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Toggle("", isOn: postProcessingEnabled)
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                    .accessibilityLabel("Post-processing")
+                    .disabled(!hasConfiguredCloudAPIKey)
+                    .opacity(hasConfiguredCloudAPIKey ? 1 : 0.45)
+            }
+
+            ModelDropdownView(
+                title: "Model",
+                subtitle: "Used for transcript cleanup and Edit Mode transforms.",
+                predefinedModels: ModelConfiguration.llmModels,
+                defaultModel: AppState.defaultPostProcessingModel,
+                textDraft: $postProcessingModelDraft,
+                onCommit: commitPostProcessingModel,
+                onReset: {
+                    postProcessingModelDraft = AppState.defaultPostProcessingModel
+                    appState.postProcessingModel = AppState.defaultPostProcessingModel
+                }
+            )
+            .disabled(!hasConfiguredCloudAPIKey)
+            .opacity(hasConfiguredCloudAPIKey ? 1 : 0.45)
+
+            if !hasConfiguredCloudAPIKey {
+                Label(
+                    appState.disablePostProcessing
+                        ? "Add an API key in Cloud Provider to enable Post-processing."
+                        : "Post-processing is on, but cloud processing is unavailable until an API key is configured.",
+                    systemImage: "exclamationmark.triangle"
+                )
+                .font(.caption)
+                .foregroundStyle(.orange)
+            }
+
+            if appState.disablePostProcessing {
+                Text("Normal dictation uses the raw transcript while Post-processing is off. Edit Mode still uses this model configuration.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            DisclosureGroup("Details") {
+                postProcessingDetails
+                    .padding(.top, 8)
+            }
+        }
+    }
+
+    private var contextEnabled: Binding<Bool> {
+        Binding(
+            get: { !appState.disableContextCapture },
+            set: { appState.disableContextCapture = !$0 }
+        )
+    }
+
+    private var contextFeatureSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Use the current app and screen to improve context.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Toggle("", isOn: contextEnabled)
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                    .accessibilityLabel("Context")
+                    .disabled(!hasConfiguredCloudAPIKey)
+                    .opacity(hasConfiguredCloudAPIKey ? 1 : 0.45)
+            }
+
+            ModelDropdownView(
+                title: "Model",
+                subtitle: "Used for context inference, with a text-only retry when screenshot analysis fails.",
+                predefinedModels: ModelConfiguration.llmModels,
+                defaultModel: AppState.defaultContextModel,
+                textDraft: $contextModelDraft,
+                onCommit: commitContextModel,
+                onReset: {
+                    contextModelDraft = AppState.defaultContextModel
+                    appState.contextModel = AppState.defaultContextModel
+                }
+            )
+            .disabled(!hasConfiguredCloudAPIKey)
+            .opacity(hasConfiguredCloudAPIKey ? 1 : 0.45)
+
+            if !hasConfiguredCloudAPIKey {
+                Label(
+                    appState.disableContextCapture
+                        ? "Add an API key in Cloud Provider to enable Context."
+                        : "Context is on, but AI context analysis is unavailable until an API key is configured.",
+                    systemImage: "exclamationmark.triangle"
+                )
+                .font(.caption)
+                .foregroundStyle(.orange)
+            }
+
+            if appState.disableContextCapture {
+                Text("Context capture is off. Quill skips app context and screenshots for normal dictation.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            DisclosureGroup("Details") {
+                contextPromptSection
+                    .padding(.top, 8)
+            }
+        }
+    }
+
+    private var postProcessingDetails: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            outputLanguageSetting
+            Divider()
+            preserveExactWordingSetting
+            Divider()
+            ModelDropdownView(
+                title: "Post-Processing Fallback Model",
+                subtitle: "Used as the explicit retry model for transcript cleanup and Edit Mode transforms.",
+                predefinedModels: ModelConfiguration.llmModels,
+                defaultModel: AppState.defaultPostProcessingFallbackModel,
+                textDraft: $postProcessingFallbackModelDraft,
+                onCommit: commitPostProcessingFallbackModel,
+                onReset: {
+                    postProcessingFallbackModelDraft = AppState.defaultPostProcessingFallbackModel
+                    appState.postProcessingFallbackModel = AppState.defaultPostProcessingFallbackModel
+                }
+            )
+            .disabled(!hasConfiguredCloudAPIKey)
+            .opacity(hasConfiguredCloudAPIKey ? 1 : 0.45)
+            Divider()
+            vocabularySection
+            Divider()
+            systemPromptSection
+            Divider()
+            instructionGuardSection
+            Divider()
+            Text("Edit Mode uses this model, fallback model, Output Language, and Custom Vocabulary. Invocation Style and Extra Modifier remain in Shortcuts.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var transcriptionLanguageSetting: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Picker("Transcription Language", selection: $appState.transcriptionLanguage) {
+                ForEach(TranscriptionLanguage.all) { lang in
+                    Text(lang.localizedDisplayName()).tag(lang)
+                }
+            }
+            .pickerStyle(.menu)
+            .frame(maxWidth: 240, alignment: .leading)
+
+            Text("Spoken language hint for speech recognition. Auto Detect works for most users.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var standardAPITranscriptionSetting: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Custom Standard API Model")
+                .font(.caption.weight(.semibold))
+
+            HStack(spacing: 8) {
+                TextField("e.g. custom-transcription-model", text: $transcriptionModelDraft)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($isEditingTranscriptionModel)
+                    .onSubmit { commitTranscriptionModel() }
+                    .onChange(of: isEditingTranscriptionModel) { editing in
+                        if !editing { commitTranscriptionModel() }
+                    }
+
+                Button("Reset to Default") {
+                    transcriptionModelDraft = ""
+                    appState.transcriptionModel = AppState.defaultTranscriptionModel
+                }
+                .font(.caption)
+            }
+
+            Text("Add a custom model ID when it is not listed in the main Model menu.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var realtimeTranscriptionSetting: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle("Show Realtime transcription option", isOn: $showRealtimeTranscriptionOption)
+
+            if showRealtimeTranscriptionOption || appState.realtimeStreamingEnabled {
+                Text("Realtime Transcription Model")
+                    .font(.caption.weight(.semibold))
+                HStack(spacing: 8) {
+                    TextField("Required by some providers, e.g. gpt-4o-transcribe", text: $realtimeStreamingModelDraft)
+                        .textFieldStyle(.roundedBorder)
+                        .focused($isEditingRealtimeStreamingModel)
+                        .onSubmit { commitRealtimeStreamingModel() }
+                        .onChange(of: isEditingRealtimeStreamingModel) { editing in
+                            if !editing { commitRealtimeStreamingModel() }
+                        }
+                    if !realtimeStreamingModelDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        Button("Reset") {
+                            realtimeStreamingModelDraft = ""
+                            appState.realtimeStreamingModel = ""
+                        }
+                        .font(.caption)
+                    }
+                }
+                Text("Used only for realtime streaming. Leave empty for providers that supply a server default.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var transcriptionProviderOverrideSetting: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Transcription API URL")
+                .font(.caption.weight(.semibold))
+            HStack(spacing: 8) {
+                TextField("Uses API Base URL when empty", text: $transcriptionAPIURLInput)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(.body, design: .monospaced))
+                    .focused($transcriptionAPIURLFocused)
+                    .onSubmit { commitTranscriptionAPIURL() }
+                    .onChange(of: transcriptionAPIURLFocused) { focused in
+                        if !focused { commitTranscriptionAPIURL() }
+                    }
+                if !transcriptionAPIURLInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Button("Clear") {
+                        transcriptionAPIURLInput = ""
+                        appState.transcriptionAPIURL = ""
+                    }
+                    .font(.caption)
+                }
+            }
+
+            Text("Transcription API Key")
+                .font(.caption.weight(.semibold))
+            HStack(spacing: 8) {
+                SecureField("Uses API Key when empty", text: $transcriptionAPIKeyInput)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(.body, design: .monospaced))
+                    .focused($transcriptionAPIKeyFocused)
+                    .onSubmit { commitTranscriptionAPIKey() }
+                    .onChange(of: transcriptionAPIKeyFocused) { focused in
+                        if !focused { commitTranscriptionAPIKey() }
+                    }
+                if !transcriptionAPIKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Button("Clear") {
+                        transcriptionAPIKeyInput = ""
+                        appState.transcriptionAPIKey = ""
+                    }
+                    .font(.caption)
+                }
+            }
+        }
+    }
+
+    private var legacyTranscriptionSettings: some View {
+        VStack(alignment: .leading, spacing: 12) {
             DisclosureGroup("Advanced Legacy mlx-whisper") {
                 VStack(alignment: .leading, spacing: 8) {
                     Toggle("Use legacy mlx-whisper", isOn: $appState.showLegacyMlxWhisperOptions)
@@ -1688,7 +2202,8 @@ struct ModelsSettingsView: View {
                                 appState.setNoteBrowserTranscriptionChoice(
                                     .nativeWhisper(modelID: NativeWhisperModelCatalog.recommended.id)
                                 )
-                            }
+                            },
+                            showsSelectionControl: false
                         )
                         .disabled(!appState.showLegacyMlxWhisperOptions)
                         .opacity(appState.showLegacyMlxWhisperOptions ? 1 : 0.55)
@@ -1704,146 +2219,46 @@ struct ModelsSettingsView: View {
         }
     }
 
-    private var apiProviderTranscriptionSettings: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("API Provider Options")
-                .font(.caption.weight(.semibold))
+    private var outputLanguageSetting: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Picker("Output Language", selection: $appState.outputLanguage) {
+                ForEach(Self.outputLanguageOptions, id: \.value) { option in
+                    Text(option.label).tag(option.value)
+                }
+            }
+            .pickerStyle(.menu)
+            .frame(minWidth: 280, maxWidth: 320, alignment: .leading)
 
-            Text("Quill uses the configured transcription model with your selected OpenAI-compatible provider.")
+            Text(outputLanguageHelpText)
                 .font(.caption)
                 .foregroundStyle(.secondary)
-
-            HStack(spacing: 8) {
-                SecureField("Enter your Groq API key", text: $apiKeyInput)
-                    .textFieldStyle(.roundedBorder)
-                    .font(.system(.body, design: .monospaced))
-                    .disabled(isValidatingKey)
-                    .onChange(of: apiKeyInput) { _ in
-                        keyValidationError = nil
-                        keyValidationSuccess = false
-                    }
-
-                Button(isValidatingKey ? "Validating..." : "Save") {
-                    validateAndSaveKey()
-                }
-                .disabled(isValidatingKey)
-            }
-
-            if let error = keyValidationError {
-                Label(error, systemImage: "xmark.circle.fill")
-                    .foregroundStyle(.red)
-                    .font(.caption)
-            } else if keyValidationSuccess {
-                Label(appState.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "API key cleared" : "API key saved", systemImage: "checkmark.circle.fill")
-                    .foregroundStyle(.green)
-                    .font(.caption)
-            }
-
-            DisclosureGroup(isExpanded: $advancedProviderSettingsExpanded) {
-                VStack(alignment: .leading, spacing: 12) {
-                    Divider()
-                    ProviderSettingsFields(
-                        apiBaseURLInput: $apiBaseURLInput,
-                        transcriptionAPIURLInput: $transcriptionAPIURLInput,
-                        transcriptionAPIKeyInput: $transcriptionAPIKeyInput,
-                        showsModelDescription: false,
-                        showsTranscriptionLanguage: false
-                    )
-                }
-            } label: {
-                HStack {
-                    Text("Advanced Provider Settings")
-                    Spacer()
-                }
-                .contentShape(Rectangle())
-                .onTapGesture { advancedProviderSettingsExpanded.toggle() }
-            }
-            .padding(.top, 4)
-        }
-    }
-
-    private var languageSettings: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            VStack(alignment: .leading, spacing: 8) {
-                Picker("Transcription Language", selection: $appState.transcriptionLanguage) {
-                    ForEach(TranscriptionLanguage.all) { lang in
-                        Text(lang.localizedDisplayName()).tag(lang)
-                    }
-                }
-                .pickerStyle(.menu)
-                .frame(maxWidth: 240, alignment: .leading)
-
-                Text("Spoken language hint for speech recognition. Auto Detect works for most users.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Divider()
-
-            VStack(alignment: .leading, spacing: 8) {
-                Picker("Output Language", selection: $appState.outputLanguage) {
-                    ForEach(Self.outputLanguageOptions, id: \.value) { option in
-                        Text(option.label).tag(option.value)
-                    }
-                }
-                .pickerStyle(.menu)
-                .frame(minWidth: 280, maxWidth: 320, alignment: .leading)
-                .disabled(appState.disablePostProcessing || appState.useLocalTranscription)
-
-                Text(outputLanguageHelpText)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
         }
     }
 
     private var outputLanguageHelpText: String {
-        let key: String
-        if appState.useLocalTranscription { key = "Use API Provider transcription to choose a final output language." }
-        else if appState.disablePostProcessing { key = "Enable post-processing to choose a final output language." }
-        else { key = "Final transcript language for post-processing." }
+        let key = appState.disablePostProcessing
+            ? "Output Language remains available for Edit Mode transforms."
+            : "Final transcript language for post-processing and Edit Mode transforms."
         return localizedCatalogString(key)
     }
 
-    private var sharedTranscriptionBehaviors: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Shared Behaviors")
-                .font(.caption.weight(.semibold))
-
-            VStack(alignment: .leading, spacing: 6) {
-                Toggle("Disable Post-Processing", isOn: $appState.disablePostProcessing)
-                Text("Skip LLM cleanup. Raw transcript is used as-is. No API call is made for post-processing.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            VStack(alignment: .leading, spacing: 6) {
-                Toggle("Preserve Exact Wording", isOn: $appState.preserveExactWording)
-                    .disabled(appState.disablePostProcessing)
-                Text("Skip cleanup while post-processing is enabled. Without an Output Language, the raw transcript is used. With one, only a literal translation is performed.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            .opacity(appState.disablePostProcessing ? 0.55 : 1)
-
-            Divider()
-
-            VStack(alignment: .leading, spacing: 6) {
-                Toggle("Disable Auto Paste", isOn: $appState.disableAutoPaste)
-                Text("Transcription will be copied to clipboard only. Paste manually when needed.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Divider()
-
-            VStack(alignment: .leading, spacing: 6) {
-                Toggle("Disable Context Capture", isOn: $appState.disableContextCapture)
-                Text("Skip screen recording and app context detection. Transcription will not adapt to the current app. Screen Recording permission is not required.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+    private var preserveExactWordingSetting: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Toggle("Preserve Exact Wording", isOn: $appState.preserveExactWording)
+                .disabled(appState.disablePostProcessing)
+            Text("Skip cleanup while post-processing is enabled. Without an Output Language, the raw transcript is used. With one, only a literal translation is performed.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
+        .opacity(appState.disablePostProcessing ? 0.55 : 1)
+    }
+
+    private func customStandardAPIModelDraft(for modelID: String) -> String {
+        let trimmed = modelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !ModelConfiguration.transcriptionModels.contains(trimmed) else {
+            return ""
+        }
+        return trimmed
     }
 
     private var vocabularySection: some View {
@@ -1869,13 +2284,74 @@ struct ModelsSettingsView: View {
         }
     }
 
+    private func commitAPIBaseURL() {
+        let trimmed = apiBaseURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedBaseURL = trimmed.isEmpty ? AppState.defaultAPIBaseURL : trimmed
+        apiBaseURLInput = resolvedBaseURL
+        appState.apiBaseURL = resolvedBaseURL
+    }
+
+    private func commitTranscriptionModel() {
+        let trimmed = transcriptionModelDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolved = trimmed.isEmpty ? AppState.defaultTranscriptionModel : trimmed
+        transcriptionModelDraft = customStandardAPIModelDraft(for: resolved)
+        guard appState.transcriptionModel != resolved else { return }
+        appState.transcriptionModel = resolved
+    }
+
+    private func commitRealtimeStreamingModel() {
+        let trimmed = realtimeStreamingModelDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        realtimeStreamingModelDraft = trimmed
+        guard appState.realtimeStreamingModel != trimmed else { return }
+        appState.realtimeStreamingModel = trimmed
+    }
+
+    private func commitPostProcessingModel() {
+        let trimmed = postProcessingModelDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolved = trimmed.isEmpty ? AppState.defaultPostProcessingModel : trimmed
+        postProcessingModelDraft = resolved
+        if appState.postProcessingModel != resolved {
+            appState.postProcessingModel = resolved
+        }
+    }
+
+    private func commitPostProcessingFallbackModel() {
+        let trimmed = postProcessingFallbackModelDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolved = trimmed.isEmpty ? AppState.defaultPostProcessingFallbackModel : trimmed
+        postProcessingFallbackModelDraft = resolved
+        if appState.postProcessingFallbackModel != resolved {
+            appState.postProcessingFallbackModel = resolved
+        }
+    }
+
+    private func commitContextModel() {
+        let trimmed = contextModelDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolved = trimmed.isEmpty ? AppState.defaultContextModel : trimmed
+        contextModelDraft = resolved
+        if appState.contextModel != resolved {
+            appState.contextModel = resolved
+        }
+    }
+
+    private func commitTranscriptionAPIURL() {
+        let trimmed = transcriptionAPIURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        transcriptionAPIURLInput = trimmed
+        guard appState.transcriptionAPIURL != trimmed else { return }
+        appState.transcriptionAPIURL = trimmed
+    }
+
+    private func commitTranscriptionAPIKey() {
+        let trimmed = transcriptionAPIKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        transcriptionAPIKeyInput = trimmed
+        guard appState.transcriptionAPIKey != trimmed else { return }
+        appState.transcriptionAPIKey = trimmed
+    }
+
     private func validateAndSaveKey() {
         let key = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
         keyValidationError = nil
-        keyValidationSuccess = false
         if key.isEmpty {
             appState.apiKey = ""
-            keyValidationSuccess = true
             isValidatingKey = false
             return
         }
@@ -1892,10 +2368,9 @@ struct ModelsSettingsView: View {
                 isValidatingKey = false
                 if valid {
                     appState.apiKey = key
-                    if !showingLocalTranscriptionSettings {
+                    if !appState.useLocalTranscription {
                         appState.setNoteBrowserTranscriptionMode(.apiStandard)
                     }
-                    keyValidationSuccess = true
                 } else {
                     keyValidationError = "Validation failed. Please check your API key and provider settings, then try again."
                 }
@@ -2488,6 +2963,18 @@ struct ShortcutsSettingsView: View {
 
     private var clipboardSection: some View {
         VStack(alignment: .leading, spacing: 10) {
+            Toggle("Paste Automatically", isOn: Binding(
+                get: { !appState.disableAutoPaste },
+                set: { appState.disableAutoPaste = !$0 }
+            ))
+
+            Text("When off, Quill copies the transcript to the clipboard so you can paste it manually.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Divider()
+                .padding(.vertical, 2)
+
             Toggle("Preserve clipboard after paste", isOn: $appState.preserveClipboard)
 
             Text("Quill will temporarily place the transcript on your clipboard to paste it, then restore whatever was there before. If you copy something else before the restore happens, Quill leaves it alone.")
@@ -3691,6 +4178,8 @@ struct NativeWhisperModelRowView: View {
     let model: NativeWhisperModel
     let isSelected: Bool
     let onSelect: () -> Void
+    let showsSelectionControl: Bool
+    let onDownloadStarted: () -> Void
 
     @State private var showDeleteConfirmation = false
     @State private var isHoveringDownloadProgress = false
@@ -3699,39 +4188,46 @@ struct NativeWhisperModelRowView: View {
     init(
         model: NativeWhisperModel = NativeWhisperModelCatalog.recommended,
         isSelected: Bool,
-        onSelect: @escaping () -> Void
+        onSelect: @escaping () -> Void,
+        showsSelectionControl: Bool = true,
+        onDownloadStarted: @escaping () -> Void = {}
     ) {
         self.model = model
         self.isSelected = isSelected
         self.onSelect = onSelect
+        self.showsSelectionControl = showsSelectionControl
+        self.onDownloadStarted = onDownloadStarted
     }
 
     private var isInstalled: Bool {
         appState.nativeWhisperInstallStatus == .ready
     }
 
+    private var showsSelectedAppearance: Bool {
+        showsSelectionControl && isSelected
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 10) {
-                Button {
-                    onSelect()
-                } label: {
-                    HStack(spacing: 8) {
-                        Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
-                            .foregroundStyle(isInstalled ? Color.accentColor : .secondary)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(verbatim: model.displayName)
-                                .font(.caption.weight(isSelected ? .semibold : .regular))
-                            Text(localizedCatalogFormat("%@. About %@.", model.localizedDescription(), ByteCountFormatter.string(fromByteCount: model.approximateBytes, countStyle: .file)))
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
+                if showsSelectionControl {
+                    Button {
+                        onSelect()
+                    } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                                .foregroundStyle(isInstalled ? Color.accentColor : .secondary)
+                            modelDescription
                         }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(Rectangle())
+                    .buttonStyle(.plain)
+                    .disabled(!isInstalled || appState.isInstallingNativeWhisper)
+                } else {
+                    modelDescription
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .buttonStyle(.plain)
-                .disabled(!isInstalled || appState.isInstallingNativeWhisper)
 
                 actionView
             }
@@ -3744,11 +4240,11 @@ struct NativeWhisperModelRowView: View {
             }
         }
         .padding(8)
-        .background(isSelected ? Color.accentColor.opacity(0.08) : Color(nsColor: .controlBackgroundColor))
+        .background(showsSelectedAppearance ? Color.accentColor.opacity(0.08) : Color(nsColor: .controlBackgroundColor))
         .cornerRadius(6)
         .overlay(
             RoundedRectangle(cornerRadius: 6)
-                .stroke(isSelected ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
+                .stroke(showsSelectedAppearance ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
         )
         .confirmationDialog(
             "Delete model?",
@@ -3762,8 +4258,15 @@ struct NativeWhisperModelRowView: View {
         } message: {
             Text("This removes the downloaded Local Whisper model. You can download it again later.")
         }
-        .onAppear {
-            appState.refreshNativeWhisperInstallStatus()
+    }
+
+    private var modelDescription: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(verbatim: model.displayName)
+                .font(.caption.weight(showsSelectionControl && isSelected ? .semibold : .regular))
+            Text(localizedCatalogFormat("%@. About %@.", model.localizedDescription(), ByteCountFormatter.string(fromByteCount: model.approximateBytes, countStyle: .file)))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -3789,6 +4292,7 @@ struct NativeWhisperModelRowView: View {
             }
         } else {
             Button("Download") {
+                onDownloadStarted()
                 appState.installNativeWhisperModel()
             }
             .font(.caption)
@@ -3843,6 +4347,7 @@ struct NativeWhisperModelRowView: View {
                 .lineLimit(1)
                 .frame(minWidth: 72, alignment: .trailing)
             Button("Download") {
+                onDownloadStarted()
                 appState.installNativeWhisperModel()
             }
             .font(.caption)
@@ -3862,6 +4367,23 @@ struct ModelRowView: View {
     let whisperBin: String
     let onSelect: () -> Void
     let onDeleted: () -> Void
+    let showsSelectionControl: Bool
+
+    init(
+        model: TranscriptionModel,
+        isSelected: Bool,
+        whisperBin: String,
+        onSelect: @escaping () -> Void,
+        onDeleted: @escaping () -> Void,
+        showsSelectionControl: Bool = true
+    ) {
+        self.model = model
+        self.isSelected = isSelected
+        self.whisperBin = whisperBin
+        self.onSelect = onSelect
+        self.onDeleted = onDeleted
+        self.showsSelectionControl = showsSelectionControl
+    }
 
     @State private var isInstalled: Bool = false
     @State private var isDownloading: Bool = false
@@ -3877,28 +4399,31 @@ struct ModelRowView: View {
         isDownloading || isDeleting
     }
 
+    private var showsSelectedAppearance: Bool {
+        showsSelectionControl && isSelected
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 10) {
-                Button {
-                    onSelect()
-                } label: {
-                    HStack(spacing: 8) {
-                        Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
-                            .foregroundStyle(isInstalled ? Color.accentColor : .secondary)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(verbatim: model.displayName)
-                                .font(.caption.weight(isSelected ? .semibold : .regular))
-                            Text(model.localizedDescription())
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
+                if showsSelectionControl {
+                    Button {
+                        onSelect()
+                    } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                                .foregroundStyle(isInstalled ? Color.accentColor : .secondary)
+                            modelDescription
                         }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(Rectangle())
+                    .buttonStyle(.plain)
+                    .disabled(!isInstalled || isBusy)
+                } else {
+                    modelDescription
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .buttonStyle(.plain)
-                .disabled(!isInstalled || isBusy)
 
                 modelActionView
             }
@@ -3911,11 +4436,11 @@ struct ModelRowView: View {
             }
         }
         .padding(8)
-        .background(isSelected ? Color.accentColor.opacity(0.08) : Color(nsColor: .controlBackgroundColor))
+        .background(showsSelectedAppearance ? Color.accentColor.opacity(0.08) : Color(nsColor: .controlBackgroundColor))
         .cornerRadius(6)
         .overlay(
             RoundedRectangle(cornerRadius: 6)
-                .stroke(isSelected ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
+                .stroke(showsSelectedAppearance ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
         )
         .confirmationDialog(
             "Delete model?",
@@ -3931,6 +4456,16 @@ struct ModelRowView: View {
         }
         .onAppear {
             refreshInstallState()
+        }
+    }
+
+    private var modelDescription: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(verbatim: model.displayName)
+                .font(.caption.weight(showsSelectedAppearance ? .semibold : .regular))
+            Text(model.localizedDescription())
+                .font(.caption2)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -59,8 +59,8 @@ struct AppStateTranscriptionConfigurationTests {
         try testNoteBrowserTranscriptionChoiceSetterUpdatesLocalBackend()
         try testNormalizationGuardsStayInsideMainActorIsolation()
         await testAPITranscriptionModesRequireResolvedAPIKey()
-        try testSettingsAPIProviderTabDoesNotForceUnavailableAPIMode()
-        try testSettingsLegacyMlxWhisperToggleControlsOptionsVisibilityOnly()
+        try testSettingsModelFirstTranscriptionUsesExistingChoiceSetter()
+        try testSettingsLegacyManagementKeepsExistingModelRows()
         try testSettingsGlobalAPIKeyCanBeCleared()
         await testTranscriptionAPIKeyEnablesAPIModesWithoutGlobalAPIKey()
         await testEmptyTranscriptionAPIKeyFallsBackToGlobalAPIKey()
@@ -293,14 +293,20 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testPreserveExactWordingSettingsAndPipelineWiring() throws {
         let settings = try String(contentsOfFile: "Sources/SettingsView.swift", encoding: .utf8)
         let appState = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
-        let sharedBehaviors = sourceBlock(
+        let postProcessingDetails = sourceBlock(
             in: settings,
-            from: "private var sharedTranscriptionBehaviors: some View",
+            from: "private var postProcessingDetails: some View",
+            to: "\n    private var preserveExactWordingSetting"
+        )
+        let preserveExactWordingSetting = sourceBlock(
+            in: settings,
+            from: "private var preserveExactWordingSetting: some View",
             to: "\n    private var vocabularySection"
         )
 
-        precondition(sharedBehaviors.contains("Toggle(\"Preserve Exact Wording\", isOn: $appState.preserveExactWording)"))
-        precondition(sharedBehaviors.contains(".disabled(appState.disablePostProcessing)"))
+        precondition(postProcessingDetails.contains("preserveExactWordingSetting"))
+        precondition(preserveExactWordingSetting.contains("Toggle(\"Preserve Exact Wording\", isOn: $appState.preserveExactWording)"))
+        precondition(preserveExactWordingSetting.contains(".disabled(appState.disablePostProcessing)"))
         precondition(appState.contains("if preserveExactWording"))
         precondition(appState.contains("postProcessingService.translateVerbatim"))
         precondition(appState.contains("preserveExactWording: preserveExactWording"))
@@ -909,73 +915,72 @@ struct AppStateTranscriptionConfigurationTests {
         }
     }
 
-    private static func testSettingsAPIProviderTabDoesNotForceUnavailableAPIMode() throws {
+    private static func testSettingsModelFirstTranscriptionUsesExistingChoiceSetter() throws {
         let source = try String(contentsOfFile: "Sources/SettingsView.swift", encoding: .utf8)
-        let transcriptionSection = sourceBlock(
+        let models = sourceBlock(
             in: source,
-            from: "private var transcriptionSection: some View",
-            to: "\n    private var localTranscriptionSettings"
-        )
-        let saveKeyBody = sourceBlock(
-            in: source,
-            from: "private func validateAndSaveKey()",
-            to: "\n    // MARK: System Prompt"
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Shortcuts Settings"
         )
 
-        precondition(source.contains("@State private var showingLocalTranscriptionSettings = true"))
-        precondition(transcriptionSection.contains("Picker(\"Transcription Mode\", selection: $showingLocalTranscriptionSettings)"))
-        precondition(transcriptionSection.contains("if showsLocal {"))
-        precondition(transcriptionSection.contains("appState.useLocalTranscription = true"))
-        precondition(transcriptionSection.contains("} else if appState.hasTranscriptionAPIKey {"))
-        precondition(transcriptionSection.contains("appState.setNoteBrowserTranscriptionMode(.apiStandard)"))
-        precondition(!transcriptionSection.contains("selection: $appState.useLocalTranscription"))
-        precondition(saveKeyBody.contains("if !showingLocalTranscriptionSettings"))
-        precondition(saveKeyBody.contains("appState.setNoteBrowserTranscriptionMode(.apiStandard)"))
+        precondition(!models.contains("showingLocalTranscriptionSettings"))
+        precondition(!models.contains("Picker(\"Transcription Mode\""))
+        precondition(models.contains("@State private var showRealtimeTranscriptionOption = false"))
+        precondition(models.contains("private var transcriptionChoiceDisplays: [TranscriptionChoiceDisplay]"))
+        precondition(models.contains("private var standardAPIModelIDs: [String]"))
+        precondition(models.contains("showRealtimeTranscriptionOption || appState.realtimeStreamingEnabled"))
+        precondition(models.contains("appState.showLegacyMlxWhisperOptions"))
+        precondition(models.contains("ModelConfiguration.transcriptionModels"))
+        precondition(models.contains("appState.noteBrowserTranscriptionDisplay(for: .apiStandard(modelID: modelID))"))
+        precondition(models.contains("appState.transcriptionModel.trimmingCharacters(in: .whitespacesAndNewlines)"))
+        precondition(models.contains("private var transcriptionChoice: Binding<TranscriptionBackendChoice>"))
+        precondition(models.contains("get: { appState.currentNoteBrowserTranscriptionChoice }"))
+        precondition(models.contains("set: { handleTranscriptionChoiceSelection($0) }"))
+        precondition(models.contains("Picker(\"Model\", selection: transcriptionChoice)"))
+        precondition(models.contains("@State private var pendingNativeModelID: String?"))
+        precondition(models.contains("NativeWhisperModelCatalog.all.map"))
+        precondition(models.contains("handleTranscriptionChoiceSelection($0)"))
+        precondition(!models.contains("private var transcriptionChoiceMenu"))
+        let customStandardAPI = sourceBlock(
+            in: models,
+            from: "private var standardAPITranscriptionSetting: some View",
+            to: "\n    private var realtimeTranscriptionSetting"
+        )
+        precondition(customStandardAPI.contains("TextField(\"e.g. custom-transcription-model\", text: $transcriptionModelDraft)"))
+        precondition(models.contains("transcriptionModelDraft = customStandardAPIModelDraft(for: appState.transcriptionModel)"))
+        precondition(models.contains(".onChange(of: appState.transcriptionModel)"))
+        precondition(models.contains("transcriptionModelDraft = customStandardAPIModelDraft(for: resolved)"))
+        precondition(!customStandardAPI.contains("TextField(AppState.defaultTranscriptionModel"))
+        precondition(!customStandardAPI.contains("ModelDropdownView("))
+        precondition(!models.contains("Required · Always On"))
+        precondition(!models.contains("isOn: $appState.realtimeStreamingEnabled"))
+        precondition(!models.contains("appState.useLocalTranscription ="))
+        precondition(!models.contains("appState.useLegacyMlxWhisper ="))
     }
 
-    private static func testSettingsLegacyMlxWhisperToggleControlsOptionsVisibilityOnly() throws {
+    private static func testSettingsLegacyManagementKeepsExistingModelRows() throws {
         let source = try String(contentsOfFile: "Sources/SettingsView.swift", encoding: .utf8)
-        let localSettings = sourceBlock(
+        let models = sourceBlock(
             in: source,
-            from: "private var localTranscriptionSettings: some View",
-            to: "\n    private var apiProviderTranscriptionSettings"
-        )
-        let appleSpeechRow = sourceBlock(
-            in: localSettings,
-            from: "ModelRowView(\n                    model: TranscriptionModel.find(id: \"apple-speech\")",
-            to: "\n\n                NativeWhisperModelRowView"
-        )
-        let nativeWhisperRow = sourceBlock(
-            in: localSettings,
-            from: "NativeWhisperModelRowView(",
-            to: "\n                Text(\"If you close Settings while the model is downloading"
-        )
-        let legacyRows = sourceBlock(
-            in: localSettings,
-            from: "ForEach(TranscriptionModel.all.filter { !$0.isAppleSpeech })",
-            to: "\n\n                    TextField(\"~/.local/bin/mlx_whisper\""
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Shortcuts Settings"
         )
 
-        precondition(localSettings.contains("Toggle(\"Use legacy mlx-whisper\", isOn: $appState.showLegacyMlxWhisperOptions)"))
-        precondition(!localSettings.contains("Toggle(\"Use legacy mlx-whisper\", isOn: $appState.useLegacyMlxWhisper)"))
-        precondition(appleSpeechRow.contains("appState.setNoteBrowserTranscriptionChoice(.appleLive)"))
-        precondition(!appleSpeechRow.contains("appState.useLegacyMlxWhisper ="))
-        precondition(nativeWhisperRow.contains("appState.setNoteBrowserTranscriptionChoice("))
-        precondition(nativeWhisperRow.contains(".nativeWhisper(modelID: NativeWhisperModelCatalog.recommended.id)"))
-        precondition(!nativeWhisperRow.contains("appState.useLegacyMlxWhisper ="))
-        precondition(legacyRows.contains("appState.setNoteBrowserTranscriptionChoice(.legacyMlxWhisper(model: model))"))
-        precondition(!legacyRows.contains("appState.useLegacyMlxWhisper ="))
-        precondition(!legacyRows.contains("appState.localTranscriptionModel = model"))
-        precondition(localSettings.contains(".disabled(!appState.showLegacyMlxWhisperOptions)"))
-        precondition(localSettings.contains(".opacity(appState.showLegacyMlxWhisperOptions ? 1 : 0.55)"))
+        precondition(models.contains("isOn: $appState.showLegacyMlxWhisperOptions"))
+        precondition(models.contains("ForEach(TranscriptionModel.all.filter { !$0.isAppleSpeech })"))
+        precondition(models.contains("appState.setNoteBrowserTranscriptionChoice(.legacyMlxWhisper(model: model))"))
+        precondition(models.contains("showsSelectionControl: false"))
+        precondition(models.contains("onDeleted:"))
+        precondition(models.contains(".nativeWhisper(modelID: NativeWhisperModelCatalog.recommended.id)"))
+        precondition(!models.contains("TranscriptionModel.find(id: \"apple-speech\")"))
     }
 
     private static func testSettingsGlobalAPIKeyCanBeCleared() throws {
         let source = try String(contentsOfFile: "Sources/SettingsView.swift", encoding: .utf8)
         let providerSection = sourceBlock(
             in: source,
-            from: "private var apiProviderTranscriptionSettings: some View",
-            to: "\n    private var languageSettings"
+            from: "private var cloudProviderSection: some View",
+            to: "\n    private var transcriptionFeatureSection"
         )
         let saveKeyBody = sourceBlock(
             in: source,
@@ -989,10 +994,11 @@ struct AppStateTranscriptionConfigurationTests {
 
         precondition(emptyKeyRange.lowerBound < validationRange.lowerBound)
         precondition(saveKeyBody.contains("appState.apiKey = \"\""))
-        precondition(saveKeyBody.contains("keyValidationSuccess = true"))
         precondition(providerSection.contains(".disabled(isValidatingKey)"))
         precondition(!providerSection.contains(".disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isValidatingKey)"))
-        precondition(providerSection.contains("API key cleared"))
+        precondition(providerSection.contains("API Key configured"))
+        precondition(!providerSection.contains("API Key not configured"))
+        precondition(providerSection.contains("Validating..."))
     }
 
     private static func testTranscriptionAPIKeyEnablesAPIModesWithoutGlobalAPIKey() async {

--- a/Tests/ModelsSettingsUIContractTests.swift
+++ b/Tests/ModelsSettingsUIContractTests.swift
@@ -1,0 +1,483 @@
+import Foundation
+
+@main
+struct ModelsSettingsUIContractTests {
+    static func main() throws {
+        let settings = try source("Sources/SettingsView.swift")
+        let appDelegate = try source("Sources/AppDelegate.swift")
+        let appState = try source("Sources/AppState.swift")
+        let postProcessing = try source("Sources/PostProcessingService.swift")
+        let context = try source("Sources/AppContextService.swift")
+        let modelConfiguration = try source("Sources/ModelConfiguration.swift")
+        let currentSpec = try source("docs/superpowers/specs/2026-07-17-model-first-settings-redesign.md")
+
+        testUIOnlyBoundary(appState: appState)
+        testExistingProviderRoutingRemains(postProcessing: postProcessing, context: context)
+        testExistingModelCatalogRemains(modelConfiguration)
+        testExistingModelLifecycleRemains(settings)
+        try testModelFirstTopLevelStructure(settings)
+        testCloudAPIReadinessPresentation(settings)
+        try testTranscriptionUsesNativePickerAndExistingChoiceAPI(settings)
+        testNativeDropdownUsesPendingContextualManagement(settings)
+        testNativeManagementRegressionGuards(settings: settings, appDelegate: appDelegate)
+        testPostProcessingUsesExplicitSwitchAndExistingState(settings)
+        testContextUsesExplicitSwitchAndExistingState(settings)
+        try testAutoPasteLivesInShortcutsClipboard(settings)
+        testTranscriptionDetailsAreManagementOnly(settings)
+        testManagementRowsKeepSelectionAsDefaultBehavior(settings)
+        testCurrentSpecDocumentsCorrectedLayout(currentSpec)
+        print("ModelsSettingsUIContractTests passed")
+    }
+
+    private static func testUIOnlyBoundary(appState: String) {
+        for forbidden in [
+            "postProcessingBackendStorageKey",
+            "postProcessingFallbackBackendStorageKey",
+            "contextBackendStorageKey",
+            "localAIBaseURLStorageKey",
+            "localAIAPIKeyStorageKey",
+            "showRealtimeTranscriptionOptionStorageKey",
+            "showLegacyTranscriptionOptionStorageKey"
+        ] {
+            precondition(!appState.contains(forbidden), "UI-only work added functional state: \(forbidden)")
+        }
+
+        for existing in [
+            "@Published var disablePostProcessing: Bool",
+            "@Published var preserveExactWording: Bool",
+            "@Published var disableContextCapture: Bool",
+            "@Published var disableAutoPaste: Bool",
+            "@Published var realtimeStreamingEnabled: Bool",
+            "@Published var showLegacyMlxWhisperOptions: Bool",
+            "func setNoteBrowserTranscriptionChoice(_ choice: TranscriptionBackendChoice)"
+        ] {
+            precondition(appState.contains(existing), "Missing existing state/action: \(existing)")
+        }
+    }
+
+    private static func testExistingProviderRoutingRemains(
+        postProcessing: String,
+        context: String
+    ) {
+        precondition(postProcessing.contains("private let apiKey: String"))
+        precondition(postProcessing.contains("private let baseURL: String"))
+        precondition(postProcessing.contains("preferredFallbackModel"))
+        precondition(context.contains("private let apiKey: String"))
+        precondition(context.contains("private let baseURL: String"))
+        precondition(context.contains("if !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty"))
+    }
+
+    private static func testExistingModelCatalogRemains(_ source: String) {
+        for model in [
+            "llama-3.3-70b-versatile",
+            "llama-3.1-8b-instant",
+            "meta-llama/llama-4-scout-17b-16e-instruct",
+            "openai/gpt-oss-20b",
+            "openai/gpt-oss-120b",
+            "qwen/qwen3-32b",
+            "qwen/qwen3.6-27b",
+            "whisper-large-v3",
+            "whisper-large-v3-turbo"
+        ] {
+            precondition(source.contains("\"\(model)\""), "Missing existing model: \(model)")
+        }
+    }
+
+    private static func testExistingModelLifecycleRemains(_ settings: String) {
+        let native = block(
+            in: settings,
+            from: "struct NativeWhisperModelRowView",
+            to: "struct ModelRowView"
+        )
+        guard let legacyStart = settings.range(of: "struct ModelRowView") else {
+            preconditionFailure("Unable to locate ModelRowView")
+        }
+        let legacy = String(settings[legacyStart.lowerBound...])
+
+        for expected in [
+            "Button(\"Download\")",
+            "cancelNativeWhisperInstall()",
+            "Delete Model",
+            "deleteNativeWhisperModel()",
+            "nativeWhisperInstallError"
+        ] {
+            precondition(native.contains(expected), "Missing Native lifecycle UI: \(expected)")
+        }
+
+        for expected in [
+            "Button(\"Download\")",
+            "cancelDownload()",
+            "Delete Model",
+            "deleteCache()",
+            "onDeleted()",
+            "errorMessage"
+        ] {
+            precondition(legacy.contains(expected), "Missing Legacy lifecycle UI: \(expected)")
+        }
+    }
+
+    private static func testModelFirstTopLevelStructure(_ source: String) throws {
+        let models = block(
+            in: source,
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Shortcuts Settings"
+        )
+        guard let cloudProvider = models.range(of: "SettingsCard(\"Cloud Provider\""),
+              let transcription = models.range(of: "SettingsCard(\"Transcription\""),
+              let postProcessing = models.range(of: "SettingsCard(\"Post-processing\""),
+              let context = models.range(of: "SettingsCard(\"Context\"") else {
+            preconditionFailure("Missing peer Settings cards")
+        }
+        precondition(cloudProvider.lowerBound < transcription.lowerBound)
+        precondition(transcription.lowerBound < postProcessing.lowerBound)
+        precondition(postProcessing.lowerBound < context.lowerBound)
+        precondition(!models.contains("SettingsCard(\"AI Models\""))
+        precondition(!models.contains("SettingsCard(\"After Transcription\""))
+        precondition(!models.contains("afterTranscriptionSection"))
+        precondition(!models.contains("autoPasteEnabled"))
+        precondition(!models.contains("Picker(\"Transcription Mode\""))
+        precondition(!models.contains("@State private var showingLocalTranscriptionSettings"))
+    }
+
+    private static func testCloudAPIReadinessPresentation(_ source: String) {
+        let models = block(
+            in: source,
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Shortcuts Settings"
+        )
+        let provider = block(
+            in: models,
+            from: "private var cloudProviderSection: some View",
+            to: "\n    private var currentTranscriptionDisplay"
+        )
+        let postProcessing = block(
+            in: models,
+            from: "private var postProcessingFeatureSection: some View",
+            to: "\n    private var contextEnabled"
+        )
+        let context = block(
+            in: models,
+            from: "private var contextFeatureSection: some View",
+            to: "\n    private var postProcessingDetails"
+        )
+        let postProcessingDetails = block(
+            in: models,
+            from: "private var postProcessingDetails: some View",
+            to: "\n    private var transcriptionLanguageSetting"
+        )
+
+        precondition(models.contains("private var hasConfiguredCloudAPIKey: Bool"))
+        precondition(models.contains("!appState.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty"))
+        precondition(!provider.contains("API Key not configured"))
+        precondition(provider.contains("API Key configured"))
+        precondition(provider.contains("Validating..."))
+        precondition(models.contains("appState.hasTranscriptionAPIKey"))
+        precondition(models.contains("Cloud transcription requires an API key. Add one in Cloud Provider or use the transcription override in Details."))
+
+        for feature in [postProcessing, context] {
+            precondition(feature.components(separatedBy: ".disabled(!hasConfiguredCloudAPIKey)").count >= 3)
+            precondition(feature.components(separatedBy: ".opacity(hasConfiguredCloudAPIKey ? 1 : 0.45)").count >= 3)
+        }
+        precondition(postProcessing.contains("Add an API key in Cloud Provider to enable Post-processing."))
+        precondition(postProcessing.contains("Post-processing is on, but cloud processing is unavailable until an API key is configured."))
+        precondition(context.contains("Add an API key in Cloud Provider to enable Context."))
+        precondition(context.contains("Context is on, but AI context analysis is unavailable until an API key is configured."))
+        precondition(postProcessingDetails.contains(".disabled(!hasConfiguredCloudAPIKey)"))
+        precondition(!postProcessingDetails.contains("postProcessingDetails\n                    .disabled(!hasConfiguredCloudAPIKey)"))
+        precondition(!context.contains("contextPromptSection\n                    .disabled(!hasConfiguredCloudAPIKey)"))
+    }
+
+    private static func testTranscriptionUsesNativePickerAndExistingChoiceAPI(_ source: String) throws {
+        let models = block(
+            in: source,
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Shortcuts Settings"
+        )
+        let picker = block(
+            in: models,
+            from: "private var transcriptionChoicePickerControl: some View",
+            to: "\n    private var currentTranscriptionUsesAPI"
+        )
+
+        precondition(models.contains("private var transcriptionChoice: Binding<TranscriptionBackendChoice>"))
+        precondition(models.contains("get: { appState.currentNoteBrowserTranscriptionChoice }"))
+        precondition(models.contains("set: { handleTranscriptionChoiceSelection($0) }"))
+        precondition(models.contains("@State private var showRealtimeTranscriptionOption = false"))
+        precondition(models.contains("private var transcriptionChoiceDisplays: [TranscriptionChoiceDisplay]"))
+        precondition(models.contains("private var standardAPIModelIDs: [String]"))
+        precondition(models.contains("ModelConfiguration.transcriptionModels"))
+        precondition(models.contains("appState.noteBrowserTranscriptionChoiceDisplays"))
+        precondition(models.contains("showRealtimeTranscriptionOption || appState.realtimeStreamingEnabled"))
+        precondition(models.contains("appState.showLegacyMlxWhisperOptions"))
+        precondition(models.contains("appState.noteBrowserTranscriptionDisplay(for: .apiStandard(modelID: modelID))"))
+        precondition(models.contains("appState.transcriptionModel.trimmingCharacters(in: .whitespacesAndNewlines)"))
+        precondition(models.contains("!modelIDs.contains(currentModelID)"))
+        precondition(picker.contains("transcriptionChoiceDisplays.filter { $0.section == section }"))
+        precondition(picker.contains("if #available(macOS 14.0, *)"))
+        precondition(picker.contains("Picker(\"Model\", selection: transcriptionChoice)"))
+        precondition(picker.contains("Section(section)"))
+        precondition(picker.contains(".selectionDisabled(!canSelectTranscriptionDisplay(display))"))
+        precondition(picker.contains("transcriptionChoiceMenuItem(display)"))
+        precondition(picker.contains(".disabled(!canSelectTranscriptionDisplay(display))"))
+        precondition(picker.contains(".pickerStyle(.menu)"))
+        precondition(picker.contains(".frame(minWidth: 280, maxWidth: 320, alignment: .leading)"))
+        precondition(picker.contains("Menu {"))
+        precondition(!models.contains("Required · Always On"))
+        precondition(models.contains("Toggle(\"Show Realtime transcription option\", isOn: $showRealtimeTranscriptionOption)"))
+        precondition(!models.contains("Toggle(\"Show Realtime transcription option\", isOn: $appState.realtimeStreamingEnabled)"))
+    }
+
+    private static func testNativeDropdownUsesPendingContextualManagement(_ source: String) {
+        let models = block(
+            in: source,
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Shortcuts Settings"
+        )
+        let transcription = block(
+            in: models,
+            from: "private var transcriptionFeatureSection: some View",
+            to: "\n    private var postProcessingEnabled"
+        )
+        let legacyDetails = block(
+            in: models,
+            from: "private var legacyTranscriptionSettings: some View",
+            to: "\n    private var outputLanguageSetting"
+        )
+        let nativeRow = block(
+            in: source,
+            from: "struct NativeWhisperModelRowView",
+            to: "struct ModelRowView"
+        )
+
+        precondition(models.contains("@State private var pendingNativeModelID: String?"))
+        precondition(models.contains("@State private var nativeInstallAutoSelectModelID: String?"))
+        precondition(models.contains("NativeWhisperModelCatalog.all.map"))
+        precondition(models.contains("handleTranscriptionChoiceSelection($0)"))
+        precondition(models.contains("pendingNativeModelID = modelID"))
+        precondition(models.contains("appState.isNoteBrowserTranscriptionChoiceAvailable(choice)"))
+        precondition(models.contains("private var managedNativeModel: NativeWhisperModel?"))
+        precondition(models.contains("private func transcriptionChoiceMenuLabel(_ display: TranscriptionChoiceDisplay) -> String"))
+        precondition(models.contains("Download required"))
+        precondition(models.contains("Downloading..."))
+        precondition(transcription.contains("NativeWhisperModelRowView("))
+        precondition(transcription.contains("onDownloadStarted:"))
+        precondition(transcription.contains("nativeInstallAutoSelectModelID = model.id"))
+        precondition(models.contains(".onChange(of: appState.nativeWhisperInstallStatus)"))
+        precondition(models.contains("appState.selectedSettingsTab == .models"))
+        precondition(!legacyDetails.contains("NativeWhisperModelRowView("))
+        precondition(legacyDetails.contains("DisclosureGroup(\"Advanced Legacy mlx-whisper\")"))
+        precondition(legacyDetails.contains("isOn: $appState.showLegacyMlxWhisperOptions"))
+        precondition(legacyDetails.contains("ForEach(TranscriptionModel.all.filter { !$0.isAppleSpeech })"))
+        precondition(nativeRow.contains("let onDownloadStarted: () -> Void"))
+        precondition(nativeRow.contains("onDownloadStarted: @escaping () -> Void = {}"))
+        precondition(nativeRow.components(separatedBy: "onDownloadStarted()").count >= 3)
+    }
+
+    private static func testNativeManagementRegressionGuards(
+        settings: String,
+        appDelegate: String
+    ) {
+        let models = block(
+            in: settings,
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Shortcuts Settings"
+        )
+        let nativeRow = block(
+            in: settings,
+            from: "struct NativeWhisperModelRowView",
+            to: "struct ModelRowView"
+        )
+        let settingsWindow = block(
+            in: appDelegate,
+            from: "private func presentSettingsWindow()",
+            to: "\n\n    func showSetupWindow()"
+        )
+
+        precondition(models.contains("initializeManagedNativeModel()"))
+        precondition(models.contains("case .nativeWhisper(let modelID):"))
+        precondition(models.contains("pendingNativeModelID = modelID"))
+        precondition(!nativeRow.contains("refreshNativeWhisperInstallStatus()"))
+        precondition(appDelegate.contains("NSWindowDelegate"))
+        precondition(appDelegate.contains("func windowShouldClose(_ sender: NSWindow) -> Bool"))
+        precondition(appDelegate.contains("appState.isInstallingNativeWhisper"))
+        precondition(appDelegate.contains("cancelNativeWhisperInstallForSettingsClose()"))
+        precondition(appDelegate.contains("Keep Settings Open"))
+        precondition(appDelegate.contains("Close and Cancel Download"))
+        precondition(settingsWindow.contains("window.delegate ="))
+    }
+
+    private static func testContextUsesExplicitSwitchAndExistingState(_ source: String) {
+        let models = block(
+            in: source,
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Shortcuts Settings"
+        )
+        let context = block(
+            in: models,
+            from: "private var contextFeatureSection: some View",
+            to: "\n    private var postProcessingDetails"
+        )
+
+        for expected in [
+            "get: { !appState.disableContextCapture }",
+            "set: { appState.disableContextCapture = !$0 }",
+            "defaultModel: AppState.defaultContextModel",
+            "contextPromptSection",
+            "selection: $appState.contextScreenshotMaxDimension"
+        ] {
+            precondition(models.contains(expected), "Missing Context binding/configuration: \(expected)")
+        }
+        for expected in [
+            "Toggle(\"\", isOn: contextEnabled)",
+            ".toggleStyle(.switch)",
+            ".accessibilityLabel(\"Context\")"
+        ] {
+            precondition(context.contains(expected), "Missing Context switch presentation: \(expected)")
+        }
+        precondition(!context.contains("Text(contextEnabled.wrappedValue ? \"On\" : \"Off\")"))
+    }
+
+    private static func testPostProcessingUsesExplicitSwitchAndExistingState(_ source: String) {
+        let models = block(
+            in: source,
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Shortcuts Settings"
+        )
+        let postProcessing = block(
+            in: models,
+            from: "private var postProcessingFeatureSection: some View",
+            to: "\n    private var contextEnabled"
+        )
+
+        for expected in [
+            "get: { !appState.disablePostProcessing }",
+            "set: { appState.disablePostProcessing = !$0 }",
+            "Toggle(\"\", isOn: postProcessingEnabled)",
+            ".toggleStyle(.switch)",
+            ".accessibilityLabel(\"Post-processing\")",
+            "predefinedModels: ModelConfiguration.llmModels",
+            "defaultModel: AppState.defaultPostProcessingModel",
+            "defaultModel: AppState.defaultPostProcessingFallbackModel",
+            "selection: $appState.outputLanguage",
+            "isOn: $appState.preserveExactWording",
+            "vocabularySection",
+            "systemPromptSection",
+            "instructionGuardSection"
+        ] {
+            precondition(models.contains(expected), "Missing Post-processing UI binding: \(expected)")
+        }
+        for expected in [
+            "Toggle(\"\", isOn: postProcessingEnabled)",
+            ".toggleStyle(.switch)",
+            ".accessibilityLabel(\"Post-processing\")"
+        ] {
+            precondition(postProcessing.contains(expected), "Missing Post-processing switch presentation: \(expected)")
+        }
+        precondition(!postProcessing.contains("Text(postProcessingEnabled.wrappedValue ? \"On\" : \"Off\")"))
+        precondition(!models.contains(".disabled(appState.disablePostProcessing || appState.useLocalTranscription)"))
+    }
+
+    private static func testAutoPasteLivesInShortcutsClipboard(_ source: String) throws {
+        let models = block(
+            in: source,
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Shortcuts Settings"
+        )
+        let shortcuts = block(
+            in: source,
+            from: "struct ShortcutsSettingsView",
+            to: "// MARK: - Input Settings"
+        )
+        let clipboard = block(
+            in: shortcuts,
+            from: "private var clipboardSection: some View",
+            to: "\n    private var macrosSection"
+        )
+
+        precondition(!models.contains("Paste Automatically"))
+        precondition(clipboard.contains("Toggle(\"Paste Automatically\", isOn: Binding("))
+        precondition(clipboard.contains("get: { !appState.disableAutoPaste }"))
+        precondition(clipboard.contains("set: { appState.disableAutoPaste = !$0 }"))
+        precondition(clipboard.contains("When off, Quill copies the transcript to the clipboard so you can paste it manually."))
+        guard let autoPaste = clipboard.range(of: "Toggle(\"Paste Automatically\""),
+              let preserveClipboard = clipboard.range(of: "Toggle(\"Preserve clipboard after paste\"") else {
+            preconditionFailure("Missing Clipboard settings")
+        }
+        precondition(autoPaste.lowerBound < preserveClipboard.lowerBound)
+    }
+
+    private static func testTranscriptionDetailsAreManagementOnly(_ source: String) {
+        let models = block(
+            in: source,
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Shortcuts Settings"
+        )
+        let local = block(
+            in: models,
+            from: "private var legacyTranscriptionSettings: some View",
+            to: "\n    private var outputLanguageSetting"
+        )
+
+        let customStandardAPI = block(
+            in: models,
+            from: "private var standardAPITranscriptionSetting: some View",
+            to: "\n    private var realtimeTranscriptionSetting"
+        )
+        precondition(customStandardAPI.contains("Text(\"Custom Standard API Model\")"))
+        precondition(customStandardAPI.contains("TextField(\"e.g. custom-transcription-model\", text: $transcriptionModelDraft)"))
+        precondition(models.contains("transcriptionModelDraft = customStandardAPIModelDraft(for: appState.transcriptionModel)"))
+        precondition(models.contains(".onChange(of: appState.transcriptionModel)"))
+        precondition(models.contains("transcriptionModelDraft = customStandardAPIModelDraft(for: resolved)"))
+        precondition(customStandardAPI.contains("Text(\"Add a custom model ID when it is not listed in the main Model menu.\")"))
+        precondition(!customStandardAPI.contains("TextField(AppState.defaultTranscriptionModel"))
+        precondition(!customStandardAPI.contains("ModelDropdownView("))
+        precondition(!models.contains("title: \"Standard API Model\""))
+        precondition(!local.contains("TranscriptionModel.find(id: \"apple-speech\")"))
+        precondition(!local.contains("NativeWhisperModelRowView("))
+        precondition(local.contains("ForEach(TranscriptionModel.all.filter { !$0.isAppleSpeech })"))
+        precondition(local.components(separatedBy: "showsSelectionControl: false").count >= 2)
+    }
+
+    private static func testManagementRowsKeepSelectionAsDefaultBehavior(_ source: String) {
+        let native = block(
+            in: source,
+            from: "struct NativeWhisperModelRowView",
+            to: "struct ModelRowView"
+        )
+        guard let legacyStart = source.range(of: "struct ModelRowView") else {
+            preconditionFailure("Unable to locate ModelRowView")
+        }
+        let legacy = String(source[legacyStart.lowerBound...])
+
+        for row in [native, legacy] {
+            precondition(row.contains("let showsSelectionControl: Bool"))
+            precondition(row.contains("showsSelectionControl: Bool = true"))
+            precondition(row.contains("if showsSelectionControl"))
+        }
+    }
+
+    private static func testCurrentSpecDocumentsCorrectedLayout(_ source: String) {
+        precondition(source.contains("- **Status:** Native Whisper dropdown management follow-up and window-close regression fixes implemented; automated verification complete"))
+        precondition(source.contains("direct Custom Standard API Model ID field"))
+        precondition(source.contains("all predefined Standard API transcription models"))
+        precondition(source.contains("without visible On/Off text"))
+        precondition(source.contains("관리 영역은 radio/selection control을 표시하지 않는다"))
+        precondition(source.contains("Paste Automatically is the first option in Shortcuts > Clipboard"))
+        precondition(source.contains("The separate `Required · Always On` badge is not rendered"))
+        precondition(source.contains("Cloud Provider, Transcription, Post-processing, Context의 네 peer card"))
+        precondition(source.contains("persisted On/Off 모양은 유지"))
+        precondition(source.contains("Settings 진입 시 key를 재검증하는 network request도 추가하지 않는다"))
+    }
+
+    private static func source(_ path: String) throws -> String {
+        try String(contentsOfFile: path, encoding: .utf8)
+    }
+
+    private static func block(in source: String, from start: String, to end: String) -> String {
+        guard let startRange = source.range(of: start),
+              let endRange = source.range(of: end, range: startRange.upperBound..<source.endIndex) else {
+            preconditionFailure("Unable to locate source block from \(start) to \(end)")
+        }
+        return String(source[startRange.lowerBound..<endRange.lowerBound])
+    }
+}

--- a/Tests/ModelsSettingsUIContractTests.swift
+++ b/Tests/ModelsSettingsUIContractTests.swift
@@ -20,6 +20,7 @@ struct ModelsSettingsUIContractTests {
         try testTranscriptionUsesNativePickerAndExistingChoiceAPI(settings)
         testNativeDropdownUsesPendingContextualManagement(settings)
         testNativeManagementRegressionGuards(settings: settings, appDelegate: appDelegate)
+        testReviewRegressionGuards(settings)
         testPostProcessingUsesExplicitSwitchAndExistingState(settings)
         testContextUsesExplicitSwitchAndExistingState(settings)
         try testAutoPasteLivesInShortcutsClipboard(settings)
@@ -304,6 +305,47 @@ struct ModelsSettingsUIContractTests {
         precondition(appDelegate.contains("Keep Settings Open"))
         precondition(appDelegate.contains("Close and Cancel Download"))
         precondition(settingsWindow.contains("window.delegate ="))
+    }
+
+    private static func testReviewRegressionGuards(_ source: String) {
+        let models = block(
+            in: source,
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Shortcuts Settings"
+        )
+        let displays = block(
+            in: models,
+            from: "private var transcriptionChoiceDisplays: [TranscriptionChoiceDisplay]",
+            to: "\n    private var transcriptionChoice"
+        )
+        let menuItem = block(
+            in: models,
+            from: "private func transcriptionChoiceMenuItem",
+            to: "\n    private var transcriptionChoicePicker"
+        )
+        let outputLanguage = block(
+            in: models,
+            from: "private var outputLanguageSetting: some View",
+            to: "\n    private var preserveExactWordingSetting"
+        )
+        let validation = block(
+            in: models,
+            from: "private func validateAndSaveKey()",
+            to: "\n    // MARK: System Prompt"
+        )
+
+        precondition(displays.contains("case .legacyMlxWhisper:"))
+        precondition(displays.contains("return display.isAvailable"))
+        precondition(!displays.contains("appState.showLegacyMlxWhisperOptions"))
+        precondition(menuItem.contains("handleTranscriptionChoiceSelection(display.choice)"))
+        precondition(!menuItem.contains("appState.setNoteBrowserTranscriptionChoice(display.choice)"))
+        precondition(outputLanguage.contains("private var isOutputLanguageAvailable: Bool"))
+        precondition(outputLanguage.contains("!appState.disablePostProcessing || appState.isCommandModeEnabled"))
+        precondition(outputLanguage.contains(".disabled(!isOutputLanguageAvailable)"))
+        precondition(outputLanguage.contains(".opacity(isOutputLanguageAvailable ? 1 : 0.55)"))
+        precondition(outputLanguage.contains("Output Language is unavailable while Post-processing and Edit Mode are off."))
+        precondition(validation.contains("appState.apiKey = key"))
+        precondition(!validation.contains("setNoteBrowserTranscriptionMode(.apiStandard)"))
     }
 
     private static func testContextUsesExplicitSwitchAndExistingState(_ source: String) {

--- a/Tests/SettingsLocalizationTests.swift
+++ b/Tests/SettingsLocalizationTests.swift
@@ -10,6 +10,7 @@ struct SettingsLocalizationTests {
         try testSettingsSectionTitlePolicy()
         try testGoogleCalendarHealthMessagesLocalizeWithoutChangingDetail()
         try testRecordingOverlaySettingsCopyLocalizes()
+        try testModelFirstSettingsCopyLocalizes()
         print("SettingsLocalizationTests passed")
     }
 
@@ -125,6 +126,58 @@ struct SettingsLocalizationTests {
         ]
         for (key, value) in expected {
             assert(localizedCatalogString(key, language: "ko", bundle: bundle) == value)
+        }
+    }
+
+    private static func testModelFirstSettingsCopyLocalizes() throws {
+        let bundle = try compiledLocalizationBundle()
+        let expected: [String: String] = [
+            "Cloud Provider": "클라우드 공급자",
+            "Cloud models use this shared OpenAI-compatible provider.": "클라우드 모델은 이 공통 OpenAI-compatible 공급자를 사용합니다.",
+            "API Key configured": "API Key가 설정됨",
+            "Convert speech to text.": "음성을 텍스트로 변환합니다.",
+            "Cloud transcription requires an API key. Add one in Cloud Provider or use the transcription override in Details.": "클라우드 전사를 사용하려면 API Key가 필요합니다. 클라우드 공급자에서 추가하거나 세부 설정의 전사 전용 설정을 사용하세요.",
+            "Details": "세부 설정",
+            "Model": "모델",
+            "Custom Standard API Model": "사용자 지정 표준 API 모델",
+            "e.g. custom-transcription-model": "예: custom-transcription-model",
+            "Add a custom model ID when it is not listed in the main Model menu.": "기본 모델 메뉴에 없는 사용자 지정 모델 ID를 추가합니다.",
+            "Show Realtime transcription option": "실시간 전사 옵션 표시",
+            "Download required": "다운로드 필요",
+            "Downloading...": "다운로드 중...",
+            "Local Whisper Download in Progress": "Local Whisper 다운로드 진행 중",
+            "Closing Settings will cancel the model download and remove the partial file.": "Settings를 닫으면 모델 다운로드가 취소되고 완료되지 않은 파일이 제거됩니다.",
+            "Keep Settings Open": "Settings 열어 두기",
+            "Close and Cancel Download": "닫고 다운로드 취소",
+            "Post-processing": "후처리",
+            "Clean up wording, formatting, and language.": "문장 표현, 형식, 언어를 정리합니다.",
+            "Add an API key in Cloud Provider to enable Post-processing.": "후처리를 활성화하려면 클라우드 공급자에서 API Key를 추가하세요.",
+            "Post-processing is on, but cloud processing is unavailable until an API key is configured.": "후처리가 켜져 있지만 API Key를 설정하기 전에는 클라우드 처리를 사용할 수 없습니다.",
+            "Normal dictation uses the raw transcript while Post-processing is off. Edit Mode still uses this model configuration.": "후처리가 꺼져 있으면 일반 받아쓰기는 원본 전사문을 사용합니다. Edit Mode는 계속 이 모델 설정을 사용합니다.",
+            "Context": "컨텍스트",
+            "Use the current app and screen to improve context.": "현재 앱과 화면을 사용해 맥락을 보완합니다.",
+            "Add an API key in Cloud Provider to enable Context.": "컨텍스트를 활성화하려면 클라우드 공급자에서 API Key를 추가하세요.",
+            "Context is on, but AI context analysis is unavailable until an API key is configured.": "컨텍스트가 켜져 있지만 API Key를 설정하기 전에는 AI 컨텍스트 분석을 사용할 수 없습니다.",
+            "Context capture is off. Quill skips app context and screenshots for normal dictation.": "컨텍스트 캡처가 꺼져 있습니다. Quill은 일반 받아쓰기에서 앱 맥락과 스크린샷을 건너뜁니다.",
+            "Paste Automatically": "자동으로 붙여넣기",
+            "When off, Quill copies the transcript to the clipboard so you can paste it manually.": "끄면 Quill이 전사문을 클립보드에 복사하며, 필요할 때 직접 붙여넣을 수 있습니다.",
+            "Used for transcript cleanup and Edit Mode transforms.": "전사문 정리와 Edit Mode 변환에 사용합니다.",
+            "Used for context inference, with a text-only retry when screenshot analysis fails.": "컨텍스트 추론에 사용하며, 스크린샷 분석에 실패하면 텍스트 전용으로 다시 시도합니다.",
+            "Post-Processing Fallback Model": "후처리 대체 모델",
+            "Used as the explicit retry model for transcript cleanup and Edit Mode transforms.": "전사문 정리와 Edit Mode 변환을 다시 시도할 때 사용할 모델입니다.",
+            "Edit Mode uses this model, fallback model, Output Language, and Custom Vocabulary. Invocation Style and Extra Modifier remain in Shortcuts.": "Edit Mode는 이 모델, 대체 모델, 출력 언어 및 사용자 지정 어휘를 사용합니다. 실행 방식과 추가 보조 키는 단축키에 그대로 있습니다.",
+            "Output Language remains available for Edit Mode transforms.": "출력 언어는 Edit Mode 변환에서도 계속 사용할 수 있습니다.",
+            "Final transcript language for post-processing and Edit Mode transforms.": "후처리와 Edit Mode 변환에 사용할 최종 전사문 언어입니다.",
+            "Spoken language hint for speech recognition. Auto Detect works for most users.": "음성 인식을 위한 발화 언어 힌트입니다. 대부분의 사용자는 자동 감지를 사용하면 됩니다.",
+            "Stream audio while recording (realtime)": "녹음 중 오디오 스트리밍(실시간)",
+            "Streams audio through the provider's OpenAI-compatible /v1/realtime WebSocket so transcription runs while you speak.": "제공자의 OpenAI-compatible /v1/realtime WebSocket으로 오디오를 스트리밍하여 말하는 동안 전사를 실행합니다.",
+            "Realtime Transcription Model": "실시간 전사 모델",
+            "Used only for realtime streaming. Leave empty for providers that supply a server default.": "실시간 스트리밍에만 사용합니다. 서버 기본값을 제공하는 공급자에서는 비워 두세요."
+        ]
+
+        for (key, korean) in expected {
+            assert(localizedCatalogString(key, language: "en", bundle: bundle) == key)
+            assert(localizedCatalogString(key, language: "ko", bundle: bundle) == korean)
         }
     }
 

--- a/Tests/SettingsLocalizationTests.swift
+++ b/Tests/SettingsLocalizationTests.swift
@@ -167,6 +167,7 @@ struct SettingsLocalizationTests {
             "Used as the explicit retry model for transcript cleanup and Edit Mode transforms.": "전사문 정리와 Edit Mode 변환을 다시 시도할 때 사용할 모델입니다.",
             "Edit Mode uses this model, fallback model, Output Language, and Custom Vocabulary. Invocation Style and Extra Modifier remain in Shortcuts.": "Edit Mode는 이 모델, 대체 모델, 출력 언어 및 사용자 지정 어휘를 사용합니다. 실행 방식과 추가 보조 키는 단축키에 그대로 있습니다.",
             "Output Language remains available for Edit Mode transforms.": "출력 언어는 Edit Mode 변환에서도 계속 사용할 수 있습니다.",
+            "Output Language is unavailable while Post-processing and Edit Mode are off.": "후처리와 Edit Mode가 모두 꺼져 있으면 출력 언어를 사용할 수 없습니다.",
             "Final transcript language for post-processing and Edit Mode transforms.": "후처리와 Edit Mode 변환에 사용할 최종 전사문 언어입니다.",
             "Spoken language hint for speech recognition. Auto Detect works for most users.": "음성 인식을 위한 발화 언어 힌트입니다. 대부분의 사용자는 자동 감지를 사용하면 됩니다.",
             "Stream audio while recording (realtime)": "녹음 중 오디오 스트리밍(실시간)",

--- a/docs/superpowers/specs/2026-06-19-model-selection-ux-design.md
+++ b/docs/superpowers/specs/2026-06-19-model-selection-ux-design.md
@@ -1,5 +1,7 @@
 # Model selection UX design
 
+> **Superseded on 2026-07-17:** This exploration is retained for history. The approved preservation-first design is [`2026-07-17-model-first-settings-redesign.md`](./2026-07-17-model-first-settings-redesign.md). The newer design does not remove existing models or options, does not change current defaults, and uses the existing transcription choice model instead of replacing it with a generic `ModelChoice`.
+
 Interactive mockup: [`2026-06-19-model-selection-ux-mockup.html`](./2026-06-19-model-selection-ux-mockup.html) (open in a browser — click the per-feature dropdowns and the bulk shortcuts).
 
 Part of Epic #145 (Local-first AI pipeline). This design covers the **settings UX and data model** for how users choose models, so that local back-ends added in Phases 2–3 land on a coherent foundation.

--- a/docs/superpowers/specs/2026-07-17-model-first-settings-redesign.md
+++ b/docs/superpowers/specs/2026-07-17-model-first-settings-redesign.md
@@ -237,7 +237,7 @@ Cloud Provider는 다음 기능에 사용된다.
 
 ### Future work — Local AI Server (not implemented in this UI pass)
 
-#64가 #145 Phase 2를 충족하도록 Post-processing과 Context에서 외부 OpenAI-compatible Local AI Server를 선택할 수 있게 한다.
+\#64가 #145 Phase 2를 충족하도록 Post-processing과 Context에서 외부 OpenAI-compatible Local AI Server를 선택할 수 있게 한다.
 
 새 설정:
 
@@ -787,7 +787,7 @@ Cloud 및 Local credential은 동일한 `AppSettingsStorage` 정책을 사용한
 | Legacy binary path | Transcription → Details | same default/custom path |
 | Legacy download/progress/cancel/retry | Transcription → Details | preserved per model |
 | Legacy installed/delete/error | Transcription → Details | preserved per model |
-| Installed Legacy dropdown entries | Transcription dropdown | existing availability, installed state, and `showLegacyMlxWhisperOptions` behavior preserved; no new visibility key |
+| Installed Legacy dropdown entries | Transcription dropdown | existing availability and installed state preserved; the management toggle does not hide installed choices and no new visibility key is added |
 | Delete selected Legacy fallback | Transcription routing | Native first, existing fallback order thereafter |
 | Output Language | Post-processing → Details | one location; not tied to transcription backend |
 | Disable Post-Processing | Post-processing card toggle | inverse binding and persisted visual value retained; disabled without common Cloud key |

--- a/docs/superpowers/specs/2026-07-17-model-first-settings-redesign.md
+++ b/docs/superpowers/specs/2026-07-17-model-first-settings-redesign.md
@@ -1,0 +1,933 @@
+# Model-first Settings redesign
+
+- **Status:** Native Whisper dropdown management follow-up and window-close regression fixes implemented; automated verification complete
+- **Date:** 2026-07-17
+- **Issue:** [#64 — Clarify transcription and AI processing provider settings](https://github.com/woosublee/quill/issues/64)
+- **Related:** [#145 — Local-first AI pipeline](https://github.com/woosublee/quill/issues/145), [#176 — General-consumer launch readiness](https://github.com/woosublee/quill/issues/176)
+- **Supersedes:** [`2026-06-19-model-selection-ux-design.md`](./2026-06-19-model-selection-ux-design.md)
+
+## Goal
+
+현재 `Models` Settings가 제공하는 기능, 옵션, 저장값, fallback, 모델 관리 동작을 **하나도 삭제하거나 의미를 바꾸지 않고**, 사용자가 다음 세 가지를 먼저 이해할 수 있는 model-first 화면으로 재구성한다.
+
+1. 어떤 기능이 켜져 있는가?
+2. 각 기능은 어떤 모델을 사용하는가?
+3. 선택한 모델을 사용하기 위해 무엇이 필요한가?
+
+변경의 목표는 기능 축소나 기본값 변경이 아니라 **정보 구조, 표현, readiness 안내의 개선**이다.
+
+## Current implementation boundary: UI-only
+
+This implementation pass changes only the information architecture and presentation of the existing `Models` Settings screen.
+
+It reuses the current `AppState` properties, provider routing, model catalogs, persistence keys, fallback behavior, and Native/Legacy model lifecycle without modification. No Local AI Server, new backend type, endpoint routing, migration, or model capability filtering is implemented in this pass.
+
+Implemented in the first UI pass: Cloud Provider placement, unified existing Transcription choice presentation, Post-processing/Context positive toggles, feature disclosures, and Auto Paste placement in Shortcuts > Clipboard. The approved follow-up separates Cloud Provider, Transcription, Post-processing, and Context into four peer `SettingsCard`s and adds UI-only readiness constraints for the currently Cloud-only Post-processing and Context controls. Runtime routing, persistence, defaults, fallbacks, and model lifecycle remain unchanged. No product functionality is added.
+
+The corrected layout keeps the main native menu Picker as the only active Transcription backend/method selector. Its API section presents all predefined Standard API transcription models from `ModelConfiguration.transcriptionModels`, plus a persisted nonempty custom model ID when needed; each entry keeps the existing AppState availability display and setter route. API transcription entries remain visible but disabled when neither the common Cloud key nor the existing Transcription override key is configured. Local and installed Legacy choices remain independently selectable.
+
+Details contains a clearly labeled direct Custom Standard API Model ID field for extending that main list without repeating the predefined model dropdown, Realtime option/model configuration, and the existing Legacy lifecycle management. Native Whisper management moves out of the separate Local Options block and appears directly below the main dropdown when the user chooses an uninstalled Native model or selects the installed Native model. The dropdown continues to display the actual active model until the Native install completes. Legacy management remains in its existing disclosure and retains its opt-in toggle, rows, binary path, and lifecycle. Post-processing and Context retain native accessible switches without visible On/Off text. When the common Cloud API key is absent, each switch keeps its persisted visual value but is disabled, and its Cloud model selector is disabled with an inline explanation. The separate `Required · Always On` badge is not rendered. Paste Automatically is the first option in Shortcuts > Clipboard, ahead of the existing clipboard settings.
+
+The Local AI Server and cross-backend routing sections below are retained only as future product exploration and are not acceptance criteria for the current UI implementation.
+
+## Non-negotiable preservation rule
+
+이 설계와 이후 구현은 다음 원칙을 반드시 지킨다.
+
+- 현재 제공 중인 모든 옵션은 새 UI에서도 접근할 수 있어야 한다.
+- 기존 저장값은 손실 없이 유지한다.
+- 업그레이드 직후 사용자의 활성 기능, 선택 모델, prompt, language, provider, 모델 설치 상태가 바뀌면 안 된다.
+- 현재 runtime의 fallback과 안전 동작을 유지한다.
+- 기존 custom model ID 입력 기능을 유지한다.
+- 현재 `ModelConfiguration`에 노출된 predefined model을 임의로 제거하거나 필터링하지 않는다.
+- Native Whisper와 Legacy mlx-whisper의 다운로드·진행률·취소·재시도·설치 확인·삭제·오류 표시를 모두 유지한다.
+- Local transcription을 선택했다는 이유로 Post-processing, Context, Edit Mode, Output Language를 사용할 수 없게 만들지 않는다.
+- Future Local AI Server 지원은 기존 Cloud 동작에 추가되는 선택지이며 Cloud 경로를 대체하지 않는다.
+
+기존 옵션을 다른 위치로 옮길 수는 있지만, 숨겨서 찾을 수 없게 하거나 다른 옵션에 암묵적으로 합치지 않는다. 구현 PR에는 이 문서의 1:1 보존표를 기준으로 누락 검증을 포함한다.
+
+## Scope
+
+### In scope
+
+- 기존 전역 Settings sidebar와 단일 `Models` 화면 유지
+- 공통 Cloud Provider 설정의 명확한 배치
+- Transcription, Post-processing, Context의 기능별 model-first 선택
+- Cloud Provider, Transcription, Post-processing, Context를 peer card로 분리
+- Post-processing과 Context의 명시적인 on/off toggle
+- 현재 Cloud-only 기능의 API Key readiness를 control과 inline 안내로 표현
+- 기능별 상세 설정을 disclosure에 재배치
+- Realtime과 Legacy mlx-whisper를 조건부 Transcription 선택지로 표현
+- Native Whisper 및 Legacy 모델 관리 UI 유지
+- 기존 Cloud provider와 transcription-only override의 역할 구분
+- 현재 옵션과 새 위치의 1:1 보존 검증
+
+### Out of scope
+
+- 기존 모델이나 옵션 삭제
+- 기본 모델, 기본 language, 기본 prompt, 기본 toggle 값 변경
+- Native Whisper 또는 Legacy mlx-whisper 교체
+- Embedded `llama-server` 및 bundled local LLM 다운로드 — #119 범위
+- Realtime protocol 또는 transcription pipeline 변경
+- Context screenshot 기능 축소
+- Edit Mode invocation style 또는 modifier를 `Models`로 이동
+- Voice Macro, Clipboard, audio input 동작 변경
+- 새로운 Settings 하위 sidebar, inspector, pipeline dashboard, 별도 detail screen 추가
+- `AppState` 전체 분해 — #192 범위
+- 외부 Local AI Server 연결, backend 선택, endpoint routing
+- Post-processing/Context/Realtime/Legacy용 새 persistence key 또는 migration
+- primary/fallback의 cross-backend 실행
+
+## Current-state problems
+
+현재 화면은 `Transcription`, `Language`, `Custom Vocabulary`, `System Prompt`, `Instruction Guard`, `Context Prompt` 카드로 나뉘지만, provider와 model은 API transcription의 `Advanced Provider Settings` 안에 모여 있다 (`Sources/SettingsView.swift:1555-1575`, `Sources/SettingsView.swift:1707-1762`).
+
+그 결과 다음 관계가 UI에서 잘못 전달된다.
+
+- 공통 `API Key`와 `API Base URL`은 Post-processing, Edit Mode, Context에도 사용되지만 API transcription 설정처럼 보인다.
+- Local transcription을 선택하면 provider model 설정이 보이지 않아 Local transcription과 Cloud Post-processing/Edit Mode를 함께 쓸 수 없다고 오해하기 쉽다.
+- `Output Language`가 Local transcription일 때 비활성화된다 (`Sources/SettingsView.swift:1783-1805`). 실제 runtime에서는 transcription backend와 독립적으로 Post-processing 및 Edit Mode에 전달된다 (`Sources/AppState.swift:2998-3009`, `Sources/AppState.swift:5221-5276`).
+- `Disable Post-Processing`, `Disable Auto Paste`, `Disable Context Capture`가 Transcription의 `Shared Behaviors` 아래 섞여 있어 서로 독립적인 단계임을 알기 어렵다 (`Sources/SettingsView.swift:1808-1846`).
+- Realtime은 별도 toggle이지만 실제로는 Standard API, Native Whisper, Apple Live, Legacy mlx-whisper와 서로 배타적인 Transcription choice다 (`Sources/AppState.swift:827-855`, `Sources/AppState.swift:1151-1263`).
+- Legacy mlx-whisper는 활성화, 설치, 선택, binary path가 한 영역에 섞여 있다.
+
+## Design decision
+
+### Keep one Models screen
+
+왼쪽 전역 navigation은 바꾸지 않는다. `Models` 내부에도 하위 navigation을 추가하지 않는다.
+
+화면은 위에서 아래로 네 개의 같은 수준인 `SettingsCard`를 갖는다.
+
+1. **Cloud Provider** — Cloud model이 공통으로 사용하는 연결 정보
+2. **Transcription** — 현재 transcription method/model과 해당 readiness
+3. **Post-processing** — 활성 상태, Cloud model, 세부 동작
+4. **Context** — 활성 상태, Cloud model, 세부 동작
+
+세 기능을 다시 `AI Models`라는 하나의 큰 카드 안에 넣지 않는다. 기능별 title, model picker, readiness 안내, `Details`가 한 카드 안에서 완결되도록 한다. `Auto Paste`는 model 설정이 아니라 clipboard delivery behavior이므로 Models에 별도 카드를 두지 않고 기존 `Shortcuts > Clipboard`의 첫 옵션으로 배치한다.
+
+### Choose the model first
+
+기능별 기본 행에서 model dropdown을 먼저 보여준다. 현재 Cloud, Local, Legacy transcription method는 별도 전역 mode가 아니라 기존 선택 결과를 설명하는 속성으로 표현한다.
+
+- Transcription: 기존 `TranscriptionBackendChoice`를 그대로 사용
+- Post-processing / fallback / Context: 기존 저장된 model ID를 그대로 표시하고 선택
+- 현재 UI pass는 backend 선택값이나 backend badge를 추가하지 않는다.
+
+### Progressive disclosure
+
+기본 화면은 다음만 보여준다.
+
+- Cloud Provider key configuration 상태
+- 각 기능의 persisted on/off 상태
+- 각 기능의 선택 model
+- 선택된 Cloud/Local method가 현재 준비됐는지 여부
+- 비활성 control 바로 아래의 readiness 이유
+
+기존 고급 옵션은 기능 행 바로 아래의 `Details` disclosure에서 제공한다. 별도 detail screen으로 이동하지 않으므로 model을 바꾸기 위해 화면을 왕복하지 않는다.
+
+## Information architecture
+
+```text
+Models
+├─ Cloud Provider
+│  ├─ API Key + Save / Clear + validation status
+│  └─ Advanced Provider Settings
+│     ├─ Cloud Base URL
+│     └─ Future Local AI Server (not implemented in this UI pass)
+│        ├─ Base URL
+│        ├─ Optional API Key
+│        ├─ Check Connection
+│        └─ discovered model status
+│
+├─ Transcription
+│  ├─ Model / method dropdown
+│  │  ├─ API choices remain visible; disabled without resolved transcription key
+│  │  └─ Local/installed Legacy choices remain independently available
+│  ├─ inline readiness reason for the current unavailable API choice
+│  ├─ contextual Native Whisper management
+│  │  ├─ download / progress / cancel / retry
+│  │  ├─ Installed / delete confirmation / delete / error
+│  │  └─ active model remains unchanged until install completes
+│  └─ Details
+│     ├─ Spoken Language
+│     ├─ Custom Standard API Model configuration
+│     ├─ Realtime option and API model configuration
+│     ├─ Transcription provider override URL / key
+│     └─ Legacy mlx-whisper availability
+│        ├─ binary path
+│        └─ per-model management
+│
+├─ Post-processing                    persisted On / Off
+│  ├─ disabled switch without common Cloud API key
+│  ├─ Primary Cloud model dropdown
+│  ├─ inline API Key readiness reason
+│  └─ Details
+│     ├─ Output Language
+│     ├─ Preserve Exact Wording
+│     ├─ Fallback Cloud Model
+│     ├─ Custom Vocabulary
+│     ├─ System Prompt
+│     │  ├─ default/custom state and editor
+│     │  ├─ newer-default notice and actions
+│     │  └─ test/result/full prompt
+│     ├─ Instruction Guard
+│     └─ Edit Mode dependency note
+│
+└─ Context                            persisted On / Off
+   ├─ disabled switch without common Cloud API key
+   ├─ Cloud Model dropdown
+   ├─ inline API Key readiness reason
+   └─ Details
+      ├─ Context Prompt
+      │  ├─ default/custom state and editor
+      │  ├─ newer-default notice and actions
+      │  └─ test/result/full prompt
+      └─ Screenshot Resolution
+
+Shortcuts
+└─ Clipboard
+   ├─ Paste Automatically              On / Off
+   └─ Existing clipboard settings
+```
+
+## Cloud Provider
+
+### Common Cloud connection
+
+상단 `Cloud Provider` 영역은 현재의 `apiKey`와 `apiBaseURL`을 그대로 사용한다 (`Sources/AppState.swift:437-449`). 저장 key를 바꾸지 않는다.
+
+기본 상태:
+
+- API Key secure field
+- `Save` 또는 `Clear`
+- `Validating…`, success, error 상태
+- 현재와 같은 `/models` 기반 validation (`Sources/TranscriptionService.swift:64-80`)
+
+Advanced disclosure:
+
+- `Cloud Base URL`
+- `Reset to Default`
+- default: `https://api.groq.com/openai/v1`
+
+Cloud Provider는 다음 기능에 사용된다.
+
+- Standard API transcription — transcription override가 비어 있을 때
+- Realtime transcription — transcription override가 비어 있을 때
+- Cloud Post-processing
+- Cloud Post-processing fallback
+- Edit Mode의 Cloud transform
+- Cloud Context inference
+- System Prompt test 및 Context Prompt test의 Cloud choice
+
+### Current UI readiness semantics
+
+이번 UI-only pass에서 Cloud readiness는 **현재 저장된 common API Key의 존재 여부**로 판단한다. 입력 중인 draft나 Settings 진입 시의 새 network validation 결과를 별도 저장하지 않는다.
+
+- persisted key 없음: 빈 secure field 자체로 미설정 상태가 명확하므로 별도의 `not configured` status를 반복하지 않음
+- validation 진행 중: `Validating…`
+- Save validation 성공: key를 저장하고 `API Key configured`
+- validation 실패: 현재 validation error를 표시하고 기존 persisted key를 변경하지 않음
+- Settings 재진입: persisted key가 있으면 `API Key configured`
+- Clear: persisted key와 configured status를 제거해 빈 secure field 상태로 돌아감
+
+`API Key configured`는 Save validation을 통과한 key가 저장되어 있음을 뜻한다. Settings 진입마다 연결을 재확인하지 않으므로 `Connected`, `Valid`, `Available`처럼 지속적인 network health를 보장하는 표현을 사용하지 않는다.
+
+현재 Cloud-only인 Post-processing과 Context에서는 common key가 비어 있으면 switch와 Cloud model selector를 비활성화한다. persisted switch/model 값은 변경하거나 숨기지 않는다. 비활성 control 바로 아래에 icon과 text를 함께 사용한 inline readiness 이유를 표시한다. `Details` 전체는 비활성화하지 않는다.
+
+### Future work — Local AI Server (not implemented in this UI pass)
+
+#64가 #145 Phase 2를 충족하도록 Post-processing과 Context에서 외부 OpenAI-compatible Local AI Server를 선택할 수 있게 한다.
+
+새 설정:
+
+- Local AI Server Base URL
+- Optional Local AI Server API Key
+- `Check Connection`
+- connection status
+- `/models`에서 발견한 model 목록
+
+기본 URL은 구현 시 Ollama/LM Studio의 OpenAI-compatible endpoint와 호환되는 값을 정하되, 빈 값과 custom URL을 모두 허용한다. API key가 비어 있으면 `Authorization` header를 보내지 않는다.
+
+Local backend readiness는 **유효한 Base URL과 연결 확인 결과**로 판단한다. 현재 `AppContextService`의 `apiKey.isEmpty` gate는 Cloud에만 적용되는 가정이므로 backend-aware readiness로 바꾼다. Local key가 비어 있어도 연결된 Local AI Server에서는 Context LLM inference를 수행해야 한다. Local Server request는 key가 있을 때만 Bearer header를 추가한다. Cloud request의 key gate와 header 구성은 기존 동작을 유지한다.
+
+연결 확인 실패가 기존 Cloud configuration을 변경하거나 비활성화해서는 안 된다.
+
+## Shared model dropdown behavior
+
+모든 model picker는 dropdown 형태를 사용한다.
+
+Post-processing, fallback, Context dropdown은 다음 group을 지원한다.
+
+- **Cloud** — 현재 `ModelConfiguration.llmModels` 전체
+- **Custom…** — 사용자가 arbitrary model ID를 직접 입력
+
+다음 보존 규칙을 지킨다.
+
+- 현재 predefined model 목록을 임의로 필터링하거나 삭제하지 않는다 (`Sources/ModelConfiguration.swift:10-32`).
+- 현재 저장된 custom model이 catalog에 없어도 `Custom…`으로 그대로 보인다.
+- `Reset to Default`는 현재 Cloud model default를 유지한다.
+- model display name을 꾸며 보여주더라도 API에 보내는 persisted `modelID`와 기존 Cloud 경로는 바꾸지 않는다.
+
+Future Local AI Server model discovery, backend choice storage, and cross-backend dropdown groups are deferred to the Future work sections below.
+
+## Transcription
+
+### Required feature
+
+Transcription은 끌 수 없지만 별도 `Required · Always On` 문구를 표시하지 않는다. 기능 제목과 유일한 model picker만으로 필수 기능임을 명확하게 유지한다.
+
+기존 `useLocalTranscription`, `realtimeStreamingEnabled`, `useLegacyMlxWhisper`, `localTranscriptionModel`, `transcriptionModel`을 대체하지 않고 현재 `TranscriptionBackendChoice` adapter를 그대로 source of truth로 사용한다 (`Sources/AppState.swift:827-855`).
+
+### Unified method/model dropdown
+
+dropdown group:
+
+1. **On This Mac**
+   - Apple Live · Apple Speech
+   - Native Whisper · 현재 recommended native model
+2. **Cloud API**
+   - Standard API · 현재 `transcriptionModel`
+   - Realtime API · 현재 `realtimeStreamingModel` 또는 `Provider default`
+3. **Legacy mlx-whisper**
+   - 설치된 Legacy model 각각
+
+선택은 현재 `setNoteBrowserTranscriptionChoice(_:)` 경로를 사용해 서로 배타적인 기존 booleans를 설정한다 (`Sources/AppState.swift:1151-1263`). 별도의 parallel transcription path를 만들지 않는다.
+
+### Readiness and unavailable choices
+
+현재 availability 조건을 그대로 사용한다 (`Sources/AppState.swift:863-935`).
+
+- Standard API: resolved transcription API key 필요
+- Realtime API: key 필요, `System Default + System Audio`에서는 사용 불가
+- Native Whisper: native model 설치 필요
+- Apple Live: `System Default + System Audio`에서는 사용 불가
+- Legacy: 해당 model 설치 필요
+
+resolved transcription key는 현재와 같이 Transcription override key를 우선하고, override가 비어 있으면 common Cloud key를 사용한다 (`Sources/AppState.swift:2181-2184`). API key가 없을 때도 dropdown 자체와 API model entries를 숨기지 않는다. Standard/Realtime API entries만 기존 unavailable reason과 함께 비활성화하고, Local 및 설치된 Legacy entries는 계속 선택 가능하다.
+
+현재 persisted choice가 unavailable API choice라면 Transcription 카드 안에 다음 의미의 inline 안내를 표시한다.
+
+> Cloud transcription requires an API key. Add one in Cloud Provider or use the transcription override in Details.
+
+이 안내는 선택값을 자동 변경하거나 fallback을 새로 실행하지 않는다.
+
+Native Whisper처럼 설치로 해결 가능한 unavailable choice는 dropdown에 보이되 `Download required` 상태를 함께 표시한다. 사용자가 선택하면 runtime choice를 즉시 unavailable 상태로 바꾸지 않고, view-local pending Native model ID를 설정해 dropdown 바로 아래에 관리 영역을 연다. Dropdown button은 실제 active choice label을 계속 표시한다.
+
+- Native 항목 클릭만으로 다운로드를 자동 시작하지 않음
+- Download 클릭 → existing AppState Native installer 시작
+- 다운로드 중 다른 Transcription choice 선택 → active choice와 pending management selection 변경, 다운로드는 계속 진행
+- 다운로드 중 다른 Settings tab 이동 → 다운로드는 AppState에서 계속 진행
+- Models로 돌아와 다운로드 중인 Native 항목 클릭 → 현재 progress와 Cancel action 복원
+- 다운로드 성공 + 같은 Native management flow를 계속 보고 있음 → 기존 `setNoteBrowserTranscriptionChoice`로 선택 확정
+- 다운로드 성공 + 다른 모델 또는 Settings tab으로 이동함 → 설치만 완료하고 active choice 유지
+- 명시적 Cancel / failure → current active choice 유지
+- Settings window 닫기 → 기존처럼 다운로드 취소 및 partial file cleanup
+- audio input incompatibility → 이유를 표시하고 current active choice 유지
+
+이 pending state는 view-local이며 저장하지 않는다. runtime fallback 규칙을 바꾸지 않는다. Cloud key가 없는 API choice는 pending management 대상으로 취급하지 않고 menu item 자체를 비활성화한다.
+
+### Spoken Language
+
+현재 `transcriptionLanguage` 전체 option과 `Auto Detect`를 Transcription details로 이동한다. speech recognition hint라는 의미와 persisted code를 그대로 유지한다 (`Sources/SettingsView.swift:1765-1779`).
+
+### Realtime API availability
+
+Realtime은 현재 `realtimeStreamingEnabled`와 `TranscriptionBackendChoice`가 결정하는 기존 Transcription choice로 표현한다.
+
+- 현재 Realtime 선택과 model field를 유지한다.
+- 빈 model은 `Provider default`라는 현재 의미를 유지한다.
+- 기존 availability 조건과 fallback 경로를 그대로 표시한다.
+
+현재 UI pass는 Realtime menu visibility preference, 새 key, migration을 추가하지 않는다. 이러한 availability preference 설계는 Future work다.
+
+### Transcription provider override
+
+현재 `transcriptionAPIURL`과 `transcriptionAPIKey`를 details에 유지한다.
+
+- 둘 다 optional
+- 빈 URL → Cloud Base URL 사용
+- 빈 key → common Cloud API Key 사용
+- `Clear` 동작 유지
+- Standard와 Realtime transcription에만 적용
+- Post-processing, Edit Mode, Context에는 적용하지 않음
+
+현재 resolution rule을 그대로 사용한다 (`Sources/AppState.swift:2176-2184`).
+
+### Native Whisper dropdown management
+
+현재 `NativeWhisperModelCatalog.all`의 모든 model을 main Transcription dropdown의 Local section에 표시한다. 현재 catalog에는 recommended Native model 한 개가 있지만, 향후 Native model 추가 시 동일한 pending-management 흐름을 사용한다.
+
+Installed Native model은 정상 selectable choice다. 미설치·partial·corrupt Native model도 dropdown에 보이지만 클릭 시 active choice를 변경하지 않고 contextual management 영역을 연다.
+
+Dropdown 바로 아래의 management 영역은 현재 `NativeWhisperModelRowView`가 제공하는 모든 lifecycle 상태를 유지한다.
+
+- model description 및 approximate size
+- Download
+- byte/progress display
+- indeterminate/determinate progress
+- hover/focus cancel
+- canceled 상태와 다시 Download
+- Installed
+- delete confirmation
+- Delete Model
+- error message
+- Settings가 닫힐 때 download cancel 및 partial file cleanup
+
+별도 Transcription Details의 `Local Options` Native block은 제거한다. Native lifecycle UI는 dropdown 아래의 contextual management 영역에만 존재한다. 관리 영역은 radio/selection control을 표시하지 않는다.
+
+#### Pending Native selection
+
+`pendingNativeModelID`는 `ModelsSettingsView`의 view-local state다.
+
+- 미설치 Native menu item 클릭 → pending ID 설정, active choice 유지
+- installed Native menu item 클릭 → pending ID 설정 및 existing setter로 active choice 즉시 변경
+- 다른 available choice 선택 → pending ID 제거
+- Native 다운로드 중 다른 Settings tab으로 이동 → view-local pending ID는 사라지지만 AppState download는 계속됨
+- Models tab 복귀 후 다운로드 중 Native item 클릭 → management 영역 다시 열림
+
+다운로드 시작 시 pending Native model ID를 별도로 기억한다. completion에서 자동 선택하려면 다음 조건을 모두 만족해야 한다.
+
+1. install result가 성공
+2. management 영역이 같은 Native model을 계속 가리킴
+3. 사용자가 그 사이 다른 Transcription choice를 선택하지 않음
+4. Models tab이 여전히 active
+
+하나라도 충족하지 않으면 install만 완료하고 current active choice를 유지한다.
+
+Native model을 삭제했을 때 현재 선택이 unavailable해지면 기존 normalization/fallback을 실행한다. active가 아닌 Native model 삭제는 active choice를 변경하지 않는다.
+
+### Legacy mlx-whisper
+
+Legacy mlx-whisper는 이번 Native-only 통합 범위에서 변경하지 않는다. 기존 `showLegacyMlxWhisperOptions`, `useLegacyMlxWhisper`, 설치 상태와 `TranscriptionBackendChoice`를 그대로 표현한다. 이 상태의 의미를 재해석하거나 새 visibility preference를 추가하지 않는다.
+
+`Manage Legacy models` disclosure는 기존 `showLegacyMlxWhisperOptions` binding을 사용한다.
+
+- `localWhisperPath`
+- Apple Speech를 제외한 현재 `TranscriptionModel.all` 전체
+- 각 model의 Download / progress / Cancel / canceled retry / Installed / Delete / error 상태
+
+설치된 Legacy 모델은 현재 availability와 선택 규칙에 따라 unified Transcription dropdown에 표현한다.
+
+- download 완료 → 현재 목록과 선택 가능 상태를 갱신
+- model 삭제 → dropdown에서 즉시 제거
+- 현재 구현과 동일하게 어느 Legacy cache를 삭제하든 `onDeleted` callback으로 Native Whisper 선택을 시도함
+- Native Whisper가 unavailable하면 기존 normalization/fallback order 사용
+- management disclosure를 닫아도 현재 choice, 설치 cache, management preference를 변경하지 않음
+- delete confirmation과 cache safety check 유지
+
+Legacy를 실제로 선택하는 행위는 unified Transcription dropdown에서 수행한다. 현재 Legacy model catalog에서 Medium/Small을 포함한 어떤 model도 삭제하지 않는다.
+
+새 Legacy menu visibility preference, key, migration은 Future work다.
+
+### Audio import preservation
+
+Realtime choice로 audio file을 import할 때 Standard API를 사용하는 현재 동작, Apple Live choice에서 available Local Whisper를 고르는 현재 동작을 유지한다 (`Sources/AppState.swift:1087-1128`).
+
+## Post-processing
+
+### Positive toggle, same state
+
+행의 switch는 사용자 친화적인 positive label `Post-processing`을 사용하지만 저장값은 기존 `disablePostProcessing`의 inverse binding이다.
+
+```swift
+Binding(
+    get: { !appState.disablePostProcessing },
+    set: { appState.disablePostProcessing = !$0 }
+)
+```
+
+별도 migration이나 중복 enable key를 만들지 않는다.
+
+- Off → 일반 dictation은 raw transcript 사용
+- Voice Macro는 현재처럼 Post-processing을 우회
+- Edit Mode는 현재처럼 Post-processing toggle과 독립적으로 model service를 사용
+
+이 순서를 유지한다 (`Sources/AppState.swift:5221-5247`).
+
+현재 Post-processing model path는 common Cloud Provider만 사용한다. persisted common key가 없을 때는 다음 UI 규칙을 적용한다.
+
+- switch를 비활성화하되 inverse binding이 나타내는 persisted On/Off 모양은 유지
+- primary model dropdown 비활성화
+- Details의 fallback model dropdown 비활성화
+- Details 전체, Output Language, Preserve Exact Wording, Custom Vocabulary, prompt editor, Instruction Guard는 숨기거나 일괄 비활성화하지 않음
+- System Prompt test의 기존 key-based 비활성화 유지
+- API key 삭제 때문에 `disablePostProcessing`, primary/fallback model 또는 다른 option을 변경하지 않음
+
+persisted toggle이 Off이면 다음 의미의 안내를 표시한다.
+
+> Add an API key in Cloud Provider to enable Post-processing.
+
+persisted toggle이 On이면 다음 의미의 안내를 표시한다.
+
+> Post-processing is on, but cloud processing is unavailable until an API key is configured.
+
+유효한 key가 다시 저장되면 기존 persisted On 상태대로 switch가 다시 조작 가능해진다. 향후 Local backend가 추가되면 선택된 backend의 readiness로 switch와 해당 model group을 판단하되, 이번 pass에서는 backend state나 routing을 추가하지 않는다.
+
+### Primary and fallback model choices
+
+Primary와 fallback은 기존 model string storage를 그대로 사용한다.
+
+- `postProcessingModel`
+- `postProcessingFallbackModel`
+
+각 dropdown은 기존 Cloud model ID와 custom model ID를 보존한다. 기존 retry 조건, cooldown behavior, Cloud endpoint/key resolution은 바꾸지 않는다 (`Sources/PostProcessingService.swift:297-515`).
+
+backend storage key, Local Server choice, cross-backend primary/fallback routing은 Future work다.
+
+### Edit Mode dependency
+
+Post-processing details에 다음 안내를 둔다.
+
+> Edit Mode uses this primary model, fallback model, Output Language, and Custom Vocabulary. Invocation Style and Extra Modifier remain in Shortcuts.
+
+중요한 UI 규칙:
+
+- Post-processing이 Off이고 Edit Mode도 Off이면 model/details를 흐리게 표시하되 저장값은 유지한다.
+- Post-processing이 Off여도 Edit Mode가 On이면 model, fallback, Output Language, Custom Vocabulary를 활성 상태로 유지한다.
+- `customSystemPrompt`는 normal Post-processing에만 적용되고 Edit Mode의 command prompt를 대체하지 않는다.
+- `Instruction Guard`는 현재처럼 normal Post-processing 결과에 적용하며 Edit Mode 의미로 확장하지 않는다 (`Sources/PostProcessingService.swift:647-652`).
+
+### Output Language
+
+`Output Language`는 Post-processing details의 **유일한 위치**다.
+
+현재 option과 persisted value를 모두 유지한다.
+
+- Same as spoken language (`""`)
+- English
+- Korean
+- Japanese
+- Chinese
+- Spanish
+- French
+- German
+- Portuguese
+
+동작:
+
+- normal Post-processing의 output language
+- Preserve Exact Wording + language 지정 시 literal translation target
+- Edit Mode command transform의 output language
+- transcription backend와 독립
+
+Local transcription이라는 이유로 비활성화하지 않는다. Post-processing과 Edit Mode가 모두 Off일 때만 현재 선택을 보존한 채 비활성 상태와 설명을 표시한다.
+
+### Preserve Exact Wording
+
+현재 의미를 그대로 유지한다.
+
+- Off → normal system prompt cleanup
+- On + Output Language 없음 → API call 없이 trimmed raw transcript
+- On + Output Language 있음 → cleanup 없이 literal translation
+- translation 실패 → raw transcript fallback
+
+Post-processing이 Off이면 비활성화하되 저장값을 삭제하지 않는다 (`Sources/AppState.swift:5245-5266`).
+
+### Custom Vocabulary
+
+현재 editor, trim, comma/newline/semicolon 안내를 유지한다.
+
+- normal Post-processing에 사용
+- Edit Mode command transform에 사용
+- custom system prompt와 독립
+
+### System Prompt
+
+현재의 모든 상태와 action을 한 disclosure 안에 유지한다.
+
+- default/custom 상태
+- custom editor
+- `Using default` / `Using custom prompt`
+- last-modified date
+- newer default available notice
+- `View Default` / `Hide`
+- `Switch to Default`
+- `Reset to Default`
+- sample input
+- `Test System Prompt`
+- running/error/result
+- `Full prompt sent` disclosure
+
+테스트 readiness는 현재 Cloud Provider key와 기존 Post-processing model 경로 기준으로 판단한다. Local Server readiness는 Future work다.
+
+### Instruction Guard
+
+`Prevent dictated prompts from being executed` toggle과 현재 default-on 저장값을 유지한다. suspected instruction execution 시 retry/fallback/raw transcript로 돌아가는 현재 동작을 바꾸지 않는다.
+
+## Context
+
+### Positive toggle, same state
+
+행의 switch는 `Context`를 사용하되 기존 `disableContextCapture`의 inverse binding이다.
+
+```swift
+Binding(
+    get: { !appState.disableContextCapture },
+    set: { appState.disableContextCapture = !$0 }
+)
+```
+
+별도 enable key를 만들지 않는다.
+
+Off이면 일반 dictation의 app metadata, screenshot capture, Context LLM inference를 현재처럼 건너뛰며 일반 Context Capture를 위한 Screen Recording permission이 필요하지 않다 (`Sources/AppState.swift:6294-6304`). Edit Mode의 selected-text snapshot과 Edit Mode가 별도로 요구하는 permission 경로는 이 toggle과 독립적으로 유지한다 (`Sources/AppState.swift:4387-4412`).
+
+현재 Context model path는 common Cloud Provider를 사용한다. persisted common key가 없을 때는 다음 UI 규칙을 적용한다.
+
+- switch를 비활성화하되 inverse binding이 나타내는 persisted On/Off 모양은 유지
+- Context model dropdown 비활성화
+- Context Prompt, Screenshot Resolution 및 Details 전체를 숨기거나 일괄 비활성화하지 않음
+- Context Prompt test의 기존 key-based 비활성화 유지
+- API key 삭제 때문에 `disableContextCapture`, `contextModel`, prompt 또는 screenshot resolution을 변경하지 않음
+
+persisted toggle이 Off이면 다음 의미의 안내를 표시한다.
+
+> Add an API key in Cloud Provider to enable Context.
+
+persisted toggle이 On이면 다음 의미의 안내를 표시한다.
+
+> Context is on, but AI context analysis is unavailable until an API key is configured.
+
+`Context` 전체가 동작하지 않는다고 표현하지 않는다. runtime은 key가 없을 때도 현재의 app/window metadata와 non-LLM fallback context를 만들 수 있기 때문이다 (`Sources/AppContextService.swift:124-154`). 이번 UI pass는 그 fallback을 변경하지 않는다. 향후 Local backend가 추가되면 선택된 backend readiness로 switch와 model group을 판단한다.
+
+### Model choice
+
+- `contextModel` string을 그대로 유지한다.
+- 기존 Cloud model ID와 custom model ID를 그대로 표시하고 선택한다.
+- 기존 Cloud endpoint, screenshot-first/text-only retry, non-LLM fallback 순서를 유지한다 (`Sources/AppContextService.swift:117-204`).
+
+`contextBackend` key, Local Server model, backend-aware readiness, capability 표시 변경은 Future work다.
+
+### Context Prompt
+
+현재의 모든 상태와 action을 유지한다.
+
+- default/custom 상태
+- custom editor
+- last-modified date
+- newer default available notice
+- View/Hide Default
+- Switch/Reset to Default
+- Test Context Prompt
+- frontmost app metadata와 screenshot capture
+- running/error/result
+- Full prompt sent
+
+테스트 readiness는 현재 Cloud Provider key와 기존 Context model 경로에 따라 판단한다. backend-aware readiness는 Future work다.
+
+### Screenshot Resolution
+
+현재 option을 그대로 유지한다.
+
+- 1024 px
+- 768 px
+- 640 px
+- 512 px
+- default/custom 상태
+- Reset to Default
+
+## Shortcuts > Clipboard delivery
+
+현재 `Disable Auto Paste`를 삭제하지 않는다. model 설정과 독립적인 결과 전달 동작이므로 Models에서 제거하고 `Shortcuts > Clipboard`의 첫 옵션으로 이동한다.
+
+positive UI label:
+
+- `Paste Automatically`
+
+저장값은 기존 `disableAutoPaste` inverse binding을 사용한다. Off이면 현재처럼 clipboard에만 복사하고 사용자가 직접 paste한다.
+
+기존 Clipboard의 restore/history, `press enter` voice command는 Auto Paste 아래에 그대로 유지하며 동작을 변경하지 않는다.
+
+## Future work — Runtime routing (not implemented in this UI pass)
+
+### Future work — Endpoint resolution (not implemented in this UI pass)
+
+```swift
+struct LLMEndpointConfiguration: Equatable, Codable {
+    var baseURL: String
+    var apiKey: String
+}
+
+struct ResolvedLLMChoice: Equatable {
+    var modelID: String
+    var endpoint: LLMEndpointConfiguration
+}
+
+func endpoint(for backend: LLMBackend) -> LLMEndpointConfiguration {
+    switch backend {
+    case .cloud:
+        return .init(baseURL: apiBaseURL, apiKey: apiKey)
+    case .localServer:
+        return .init(baseURL: localAIBaseURL, apiKey: localAIAPIKey)
+    }
+}
+```
+
+- Transcription routing은 기존 별도 경로 유지
+- Post-processing primary/fallback은 각각 `ResolvedLLMChoice`로 resolve하고 각 choice endpoint를 사용
+- Edit Mode는 Post-processing primary/fallback choice 공유
+- Context는 Context choice endpoint 사용
+- `LLMAPITransport`는 그대로 재사용
+- Local Server key가 비어 있으면 Authorization header를 생략
+- Cloud request는 현재 key gate와 Authorization header 구성을 유지
+- Context는 `apiKey.isEmpty`가 아니라 selected backend readiness로 LLM inference 여부를 판단
+- model-specific `ModelConfiguration.config(for:)`와 think-tag cleanup은 그대로 적용
+
+### Future work — Cross-backend fallback and cooldown (not implemented in this UI pass)
+
+현재 `LLMCooldownManager.effectivePrimary(baseURL:primary:fallback:)`는 두 model이 하나의 endpoint를 공유한다고 가정한다. primary/fallback이 서로 다른 backend를 선택할 수 있으므로 choice-aware API를 추가한다.
+
+```swift
+func effectiveChoice(
+    primary: ResolvedLLMChoice,
+    fallback: ResolvedLLMChoice?
+) -> ResolvedLLMChoice?
+```
+
+각 cooldown identity는 현재와 동일하게 `normalized baseURL + normalized modelID`다. primary가 cooldown이면 fallback 자신의 endpoint identity를 검사한다. 실제 retry request도 선택된 fallback endpoint/key로 보낸다. 기존 same-endpoint Cloud/Cloud 동작과 persisted cooldown key 형식은 유지한다.
+
+### Snapshot consistency across every invocation path
+
+녹음 시작 또는 작업 시작 시 model choice와 resolved endpoint를 함께 snapshot하여 작업 도중 Settings 변경이 진행 중인 요청을 바꾸지 않게 한다.
+
+반드시 포함할 경로:
+
+- normal recording completion의 `PostProcessingService` construction
+- Edit Mode transform
+- audio import의 `AudioImportTaskConfiguration`
+- history retry의 `RetrySnapshot` 및 service construction
+- System Prompt test
+- Context capture 및 Context Prompt test
+
+`AudioImportTaskConfiguration`과 retry/recording snapshot에는 primary와 fallback의 backend/endpoint 정보가 모두 들어가야 한다. audio import나 history retry가 현재 global Cloud URL/key를 다시 읽어 Local choice를 잃어서는 안 된다.
+
+`contextBackend`, `localAIBaseURL`, `localAIAPIKey`, `contextModel`, Cloud endpoint 값이 바뀌면 cached `contextService`를 재생성한다. endpoint 전환 직후 시작한 다음 Context capture는 새 configuration을 사용한다.
+
+### Failure behavior preservation
+
+- Standard/Realtime transcription availability 및 fallback order 유지
+- Realtime 실패 시 file-based Standard API fallback 유지
+- Post-processing 실패 시 raw transcript fallback 유지
+- Preserve Exact Wording translation 실패 시 raw transcript fallback 유지
+- Edit Mode 실패 시 selected text fallback 유지
+- Context vision 실패 시 text-only retry, 이후 non-LLM fallback 유지
+- rate-limit cooldown은 `baseURL + model` 단위의 현재 의미 유지
+
+## Future work — Persistence and migration additions (not implemented in this UI pass)
+
+### Existing properties and physical storage retained
+
+기존 property와 실제 storage account/key를 rename하거나 삭제하지 않는다.
+
+| AppState property | Existing physical storage |
+|---|---|
+| `apiKey` | `AppSettingsStorage`: `groq_api_key` |
+| `apiBaseURL` | `AppSettingsStorage`: `api_base_url` |
+| `transcriptionAPIURL` | `AppSettingsStorage`: `transcription_api_url` |
+| `transcriptionAPIKey` | `AppSettingsStorage`: `transcription_api_key` |
+| `transcriptionModel` | `UserDefaults`: `transcription_model` |
+| `postProcessingModel` | `UserDefaults`: `post_processing_model` |
+| `postProcessingFallbackModel` | `UserDefaults`: `post_processing_fallback_model` |
+| `contextModel` | `UserDefaults`: `context_model` |
+| Realtime / Local / Legacy / enablement / language / prompt / screenshot properties | 현재 `AppState`의 기존 `UserDefaults` keys 그대로 |
+
+Cloud 및 Local credential은 동일한 `AppSettingsStorage` 정책을 사용한다. 이 저장소는 Application Support의 owner-only `.settings` 파일을 사용하므로, 새 Local credential도 임의로 `UserDefaults`에 넣지 않는다 (`Sources/KeychainStorage.swift:3-63`).
+
+### New additive storage
+
+`UserDefaults`:
+
+- `show_realtime_transcription_option`
+- `show_legacy_transcription_option`
+- `post_processing_backend`
+- `post_processing_fallback_backend`
+- `context_backend`
+
+`AppSettingsStorage`:
+
+- `local_ai_base_url`
+- `local_ai_api_key`
+
+### Migration rules
+
+1. backend key 없음 → Cloud
+2. `show_realtime_transcription_option` key 없음 → true; 현재 Realtime 선택도 그대로 유지
+3. `show_legacy_transcription_option` key 없음 → true; 현재 설치된 Legacy choice와 선택 가능성 유지
+4. `showLegacyMlxWhisperOptions`와 `useLegacyMlxWhisper`는 기존 값을 그대로 유지하며 새 의미를 부여하지 않음
+5. 이번 migration은 기존 `migrateModelStorageKeys()`와 `loadStoredContextModel()`이 수행하는 현재 정규화 외에 model string을 추가로 rewrite하지 않음
+6. prompt, language, 기존 toggle, URL, key 값은 이번 migration 중 다시 쓰지 않음
+7. migration은 idempotent하며 기존 migration guard pattern을 따른다
+
+## Current-to-new 1:1 preservation map
+
+| Current option / behavior | New location | Preservation rule |
+|---|---|---|
+| API Key secure input | Cloud Provider | same stored key, validation, clear behavior |
+| API Base URL | Cloud Provider → Advanced | same default, custom value, reset |
+| Post-Processing Model | Post-processing card | same model ID and existing Cloud path; selector disabled without common Cloud key |
+| Post-Processing Fallback Model | Post-processing → Details | same model ID, existing Cloud path, and fallback conditions; selector disabled without common Cloud key |
+| Context Model | Context card | same model ID and existing Cloud path; selector disabled without common Cloud key |
+| Transcription Local/API mode | Transcription dropdown | same `TranscriptionBackendChoice` adapter |
+| API Transcription Model | Transcription dropdown / Details | same predefined and Custom model IDs |
+| Transcription Language | Transcription → Details | same options and persisted code |
+| Transcription API URL | Transcription → Details → Provider Override | same optional fallback behavior |
+| Transcription API Key | Transcription → Details → Provider Override | same optional fallback behavior |
+| Realtime on/off | Transcription dropdown | existing `realtimeStreamingEnabled` and selected Realtime behavior preserved; no new availability key |
+| Realtime model | Transcription → Details | empty remains Provider default |
+| Apple Speech | Transcription dropdown | built-in, no download/delete |
+| Native Whisper selection | Transcription dropdown | installed model selects immediately; unavailable model opens view-local pending management without changing active choice |
+| Native download | Transcription dropdown → contextual management | preserved; selecting item alone does not start download |
+| Native progress / cancel | Transcription dropdown → contextual management | preserved, keyboard accessibility included; survives model/tab navigation |
+| Native canceled retry | Transcription dropdown → contextual management | preserved |
+| Native installed state | Transcription dropdown / contextual management | preserved; completion auto-selects only while the same pending flow remains active |
+| Native delete confirmation/delete/error | Transcription dropdown → contextual management | preserved |
+| Settings-close native cancellation/partial cleanup | lifecycle | preserved |
+| Show legacy mlx-whisper management | Transcription → Details | same key and management-visibility meaning; does not hide installed choices |
+| Legacy model catalog | Transcription → Details | all existing models retained |
+| Legacy binary path | Transcription → Details | same default/custom path |
+| Legacy download/progress/cancel/retry | Transcription → Details | preserved per model |
+| Legacy installed/delete/error | Transcription → Details | preserved per model |
+| Installed Legacy dropdown entries | Transcription dropdown | existing availability, installed state, and `showLegacyMlxWhisperOptions` behavior preserved; no new visibility key |
+| Delete selected Legacy fallback | Transcription routing | Native first, existing fallback order thereafter |
+| Output Language | Post-processing → Details | one location; not tied to transcription backend |
+| Disable Post-Processing | Post-processing card toggle | inverse binding and persisted visual value retained; disabled without common Cloud key |
+| Preserve Exact Wording | Post-processing → Details | same raw/literal translation behavior |
+| Disable Auto Paste | Shortcuts → Clipboard | inverse binding, same clipboard-only behavior |
+| Disable Context Capture | Context card toggle | inverse binding and persisted visual value retained; disabled without common Cloud key; same fallback/permission behavior |
+| Custom Vocabulary | Post-processing → Details | same editor and Post/Edit usage |
+| Custom System Prompt editor | Post-processing → Details | same default/custom storage |
+| System Prompt newer-default notice/actions | Post-processing → Details | preserved |
+| Test System Prompt/result/full prompt | Post-processing → Details | preserved; existing Cloud readiness |
+| Instruction Guard | Post-processing → Details | same default and post-processing-only behavior |
+| Custom Context Prompt editor | Context → Details | same default/custom storage |
+| Context Prompt newer-default notice/actions | Context → Details | preserved |
+| Screenshot Resolution | Context → Details | same options/default/reset |
+| Test Context Prompt/result/full prompt | Context → Details | preserved; existing Cloud readiness |
+| Edit Mode provider/model dependency | Post-processing inline note | behavior unchanged; invocation controls remain in Shortcuts |
+| Custom model string | every LLM/Cloud transcription dropdown | `Custom…` retained; never discard unknown IDs |
+
+## Interaction and accessibility
+
+- disclosure는 `DisclosureGroup` 또는 동일한 keyboard-accessible control 사용
+- toggle, picker, download cancel, delete action에 accessibility label 제공
+- 상태를 color만으로 표현하지 않고 icon + text 병행
+- destructive model deletion은 현재와 같은 confirmation 유지
+- download 중 Settings를 닫을 때의 취소 안내 유지
+- focus 중인 custom field 값은 외부 state update로 덮어쓰지 않음
+- validation, download, test 실행 중 즉시 status feedback 제공
+- disabled Cloud control은 바로 아래에서 icon + text로 이유를 설명
+- persisted On 상태가 readiness 부족으로 disabled여도 switch의 On 모양을 유지
+- Reduce Motion 환경에서는 disclosure/layout 전환에 큰 slide motion을 사용하지 않음
+- 모든 새 user-facing string은 기존 en/ko localization 체계를 따른다
+
+## Implementation boundaries
+
+현재 UI pass는 existing `AppState`와 runtime behavior를 재사용하며, 다음 영역으로만 구현 diff를 제한한다.
+
+- `Sources/SettingsView.swift`
+  - `ModelsSettingsView`를 Cloud Provider, Transcription, Post-processing, Context peer cards로 재배치
+  - view-local common Cloud key readiness 계산
+  - 기존 provider, feature section, disclosure, prompt/model view 재사용
+  - switch 및 Cloud model selector에 readiness 기반 `.disabled(...)`와 inline reason 적용
+- 기존 localization resources
+  - 새 UI 문구의 en/ko localization
+- UI tests
+  - 모델 화면의 정보 구조, disclosure, 기존 state 표시, model management lifecycle 보존
+- documentation
+  - 이 보존표와 UI-only 경계의 유지
+
+`Sources/AppState.swift`, services, cooldown manager, audio import/recording/retry configuration, persistence keys, migration, endpoint routing, backend-aware runtime readiness, and cross-backend fallback are not changed in this pass. They are Future work. Settings 진입 시 key를 재검증하는 network request도 추가하지 않는다.
+
+## Verification matrix
+
+### Upgrade preservation
+
+기존 설정 fixture를 만든 뒤 새 버전을 시작해 모든 값이 같은지 검증한다.
+
+- Cloud URL/key + transcription override
+- Local/Cloud/Realtime/Apple/Native/Legacy active choice
+- custom model IDs
+- all toggles
+- prompt values and last-modified dates
+- language values
+- installed model selection
+
+### Current UI preservation combinations
+
+최소 다음 기존 UI와 lifecycle 보존 조합을 검증한다.
+
+1. Local Native transcription + Cloud Post-processing + Cloud Context
+2. Apple Live + Post-processing Off + Context Off
+3. Standard Cloud transcription override + common Cloud Post-processing
+4. Realtime + Cloud Post-processing + Context
+5. Legacy installed model + Cloud Post-processing
+6. Post-processing Off + Edit Mode On
+7. Preserve Exact Wording with no Output Language
+8. Preserve Exact Wording with translation language
+9. Context screenshot failure → 기존 text-only retry와 non-LLM fallback 설명이 유지됨
+10. no common key + no transcription override → API transcription entries disabled, Local/installed Legacy entries remain selectable
+11. no common key + transcription override key → API transcription entries remain selectable
+12. Post-processing persisted Off + no common key → Off switch remains visible but disabled; enable-key explanation shown
+13. Post-processing persisted On + key deleted → On switch remains visible but disabled; unavailable explanation shown; persisted state unchanged
+14. Context persisted Off + no common key → Off switch remains visible but disabled; enable-key explanation shown
+15. Context persisted On + key deleted → On switch remains visible but disabled; AI-analysis unavailable explanation shown; non-LLM fallback unchanged
+16. common key validation failure while an older persisted key exists → older readiness and stored key remain unchanged
+
+### Future work verification (not implemented in this UI pass)
+
+- Standard Cloud transcription + Local Server Post-processing + Cloud Context
+- Local Context endpoint failure → non-LLM fallback
+- primary/fallback on different backends, 각 endpoint의 cooldown identity와 request 확인
+- Local Server Post-processing으로 audio import
+- Local Server Post-processing으로 history retry
+- recording 중 Settings backend 변경 시 시작 시점 snapshot 유지
+- keyless Local Server Context inference 및 Authorization header 생략
+- Context backend/Local URL/key 변경 후 다음 capture가 새 service 사용
+
+### Model management
+
+- unavailable Native dropdown item click → active model unchanged → contextual Download UI shown
+- Native Download → progress → 다른 model 선택 → download continues → completion installs without auto-selection
+- Native Download → progress → 다른 Settings tab 이동 → download continues → returning and reselecting item restores progress UI
+- Native Download → progress → same pending flow remains active → completion selects Native
+- Native Cancel → retry → Installed → Delete
+- Settings close during Native download cleans partial file
+- each Legacy model Download → progress → Cancel → retry → Installed → dropdown entry
+- deleting unselected Legacy removes dropdown entry and preserves current implementation's Native selection callback
+- deleting selected Legacy applies fallback
+- hiding Legacy management does not hide installed dropdown choices or change current selection
+- unavailable Realtime/Apple choices with `System Default + System Audio`
+
+### UI preservation audit
+
+구현 PR에서 이 문서의 1:1 표 각 행을 다음 중 하나로 표시한다.
+
+- `present and verified`
+- `moved and verified`
+- `not applicable` — 근거 필수
+
+누락 행이 하나라도 있으면 구현 완료로 간주하지 않는다.
+
+## Acceptance criteria
+
+- Models 화면은 Cloud Provider, Transcription, Post-processing, Context의 네 peer card로 구성되며 `AI Models` 통합 카드를 사용하지 않는다.
+- Transcription은 항상 켜져 있고 하나의 dropdown에서 현재 지원되는 method/model을 선택한다.
+- API key가 없어도 Transcription dropdown은 유지되며 API entries만 비활성화되고 Local/installed Legacy entries는 계속 선택 가능하다.
+- Post-processing과 Context는 common Cloud key가 구성됐을 때 직접 켜고 끌 수 있다.
+- common Cloud key가 없으면 Post-processing/Context switch와 Cloud model selector가 비활성화되고 control 바로 아래에 이유가 표시된다.
+- key 삭제 전 persisted On인 switch는 On 모양을 유지한 채 비활성화되며 저장값을 자동으로 Off로 바꾸지 않는다.
+- 모든 model choice는 dropdown이며 custom model ID를 계속 지원한다.
+- 모든 현재 옵션과 모델 관리 action이 새 UI에 존재한다.
+- Local transcription은 기존 Cloud Post-processing, Context, Edit Mode 설정을 막지 않는다.
+- Output Language는 단 한 곳에 있고 transcription backend 때문에 비활성화되지 않는다.
+- Realtime과 Legacy는 기존 `realtimeStreamingEnabled`, `showLegacyMlxWhisperOptions`, 설치 상태, availability 규칙을 보존한 채 Transcription dropdown에 나타난다.
+- Legacy dropdown에는 설치된 model만 나타난다.
+- 모든 Native catalog model이 Transcription dropdown에 나타나며, unavailable Native 선택은 active model을 바꾸지 않고 dropdown 아래 contextual lifecycle UI를 연다.
+- Native 다운로드는 다른 model 또는 Settings tab으로 이동해도 계속되며, Settings window를 닫을 때만 기존처럼 취소된다.
+- Native/Legacy 다운로드, 취소, 설치, 삭제, fallback이 유지되며, Legacy 관리 구조는 이번 Native-only 통합에서 변경하지 않는다.
+- 기존 설정으로 업그레이드했을 때 사용자의 active behavior가 바뀌지 않는다.
+- 기존 Cloud 사용자는 추가 설정 없이 이전과 동일하게 동작한다.
+- Cloud Provider status는 persisted key presence와 현재 Save validation 상태만 표현하며 Settings 진입 시 상시 재검증하지 않는다.
+- Context의 keyless app/window metadata 및 non-LLM fallback runtime은 그대로 유지한다.
+- 구현 diff는 Settings UI, localization, tests, documentation으로 제한된다.
+- 기존 runtime 및 persistence 파일은 변경되지 않는다.


### PR DESCRIPTION
## Summary

- reorganize Models Settings into separate Cloud Provider, Transcription, Post-processing, and Context cards
- present API, Native Whisper, Apple Speech, and opt-in Legacy choices through a model-first transcription menu while preserving existing runtime routing and saved values
- add API-key readiness states, contextual Native Whisper download management, and a download cancellation confirmation when Settings closes
- move automatic paste to Shortcuts > Clipboard and keep advanced model configuration under feature-specific Details sections
- add English/Korean localization and source-level regression coverage for the redesigned settings

## Verification

- `make test`
- `git diff --check`
- `make all APP_NAME="Quill Dev" BUNDLE_ID="com.woosublee.quill.dev" CODESIGN_IDENTITY="Quill"`
- `xattr -cr build/ && codesign --verify --deep --strict --verbose=2 "build/Quill Dev.app"`
- manually verified the isolated Quill Dev build

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 모델 설정 화면을 Cloud Provider, 전사, 후처리, 컨텍스트 영역으로 재구성했습니다.
  - 전사 모델 선택과 사용자 지정 표준 API 모델 설정을 개선했습니다.
  - API 키 상태와 클라우드 기능 사용 가능 여부를 설정 화면에서 안내합니다.
  - Native Whisper 다운로드 중 설정을 닫을 때 취소 및 부분 파일 삭제 여부를 선택할 수 있습니다.

- **개선 사항**
  - 출력 언어, 원문 유지, 실시간 전사 관련 설정과 안내 문구를 개선했습니다.
  - 한국어 설정 화면 번역을 확장하고 용어를 정비했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->