### PR TITLE
Stream combined audio mixdown with bounded memory

### DIFF
--- a/Sources/AudioMixdownService.swift
+++ b/Sources/AudioMixdownService.swift
@@ -8,32 +8,47 @@ public struct AudioMixdownService {
     /// activity) avoids the per-sample amplitude jumps that produced audible
     /// crackle when the microphone was recorded alongside system audio.
     private static let mixHeadroom: Float = 0.8
+    private static let streamingFrameCount = 4_096
 
     public init() {}
 
     public func mix(microphoneURL: URL, systemAudioURL: URL) throws -> URL {
-        let microphoneSamples = try readSamples(from: microphoneURL)
-        let systemAudioSamples = try readSamples(from: systemAudioURL)
-        let outputFrameCount = max(microphoneSamples.count, systemAudioSamples.count)
-        let systemGain = systemAudioGain(microphoneSamples: microphoneSamples, systemAudioSamples: systemAudioSamples)
-
-        var mixedSamples: [Int16] = []
-        mixedSamples.reserveCapacity(outputFrameCount)
-
-        for index in 0..<outputFrameCount {
-            // A source that has run out (the shorter recording) contributes
-            // silence, so the same continuous mix runs across the whole file
-            // without an amplitude step at the boundary.
-            let microphoneSample = index < microphoneSamples.count ? microphoneSamples[index] : 0
-            let systemAudioSample = index < systemAudioSamples.count ? systemAudioSamples[index] : 0
-            mixedSamples.append(mix(microphoneSample: microphoneSample, systemAudioSample: systemAudioSample, systemGain: systemGain))
-        }
+        let microphoneScan = try scanSamples(at: microphoneURL)
+        let systemAudioScan = try scanSamples(at: systemAudioURL)
+        let outputFrameCount = max(
+            microphoneScan.frameCount,
+            systemAudioScan.frameCount
+        )
+        let outputDataByteCount = try validatedOutputDataByteCount(
+            frameCount: outputFrameCount
+        )
+        let systemGain = systemAudioGain(
+            microphoneStatistics: microphoneScan.statistics,
+            systemAudioStatistics: systemAudioScan.statistics
+        )
 
         let outputURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
             .appendingPathExtension("wav")
-        try writeWAV(samples: mixedSamples, to: outputURL)
-        return outputURL
+        do {
+            try writeStreamingMix(
+                microphoneURL: microphoneURL,
+                systemAudioURL: systemAudioURL,
+                outputURL: outputURL,
+                outputFrameCount: outputFrameCount,
+                outputDataByteCount: outputDataByteCount,
+                systemGain: systemGain
+            )
+            let validationReader = try StreamingPCM16WAVReader(url: outputURL)
+            defer { try? validationReader.close() }
+            guard validationReader.frameCount == outputFrameCount else {
+                throw AudioMixdownServiceError.invalidWAVFile
+            }
+            return outputURL
+        } catch {
+            try? FileManager.default.removeItem(at: outputURL)
+            throw error
+        }
     }
 
     /// Concatenates 16 kHz mono 16-bit PCM WAV segments end to end into a single
@@ -74,41 +89,122 @@ public struct AudioMixdownService {
         return outputURL
     }
 
-    private func systemAudioGain(microphoneSamples: [Int16], systemAudioSamples: [Int16]) -> Float {
-        let systemRMS = activeRMS(systemAudioSamples)
+    private func scanSamples(at url: URL) throws -> SampleScan {
+        var reader = try StreamingPCM16WAVReader(url: url)
+        defer { try? reader.close() }
+
+        var statistics = SampleStatistics()
+        while true {
+            let samples = try reader.readChunk(
+                maximumFrameCount: Self.streamingFrameCount
+            )
+            guard !samples.isEmpty else { break }
+            statistics.consume(samples)
+        }
+        return SampleScan(
+            frameCount: reader.frameCount,
+            statistics: statistics
+        )
+    }
+
+    private func writeStreamingMix(
+        microphoneURL: URL,
+        systemAudioURL: URL,
+        outputURL: URL,
+        outputFrameCount: UInt64,
+        outputDataByteCount: UInt32,
+        systemGain: Float
+    ) throws {
+        var microphoneReader = try StreamingPCM16WAVReader(url: microphoneURL)
+        defer { try? microphoneReader.close() }
+        var systemAudioReader = try StreamingPCM16WAVReader(url: systemAudioURL)
+        defer { try? systemAudioReader.close() }
+
+        try wavHeader(dataByteCount: 0).write(to: outputURL, options: .atomic)
+        let outputHandle = try FileHandle(forWritingTo: outputURL)
+        defer { try? outputHandle.close() }
+        try outputHandle.seekToEnd()
+
+        var remainingOutputFrames = outputFrameCount
+        while remainingOutputFrames > 0 {
+            let frameCount = Int(min(
+                UInt64(Self.streamingFrameCount),
+                remainingOutputFrames
+            ))
+            let microphoneSamples = try microphoneReader.readChunk(
+                maximumFrameCount: frameCount
+            )
+            let systemAudioSamples = try systemAudioReader.readChunk(
+                maximumFrameCount: frameCount
+            )
+            var outputData = Data()
+            outputData.reserveCapacity(frameCount * MemoryLayout<Int16>.size)
+
+            for index in 0..<frameCount {
+                let microphoneSample = index < microphoneSamples.count
+                    ? microphoneSamples[index]
+                    : 0
+                let systemAudioSample = index < systemAudioSamples.count
+                    ? systemAudioSamples[index]
+                    : 0
+                let mixedSample = mix(
+                    microphoneSample: microphoneSample,
+                    systemAudioSample: systemAudioSample,
+                    systemGain: systemGain
+                )
+                outputData.appendUInt16LE(UInt16(bitPattern: mixedSample))
+            }
+            try outputHandle.write(contentsOf: outputData)
+            remainingOutputFrames -= UInt64(frameCount)
+        }
+
+        try outputHandle.seek(toOffset: 0)
+        try outputHandle.write(
+            contentsOf: wavHeader(dataByteCount: outputDataByteCount)
+        )
+    }
+
+    private func validatedOutputDataByteCount(
+        frameCount: UInt64
+    ) throws -> UInt32 {
+        let maximumDataByteCount = UInt64(UInt32.max - 36)
+        let bytesPerFrame = UInt64(MemoryLayout<Int16>.size)
+        guard frameCount <= maximumDataByteCount / bytesPerFrame else {
+            throw AudioMixdownServiceError.outputTooLarge
+        }
+        return UInt32(frameCount * bytesPerFrame)
+    }
+
+    private func systemAudioGain(
+        microphoneStatistics: SampleStatistics,
+        systemAudioStatistics: SampleStatistics
+    ) -> Float {
+        let systemRMS = systemAudioStatistics.activeRMS
         guard systemRMS > 0 else { return 1 }
 
-        let microphoneRMS = activeRMS(microphoneSamples)
+        let microphoneRMS = microphoneStatistics.activeRMS
         guard microphoneRMS > 0 else { return 1 }
 
         let targetSystemRMS = microphoneRMS * 0.8
         let requestedGain = min(2, max(1, targetSystemRMS / systemRMS))
-        return peakSafeGain(for: systemAudioSamples, requestedGain: requestedGain)
+        return peakSafeGain(
+            peak: systemAudioStatistics.peak,
+            requestedGain: requestedGain
+        )
     }
 
-    private func peakSafeGain(for samples: [Int16], requestedGain: Float) -> Float {
-        let peak = samples.map { abs(Int($0)) }.max() ?? 0
+    private func peakSafeGain(peak: Int, requestedGain: Float) -> Float {
         guard peak > 0 else { return requestedGain }
 
         let headroomGain = (Float(Int16.max) * 0.95) / Float(peak)
         return min(requestedGain, max(1, headroomGain))
     }
 
-    private func activeRMS(_ samples: [Int16]) -> Float {
-        var sum = Float(0)
-        var count = 0
-        for sample in samples {
-            let floatSample = Float(sample)
-            if abs(floatSample) > 32 {
-                sum += floatSample * floatSample
-                count += 1
-            }
-        }
-        guard count > 0 else { return 0 }
-        return sqrt(sum / Float(count))
-    }
-
-    private func mix(microphoneSample: Int16, systemAudioSample: Int16, systemGain: Float) -> Int16 {
+    private func mix(
+        microphoneSample: Int16,
+        systemAudioSample: Int16,
+        systemGain: Float
+    ) -> Int16 {
         let microphone = Float(microphoneSample) * Self.mixHeadroom
         let systemAudio = Float(systemAudioSample) * systemGain * Self.mixHeadroom
         return clampedInt16(Int((microphone + systemAudio).rounded()))
@@ -119,8 +215,8 @@ public struct AudioMixdownService {
     }
 
     /// Parses a 16 kHz mono 16-bit PCM WAV and returns just its `data` chunk
-    /// bytes (0-based copy), validating the format. Used both to decode samples
-    /// and to concatenate raw PCM without a per-sample round trip.
+    /// bytes (0-based copy), validating the format. Used by the existing input
+    /// switching concatenation path until segment recovery is implemented.
     private func pcmDataChunk(from url: URL) throws -> Data {
         let data = try Data(contentsOf: url)
         guard data.count >= 44 else {
@@ -140,7 +236,7 @@ public struct AudioMixdownService {
 
         while offset + 8 <= data.count {
             let chunkID = String(bytes: data[offset..<(offset + 4)], encoding: .ascii)
-            let chunkSize = Int(readUInt32LE(data, at: offset + 4))
+            let chunkSize = Int(data.readUInt32LE(at: offset + 4))
             let chunkStart = offset + 8
             let chunkEnd = chunkStart + chunkSize
             guard chunkEnd <= data.count else {
@@ -151,10 +247,10 @@ public struct AudioMixdownService {
                 guard chunkSize >= 16 else {
                     throw AudioMixdownServiceError.invalidWAVFile
                 }
-                audioFormat = readUInt16LE(data, at: chunkStart)
-                channelCount = readUInt16LE(data, at: chunkStart + 2)
-                sampleRate = readUInt32LE(data, at: chunkStart + 4)
-                bitsPerSample = readUInt16LE(data, at: chunkStart + 14)
+                audioFormat = data.readUInt16LE(at: chunkStart)
+                channelCount = data.readUInt16LE(at: chunkStart + 2)
+                sampleRate = data.readUInt32LE(at: chunkStart + 4)
+                bitsPerSample = data.readUInt16LE(at: chunkStart + 14)
             } else if chunkID == "data" {
                 sampleData = data[chunkStart..<chunkEnd]
             }
@@ -170,20 +266,6 @@ public struct AudioMixdownService {
             throw AudioMixdownServiceError.unsupportedWAVFormat
         }
         return Data(sampleData)
-    }
-
-    private func readSamples(from url: URL) throws -> [Int16] {
-        let sampleData = try pcmDataChunk(from: url)
-        var samples: [Int16] = []
-        samples.reserveCapacity(sampleData.count / 2)
-        var sampleOffset = sampleData.startIndex
-        while sampleOffset + 1 < sampleData.endIndex {
-            let low = UInt16(sampleData[sampleOffset])
-            let high = UInt16(sampleData[sampleData.index(after: sampleOffset)]) << 8
-            samples.append(Int16(bitPattern: high | low))
-            sampleOffset = sampleData.index(sampleOffset, offsetBy: 2)
-        }
-        return samples
     }
 
     /// 44-byte canonical header for 16 kHz mono 16-bit PCM WAV.
@@ -210,24 +292,181 @@ public struct AudioMixdownService {
         data.appendUInt32LE(value)
         return data
     }
+}
 
-    private func writeWAV(samples: [Int16], to url: URL) throws {
-        var data = wavHeader(dataByteCount: UInt32(samples.count * MemoryLayout<Int16>.size))
+private struct SampleScan {
+    let frameCount: UInt64
+    let statistics: SampleStatistics
+}
+
+private struct SampleStatistics {
+    private var activeSquareSum: Float = 0
+    private var activeSampleCount = 0
+    private(set) var peak = 0
+
+    var activeRMS: Float {
+        guard activeSampleCount > 0 else { return 0 }
+        return sqrt(activeSquareSum / Float(activeSampleCount))
+    }
+
+    mutating func consume(_ samples: [Int16]) {
         for sample in samples {
-            data.appendUInt16LE(UInt16(bitPattern: sample))
+            let integerSample = Int(sample)
+            peak = max(peak, abs(integerSample))
+
+            let floatSample = Float(sample)
+            if abs(floatSample) > 32 {
+                activeSquareSum += floatSample * floatSample
+                activeSampleCount += 1
+            }
         }
-        try data.write(to: url, options: .atomic)
+    }
+}
+
+private struct StreamingPCM16WAVReader {
+    let frameCount: UInt64
+
+    private let handle: FileHandle
+    private var remainingDataByteCount: UInt64
+
+    init(url: URL) throws {
+        let openedHandle = try FileHandle(forReadingFrom: url)
+        do {
+            let layout = try Self.parseLayout(from: openedHandle)
+            try openedHandle.seek(toOffset: layout.dataOffset)
+            handle = openedHandle
+            frameCount = layout.dataByteCount / UInt64(MemoryLayout<Int16>.size)
+            remainingDataByteCount = layout.dataByteCount
+        } catch {
+            try? openedHandle.close()
+            throw error
+        }
     }
 
-    private func readUInt16LE(_ data: Data, at offset: Int) -> UInt16 {
-        UInt16(data[offset]) | (UInt16(data[offset + 1]) << 8)
+    mutating func readChunk(maximumFrameCount: Int) throws -> [Int16] {
+        guard maximumFrameCount > 0, remainingDataByteCount > 0 else {
+            return []
+        }
+        let requestedByteCount = min(
+            UInt64(maximumFrameCount * MemoryLayout<Int16>.size),
+            remainingDataByteCount
+        )
+        let data = try Self.readExactly(
+            Int(requestedByteCount),
+            from: handle
+        )
+        remainingDataByteCount -= requestedByteCount
+
+        var samples: [Int16] = []
+        samples.reserveCapacity(data.count / MemoryLayout<Int16>.size)
+        var offset = 0
+        while offset < data.count {
+            samples.append(Int16(bitPattern: data.readUInt16LE(at: offset)))
+            offset += MemoryLayout<Int16>.size
+        }
+        return samples
     }
 
-    private func readUInt32LE(_ data: Data, at offset: Int) -> UInt32 {
-        UInt32(data[offset])
-            | (UInt32(data[offset + 1]) << 8)
-            | (UInt32(data[offset + 2]) << 16)
-            | (UInt32(data[offset + 3]) << 24)
+    func close() throws {
+        try handle.close()
+    }
+
+    private static func parseLayout(from handle: FileHandle) throws -> WAVLayout {
+        let physicalByteCount = try handle.seekToEnd()
+        guard physicalByteCount >= 12 else {
+            throw AudioMixdownServiceError.invalidWAVFile
+        }
+        try handle.seek(toOffset: 0)
+        let riffHeader = try readExactly(12, from: handle)
+        guard String(bytes: riffHeader[0..<4], encoding: .ascii) == "RIFF",
+              String(bytes: riffHeader[8..<12], encoding: .ascii) == "WAVE" else {
+            throw AudioMixdownServiceError.invalidWAVFile
+        }
+
+        let riffByteCount = UInt64(riffHeader.readUInt32LE(at: 4)) + 8
+        guard riffByteCount >= 12, riffByteCount <= physicalByteCount else {
+            throw AudioMixdownServiceError.invalidWAVFile
+        }
+
+        var offset: UInt64 = 12
+        var audioFormat: UInt16?
+        var channelCount: UInt16?
+        var sampleRate: UInt32?
+        var byteRate: UInt32?
+        var blockAlign: UInt16?
+        var bitsPerSample: UInt16?
+        var dataOffset: UInt64?
+        var dataByteCount: UInt64?
+
+        while offset + 8 <= riffByteCount {
+            try handle.seek(toOffset: offset)
+            let chunkHeader = try readExactly(8, from: handle)
+            let chunkID = String(bytes: chunkHeader[0..<4], encoding: .ascii)
+            let chunkByteCount = UInt64(chunkHeader.readUInt32LE(at: 4))
+            let chunkDataOffset = offset + 8
+            let paddedChunkByteCount = chunkByteCount + (chunkByteCount % 2)
+            guard chunkDataOffset <= riffByteCount,
+                  paddedChunkByteCount <= riffByteCount - chunkDataOffset else {
+                throw AudioMixdownServiceError.invalidWAVFile
+            }
+
+            if chunkID == "fmt " {
+                guard chunkByteCount >= 16 else {
+                    throw AudioMixdownServiceError.invalidWAVFile
+                }
+                try handle.seek(toOffset: chunkDataOffset)
+                let formatData = try readExactly(16, from: handle)
+                audioFormat = formatData.readUInt16LE(at: 0)
+                channelCount = formatData.readUInt16LE(at: 2)
+                sampleRate = formatData.readUInt32LE(at: 4)
+                byteRate = formatData.readUInt32LE(at: 8)
+                blockAlign = formatData.readUInt16LE(at: 12)
+                bitsPerSample = formatData.readUInt16LE(at: 14)
+            } else if chunkID == "data", dataOffset == nil {
+                guard chunkByteCount % UInt64(MemoryLayout<Int16>.size) == 0 else {
+                    throw AudioMixdownServiceError.invalidWAVFile
+                }
+                dataOffset = chunkDataOffset
+                dataByteCount = chunkByteCount
+            }
+
+            offset = chunkDataOffset + paddedChunkByteCount
+        }
+
+        guard audioFormat == 1,
+              channelCount == 1,
+              sampleRate == 16_000,
+              byteRate == 16_000 * 2,
+              blockAlign == 2,
+              bitsPerSample == 16,
+              let dataOffset,
+              let dataByteCount else {
+            throw AudioMixdownServiceError.unsupportedWAVFormat
+        }
+        guard dataOffset <= physicalByteCount,
+              dataByteCount <= physicalByteCount - dataOffset else {
+            throw AudioMixdownServiceError.invalidWAVFile
+        }
+        return WAVLayout(
+            dataOffset: dataOffset,
+            dataByteCount: dataByteCount
+        )
+    }
+
+    private static func readExactly(
+        _ byteCount: Int,
+        from handle: FileHandle
+    ) throws -> Data {
+        guard let data = try handle.read(upToCount: byteCount),
+              data.count == byteCount else {
+            throw AudioMixdownServiceError.invalidWAVFile
+        }
+        return data
+    }
+
+    private struct WAVLayout {
+        let dataOffset: UInt64
+        let dataByteCount: UInt64
     }
 }
 
@@ -235,6 +474,7 @@ enum AudioMixdownServiceError: Error {
     case invalidWAVFile
     case unsupportedWAVFormat
     case noSegmentsToConcatenate
+    case outputTooLarge
 }
 
 private extension Data {
@@ -252,5 +492,16 @@ private extension Data {
         append(UInt8((value & 0x0000ff00) >> 8))
         append(UInt8((value & 0x00ff0000) >> 16))
         append(UInt8((value & 0xff000000) >> 24))
+    }
+
+    func readUInt16LE(at offset: Int) -> UInt16 {
+        UInt16(self[offset]) | (UInt16(self[offset + 1]) << 8)
+    }
+
+    func readUInt32LE(at offset: Int) -> UInt32 {
+        UInt32(self[offset])
+            | (UInt32(self[offset + 1]) << 8)
+            | (UInt32(self[offset + 2]) << 16)
+            | (UInt32(self[offset + 3]) << 24)
     }
 }

--- a/Sources/AudioMixdownService.swift
+++ b/Sources/AudioMixdownService.swift
@@ -300,13 +300,13 @@ private struct SampleScan {
 }
 
 private struct SampleStatistics {
-    private var activeSquareSum: Float = 0
+    private var activeSquareSum: Double = 0
     private var activeSampleCount = 0
     private(set) var peak = 0
 
     var activeRMS: Float {
         guard activeSampleCount > 0 else { return 0 }
-        return sqrt(activeSquareSum / Float(activeSampleCount))
+        return Float(sqrt(activeSquareSum / Double(activeSampleCount)))
     }
 
     mutating func consume(_ samples: [Int16]) {
@@ -314,9 +314,9 @@ private struct SampleStatistics {
             let integerSample = Int(sample)
             peak = max(peak, abs(integerSample))
 
-            let floatSample = Float(sample)
-            if abs(floatSample) > 32 {
-                activeSquareSum += floatSample * floatSample
+            let doubleSample = Double(sample)
+            if abs(doubleSample) > 32 {
+                activeSquareSum += doubleSample * doubleSample
                 activeSampleCount += 1
             }
         }

--- a/Tests/AudioMixdownServiceTests.swift
+++ b/Tests/AudioMixdownServiceTests.swift
@@ -10,7 +10,12 @@ struct AudioMixdownServiceTests {
             try preservesSystemAudioWhenMicrophoneIsSilent()
             try doesNotClipLoudSystemAudio()
             try outputFormatIs16kHzMonoInt16AndFrameCountIsMaxInputFrameCount()
-            try activeRMSAvoidsIntermediateArrays()
+            try streamsAcrossFixedChunkBoundaries()
+            try mixesLongSyntheticWAVWithConstantMemoryContract()
+            try rejectsEmptyFile()
+            try rejectsTruncatedPayload()
+            try rejectsOddBytePCM16Payload()
+            try mixPathAvoidsDurationSizedMaterialization()
             try concatenatesSegmentsInOrder()
             try concatenateWithSingleSegmentReturnsSameSamples()
             try concatenateOutputIs16kHzMonoInt16InTempDir()
@@ -118,6 +123,154 @@ struct AudioMixdownServiceTests {
         try expectEqual(samples, [400, 640, 640, 800, 960], "mixed samples should silence-pad shorter input")
     }
 
+    private static func streamsAcrossFixedChunkBoundaries() throws {
+        let chunkFrameCount = 4_096
+        let microphoneURL = try writeTinyWAV(
+            samples: Array(repeating: 1_000, count: chunkFrameCount + 1)
+        )
+        let systemAudioURL = try writeTinyWAV(
+            samples: Array(repeating: 3_000, count: chunkFrameCount + 3)
+        )
+        defer { try? FileManager.default.removeItem(at: microphoneURL) }
+        defer { try? FileManager.default.removeItem(at: systemAudioURL) }
+
+        let outputURL = try AudioMixdownService().mix(
+            microphoneURL: microphoneURL,
+            systemAudioURL: systemAudioURL
+        )
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        let samples = try readSamples(from: outputURL)
+        try expectEqual(samples.count, chunkFrameCount + 3, "chunk-boundary output frame count")
+        try expectEqual(samples[chunkFrameCount - 1], 3_200, "last sample before chunk boundary")
+        try expectEqual(samples[chunkFrameCount], 3_200, "first sample after chunk boundary")
+        try expectEqual(samples[chunkFrameCount + 1], 2_400, "first system-only tail sample")
+        try expectEqual(samples[chunkFrameCount + 2], 2_400, "last system-only tail sample")
+    }
+
+    private static func mixesLongSyntheticWAVWithConstantMemoryContract() throws {
+        let microphoneFrameCount = 1_000_003
+        let systemAudioFrameCount = 1_000_017
+        let microphoneURL = try writeRepeatedSampleWAV(
+            sample: 1_000,
+            frameCount: microphoneFrameCount
+        )
+        let systemAudioURL = try writeRepeatedSampleWAV(
+            sample: 100,
+            frameCount: systemAudioFrameCount
+        )
+        defer { try? FileManager.default.removeItem(at: microphoneURL) }
+        defer { try? FileManager.default.removeItem(at: systemAudioURL) }
+
+        let outputURL = try AudioMixdownService().mix(
+            microphoneURL: microphoneURL,
+            systemAudioURL: systemAudioURL
+        )
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: outputURL.path)
+        let physicalByteCount = try requireFileSize(attributes[.size])
+        try expectEqual(
+            physicalByteCount,
+            UInt64(44 + systemAudioFrameCount * MemoryLayout<Int16>.size),
+            "long output physical byte count"
+        )
+        try expectEqual(
+            try readCanonicalSample(from: outputURL, atFrame: 0),
+            960,
+            "long output first mixed sample"
+        )
+        try expectEqual(
+            try readCanonicalSample(from: outputURL, atFrame: 4_096),
+            960,
+            "long output sample after first chunk boundary"
+        )
+        try expectEqual(
+            try readCanonicalSample(from: outputURL, atFrame: microphoneFrameCount),
+            160,
+            "long output system-only tail sample"
+        )
+        try expectEqual(
+            try readCanonicalSample(from: outputURL, atFrame: systemAudioFrameCount - 1),
+            160,
+            "long output final sample"
+        )
+    }
+
+    private static func rejectsEmptyFile() throws {
+        let emptyURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("wav")
+        let validURL = try writeTinyWAV(samples: [1])
+        try Data().write(to: emptyURL)
+        defer { try? FileManager.default.removeItem(at: emptyURL) }
+        defer { try? FileManager.default.removeItem(at: validURL) }
+
+        try expectInvalidWAV {
+            _ = try AudioMixdownService().mix(
+                microphoneURL: emptyURL,
+                systemAudioURL: validURL
+            )
+        }
+    }
+
+    private static func rejectsTruncatedPayload() throws {
+        let truncatedURL = try writeCanonicalWAVPayload(
+            declaredDataByteCount: 4,
+            payload: Data([0x01, 0x00])
+        )
+        let validURL = try writeTinyWAV(samples: [1])
+        defer { try? FileManager.default.removeItem(at: truncatedURL) }
+        defer { try? FileManager.default.removeItem(at: validURL) }
+
+        try expectInvalidWAV {
+            _ = try AudioMixdownService().mix(
+                microphoneURL: truncatedURL,
+                systemAudioURL: validURL
+            )
+        }
+    }
+
+    private static func rejectsOddBytePCM16Payload() throws {
+        let oddPayloadURL = try writeCanonicalWAVPayload(
+            declaredDataByteCount: 1,
+            payload: Data([0x01])
+        )
+        let validURL = try writeTinyWAV(samples: [1])
+        defer { try? FileManager.default.removeItem(at: oddPayloadURL) }
+        defer { try? FileManager.default.removeItem(at: validURL) }
+
+        try expectInvalidWAV {
+            _ = try AudioMixdownService().mix(
+                microphoneURL: oddPayloadURL,
+                systemAudioURL: validURL
+            )
+        }
+    }
+
+    private static func mixPathAvoidsDurationSizedMaterialization() throws {
+        let source = try String(contentsOf: audioMixdownServiceSourceURL, encoding: .utf8)
+        let mixBody = try functionBody(
+            startingWith: "public func mix(microphoneURL: URL, systemAudioURL: URL)",
+            in: source
+        )
+        guard !mixBody.contains("readSamples(") else {
+            throw TestFailure("mix should not decode an entire source into [Int16]")
+        }
+        guard !mixBody.contains("mixedSamples") else {
+            throw TestFailure("mix should not build a duration-sized mixedSamples array")
+        }
+        guard !mixBody.contains("reserveCapacity(outputFrameCount)") else {
+            throw TestFailure("mix should not reserve output memory proportional to recording duration")
+        }
+        guard !source.contains("private func readSamples(from url: URL) throws -> [Int16]") else {
+            throw TestFailure("production mixdown should not retain a full-source [Int16] decoder")
+        }
+        guard countOccurrences(of: "Data(contentsOf:", in: source) == 1 else {
+            throw TestFailure("only the unchanged concatenate path may use Data(contentsOf:)")
+        }
+    }
+
     private static func concatenatesSegmentsInOrder() throws {
         let first = try writeTinyWAV(samples: [1, 2, 3])
         let second = try writeTinyWAV(samples: [4, 5])
@@ -179,14 +332,127 @@ struct AudioMixdownServiceTests {
         }
     }
 
-    private static func activeRMSAvoidsIntermediateArrays() throws {
-        let source = try String(contentsOf: audioMixdownServiceSourceURL, encoding: .utf8)
-        guard !source.contains("samples.map { Float($0) }.filter") else {
-            throw TestFailure("activeRMS should avoid building an intermediate activeSamples array")
+    private static func functionBody(
+        startingWith signature: String,
+        in source: String
+    ) throws -> String {
+        guard let signatureRange = source.range(of: signature),
+              let openingBrace = source[signatureRange.upperBound...].firstIndex(of: "{") else {
+            throw TestFailure("missing function signature: \(signature)")
         }
-        guard source.contains("for sample in samples") else {
-            throw TestFailure("activeRMS should scan samples directly")
+
+        var depth = 0
+        var index = openingBrace
+        while index < source.endIndex {
+            switch source[index] {
+            case "{":
+                depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 {
+                    return String(source[source.index(after: openingBrace)..<index])
+                }
+            default:
+                break
+            }
+            index = source.index(after: index)
         }
+        throw TestFailure("missing closing brace for: \(signature)")
+    }
+
+    private static func countOccurrences(of needle: String, in text: String) -> Int {
+        text.components(separatedBy: needle).count - 1
+    }
+
+    private static func expectInvalidWAV(_ operation: () throws -> Void) throws {
+        do {
+            try operation()
+            throw TestFailure("expected invalid WAV error")
+        } catch AudioMixdownServiceError.invalidWAVFile {
+            // expected
+        }
+    }
+
+    private static func requireFileSize(_ value: Any?) throws -> UInt64 {
+        guard let number = value as? NSNumber else {
+            throw TestFailure("missing output file size")
+        }
+        return number.uint64Value
+    }
+
+    private static func readCanonicalSample(
+        from url: URL,
+        atFrame frame: Int
+    ) throws -> Int16 {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        try handle.seek(toOffset: UInt64(44 + frame * MemoryLayout<Int16>.size))
+        let bytes = try handle.read(upToCount: 2) ?? Data()
+        guard bytes.count == 2 else {
+            throw TestFailure("missing sample at frame \(frame)")
+        }
+        return Int16(bitPattern: UInt16(bytes[0]) | (UInt16(bytes[1]) << 8))
+    }
+
+    private static func writeRepeatedSampleWAV(
+        sample: Int16,
+        frameCount: Int
+    ) throws -> URL {
+        let dataByteCount = frameCount * MemoryLayout<Int16>.size
+        guard dataByteCount <= Int(UInt32.max) else {
+            throw TestFailure("test WAV is too large")
+        }
+
+        let url = try writeCanonicalWAVPayload(
+            declaredDataByteCount: UInt32(dataByteCount),
+            payload: Data()
+        )
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+
+        let chunkFrameCount = 4_096
+        var chunk = Data()
+        chunk.reserveCapacity(chunkFrameCount * MemoryLayout<Int16>.size)
+        for _ in 0..<chunkFrameCount {
+            chunk.appendUInt16LE(UInt16(bitPattern: sample))
+        }
+
+        var remainingFrames = frameCount
+        while remainingFrames > 0 {
+            let framesToWrite = min(chunkFrameCount, remainingFrames)
+            try handle.write(
+                contentsOf: chunk.prefix(framesToWrite * MemoryLayout<Int16>.size)
+            )
+            remainingFrames -= framesToWrite
+        }
+        return url
+    }
+
+    private static func writeCanonicalWAVPayload(
+        declaredDataByteCount: UInt32,
+        payload: Data
+    ) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("wav")
+        var data = Data()
+        data.appendASCII("RIFF")
+        data.appendUInt32LE(36 + declaredDataByteCount)
+        data.appendASCII("WAVE")
+        data.appendASCII("fmt ")
+        data.appendUInt32LE(16)
+        data.appendUInt16LE(1)
+        data.appendUInt16LE(1)
+        data.appendUInt32LE(16_000)
+        data.appendUInt32LE(16_000 * 2)
+        data.appendUInt16LE(2)
+        data.appendUInt16LE(16)
+        data.appendASCII("data")
+        data.appendUInt32LE(declaredDataByteCount)
+        data.append(payload)
+        try data.write(to: url, options: .atomic)
+        return url
     }
 
     private static var audioMixdownServiceSourceURL: URL {

--- a/Tests/AudioMixdownServiceTests.swift
+++ b/Tests/AudioMixdownServiceTests.swift
@@ -12,6 +12,7 @@ struct AudioMixdownServiceTests {
             try outputFormatIs16kHzMonoInt16AndFrameCountIsMaxInputFrameCount()
             try streamsAcrossFixedChunkBoundaries()
             try mixesLongSyntheticWAVWithConstantMemoryContract()
+            try preservesGainAccuracyAcrossLongRecordings()
             try rejectsEmptyFile()
             try rejectsTruncatedPayload()
             try rejectsOddBytePCM16Payload()
@@ -197,6 +198,32 @@ struct AudioMixdownServiceTests {
         )
     }
 
+    private static func preservesGainAccuracyAcrossLongRecordings() throws {
+        let frameCount = 1_000_000
+        let microphoneURL = try writeRepeatedSampleWAV(
+            sample: 300,
+            frameCount: frameCount
+        )
+        let systemAudioURL = try writeRepeatedSampleWAV(
+            sample: 200,
+            frameCount: frameCount
+        )
+        defer { try? FileManager.default.removeItem(at: microphoneURL) }
+        defer { try? FileManager.default.removeItem(at: systemAudioURL) }
+
+        let outputURL = try AudioMixdownService().mix(
+            microphoneURL: microphoneURL,
+            systemAudioURL: systemAudioURL
+        )
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        try expectEqual(
+            try readCanonicalSample(from: outputURL, atFrame: frameCount - 1),
+            432,
+            "long recording gain should match exact constant-amplitude RMS"
+        )
+    }
+
     private static func rejectsEmptyFile() throws {
         let emptyURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
@@ -234,7 +261,8 @@ struct AudioMixdownServiceTests {
     private static func rejectsOddBytePCM16Payload() throws {
         let oddPayloadURL = try writeCanonicalWAVPayload(
             declaredDataByteCount: 1,
-            payload: Data([0x01])
+            payload: Data([0x01]),
+            padOddDataChunk: true
         )
         let validURL = try writeTinyWAV(samples: [1])
         defer { try? FileManager.default.removeItem(at: oddPayloadURL) }
@@ -431,14 +459,18 @@ struct AudioMixdownServiceTests {
 
     private static func writeCanonicalWAVPayload(
         declaredDataByteCount: UInt32,
-        payload: Data
+        payload: Data,
+        padOddDataChunk: Bool = false
     ) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
             .appendingPathExtension("wav")
+        let needsPadding = padOddDataChunk && declaredDataByteCount % 2 == 1
         var data = Data()
         data.appendASCII("RIFF")
-        data.appendUInt32LE(36 + declaredDataByteCount)
+        data.appendUInt32LE(
+            36 + declaredDataByteCount + (needsPadding ? 1 : 0)
+        )
         data.appendASCII("WAVE")
         data.appendASCII("fmt ")
         data.appendUInt32LE(16)
@@ -451,6 +483,9 @@ struct AudioMixdownServiceTests {
         data.appendASCII("data")
         data.appendUInt32LE(declaredDataByteCount)
         data.append(payload)
+        if needsPadding {
+            data.append(0)
+        }
         try data.write(to: url, options: .atomic)
         return url
     }


### PR DESCRIPTION
## Summary

- replace duration-sized PCM arrays with a two-pass, fixed-chunk WAV mixer
- preserve the existing headroom, quiet System Audio gain, peak cap, and silence-padding behavior
- validate canonical PCM16 WAV input and reject truncated or odd-byte payloads
- add chunk-boundary, long synthetic input, malformed input, and no-full-materialization coverage

## Scope

This changes only the combined normal-stop mix path. It does not change input-switch concatenation, recording journals, or Issue #181 Phase 3 recovery behavior.

## Verification

- `swiftc -parse-as-library Sources/AudioMixdownService.swift Tests/AudioMixdownServiceTests.swift -o /tmp/AudioMixdownServiceTests && /tmp/AudioMixdownServiceTests`
- `make check-test-wiring`
- `make test`
- `make all APP_NAME=\"Quill Dev\" BUNDLE_ID=\"com.woosublee.quill.dev\" CODESIGN_IDENTITY=Quill`
- `codesign --verify --deep --strict --verbose=2 \"build/Quill Dev.app\"`
- `git diff --check`

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 오디오 믹스다운이 대용량 WAV 파일에서도 메모리를 효율적으로 사용하도록 개선되었습니다.
  * 처리 중 출력 파일의 크기와 프레임 수를 검증해 결과의 안정성이 향상되었습니다.
  * WAV 파일의 손상, 잘림, 잘못된 형식 등을 더욱 정확하게 감지하고 거부합니다.
  * 오류 발생 시 불완전한 임시 출력 파일이 남지 않도록 정리됩니다.
  * 긴 오디오와 다양한 청크 경계에서도 일관된 샘플 결과를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->