### PR TITLE
Add combined recording journal foundation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,6 +344,8 @@ test: check-test-wiring $(SPARKLE_STAMP) $(LOCALIZATION_STAMP)
 	@/tmp/RecordingJournalManifestTests
 	@swiftc -parse-as-library Sources/RecordingJournalModels.swift Sources/RecordingJournalStore.swift Sources/RecordingPCMJournalWriter.swift Sources/RecordingArtifactFinalizer.swift Sources/InflightRecordingRecovery.swift Sources/RecordingJournalRecoveryExecutor.swift Tests/RecordingJournalRuntimeTests.swift -o /tmp/RecordingJournalRuntimeTests
 	@/tmp/RecordingJournalRuntimeTests
+	@swiftc -parse-as-library Sources/RecordingJournalModels.swift Sources/RecordingJournalStore.swift Sources/RecordingPCMJournalWriter.swift Sources/CombinedRecordingJournalController.swift Tests/CombinedRecordingJournalControllerTests.swift -o /tmp/CombinedRecordingJournalControllerTests
+	@/tmp/CombinedRecordingJournalControllerTests
 	@swiftc -parse-as-library -framework AVFoundation Sources/RecordingPCMBufferCopy.swift Tests/RecordingPCMBufferCopyTests.swift -o /tmp/RecordingPCMBufferCopyTests
 	@/tmp/RecordingPCMBufferCopyTests
 	@swiftc -parse-as-library Tests/AudioRecorderJournalIntegrationSourceTests.swift -o /tmp/AudioRecorderJournalIntegrationSourceTests

--- a/Sources/CombinedRecordingJournalController.swift
+++ b/Sources/CombinedRecordingJournalController.swift
@@ -1,0 +1,284 @@
+import Foundation
+
+enum CombinedRecordingJournalControllerError: Error, Equatable {
+    case controllerClosed
+}
+
+struct CombinedRecordingJournalStopResult: Equatable {
+    let microphoneSourceURL: URL
+    let microphoneCommit: RecordingJournalSourceCommit
+    let systemAudioSourceURL: URL
+    let systemAudioCommit: RecordingJournalSourceCommit
+}
+
+final class CombinedRecordingJournalController {
+    private static let lifecycleQueueKey = DispatchSpecificKey<UInt8>()
+
+    private enum State {
+        case recording
+        case stopped(CombinedRecordingJournalStopResult)
+        case recoverable
+        case discarded
+    }
+
+    let recordingID: UUID
+    let microphoneSink: any NormalizedPCM16Sink
+    let systemAudioSink: any NormalizedPCM16Sink
+
+    private let store: RecordingJournalStore
+    private let microphoneWriter: RecordingPCMJournalWriter
+    private let systemAudioWriter: RecordingPCMJournalWriter
+    private let microphoneSourceID: UUID
+    private let systemAudioSourceID: UUID
+    private let microphoneSourceURL: URL
+    private let systemAudioSourceURL: URL
+    private let lifecycleQueue = DispatchQueue(
+        label: "com.woosublee.quill.recording-journal.combined-lifecycle"
+    )
+    private var checkpointTimer: DispatchSourceTimer?
+    private var state: State = .recording
+    private var didReportCheckpointFailure = false
+
+    convenience init(
+        request: CombinedRecordingJournalCreateRequest,
+        store: RecordingJournalStore
+    ) throws {
+        try self.init(
+            request: request,
+            store: store,
+            makeWriter: RecordingPCMJournalWriter.init
+        )
+    }
+
+    init(
+        request: CombinedRecordingJournalCreateRequest,
+        store: RecordingJournalStore,
+        makeWriter: (
+            RecordingJournalSession,
+            RecordingJournalStore
+        ) throws -> RecordingPCMJournalWriter
+    ) throws {
+        let session = try store.createCombined(request)
+        let microphoneWriter: RecordingPCMJournalWriter
+        let systemAudioWriter: RecordingPCMJournalWriter
+        do {
+            microphoneWriter = try makeWriter(
+                session.microphoneSession,
+                store
+            )
+            systemAudioWriter = try makeWriter(
+                session.systemAudioSession,
+                store
+            )
+        } catch {
+            try? store.markDiscarded(recordingID: request.recordingID)
+            try? store.discardInflightRecording(
+                recordingID: request.recordingID
+            )
+            throw error
+        }
+
+        self.recordingID = request.recordingID
+        self.store = store
+        self.microphoneWriter = microphoneWriter
+        self.systemAudioWriter = systemAudioWriter
+        self.microphoneSink = microphoneWriter
+        self.systemAudioSink = systemAudioWriter
+        self.microphoneSourceID = request.microphoneSourceID
+        self.systemAudioSourceID = request.systemAudioSourceID
+        self.microphoneSourceURL = session.microphoneSession.sourceURL
+        self.systemAudioSourceURL = session.systemAudioSession.sourceURL
+        lifecycleQueue.setSpecific(
+            key: Self.lifecycleQueueKey,
+            value: 1
+        )
+    }
+
+    deinit {
+        let cancelTimer = {
+            self.cancelCheckpointTimerLocked()
+        }
+        if DispatchQueue.getSpecific(
+            key: Self.lifecycleQueueKey
+        ) != nil {
+            cancelTimer()
+        } else {
+            lifecycleQueue.sync(execute: cancelTimer)
+        }
+    }
+
+    func startCheckpointing(
+        every interval: TimeInterval = 7,
+        onFirstFailure: @escaping (Error) -> Void
+    ) {
+        lifecycleQueue.async { [weak self] in
+            guard let self else { return }
+            guard case .recording = self.state,
+                  self.checkpointTimer == nil else {
+                return
+            }
+
+            let timer = DispatchSource.makeTimerSource(
+                queue: self.lifecycleQueue
+            )
+            timer.schedule(
+                deadline: .now() + interval,
+                repeating: interval
+            )
+            timer.setEventHandler { [weak self] in
+                guard let self else { return }
+                do {
+                    try self.checkpointLocked()
+                } catch {
+                    guard !self.didReportCheckpointFailure else {
+                        return
+                    }
+                    self.didReportCheckpointFailure = true
+                    onFirstFailure(error)
+                }
+            }
+            timer.resume()
+            self.checkpointTimer = timer
+        }
+    }
+
+    func checkpoint() throws {
+        try lifecycleQueue.sync {
+            guard case .recording = state else {
+                throw CombinedRecordingJournalControllerError.controllerClosed
+            }
+            try checkpointLocked()
+        }
+    }
+
+    func stopAndClose() throws -> CombinedRecordingJournalStopResult {
+        try lifecycleQueue.sync {
+            switch state {
+            case .stopped(let result):
+                return result
+            case .recording:
+                cancelCheckpointTimerLocked()
+                _ = try store.transition(
+                    recordingID: recordingID,
+                    to: .stopping
+                )
+                do {
+                    let commits = try drainAndCommitLocked()
+                    let result = CombinedRecordingJournalStopResult(
+                        microphoneSourceURL: microphoneSourceURL,
+                        microphoneCommit: commits.microphone,
+                        systemAudioSourceURL: systemAudioSourceURL,
+                        systemAudioCommit: commits.systemAudio
+                    )
+                    state = .stopped(result)
+                    return result
+                } catch {
+                    try? preserveAfterCloseFailureLocked()
+                    throw error
+                }
+            case .recoverable, .discarded:
+                throw CombinedRecordingJournalControllerError.controllerClosed
+            }
+        }
+    }
+
+    func preserveForRecovery() throws {
+        try lifecycleQueue.sync {
+            switch state {
+            case .recoverable, .stopped:
+                return
+            case .discarded:
+                throw CombinedRecordingJournalControllerError.controllerClosed
+            case .recording:
+                cancelCheckpointTimerLocked()
+                do {
+                    _ = try drainAndCommitLocked()
+                    _ = try store.transition(
+                        recordingID: recordingID,
+                        to: .recoverable
+                    )
+                    state = .recoverable
+                } catch {
+                    try? preserveAfterCloseFailureLocked()
+                    throw error
+                }
+            }
+        }
+    }
+
+    func discard() throws {
+        try lifecycleQueue.sync {
+            switch state {
+            case .discarded:
+                return
+            case .stopped:
+                throw CombinedRecordingJournalControllerError.controllerClosed
+            case .recording:
+                cancelCheckpointTimerLocked()
+                _ = try? microphoneWriter.drainAndCloseSnapshot()
+                _ = try? systemAudioWriter.drainAndCloseSnapshot()
+                try discardJournalLocked()
+            case .recoverable:
+                try discardJournalLocked()
+            }
+        }
+    }
+
+    private func checkpointLocked() throws {
+        let microphoneCommit = try microphoneWriter.checkpointSnapshot()
+        let systemAudioCommit = try systemAudioWriter.checkpointSnapshot()
+        _ = try store.recordCheckpoints(
+            recordingID: recordingID,
+            commitsBySourceID: [
+                microphoneSourceID: microphoneCommit,
+                systemAudioSourceID: systemAudioCommit
+            ]
+        )
+    }
+
+    private func drainAndCommitLocked() throws -> (
+        microphone: RecordingJournalSourceCommit,
+        systemAudio: RecordingJournalSourceCommit
+    ) {
+        let microphoneCommit =
+            try microphoneWriter.drainAndCloseSnapshot()
+        let systemAudioCommit =
+            try systemAudioWriter.drainAndCloseSnapshot()
+        _ = try store.recordCheckpoints(
+            recordingID: recordingID,
+            commitsBySourceID: [
+                microphoneSourceID: microphoneCommit,
+                systemAudioSourceID: systemAudioCommit
+            ]
+        )
+        return (microphoneCommit, systemAudioCommit)
+    }
+
+    private func discardJournalLocked() throws {
+        try store.markDiscarded(recordingID: recordingID)
+        try store.discardInflightRecording(recordingID: recordingID)
+        state = .discarded
+    }
+
+    private func preserveAfterCloseFailureLocked() throws {
+        let manifest = try store.loadManifest(recordingID: recordingID)
+        switch manifest.state {
+        case .recording, .stopping:
+            _ = try store.transition(
+                recordingID: recordingID,
+                to: .recoverable
+            )
+            state = .recoverable
+        case .recoverable:
+            state = .recoverable
+        case .promoted, .historyStored, .finalized:
+            throw CombinedRecordingJournalControllerError.controllerClosed
+        }
+    }
+
+    private func cancelCheckpointTimerLocked() {
+        checkpointTimer?.setEventHandler {}
+        checkpointTimer?.cancel()
+        checkpointTimer = nil
+    }
+}

--- a/Sources/CombinedRecordingJournalController.swift
+++ b/Sources/CombinedRecordingJournalController.swift
@@ -71,10 +71,12 @@ final class CombinedRecordingJournalController {
                 store
             )
         } catch {
-            try? store.markDiscarded(recordingID: request.recordingID)
-            try? store.discardInflightRecording(
-                recordingID: request.recordingID
-            )
+            if session.creationDisposition == .created {
+                try? store.markDiscarded(recordingID: request.recordingID)
+                try? store.discardInflightRecording(
+                    recordingID: request.recordingID
+                )
+            }
             throw error
         }
 
@@ -95,20 +97,13 @@ final class CombinedRecordingJournalController {
     }
 
     deinit {
-        let cancelTimer = {
-            self.cancelCheckpointTimerLocked()
-        }
-        if DispatchQueue.getSpecific(
-            key: Self.lifecycleQueueKey
-        ) != nil {
-            cancelTimer()
-        } else {
-            lifecycleQueue.sync(execute: cancelTimer)
-        }
+        checkpointTimer?.setEventHandler {}
+        checkpointTimer?.cancel()
     }
 
     func startCheckpointing(
         every interval: TimeInterval = 7,
+        callbackQueue: DispatchQueue = .main,
         onFirstFailure: @escaping (Error) -> Void
     ) {
         lifecycleQueue.async { [weak self] in
@@ -134,7 +129,9 @@ final class CombinedRecordingJournalController {
                         return
                     }
                     self.didReportCheckpointFailure = true
-                    onFirstFailure(error)
+                    callbackQueue.async {
+                        onFirstFailure(error)
+                    }
                 }
             }
             timer.resume()
@@ -240,10 +237,25 @@ final class CombinedRecordingJournalController {
         microphone: RecordingJournalSourceCommit,
         systemAudio: RecordingJournalSourceCommit
     ) {
-        let microphoneCommit =
-            try microphoneWriter.drainAndCloseSnapshot()
-        let systemAudioCommit =
-            try systemAudioWriter.drainAndCloseSnapshot()
+        var microphoneCommit: RecordingJournalSourceCommit?
+        var systemAudioCommit: RecordingJournalSourceCommit?
+        var firstError: Error?
+
+        do {
+            microphoneCommit = try microphoneWriter.drainAndCloseSnapshot()
+        } catch {
+            firstError = error
+        }
+        do {
+            systemAudioCommit = try systemAudioWriter.drainAndCloseSnapshot()
+        } catch {
+            if firstError == nil { firstError = error }
+        }
+        if let firstError { throw firstError }
+        guard let microphoneCommit, let systemAudioCommit else {
+            throw CombinedRecordingJournalControllerError.controllerClosed
+        }
+
         _ = try store.recordCheckpoints(
             recordingID: recordingID,
             commitsBySourceID: [

--- a/Sources/InflightRecordingRecovery.swift
+++ b/Sources/InflightRecordingRecovery.swift
@@ -25,6 +25,7 @@ enum InflightRecordingRecoveryDiagnostic: String, Equatable, Hashable {
     case sourceTruncated
     case oddTrailingByte
     case promotionConflict
+    case combinedRecoveryPending
 }
 
 struct InflightRecordingRecoveryCandidate: Equatable {
@@ -129,6 +130,12 @@ struct InflightRecordingRecovery {
                 directory: directory,
                 recordingID: manifest.recordingID,
                 diagnostics: [.recordingIDMismatch]
+            )
+        }
+        if manifest.sourceMode == .combined {
+            return scanCombinedManifest(
+                manifest,
+                directory: directory
             )
         }
         guard manifest.sources.count == 1,
@@ -321,6 +328,73 @@ struct InflightRecordingRecovery {
                 diagnostics: diagnostics
             )
         }
+    }
+
+    private func scanCombinedManifest(
+        _ manifest: RecordingJournalManifest,
+        directory: URL
+    ) -> InflightRecordingRecoveryCandidate {
+        var diagnostics: Set<InflightRecordingRecoveryDiagnostic> = [
+            .combinedRecoveryPending
+        ]
+
+        for source in manifest.sources {
+            let sourceURL: URL
+            do {
+                sourceURL = try store.sourceURL(
+                    recordingID: manifest.recordingID,
+                    fileName: source.fileName
+                )
+            } catch {
+                diagnostics.insert(.unsafeSourceFileName)
+                continue
+            }
+            guard FileManager.default.fileExists(
+                atPath: sourceURL.path
+            ) else {
+                diagnostics.insert(.missingSource)
+                continue
+            }
+
+            let sourceSize: UInt64
+            do {
+                sourceSize = try RecordingJournalDurability.fileSize(
+                    at: sourceURL
+                )
+            } catch {
+                diagnostics.insert(.missingSource)
+                continue
+            }
+            guard sourceSize
+                    >= UInt64(RecordingCanonicalWAV.headerByteCount) else {
+                diagnostics.insert(.sourceTooShort)
+                continue
+            }
+
+            let actualPayload = sourceSize
+                - UInt64(RecordingCanonicalWAV.headerByteCount)
+            let frameSize = UInt64(
+                RecordingPCMFormat.canonical.bytesPerFrame
+            )
+            let evenPayload = actualPayload - (actualPayload % frameSize)
+            if actualPayload != evenPayload {
+                diagnostics.insert(.oddTrailingByte)
+            }
+            if evenPayload > source.committedDataByteCount {
+                diagnostics.insert(.manifestBehind)
+            } else if evenPayload < source.committedDataByteCount {
+                diagnostics.insert(.sourceTruncated)
+            }
+            if evenPayload == 0 {
+                diagnostics.insert(.emptySource)
+            }
+        }
+
+        return manualCandidate(
+            directory: directory,
+            recordingID: manifest.recordingID,
+            diagnostics: diagnostics
+        )
     }
 
     private func stateCandidate(

--- a/Sources/RecordingJournalModels.swift
+++ b/Sources/RecordingJournalModels.swift
@@ -167,29 +167,15 @@ struct RecordingJournalManifest: Codable, Equatable {
         guard pcmFormat == .canonical else {
             throw RecordingJournalError.invalidManifest("Unsupported PCM format.")
         }
-        guard !sources.isEmpty, segments.count == 1 else {
+        guard !sources.isEmpty, !segments.isEmpty else {
             throw RecordingJournalError.invalidManifest(
-                "Manifest must contain sources and exactly one segment."
+                "Manifest must contain a source and segment."
             )
         }
 
-        switch sourceMode {
-        case .microphone:
-            guard sources.count == 1,
-                  sources[0].kind == .microphone else {
-                throw RecordingJournalError.invalidManifest(
-                    "Microphone recordings require exactly one microphone source."
-                )
-            }
-        case .systemAudio:
-            guard sources.count == 1,
-                  sources[0].kind == .systemAudio else {
-                throw RecordingJournalError.invalidManifest(
-                    "System Audio recordings require exactly one System Audio source."
-                )
-            }
-        case .combined:
+        if sourceMode == .combined {
             guard sources.count == 2,
+                  segments.count == 1,
                   sources.filter({ $0.kind == .microphone }).count == 1,
                   sources.filter({ $0.kind == .systemAudio }).count == 1 else {
                 throw RecordingJournalError.invalidManifest(
@@ -204,10 +190,12 @@ struct RecordingJournalManifest: Codable, Equatable {
                 "Source identifiers must be unique."
             )
         }
-        guard Set(sources.map(\.fileName)).count == sources.count else {
-            throw RecordingJournalError.invalidManifest(
-                "Source filenames must be unique."
-            )
+        if sourceMode == .combined {
+            guard Set(sources.map(\.fileName)).count == sources.count else {
+                throw RecordingJournalError.invalidManifest(
+                    "Combined source filenames must be unique."
+                )
+            }
         }
         let segmentIDs = Set(segments.map(\.id))
         guard segmentIDs.count == segments.count else {
@@ -230,14 +218,25 @@ struct RecordingJournalManifest: Codable, Equatable {
                 throw RecordingJournalError.invalidManifest("Committed byte and frame counts disagree.")
             }
         }
-        let segment = segments[0]
-        let segmentSourceIDs = Set(segment.sourceIDs)
-        guard segmentSourceIDs.count == segment.sourceIDs.count,
-              segmentSourceIDs == sourceIDs,
-              sources.allSatisfy({ $0.segmentID == segment.id }) else {
-            throw RecordingJournalError.invalidManifest(
-                "The recording segment must reference every source exactly once."
-            )
+        if sourceMode == .combined {
+            let segment = segments[0]
+            let segmentSourceIDs = Set(segment.sourceIDs)
+            guard segmentSourceIDs.count == segment.sourceIDs.count,
+                  segmentSourceIDs == sourceIDs,
+                  sources.allSatisfy({ $0.segmentID == segment.id }) else {
+                throw RecordingJournalError.invalidManifest(
+                    "The combined recording segment must reference every source exactly once."
+                )
+            }
+        } else {
+            for segment in segments {
+                guard !segment.sourceIDs.isEmpty,
+                      segment.sourceIDs.allSatisfy(sourceIDs.contains) else {
+                    throw RecordingJournalError.invalidManifest(
+                        "Segment references an unknown source."
+                    )
+                }
+            }
         }
 
         if let promotion {

--- a/Sources/RecordingJournalModels.swift
+++ b/Sources/RecordingJournalModels.swift
@@ -167,13 +167,47 @@ struct RecordingJournalManifest: Codable, Equatable {
         guard pcmFormat == .canonical else {
             throw RecordingJournalError.invalidManifest("Unsupported PCM format.")
         }
-        guard !sources.isEmpty, !segments.isEmpty else {
-            throw RecordingJournalError.invalidManifest("Manifest must contain a source and segment.")
+        guard !sources.isEmpty, segments.count == 1 else {
+            throw RecordingJournalError.invalidManifest(
+                "Manifest must contain sources and exactly one segment."
+            )
+        }
+
+        switch sourceMode {
+        case .microphone:
+            guard sources.count == 1,
+                  sources[0].kind == .microphone else {
+                throw RecordingJournalError.invalidManifest(
+                    "Microphone recordings require exactly one microphone source."
+                )
+            }
+        case .systemAudio:
+            guard sources.count == 1,
+                  sources[0].kind == .systemAudio else {
+                throw RecordingJournalError.invalidManifest(
+                    "System Audio recordings require exactly one System Audio source."
+                )
+            }
+        case .combined:
+            guard sources.count == 2,
+                  sources.filter({ $0.kind == .microphone }).count == 1,
+                  sources.filter({ $0.kind == .systemAudio }).count == 1 else {
+                throw RecordingJournalError.invalidManifest(
+                    "Combined recordings require one microphone and one System Audio source."
+                )
+            }
         }
 
         let sourceIDs = Set(sources.map(\.id))
         guard sourceIDs.count == sources.count else {
-            throw RecordingJournalError.invalidManifest("Source identifiers must be unique.")
+            throw RecordingJournalError.invalidManifest(
+                "Source identifiers must be unique."
+            )
+        }
+        guard Set(sources.map(\.fileName)).count == sources.count else {
+            throw RecordingJournalError.invalidManifest(
+                "Source filenames must be unique."
+            )
         }
         let segmentIDs = Set(segments.map(\.id))
         guard segmentIDs.count == segments.count else {
@@ -196,11 +230,14 @@ struct RecordingJournalManifest: Codable, Equatable {
                 throw RecordingJournalError.invalidManifest("Committed byte and frame counts disagree.")
             }
         }
-        for segment in segments {
-            guard !segment.sourceIDs.isEmpty,
-                  segment.sourceIDs.allSatisfy(sourceIDs.contains) else {
-                throw RecordingJournalError.invalidManifest("Segment references an unknown source.")
-            }
+        let segment = segments[0]
+        let segmentSourceIDs = Set(segment.sourceIDs)
+        guard segmentSourceIDs.count == segment.sourceIDs.count,
+              segmentSourceIDs == sourceIDs,
+              sources.allSatisfy({ $0.segmentID == segment.id }) else {
+            throw RecordingJournalError.invalidManifest(
+                "The recording segment must reference every source exactly once."
+            )
         }
 
         if let promotion {

--- a/Sources/RecordingJournalStore.swift
+++ b/Sources/RecordingJournalStore.swift
@@ -43,6 +43,11 @@ struct CombinedRecordingJournalCreateRequest: Equatable {
     var pipeline: RecordingPipelineSnapshot
 }
 
+enum RecordingJournalCreationDisposition: Equatable {
+    case created
+    case reused
+}
+
 struct CombinedRecordingJournalSession: Equatable {
     let recordingID: UUID
     let segmentID: UUID
@@ -50,6 +55,7 @@ struct CombinedRecordingJournalSession: Equatable {
     let manifestURL: URL
     let microphoneSession: RecordingJournalSession
     let systemAudioSession: RecordingJournalSession
+    let creationDisposition: RecordingJournalCreationDisposition
 }
 
 struct RecordingJournalSourceCommit: Equatable {
@@ -229,9 +235,16 @@ final class RecordingJournalStore {
         try lock.withLock {
             try ensureDirectory(audioDirectory, permissions: 0o700)
             try ensureDirectory(inflightDirectory, permissions: 0o700)
-            let combinedSession = combinedSession(request: request)
+            let createdSession = combinedSession(
+                request: request,
+                creationDisposition: .created
+            )
 
-            if fileManager.fileExists(atPath: combinedSession.manifestURL.path) {
+            if fileManager.fileExists(atPath: createdSession.manifestURL.path) {
+                let combinedSession = combinedSession(
+                    request: request,
+                    creationDisposition: .reused
+                )
                 let manifest = try loadManifestUnlocked(
                     recordingID: request.recordingID
                 )
@@ -255,6 +268,7 @@ final class RecordingJournalStore {
                 }
                 return combinedSession
             }
+            let combinedSession = createdSession
             if fileManager.fileExists(
                 atPath: combinedSession.recordingDirectory.path
             ) {
@@ -584,7 +598,8 @@ final class RecordingJournalStore {
     }
 
     private func combinedSession(
-        request: CombinedRecordingJournalCreateRequest
+        request: CombinedRecordingJournalCreateRequest,
+        creationDisposition: RecordingJournalCreationDisposition
     ) -> CombinedRecordingJournalSession {
         let microphoneSession = session(
             recordingID: request.recordingID,
@@ -604,7 +619,8 @@ final class RecordingJournalStore {
             recordingDirectory: microphoneSession.recordingDirectory,
             manifestURL: microphoneSession.manifestURL,
             microphoneSession: microphoneSession,
-            systemAudioSession: systemAudioSession
+            systemAudioSession: systemAudioSession,
+            creationDisposition: creationDisposition
         )
     }
 

--- a/Sources/RecordingJournalStore.swift
+++ b/Sources/RecordingJournalStore.swift
@@ -33,6 +33,25 @@ struct RecordingJournalSession: Equatable {
     let sourceURL: URL
 }
 
+struct CombinedRecordingJournalCreateRequest: Equatable {
+    var recordingID: UUID
+    var microphoneSourceID: UUID
+    var systemAudioSourceID: UUID
+    var segmentID: UUID
+    var startedAt: Date
+    var monotonicAnchorNanoseconds: UInt64
+    var pipeline: RecordingPipelineSnapshot
+}
+
+struct CombinedRecordingJournalSession: Equatable {
+    let recordingID: UUID
+    let segmentID: UUID
+    let recordingDirectory: URL
+    let manifestURL: URL
+    let microphoneSession: RecordingJournalSession
+    let systemAudioSession: RecordingJournalSession
+}
+
 struct RecordingJournalSourceCommit: Equatable {
     let dataByteCount: UInt64
     let frameCount: UInt64
@@ -204,6 +223,124 @@ final class RecordingJournalStore {
         }
     }
 
+    func createCombined(
+        _ request: CombinedRecordingJournalCreateRequest
+    ) throws -> CombinedRecordingJournalSession {
+        try lock.withLock {
+            try ensureDirectory(audioDirectory, permissions: 0o700)
+            try ensureDirectory(inflightDirectory, permissions: 0o700)
+            let combinedSession = combinedSession(request: request)
+
+            if fileManager.fileExists(atPath: combinedSession.manifestURL.path) {
+                let manifest = try loadManifestUnlocked(
+                    recordingID: request.recordingID
+                )
+                guard manifestMatchesCombinedRequest(
+                    manifest,
+                    request: request
+                ) else {
+                    throw RecordingJournalStoreError.conflictingExistingRecording(
+                        request.recordingID
+                    )
+                }
+                guard fileManager.fileExists(
+                        atPath: combinedSession.microphoneSession.sourceURL.path
+                    ),
+                    fileManager.fileExists(
+                        atPath: combinedSession.systemAudioSession.sourceURL.path
+                    ) else {
+                    throw RecordingJournalStoreError.incompleteExistingRecording(
+                        request.recordingID
+                    )
+                }
+                return combinedSession
+            }
+            if fileManager.fileExists(
+                atPath: combinedSession.recordingDirectory.path
+            ) {
+                throw RecordingJournalStoreError.incompleteExistingRecording(
+                    request.recordingID
+                )
+            }
+
+            try ensureDirectory(
+                combinedSession.recordingDirectory,
+                permissions: 0o700
+            )
+            do {
+                try RecordingJournalDurability.syncDirectory(inflightDirectory)
+                try createReservedSource(
+                    at: combinedSession.microphoneSession.sourceURL
+                )
+                try createReservedSource(
+                    at: combinedSession.systemAudioSession.sourceURL
+                )
+                try RecordingJournalDurability.syncDirectory(
+                    combinedSession.recordingDirectory
+                )
+
+                let microphoneSource = RecordingJournalSource(
+                    id: request.microphoneSourceID,
+                    kind: .microphone,
+                    fileName: "microphone.wav.part",
+                    storageLayout: .reservedWAVHeader44,
+                    committedDataByteCount: 0,
+                    committedFrameCount: 0,
+                    firstCommittedFrameOffset: nil,
+                    segmentID: request.segmentID
+                )
+                let systemAudioSource = RecordingJournalSource(
+                    id: request.systemAudioSourceID,
+                    kind: .systemAudio,
+                    fileName: "system-audio.wav.part",
+                    storageLayout: .reservedWAVHeader44,
+                    committedDataByteCount: 0,
+                    committedFrameCount: 0,
+                    firstCommittedFrameOffset: nil,
+                    segmentID: request.segmentID
+                )
+                let manifest = RecordingJournalManifest(
+                    schemaVersion: 1,
+                    generation: 1,
+                    recordingID: request.recordingID,
+                    startedAt: request.startedAt,
+                    updatedAt: now(),
+                    monotonicAnchorNanoseconds:
+                        request.monotonicAnchorNanoseconds,
+                    state: .recording,
+                    sourceMode: .combined,
+                    pcmFormat: .canonical,
+                    sources: [microphoneSource, systemAudioSource],
+                    segments: [RecordingJournalSegment(
+                        id: request.segmentID,
+                        sequence: 0,
+                        sourceIDs: [
+                            request.microphoneSourceID,
+                            request.systemAudioSourceID
+                        ]
+                    )],
+                    pipeline: request.pipeline,
+                    promotion: nil,
+                    historyItemID: nil
+                )
+                try manifest.validate()
+                try writeManifestUnlocked(
+                    manifest,
+                    to: combinedSession.manifestURL
+                )
+                return combinedSession
+            } catch {
+                try? fileManager.removeItem(
+                    at: combinedSession.recordingDirectory
+                )
+                try? RecordingJournalDurability.syncDirectory(
+                    inflightDirectory
+                )
+                throw error
+            }
+        }
+    }
+
     func loadManifest(recordingID: UUID) throws -> RecordingJournalManifest {
         try lock.withLock {
             try loadManifestUnlocked(recordingID: recordingID)
@@ -215,54 +352,95 @@ final class RecordingJournalStore {
         sourceID: UUID,
         commit: RecordingJournalSourceCommit
     ) throws -> RecordingJournalManifest {
+        try recordCheckpoints(
+            recordingID: recordingID,
+            commitsBySourceID: [sourceID: commit]
+        )
+    }
+
+    func recordCheckpoints(
+        recordingID: UUID,
+        commitsBySourceID: [UUID: RecordingJournalSourceCommit]
+    ) throws -> RecordingJournalManifest {
         try lock.withLock {
             var manifest = try loadManifestUnlocked(recordingID: recordingID)
             guard manifest.state == .recording
                     || manifest.state == .stopping
                     || manifest.state == .recoverable else {
-                throw RecordingJournalStoreError.invalidCheckpointState(manifest.state)
-            }
-            guard let index = manifest.sources.firstIndex(where: { $0.id == sourceID }) else {
-                throw RecordingJournalStoreError.sourceNotFound(sourceID)
-            }
-            let existing = manifest.sources[index]
-            let (expectedDataByteCount, overflow) = commit.frameCount.multipliedReportingOverflow(
-                by: UInt64(manifest.pcmFormat.bytesPerFrame)
-            )
-            guard !overflow,
-                  commit.dataByteCount == expectedDataByteCount,
-                  commit.dataByteCount >= existing.committedDataByteCount,
-                  commit.frameCount >= existing.committedFrameCount else {
-                throw RecordingJournalStoreError.checkpointRegression
-            }
-            if let existingOffset = existing.firstCommittedFrameOffset,
-               let requestedOffset = commit.firstCommittedFrameOffset,
-               existingOffset != requestedOffset {
-                throw RecordingJournalStoreError.checkpointRegression
-            }
-            let resolvedOffset = existing.firstCommittedFrameOffset ?? commit.firstCommittedFrameOffset
-            guard commit.dataByteCount == 0 || resolvedOffset != nil else {
-                throw RecordingJournalStoreError.checkpointRegression
-            }
-            guard commit.dataByteCount != existing.committedDataByteCount
-                    || resolvedOffset != existing.firstCommittedFrameOffset else {
-                return manifest
+                throw RecordingJournalStoreError.invalidCheckpointState(
+                    manifest.state
+                )
             }
 
-            let (nextGeneration, generationOverflow) = manifest.generation.addingReportingOverflow(1)
+            var updates: [Int: RecordingJournalSourceCommit] = [:]
+            for (sourceID, commit) in commitsBySourceID {
+                guard let index = manifest.sources.firstIndex(where: {
+                    $0.id == sourceID
+                }) else {
+                    throw RecordingJournalStoreError.sourceNotFound(sourceID)
+                }
+                let existing = manifest.sources[index]
+                let (expectedDataByteCount, overflow) =
+                    commit.frameCount.multipliedReportingOverflow(
+                        by: UInt64(manifest.pcmFormat.bytesPerFrame)
+                    )
+                guard !overflow,
+                      commit.dataByteCount == expectedDataByteCount,
+                      commit.dataByteCount >= existing.committedDataByteCount,
+                      commit.frameCount >= existing.committedFrameCount else {
+                    throw RecordingJournalStoreError.checkpointRegression
+                }
+                if let existingOffset = existing.firstCommittedFrameOffset,
+                   let requestedOffset = commit.firstCommittedFrameOffset,
+                   existingOffset != requestedOffset {
+                    throw RecordingJournalStoreError.checkpointRegression
+                }
+                let resolvedOffset = existing.firstCommittedFrameOffset
+                    ?? commit.firstCommittedFrameOffset
+                guard commit.dataByteCount == 0 || resolvedOffset != nil else {
+                    throw RecordingJournalStoreError.checkpointRegression
+                }
+                updates[index] = RecordingJournalSourceCommit(
+                    dataByteCount: commit.dataByteCount,
+                    frameCount: commit.frameCount,
+                    firstCommittedFrameOffset: resolvedOffset
+                )
+            }
+
+            let changedUpdates = updates.filter { index, commit in
+                let existing = manifest.sources[index]
+                return commit.dataByteCount
+                        != existing.committedDataByteCount
+                    || commit.frameCount
+                        != existing.committedFrameCount
+                    || commit.firstCommittedFrameOffset
+                        != existing.firstCommittedFrameOffset
+            }
+            guard !changedUpdates.isEmpty else { return manifest }
+
+            let (nextGeneration, generationOverflow) =
+                manifest.generation.addingReportingOverflow(1)
             guard !generationOverflow else {
                 throw RecordingJournalError.invalidManifest(
                     "Manifest generation overflow."
                 )
             }
 
-            manifest.sources[index].committedDataByteCount = commit.dataByteCount
-            manifest.sources[index].committedFrameCount = commit.frameCount
-            manifest.sources[index].firstCommittedFrameOffset = resolvedOffset
+            for (index, commit) in changedUpdates {
+                manifest.sources[index].committedDataByteCount =
+                    commit.dataByteCount
+                manifest.sources[index].committedFrameCount =
+                    commit.frameCount
+                manifest.sources[index].firstCommittedFrameOffset =
+                    commit.firstCommittedFrameOffset
+            }
             manifest.generation = nextGeneration
             manifest.updatedAt = now()
             try manifest.validate()
-            try writeManifestUnlocked(manifest, to: manifestURL(recordingID: recordingID))
+            try writeManifestUnlocked(
+                manifest,
+                to: manifestURL(recordingID: recordingID)
+            )
             return manifest
         }
     }
@@ -405,6 +583,31 @@ final class RecordingJournalStore {
         )
     }
 
+    private func combinedSession(
+        request: CombinedRecordingJournalCreateRequest
+    ) -> CombinedRecordingJournalSession {
+        let microphoneSession = session(
+            recordingID: request.recordingID,
+            sourceID: request.microphoneSourceID,
+            segmentID: request.segmentID,
+            sourceFileName: "microphone.wav.part"
+        )
+        let systemAudioSession = session(
+            recordingID: request.recordingID,
+            sourceID: request.systemAudioSourceID,
+            segmentID: request.segmentID,
+            sourceFileName: "system-audio.wav.part"
+        )
+        return CombinedRecordingJournalSession(
+            recordingID: request.recordingID,
+            segmentID: request.segmentID,
+            recordingDirectory: microphoneSession.recordingDirectory,
+            manifestURL: microphoneSession.manifestURL,
+            microphoneSession: microphoneSession,
+            systemAudioSession: systemAudioSession
+        )
+    }
+
     private func ensureDirectory(_ url: URL, permissions: Int) throws {
         if !fileManager.fileExists(atPath: url.path) {
             try fileManager.createDirectory(
@@ -495,6 +698,43 @@ final class RecordingJournalStore {
             throw RecordingJournalStoreError.systemCall("rename manifest", errno)
         }
         try RecordingJournalDurability.syncDirectory(targetURL.deletingLastPathComponent())
+    }
+
+    private func manifestMatchesCombinedRequest(
+        _ manifest: RecordingJournalManifest,
+        request: CombinedRecordingJournalCreateRequest
+    ) -> Bool {
+        guard manifest.recordingID == request.recordingID,
+              manifest.startedAt == request.startedAt,
+              manifest.monotonicAnchorNanoseconds
+                == request.monotonicAnchorNanoseconds,
+              manifest.sourceMode == .combined,
+              manifest.pipeline == request.pipeline,
+              manifest.sources.count == 2,
+              manifest.segments.count == 1 else {
+            return false
+        }
+        let segment = manifest.segments[0]
+        guard segment.id == request.segmentID,
+              segment.sequence == 0,
+              Set(segment.sourceIDs) == Set([
+                request.microphoneSourceID,
+                request.systemAudioSourceID
+              ]) else {
+            return false
+        }
+        let microphoneSource = manifest.sources.first(where: {
+            $0.kind == .microphone
+        })
+        let systemAudioSource = manifest.sources.first(where: {
+            $0.kind == .systemAudio
+        })
+        return microphoneSource?.id == request.microphoneSourceID
+            && microphoneSource?.fileName == "microphone.wav.part"
+            && microphoneSource?.segmentID == request.segmentID
+            && systemAudioSource?.id == request.systemAudioSourceID
+            && systemAudioSource?.fileName == "system-audio.wav.part"
+            && systemAudioSource?.segmentID == request.segmentID
     }
 
     private func manifestMatchesRequest(

--- a/Sources/RecordingPCMJournalWriter.swift
+++ b/Sources/RecordingPCMJournalWriter.swift
@@ -78,11 +78,40 @@ final class RecordingPCMJournalWriter: NormalizedPCM16Sink {
 
     func checkpoint() throws -> RecordingJournalSourceCommit {
         try queue.sync {
-            try checkpointLocked(closeAfterCheckpoint: false)
+            let commit = try checkpointLocked(
+                closeAfterCheckpoint: false
+            )
+            _ = try store.recordCheckpoint(
+                recordingID: session.recordingID,
+                sourceID: session.sourceID,
+                commit: commit
+            )
+            return commit
         }
     }
 
     func drainAndClose() throws -> RecordingJournalSourceCommit {
+        try queue.sync {
+            let commit = try checkpointLocked(
+                closeAfterCheckpoint: false
+            )
+            _ = try store.recordCheckpoint(
+                recordingID: session.recordingID,
+                sourceID: session.sourceID,
+                commit: commit
+            )
+            try closeLocked()
+            return commit
+        }
+    }
+
+    func checkpointSnapshot() throws -> RecordingJournalSourceCommit {
+        try queue.sync {
+            try checkpointLocked(closeAfterCheckpoint: false)
+        }
+    }
+
+    func drainAndCloseSnapshot() throws -> RecordingJournalSourceCommit {
         try queue.sync {
             try checkpointLocked(closeAfterCheckpoint: true)
         }
@@ -108,22 +137,23 @@ final class RecordingPCMJournalWriter: NormalizedPCM16Sink {
             frameCount: writtenDataByteCount / UInt64(RecordingPCMFormat.canonical.bytesPerFrame),
             firstCommittedFrameOffset: writtenDataByteCount > 0 ? firstCommittedFrameOffset : nil
         )
-        _ = try store.recordCheckpoint(
-            recordingID: session.recordingID,
-            sourceID: session.sourceID,
-            commit: commit
-        )
-
         if closeAfterCheckpoint {
-            do {
-                try handle.close()
-                self.handle = nil
-                isClosed = true
-            } catch {
-                failure = .writeFailed(error.localizedDescription)
-                throw error
-            }
+            try closeLocked()
         }
         return commit
+    }
+
+    private func closeLocked() throws {
+        guard !isClosed, let handle else {
+            throw RecordingPCMJournalWriterError.writerClosed
+        }
+        do {
+            try handle.close()
+            self.handle = nil
+            isClosed = true
+        } catch {
+            failure = .writeFailed(error.localizedDescription)
+            throw error
+        }
     }
 }

--- a/Tests/CombinedRecordingJournalControllerTests.swift
+++ b/Tests/CombinedRecordingJournalControllerTests.swift
@@ -1,0 +1,323 @@
+import Foundation
+
+@main
+struct CombinedRecordingJournalControllerTests {
+    static func main() {
+        do {
+            try independentSinksCheckpointInOneGeneration()
+            try checkpointPreservesNonemptySourceWhenOtherSourceIsEmpty()
+            try stopDrainsBothSourcesAndReturnsStableResult()
+            try preserveForRecoveryCommitsBothSources()
+            try preserveFailureStillMarksJournalRecoverable()
+            try discardRemovesCombinedJournal()
+            try initializationFailureRollsBackCombinedJournal()
+            print("CombinedRecordingJournalControllerTests passed")
+        } catch {
+            fputs(
+                "CombinedRecordingJournalControllerTests failed: \(error)\n",
+                stderr
+            )
+            exit(1)
+        }
+    }
+
+    private static func independentSinksCheckpointInOneGeneration() throws {
+        try withFixture { fixture in
+            let controller = try CombinedRecordingJournalController(
+                request: fixture.request,
+                store: fixture.store
+            )
+            controller.microphoneSink.enqueue(
+                Data([0x01, 0x00, 0x02, 0x00])
+            )
+            controller.systemAudioSink.enqueue(Data([0x03, 0x00]))
+
+            try controller.checkpoint()
+
+            let manifest = try fixture.store.loadManifest(
+                recordingID: fixture.recordingID
+            )
+            try expectEqual(manifest.generation, 2, "checkpoint generation")
+            try expectEqual(
+                committedBytes(
+                    in: manifest,
+                    kind: .microphone
+                ),
+                4,
+                "microphone bytes"
+            )
+            try expectEqual(
+                committedBytes(
+                    in: manifest,
+                    kind: .systemAudio
+                ),
+                2,
+                "System Audio bytes"
+            )
+        }
+    }
+
+    private static func checkpointPreservesNonemptySourceWhenOtherSourceIsEmpty() throws {
+        try withFixture { fixture in
+            let controller = try CombinedRecordingJournalController(
+                request: fixture.request,
+                store: fixture.store
+            )
+            controller.microphoneSink.enqueue(Data([0x01, 0x00]))
+
+            try controller.checkpoint()
+
+            let manifest = try fixture.store.loadManifest(
+                recordingID: fixture.recordingID
+            )
+            try expectEqual(
+                committedBytes(in: manifest, kind: .microphone),
+                2,
+                "one-source microphone bytes"
+            )
+            try expectEqual(
+                committedBytes(in: manifest, kind: .systemAudio),
+                0,
+                "one-source empty System Audio bytes"
+            )
+        }
+    }
+
+    private static func stopDrainsBothSourcesAndReturnsStableResult() throws {
+        try withFixture { fixture in
+            let controller = try CombinedRecordingJournalController(
+                request: fixture.request,
+                store: fixture.store
+            )
+            controller.microphoneSink.enqueue(Data([0x01, 0x00]))
+            controller.systemAudioSink.enqueue(
+                Data([0x02, 0x00, 0x03, 0x00])
+            )
+
+            let first = try controller.stopAndClose()
+            let second = try controller.stopAndClose()
+
+            try expectEqual(second, first, "repeated stop result")
+            try expectEqual(
+                first.microphoneCommit.dataByteCount,
+                2,
+                "stopped microphone bytes"
+            )
+            try expectEqual(
+                first.systemAudioCommit.dataByteCount,
+                4,
+                "stopped System Audio bytes"
+            )
+            let manifest = try fixture.store.loadManifest(
+                recordingID: fixture.recordingID
+            )
+            try expectEqual(manifest.state, .stopping, "stopped state")
+            try expectEqual(manifest.generation, 3, "stopped generation")
+        }
+    }
+
+    private static func preserveForRecoveryCommitsBothSources() throws {
+        try withFixture { fixture in
+            let controller = try CombinedRecordingJournalController(
+                request: fixture.request,
+                store: fixture.store
+            )
+            controller.microphoneSink.enqueue(Data([0x01, 0x00]))
+            controller.systemAudioSink.enqueue(Data([0x02, 0x00]))
+
+            try controller.preserveForRecovery()
+            try controller.preserveForRecovery()
+
+            let manifest = try fixture.store.loadManifest(
+                recordingID: fixture.recordingID
+            )
+            try expectEqual(manifest.state, .recoverable, "recoverable state")
+            try expectEqual(
+                manifest.sources.map(\.committedDataByteCount),
+                [2, 2],
+                "recoverable source bytes"
+            )
+        }
+    }
+
+    private static func preserveFailureStillMarksJournalRecoverable() throws {
+        try withFixture { fixture in
+            let controller = try CombinedRecordingJournalController(
+                request: fixture.request,
+                store: fixture.store
+            )
+            controller.microphoneSink.enqueue(Data([0x01, 0x00]))
+            controller.systemAudioSink.enqueue(Data([0xFF]))
+
+            do {
+                try controller.preserveForRecovery()
+                throw TestFailure("odd System Audio chunk must fail preserve")
+            } catch RecordingPCMJournalWriterError.oddByteChunk {
+                // expected
+            }
+
+            let manifest = try fixture.store.loadManifest(
+                recordingID: fixture.recordingID
+            )
+            try expectEqual(
+                manifest.state,
+                .recoverable,
+                "failed preserve state"
+            )
+        }
+    }
+
+    private static func discardRemovesCombinedJournal() throws {
+        try withFixture { fixture in
+            let controller = try CombinedRecordingJournalController(
+                request: fixture.request,
+                store: fixture.store
+            )
+            controller.microphoneSink.enqueue(Data([0x01, 0x00]))
+            controller.systemAudioSink.enqueue(Data([0x02, 0x00]))
+
+            try controller.discard()
+            try controller.discard()
+
+            guard !FileManager.default.fileExists(
+                atPath: fixture.store.recordingDirectory(
+                    recordingID: fixture.recordingID
+                ).path
+            ) else {
+                throw TestFailure("discard must remove combined journal")
+            }
+        }
+    }
+
+    private static func initializationFailureRollsBackCombinedJournal() throws {
+        try withFixture { fixture in
+            var writerCount = 0
+            do {
+                _ = try CombinedRecordingJournalController(
+                    request: fixture.request,
+                    store: fixture.store,
+                    makeWriter: { session, store in
+                        writerCount += 1
+                        if writerCount == 2 {
+                            throw TestFailure("injected second writer failure")
+                        }
+                        return try RecordingPCMJournalWriter(
+                            session: session,
+                            store: store
+                        )
+                    }
+                )
+                throw TestFailure("controller initialization must fail")
+            } catch let error as TestFailure
+                where error.description == "injected second writer failure" {
+                // expected
+            }
+
+            guard !FileManager.default.fileExists(
+                atPath: fixture.store.recordingDirectory(
+                    recordingID: fixture.recordingID
+                ).path
+            ) else {
+                throw TestFailure(
+                    "failed initialization must remove combined journal"
+                )
+            }
+        }
+    }
+
+    private static func committedBytes(
+        in manifest: RecordingJournalManifest,
+        kind: RecordingJournalSourceKind
+    ) -> UInt64? {
+        manifest.sources.first(where: { $0.kind == kind })?
+            .committedDataByteCount
+    }
+
+    private static func withFixture(
+        _ body: (Fixture) throws -> Void
+    ) throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "quill-combined-journal-controller-tests-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let recordingID = UUID()
+        let store = RecordingJournalStore(
+            audioDirectory: root.appendingPathComponent(
+                "audio",
+                isDirectory: true
+            )
+        )
+        let request = CombinedRecordingJournalCreateRequest(
+            recordingID: recordingID,
+            microphoneSourceID: UUID(),
+            systemAudioSourceID: UUID(),
+            segmentID: UUID(),
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            monotonicAnchorNanoseconds: 100,
+            pipeline: makePipelineSnapshot()
+        )
+        try body(Fixture(
+            recordingID: recordingID,
+            store: store,
+            request: request
+        ))
+    }
+
+    private static func makePipelineSnapshot() -> RecordingPipelineSnapshot {
+        RecordingPipelineSnapshot(
+            trigger: .toggle,
+            intent: .dictation,
+            selectedText: nil,
+            title: nil,
+            calendar: nil,
+            transcription: RecordingTranscriptionSnapshot(
+                backend: .apiStandard,
+                modelID: "whisper-large-v3",
+                spokenLanguageCode: "auto",
+                providerSelection: .defaultConfiguration
+            ),
+            processing: RecordingProcessingSnapshot(
+                postProcessingEnabled: false,
+                preferredModelID: nil,
+                fallbackModelID: nil,
+                outputLanguage: "auto",
+                preserveExactWording: false,
+                contextCaptureEnabled: false,
+                instructionExecutionGuardEnabled: true,
+                customVocabulary: [],
+                customSystemPrompt: nil
+            )
+        )
+    }
+
+    private static func expectEqual<T: Equatable>(
+        _ actual: T,
+        _ expected: T,
+        _ label: String
+    ) throws {
+        guard actual == expected else {
+            throw TestFailure("\(label): expected \(expected), got \(actual)")
+        }
+    }
+
+    private struct Fixture {
+        let recordingID: UUID
+        let store: RecordingJournalStore
+        let request: CombinedRecordingJournalCreateRequest
+    }
+
+    private struct TestFailure: Error, CustomStringConvertible {
+        let description: String
+
+        init(_ description: String) {
+            self.description = description
+        }
+    }
+}

--- a/Tests/CombinedRecordingJournalControllerTests.swift
+++ b/Tests/CombinedRecordingJournalControllerTests.swift
@@ -9,8 +9,12 @@ struct CombinedRecordingJournalControllerTests {
             try stopDrainsBothSourcesAndReturnsStableResult()
             try preserveForRecoveryCommitsBothSources()
             try preserveFailureStillMarksJournalRecoverable()
+            try failedMicrophoneDrainStillClosesSystemAudioWriter()
+            try checkpointFailureCallbackRunsOffLifecycleQueue()
             try discardRemovesCombinedJournal()
             try initializationFailureRollsBackCombinedJournal()
+            try reusedInitializationFailurePreservesCombinedJournal()
+            try deinitAvoidsLifecycleQueueSync()
             print("CombinedRecordingJournalControllerTests passed")
         } catch {
             fputs(
@@ -167,6 +171,77 @@ struct CombinedRecordingJournalControllerTests {
         }
     }
 
+    private static func failedMicrophoneDrainStillClosesSystemAudioWriter() throws {
+        try withFixture { fixture in
+            let controller = try CombinedRecordingJournalController(
+                request: fixture.request,
+                store: fixture.store
+            )
+            controller.microphoneSink.enqueue(Data([0xFF]))
+            controller.systemAudioSink.enqueue(Data([0x01, 0x00]))
+
+            do {
+                try controller.preserveForRecovery()
+                throw TestFailure("odd microphone chunk must fail preserve")
+            } catch RecordingPCMJournalWriterError.oddByteChunk {
+                // expected
+            }
+
+            controller.systemAudioSink.enqueue(Data([0x02, 0x00]))
+            let systemAudioURL = try fixture.store.sourceURL(
+                recordingID: fixture.recordingID,
+                fileName: "system-audio.wav.part"
+            )
+            Thread.sleep(forTimeInterval: 0.05)
+            try expectEqual(
+                try payloadData(from: systemAudioURL),
+                Data([0x01, 0x00]),
+                "failed preserve must close System Audio writer"
+            )
+        }
+    }
+
+    private static func checkpointFailureCallbackRunsOffLifecycleQueue() throws {
+        try withFixture { fixture in
+            let controller = try CombinedRecordingJournalController(
+                request: fixture.request,
+                store: fixture.store
+            )
+            let callbackQueue = DispatchQueue(
+                label: "com.woosublee.quill.tests.combined-callback"
+            )
+            let callbackQueueKey = DispatchSpecificKey<UInt8>()
+            callbackQueue.setSpecific(key: callbackQueueKey, value: 1)
+            let callbackFinished = DispatchSemaphore(value: 0)
+            var callbackError: Error?
+
+            controller.microphoneSink.enqueue(Data([0xFF]))
+            controller.startCheckpointing(
+                every: 0.01,
+                callbackQueue: callbackQueue
+            ) { _ in
+                do {
+                    guard DispatchQueue.getSpecific(
+                        key: callbackQueueKey
+                    ) != nil else {
+                        throw TestFailure(
+                            "checkpoint failure callback used the lifecycle queue"
+                        )
+                    }
+                    try controller.discard()
+                } catch {
+                    callbackError = error
+                }
+                callbackFinished.signal()
+            }
+
+            guard callbackFinished.wait(timeout: .now() + 2) == .success else {
+                throw TestFailure("checkpoint failure callback timed out")
+            }
+            if let callbackError { throw callbackError }
+        }
+    }
+
     private static func discardRemovesCombinedJournal() throws {
         try withFixture { fixture in
             let controller = try CombinedRecordingJournalController(
@@ -223,6 +298,80 @@ struct CombinedRecordingJournalControllerTests {
                 )
             }
         }
+    }
+
+    private static func reusedInitializationFailurePreservesCombinedJournal() throws {
+        try withFixture { fixture in
+            let session = try fixture.store.createCombined(fixture.request)
+            let microphoneBefore = try Data(
+                contentsOf: session.microphoneSession.sourceURL
+            )
+            let systemAudioBefore = try Data(
+                contentsOf: session.systemAudioSession.sourceURL
+            )
+            let manifestBefore = try Data(contentsOf: session.manifestURL)
+
+            do {
+                _ = try CombinedRecordingJournalController(
+                    request: fixture.request,
+                    store: fixture.store,
+                    makeWriter: { _, _ in
+                        throw TestFailure("injected reused writer failure")
+                    }
+                )
+                throw TestFailure("reused controller initialization must fail")
+            } catch let error as TestFailure
+                where error.description == "injected reused writer failure" {
+                // expected
+            }
+
+            try expectEqual(
+                try Data(contentsOf: session.manifestURL),
+                manifestBefore,
+                "reused manifest preservation"
+            )
+            try expectEqual(
+                try Data(contentsOf: session.microphoneSession.sourceURL),
+                microphoneBefore,
+                "reused microphone preservation"
+            )
+            try expectEqual(
+                try Data(contentsOf: session.systemAudioSession.sourceURL),
+                systemAudioBefore,
+                "reused System Audio preservation"
+            )
+        }
+    }
+
+    private static func deinitAvoidsLifecycleQueueSync() throws {
+        let source = try String(
+            contentsOfFile: "Sources/CombinedRecordingJournalController.swift",
+            encoding: .utf8
+        )
+        guard let deinitRange = source.range(of: "deinit {") else {
+            throw TestFailure("missing controller deinit")
+        }
+        let suffix = source[deinitRange.lowerBound...]
+        guard let endRange = suffix.range(of: "\n    }\n\n    func startCheckpointing") else {
+            throw TestFailure("missing controller deinit boundary")
+        }
+        let body = String(suffix[..<endRange.lowerBound])
+        guard !body.contains("lifecycleQueue.sync"),
+              body.contains("checkpointTimer?.cancel()") else {
+            throw TestFailure(
+                "controller deinit must cancel the timer without queue sync"
+            )
+        }
+    }
+
+    private static func payloadData(from url: URL) throws -> Data {
+        let data = try Data(contentsOf: url)
+        guard data.count >= RecordingCanonicalWAV.headerByteCount else {
+            throw TestFailure("source is shorter than reserved WAV header")
+        }
+        return data.subdata(
+            in: RecordingCanonicalWAV.headerByteCount..<data.count
+        )
     }
 
     private static func committedBytes(

--- a/Tests/RecordingJournalManifestTests.swift
+++ b/Tests/RecordingJournalManifestTests.swift
@@ -6,6 +6,8 @@ struct RecordingJournalManifestTests {
         do {
             try canonicalFormatMatchesRecorderContract()
             try manifestRoundTripPreservesStableMetadata()
+            try combinedManifestAcceptsCanonicalShape()
+            try manifestRejectsSourceModeShapeMismatch()
             try stateMachineAllowsOnlyDocumentedTransitions()
             try sameStateTransitionIsIdempotent()
             try conflictingIdempotentTransitionIsRejected()
@@ -41,6 +43,49 @@ struct RecordingJournalManifestTests {
 
         try expectEqual(decoded, manifest, "manifest round trip")
         try decoded.validate()
+    }
+
+    private static func combinedManifestAcceptsCanonicalShape() throws {
+        let manifest = try makeCombinedManifest()
+
+        try manifest.validate()
+        try expectEqual(manifest.sourceMode, .combined, "combined source mode")
+        try expectEqual(manifest.sources.count, 2, "combined source count")
+        try expectEqual(
+            Set(manifest.sources.map(\.kind)),
+            Set([.microphone, .systemAudio]),
+            "combined source kinds"
+        )
+        try expectEqual(
+            Set(manifest.segments[0].sourceIDs),
+            Set(manifest.sources.map(\.id)),
+            "combined segment sources"
+        )
+    }
+
+    private static func manifestRejectsSourceModeShapeMismatch() throws {
+        try expectInvalidManifest(
+            makeCombinedManifest(systemSourceKind: .microphone),
+            "combined duplicate source kind"
+        )
+        try expectInvalidManifest(
+            makeCombinedManifest(sourceMode: .microphone),
+            "single-source mode with two sources"
+        )
+        try expectInvalidManifest(
+            makeCombinedManifest(includeSystemSource: false),
+            "combined mode missing System Audio source"
+        )
+        try expectInvalidManifest(
+            makeCombinedManifest(segmentSourceIDs: [sourceID]),
+            "combined segment missing a source"
+        )
+        try expectInvalidManifest(
+            makeCombinedManifest(
+                systemSourceFileName: "microphone.wav.part"
+            ),
+            "combined duplicate source filename"
+        )
     }
 
     private static func stateMachineAllowsOnlyDocumentedTransitions() throws {
@@ -298,8 +343,72 @@ struct RecordingJournalManifestTests {
         return manifest
     }
 
+    private static func makeCombinedManifest(
+        sourceMode: RecordingAudioSourceMode = .combined,
+        systemSourceKind: RecordingJournalSourceKind = .systemAudio,
+        systemSourceFileName: String = "system-audio.wav.part",
+        includeSystemSource: Bool = true,
+        segmentSourceIDs: [UUID]? = nil
+    ) throws -> RecordingJournalManifest {
+        var sources = [RecordingJournalSource(
+            id: sourceID,
+            kind: .microphone,
+            fileName: "microphone.wav.part",
+            storageLayout: .reservedWAVHeader44,
+            committedDataByteCount: 0,
+            committedFrameCount: 0,
+            firstCommittedFrameOffset: nil,
+            segmentID: segmentID
+        )]
+        if includeSystemSource {
+            sources.append(RecordingJournalSource(
+                id: systemSourceID,
+                kind: systemSourceKind,
+                fileName: systemSourceFileName,
+                storageLayout: .reservedWAVHeader44,
+                committedDataByteCount: 0,
+                committedFrameCount: 0,
+                firstCommittedFrameOffset: nil,
+                segmentID: segmentID
+            ))
+        }
+        return RecordingJournalManifest(
+            schemaVersion: 1,
+            generation: 1,
+            recordingID: recordingID,
+            startedAt: fixedDate,
+            updatedAt: fixedDate,
+            monotonicAnchorNanoseconds: 123_456,
+            state: .recording,
+            sourceMode: sourceMode,
+            pcmFormat: .canonical,
+            sources: sources,
+            segments: [RecordingJournalSegment(
+                id: segmentID,
+                sequence: 0,
+                sourceIDs: segmentSourceIDs ?? sources.map(\.id)
+            )],
+            pipeline: try makeManifest().pipeline,
+            promotion: nil,
+            historyItemID: nil
+        )
+    }
+
+    private static func expectInvalidManifest(
+        _ manifest: RecordingJournalManifest,
+        _ label: String
+    ) throws {
+        do {
+            try manifest.validate()
+            throw TestFailure("\(label) must fail validation")
+        } catch RecordingJournalError.invalidManifest {
+            // expected
+        }
+    }
+
     private static let recordingID = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
     private static let sourceID = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+    private static let systemSourceID = UUID(uuidString: "66666666-7777-8888-9999-AAAAAAAAAAAA")!
     private static let segmentID = UUID(uuidString: "99999999-8888-7777-6666-555555555555")!
     private static let fixedDate = Date(timeIntervalSince1970: 1_700_000_000.123)
 

--- a/Tests/RecordingJournalManifestTests.swift
+++ b/Tests/RecordingJournalManifestTests.swift
@@ -7,6 +7,7 @@ struct RecordingJournalManifestTests {
             try canonicalFormatMatchesRecorderContract()
             try manifestRoundTripPreservesStableMetadata()
             try combinedManifestAcceptsCanonicalShape()
+            try legacySingleSourceManifestShapeRemainsValid()
             try manifestRejectsSourceModeShapeMismatch()
             try stateMachineAllowsOnlyDocumentedTransitions()
             try sameStateTransitionIsIdempotent()
@@ -63,14 +64,50 @@ struct RecordingJournalManifestTests {
         )
     }
 
+    private static func legacySingleSourceManifestShapeRemainsValid() throws {
+        var manifest = try makeManifest()
+        let secondSegmentID = UUID()
+        manifest.sources.append(RecordingJournalSource(
+            id: systemSourceID,
+            kind: .systemAudio,
+            fileName: "microphone.wav.part",
+            storageLayout: .reservedWAVHeader44,
+            committedDataByteCount: 0,
+            committedFrameCount: 0,
+            firstCommittedFrameOffset: nil,
+            segmentID: secondSegmentID
+        ))
+        manifest = RecordingJournalManifest(
+            schemaVersion: manifest.schemaVersion,
+            generation: manifest.generation,
+            recordingID: manifest.recordingID,
+            startedAt: manifest.startedAt,
+            updatedAt: manifest.updatedAt,
+            monotonicAnchorNanoseconds: manifest.monotonicAnchorNanoseconds,
+            state: manifest.state,
+            sourceMode: .microphone,
+            pcmFormat: manifest.pcmFormat,
+            sources: manifest.sources,
+            segments: [
+                manifest.segments[0],
+                RecordingJournalSegment(
+                    id: secondSegmentID,
+                    sequence: 1,
+                    sourceIDs: [systemSourceID]
+                )
+            ],
+            pipeline: manifest.pipeline,
+            promotion: nil,
+            historyItemID: nil
+        )
+
+        try manifest.validate()
+    }
+
     private static func manifestRejectsSourceModeShapeMismatch() throws {
         try expectInvalidManifest(
             makeCombinedManifest(systemSourceKind: .microphone),
             "combined duplicate source kind"
-        )
-        try expectInvalidManifest(
-            makeCombinedManifest(sourceMode: .microphone),
-            "single-source mode with two sources"
         )
         try expectInvalidManifest(
             makeCombinedManifest(includeSystemSource: false),

--- a/Tests/RecordingJournalRuntimeTests.swift
+++ b/Tests/RecordingJournalRuntimeTests.swift
@@ -6,11 +6,18 @@ struct RecordingJournalRuntimeTests {
     static func main() {
         do {
             try createBuildsSingleSourceInflightLayout()
+            try createCombinedBuildsTwoSourceInflightLayout()
             try duplicateCreateReusesExistingRecordingWithoutTruncation()
+            try duplicateCombinedCreateReusesBothSourcesWithoutTruncation()
             try conflictingCreatePreservesExistingArtifact()
+            try conflictingCombinedCreatePreservesExistingArtifacts()
             try failedCreateRemovesNewInflightDirectory()
+            try failedCombinedCreateRemovesPartialInflightDirectory()
             try failedReplacementLeavesPreviousManifestReadable()
             try checkpointRejectsOverflowingGenerationWithoutTrapping()
+            try batchCheckpointCommitsBothSourcesInOneGeneration()
+            try invalidBatchCheckpointPreservesPreviousManifest()
+            try writerSnapshotsDoNotWriteManifestBeforeBatchCommit()
             try writerCheckpointsOrderedPCMWithoutPerAppendManifestWrites()
             try writerRejectsOddChunksAndPostCloseWritesWithoutDamagingPCM()
             try writerCanBeReleasedAfterQueuedWriteWithoutCrashing()
@@ -19,6 +26,9 @@ struct RecordingJournalRuntimeTests {
             try finalizerRejectsTruncatedCommittedPayload()
             try finalizerPreservesEmptyAndConflictingArtifacts()
             try discardedJournalIsNeverRecovered()
+            try scannerPreservesValidCombinedJournalForManualRecovery()
+            try scannerDiagnosesEmptyCombinedSource()
+            try scannerDiagnosesDegradedCombinedSourcesWithoutDeletingThem()
             try scannerPreservesManualRecoveryArtifactsAndUsesActualEvenPayload()
             try manualRecoveryCandidateProtectsDerivedPermanentFileName()
             try scannerReturnsExecutablePlanForRecordingState()
@@ -58,6 +68,52 @@ struct RecordingJournalRuntimeTests {
         }
     }
 
+    private static func createCombinedBuildsTwoSourceInflightLayout() throws {
+        try withFixture { fixture in
+            let request = combinedRequest(fixture)
+            let session = try fixture.store.createCombined(request)
+
+            try expectEqual(
+                session.microphoneSession.sourceURL.lastPathComponent,
+                "microphone.wav.part",
+                "combined microphone filename"
+            )
+            try expectEqual(
+                session.systemAudioSession.sourceURL.lastPathComponent,
+                "system-audio.wav.part",
+                "combined System Audio filename"
+            )
+            for sourceURL in [
+                session.microphoneSession.sourceURL,
+                session.systemAudioSession.sourceURL
+            ] {
+                let sourceData = try Data(contentsOf: sourceURL)
+                try expectEqual(
+                    sourceData.count,
+                    RecordingCanonicalWAV.headerByteCount,
+                    "combined empty source size"
+                )
+                try expectEqual(
+                    RecordingCanonicalWAV.dataByteCount(in: sourceData),
+                    0,
+                    "combined empty WAV data size"
+                )
+            }
+
+            let manifest = try fixture.store.loadManifest(
+                recordingID: fixture.recordingID
+            )
+            try expectEqual(manifest.sourceMode, .combined, "combined source mode")
+            try expectEqual(manifest.sources.count, 2, "combined source count")
+            try expectEqual(manifest.segments.count, 1, "combined segment count")
+            try expectEqual(
+                Set(manifest.sources.map(\.kind)),
+                Set([.microphone, .systemAudio]),
+                "combined source kinds"
+            )
+        }
+    }
+
     private static func duplicateCreateReusesExistingRecordingWithoutTruncation() throws {
         try withFixture { fixture in
             let first = try fixture.store.createSingleSource(fixture.request)
@@ -67,6 +123,41 @@ struct RecordingJournalRuntimeTests {
             let second = try fixture.store.createSingleSource(fixture.request)
             try expectEqual(second, first, "duplicate session")
             try expectEqual(try fileSize(second.sourceURL), sizeBefore, "duplicate create source size")
+        }
+    }
+
+    private static func duplicateCombinedCreateReusesBothSourcesWithoutTruncation() throws {
+        try withFixture { fixture in
+            let request = combinedRequest(fixture)
+            let first = try fixture.store.createCombined(request)
+            try appendRaw(
+                Data([0x01, 0x00]),
+                to: first.microphoneSession.sourceURL
+            )
+            try appendRaw(
+                Data([0x02, 0x00]),
+                to: first.systemAudioSession.sourceURL
+            )
+            let microphoneBefore = try Data(
+                contentsOf: first.microphoneSession.sourceURL
+            )
+            let systemAudioBefore = try Data(
+                contentsOf: first.systemAudioSession.sourceURL
+            )
+
+            let second = try fixture.store.createCombined(request)
+
+            try expectEqual(second, first, "duplicate combined session")
+            try expectEqual(
+                try Data(contentsOf: second.microphoneSession.sourceURL),
+                microphoneBefore,
+                "duplicate combined microphone preservation"
+            )
+            try expectEqual(
+                try Data(contentsOf: second.systemAudioSession.sourceURL),
+                systemAudioBefore,
+                "duplicate combined System Audio preservation"
+            )
         }
     }
 
@@ -91,6 +182,53 @@ struct RecordingJournalRuntimeTests {
         }
     }
 
+    private static func conflictingCombinedCreatePreservesExistingArtifacts() throws {
+        try withFixture { fixture in
+            let request = combinedRequest(fixture)
+            let session = try fixture.store.createCombined(request)
+            try appendRaw(
+                Data([0x01, 0x00]),
+                to: session.microphoneSession.sourceURL
+            )
+            try appendRaw(
+                Data([0x02, 0x00]),
+                to: session.systemAudioSession.sourceURL
+            )
+            let manifestBefore = try Data(contentsOf: session.manifestURL)
+            let microphoneBefore = try Data(
+                contentsOf: session.microphoneSession.sourceURL
+            )
+            let systemAudioBefore = try Data(
+                contentsOf: session.systemAudioSession.sourceURL
+            )
+
+            var conflict = request
+            conflict.systemAudioSourceID = UUID()
+            do {
+                _ = try fixture.store.createCombined(conflict)
+                throw TestFailure("conflicting combined create should fail")
+            } catch RecordingJournalStoreError.conflictingExistingRecording {
+                // expected
+            }
+
+            try expectEqual(
+                try Data(contentsOf: session.manifestURL),
+                manifestBefore,
+                "combined conflict manifest preservation"
+            )
+            try expectEqual(
+                try Data(contentsOf: session.microphoneSession.sourceURL),
+                microphoneBefore,
+                "combined conflict microphone preservation"
+            )
+            try expectEqual(
+                try Data(contentsOf: session.systemAudioSession.sourceURL),
+                systemAudioBefore,
+                "combined conflict System Audio preservation"
+            )
+        }
+    }
+
     private static func failedCreateRemovesNewInflightDirectory() throws {
         try withFixture { fixture in
             var invalidRequest = fixture.request
@@ -109,6 +247,32 @@ struct RecordingJournalRuntimeTests {
                 ).path
             ) else {
                 throw TestFailure("failed create must remove the new inflight directory")
+            }
+        }
+    }
+
+    private static func failedCombinedCreateRemovesPartialInflightDirectory() throws {
+        try withFixture { fixture in
+            var invalidRequest = combinedRequest(fixture)
+            invalidRequest.systemAudioSourceID = invalidRequest.microphoneSourceID
+
+            do {
+                _ = try fixture.store.createCombined(invalidRequest)
+                throw TestFailure("duplicate combined source IDs must fail")
+            } catch let error as TestFailure {
+                throw error
+            } catch {
+                // expected
+            }
+
+            guard !FileManager.default.fileExists(
+                atPath: fixture.store.recordingDirectory(
+                    recordingID: fixture.recordingID
+                ).path
+            ) else {
+                throw TestFailure(
+                    "failed combined create must remove its partial directory"
+                )
             }
         }
     }
@@ -166,6 +330,120 @@ struct RecordingJournalRuntimeTests {
             } catch RecordingJournalError.invalidManifest {
                 // expected
             }
+        }
+    }
+
+    private static func batchCheckpointCommitsBothSourcesInOneGeneration() throws {
+        try withFixture { fixture in
+            let request = combinedRequest(fixture)
+            _ = try fixture.store.createCombined(request)
+
+            let manifest = try fixture.store.recordCheckpoints(
+                recordingID: fixture.recordingID,
+                commitsBySourceID: [
+                    request.microphoneSourceID: RecordingJournalSourceCommit(
+                        dataByteCount: 4,
+                        frameCount: 2,
+                        firstCommittedFrameOffset: 0
+                    ),
+                    request.systemAudioSourceID: RecordingJournalSourceCommit(
+                        dataByteCount: 6,
+                        frameCount: 3,
+                        firstCommittedFrameOffset: 0
+                    )
+                ]
+            )
+
+            try expectEqual(manifest.generation, 2, "batch checkpoint generation")
+            try expectEqual(
+                manifest.sources.first(where: {
+                    $0.id == request.microphoneSourceID
+                })?.committedDataByteCount,
+                4,
+                "batch microphone bytes"
+            )
+            try expectEqual(
+                manifest.sources.first(where: {
+                    $0.id == request.systemAudioSourceID
+                })?.committedDataByteCount,
+                6,
+                "batch System Audio bytes"
+            )
+        }
+    }
+
+    private static func invalidBatchCheckpointPreservesPreviousManifest() throws {
+        try withFixture { fixture in
+            let request = combinedRequest(fixture)
+            let session = try fixture.store.createCombined(request)
+            let before = try Data(contentsOf: session.manifestURL)
+
+            do {
+                _ = try fixture.store.recordCheckpoints(
+                    recordingID: fixture.recordingID,
+                    commitsBySourceID: [
+                        request.microphoneSourceID: RecordingJournalSourceCommit(
+                            dataByteCount: 4,
+                            frameCount: 2,
+                            firstCommittedFrameOffset: 0
+                        ),
+                        request.systemAudioSourceID: RecordingJournalSourceCommit(
+                            dataByteCount: 3,
+                            frameCount: 1,
+                            firstCommittedFrameOffset: 0
+                        )
+                    ]
+                )
+                throw TestFailure("invalid batch checkpoint must fail")
+            } catch RecordingJournalStoreError.checkpointRegression {
+                // expected
+            }
+
+            try expectEqual(
+                try Data(contentsOf: session.manifestURL),
+                before,
+                "invalid batch manifest preservation"
+            )
+        }
+    }
+
+    private static func writerSnapshotsDoNotWriteManifestBeforeBatchCommit() throws {
+        try withFixture { fixture in
+            let request = combinedRequest(fixture)
+            let session = try fixture.store.createCombined(request)
+            let microphoneWriter = try RecordingPCMJournalWriter(
+                session: session.microphoneSession,
+                store: fixture.store
+            )
+            let systemAudioWriter = try RecordingPCMJournalWriter(
+                session: session.systemAudioSession,
+                store: fixture.store
+            )
+            microphoneWriter.enqueue(Data([0x01, 0x00, 0x02, 0x00]))
+            systemAudioWriter.enqueue(Data([0x03, 0x00]))
+
+            let microphoneCommit = try microphoneWriter.checkpointSnapshot()
+            let systemAudioCommit = try systemAudioWriter.checkpointSnapshot()
+            let beforeBatch = try fixture.store.loadManifest(
+                recordingID: fixture.recordingID
+            )
+            try expectEqual(beforeBatch.generation, 1, "snapshot generation")
+            try expectEqual(
+                beforeBatch.sources.map(\.committedDataByteCount),
+                [0, 0],
+                "snapshot manifest bytes"
+            )
+
+            let committed = try fixture.store.recordCheckpoints(
+                recordingID: fixture.recordingID,
+                commitsBySourceID: [
+                    request.microphoneSourceID: microphoneCommit,
+                    request.systemAudioSourceID: systemAudioCommit
+                ]
+            )
+            try expectEqual(committed.generation, 2, "snapshot batch generation")
+            _ = try microphoneWriter.drainAndCloseSnapshot()
+            _ = try systemAudioWriter.drainAndCloseSnapshot()
         }
     }
 
@@ -436,6 +714,141 @@ struct RecordingJournalRuntimeTests {
         }
     }
 
+    private static func scannerPreservesValidCombinedJournalForManualRecovery() throws {
+        try withFixture { fixture in
+            let request = combinedRequest(fixture)
+            let session = try fixture.store.createCombined(request)
+            let microphoneWriter = try RecordingPCMJournalWriter(
+                session: session.microphoneSession,
+                store: fixture.store
+            )
+            let systemAudioWriter = try RecordingPCMJournalWriter(
+                session: session.systemAudioSession,
+                store: fixture.store
+            )
+            microphoneWriter.enqueue(Data([0x01, 0x00, 0x02, 0x00]))
+            systemAudioWriter.enqueue(Data([0x03, 0x00]))
+            let microphoneCommit = try microphoneWriter.drainAndCloseSnapshot()
+            let systemAudioCommit = try systemAudioWriter.drainAndCloseSnapshot()
+            _ = try fixture.store.recordCheckpoints(
+                recordingID: fixture.recordingID,
+                commitsBySourceID: [
+                    request.microphoneSourceID: microphoneCommit,
+                    request.systemAudioSourceID: systemAudioCommit
+                ]
+            )
+
+            let before = try snapshotTree(fixture.audioDirectory)
+            guard let candidate = InflightRecordingRecovery(
+                store: fixture.store
+            ).scan().first(where: {
+                $0.recordingID == fixture.recordingID
+            }) else {
+                throw TestFailure("missing combined recovery candidate")
+            }
+            let after = try snapshotTree(fixture.audioDirectory)
+
+            try expectEqual(
+                candidate.action,
+                .manualRecoveryRequired,
+                "combined recovery action"
+            )
+            try expectEqual(
+                candidate.diagnostics,
+                [.combinedRecoveryPending],
+                "combined recovery diagnostic"
+            )
+            try expectEqual(after, before, "combined scanner preservation")
+        }
+    }
+
+    private static func scannerDiagnosesEmptyCombinedSource() throws {
+        try withFixture { fixture in
+            let request = combinedRequest(fixture)
+            let session = try fixture.store.createCombined(request)
+            let microphoneWriter = try RecordingPCMJournalWriter(
+                session: session.microphoneSession,
+                store: fixture.store
+            )
+            microphoneWriter.enqueue(Data([0x01, 0x00]))
+            let microphoneCommit = try microphoneWriter.drainAndCloseSnapshot()
+            _ = try fixture.store.recordCheckpoints(
+                recordingID: fixture.recordingID,
+                commitsBySourceID: [
+                    request.microphoneSourceID: microphoneCommit
+                ]
+            )
+
+            guard let candidate = InflightRecordingRecovery(
+                store: fixture.store
+            ).scan().first(where: {
+                $0.recordingID == fixture.recordingID
+            }) else {
+                throw TestFailure("missing empty combined candidate")
+            }
+
+            guard candidate.diagnostics.contains(.emptySource) else {
+                throw TestFailure(
+                    "empty combined diagnostics: \(candidate.diagnostics)"
+                )
+            }
+            guard FileManager.default.fileExists(
+                atPath: session.systemAudioSession.sourceURL.path
+            ) else {
+                throw TestFailure("scanner must preserve empty source file")
+            }
+        }
+    }
+
+    private static func scannerDiagnosesDegradedCombinedSourcesWithoutDeletingThem() throws {
+        try withFixture { fixture in
+            let request = combinedRequest(fixture)
+            let session = try fixture.store.createCombined(request)
+            let microphoneWriter = try RecordingPCMJournalWriter(
+                session: session.microphoneSession,
+                store: fixture.store
+            )
+            microphoneWriter.enqueue(Data([0x01, 0x00, 0x02, 0x00]))
+            let microphoneCommit = try microphoneWriter.drainAndCloseSnapshot()
+            _ = try fixture.store.recordCheckpoints(
+                recordingID: fixture.recordingID,
+                commitsBySourceID: [
+                    request.microphoneSourceID: microphoneCommit
+                ]
+            )
+            try FileManager.default.removeItem(
+                at: session.systemAudioSession.sourceURL
+            )
+
+            guard let candidate = InflightRecordingRecovery(
+                store: fixture.store
+            ).scan().first(where: {
+                $0.recordingID == fixture.recordingID
+            }) else {
+                throw TestFailure("missing degraded combined candidate")
+            }
+
+            try expectEqual(
+                candidate.action,
+                .manualRecoveryRequired,
+                "degraded combined action"
+            )
+            guard candidate.diagnostics.contains(.combinedRecoveryPending),
+                  candidate.diagnostics.contains(.missingSource) else {
+                throw TestFailure(
+                    "degraded combined diagnostics: \(candidate.diagnostics)"
+                )
+            }
+            guard FileManager.default.fileExists(
+                atPath: session.microphoneSession.sourceURL.path
+            ) else {
+                throw TestFailure(
+                    "scanner must preserve surviving combined source"
+                )
+            }
+        }
+    }
+
     private static func scannerPreservesManualRecoveryArtifactsAndUsesActualEvenPayload() throws {
         try withFixture { fixture in
             let missingManifestDirectory = fixture.audioDirectory
@@ -632,7 +1045,24 @@ struct RecordingJournalRuntimeTests {
         }
     }
 
-    private static func withFixture(_ body: (Fixture) throws -> Void) throws {
+    private static func combinedRequest(
+        _ fixture: Fixture
+    ) -> CombinedRecordingJournalCreateRequest {
+        CombinedRecordingJournalCreateRequest(
+            recordingID: fixture.recordingID,
+            microphoneSourceID: fixture.sourceID,
+            systemAudioSourceID: fixture.systemAudioSourceID,
+            segmentID: fixture.segmentID,
+            startedAt: fixture.request.startedAt,
+            monotonicAnchorNanoseconds:
+                fixture.request.monotonicAnchorNanoseconds,
+            pipeline: fixture.request.pipeline
+        )
+    }
+
+    private static func withFixture(
+        _ body: (Fixture) throws -> Void
+    ) throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("quill-recording-journal-tests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -640,6 +1070,7 @@ struct RecordingJournalRuntimeTests {
 
         let recordingID = UUID()
         let sourceID = UUID()
+        let systemAudioSourceID = UUID()
         let segmentID = UUID()
         let audioDirectory = root.appendingPathComponent("audio", isDirectory: true)
         var now = Date(timeIntervalSince1970: 1_700_000_000)
@@ -662,6 +1093,7 @@ struct RecordingJournalRuntimeTests {
             audioDirectory: audioDirectory,
             recordingID: recordingID,
             sourceID: sourceID,
+            systemAudioSourceID: systemAudioSourceID,
             segmentID: segmentID,
             store: store,
             request: request
@@ -770,6 +1202,7 @@ struct RecordingJournalRuntimeTests {
         let audioDirectory: URL
         let recordingID: UUID
         let sourceID: UUID
+        let systemAudioSourceID: UUID
         let segmentID: UUID
         let store: RecordingJournalStore
         let request: RecordingJournalCreateRequest

--- a/Tests/RecordingJournalRuntimeTests.swift
+++ b/Tests/RecordingJournalRuntimeTests.swift
@@ -28,6 +28,10 @@ struct RecordingJournalRuntimeTests {
             try discardedJournalIsNeverRecovered()
             try scannerPreservesValidCombinedJournalForManualRecovery()
             try scannerDiagnosesEmptyCombinedSource()
+            try scannerDiagnosesShortCombinedSource()
+            try scannerDiagnosesOddCombinedTail()
+            try scannerDiagnosesCombinedManifestBehind()
+            try scannerDiagnosesTruncatedCombinedSource()
             try scannerDiagnosesDegradedCombinedSourcesWithoutDeletingThem()
             try scannerPreservesManualRecoveryArtifactsAndUsesActualEvenPayload()
             try manualRecoveryCandidateProtectsDerivedPermanentFileName()
@@ -147,7 +151,31 @@ struct RecordingJournalRuntimeTests {
 
             let second = try fixture.store.createCombined(request)
 
-            try expectEqual(second, first, "duplicate combined session")
+            try expectEqual(
+                first.creationDisposition,
+                .created,
+                "first combined creation disposition"
+            )
+            try expectEqual(
+                second.creationDisposition,
+                .reused,
+                "duplicate combined creation disposition"
+            )
+            try expectEqual(
+                second.recordingDirectory,
+                first.recordingDirectory,
+                "duplicate combined recording directory"
+            )
+            try expectEqual(
+                second.microphoneSession,
+                first.microphoneSession,
+                "duplicate combined microphone session"
+            )
+            try expectEqual(
+                second.systemAudioSession,
+                first.systemAudioSession,
+                "duplicate combined System Audio session"
+            )
             try expectEqual(
                 try Data(contentsOf: second.microphoneSession.sourceURL),
                 microphoneBefore,
@@ -261,7 +289,7 @@ struct RecordingJournalRuntimeTests {
                 throw TestFailure("duplicate combined source IDs must fail")
             } catch let error as TestFailure {
                 throw error
-            } catch {
+            } catch RecordingJournalError.invalidManifest {
                 // expected
             }
 
@@ -800,6 +828,126 @@ struct RecordingJournalRuntimeTests {
         }
     }
 
+    private static func scannerDiagnosesShortCombinedSource() throws {
+        try withFixture { fixture in
+            let session = try fixture.store.createCombined(
+                combinedRequest(fixture)
+            )
+            try Data(repeating: 0, count: 10).write(
+                to: session.systemAudioSession.sourceURL,
+                options: .atomic
+            )
+
+            let candidate = try requireCandidate(
+                recordingID: fixture.recordingID,
+                store: fixture.store
+            )
+            guard candidate.diagnostics.contains(.sourceTooShort) else {
+                throw TestFailure(
+                    "short combined diagnostics: \(candidate.diagnostics)"
+                )
+            }
+            guard FileManager.default.fileExists(
+                atPath: session.systemAudioSession.sourceURL.path
+            ) else {
+                throw TestFailure("scanner must preserve short source file")
+            }
+        }
+    }
+
+    private static func scannerDiagnosesOddCombinedTail() throws {
+        try withFixture { fixture in
+            let session = try fixture.store.createCombined(
+                combinedRequest(fixture)
+            )
+            try appendRaw(
+                Data([0xFF]),
+                to: session.systemAudioSession.sourceURL
+            )
+
+            let candidate = try requireCandidate(
+                recordingID: fixture.recordingID,
+                store: fixture.store
+            )
+            guard candidate.diagnostics.contains(.oddTrailingByte) else {
+                throw TestFailure(
+                    "odd combined diagnostics: \(candidate.diagnostics)"
+                )
+            }
+            guard FileManager.default.fileExists(
+                atPath: session.systemAudioSession.sourceURL.path
+            ) else {
+                throw TestFailure("scanner must preserve odd-tail source")
+            }
+        }
+    }
+
+    private static func scannerDiagnosesCombinedManifestBehind() throws {
+        try withFixture { fixture in
+            let session = try fixture.store.createCombined(
+                combinedRequest(fixture)
+            )
+            try appendRaw(
+                Data([0x01, 0x00]),
+                to: session.systemAudioSession.sourceURL
+            )
+
+            let candidate = try requireCandidate(
+                recordingID: fixture.recordingID,
+                store: fixture.store
+            )
+            guard candidate.diagnostics.contains(.manifestBehind) else {
+                throw TestFailure(
+                    "manifest-behind combined diagnostics: \(candidate.diagnostics)"
+                )
+            }
+            guard FileManager.default.fileExists(
+                atPath: session.systemAudioSession.sourceURL.path
+            ) else {
+                throw TestFailure("scanner must preserve uncommitted source tail")
+            }
+        }
+    }
+
+    private static func scannerDiagnosesTruncatedCombinedSource() throws {
+        try withFixture { fixture in
+            let request = combinedRequest(fixture)
+            let session = try fixture.store.createCombined(request)
+            let writer = try RecordingPCMJournalWriter(
+                session: session.systemAudioSession,
+                store: fixture.store
+            )
+            writer.enqueue(Data([0x01, 0x00, 0x02, 0x00]))
+            let commit = try writer.drainAndCloseSnapshot()
+            _ = try fixture.store.recordCheckpoints(
+                recordingID: fixture.recordingID,
+                commitsBySourceID: [request.systemAudioSourceID: commit]
+            )
+            let handle = try FileHandle(
+                forUpdating: session.systemAudioSession.sourceURL
+            )
+            try handle.truncate(
+                atOffset: UInt64(RecordingCanonicalWAV.headerByteCount + 2)
+            )
+            try handle.close()
+
+            let candidate = try requireCandidate(
+                recordingID: fixture.recordingID,
+                store: fixture.store
+            )
+            guard candidate.diagnostics.contains(.sourceTruncated) else {
+                throw TestFailure(
+                    "truncated combined diagnostics: \(candidate.diagnostics)"
+                )
+            }
+            guard FileManager.default.fileExists(
+                atPath: session.systemAudioSession.sourceURL.path
+            ) else {
+                throw TestFailure("scanner must preserve truncated source")
+            }
+        }
+    }
+
     private static func scannerDiagnosesDegradedCombinedSourcesWithoutDeletingThem() throws {
         try withFixture { fixture in
             let request = combinedRequest(fixture)
@@ -1043,6 +1191,18 @@ struct RecordingJournalRuntimeTests {
             try expectEqual(before, middle, "first scan preservation")
             try expectEqual(middle, after, "second scan preservation")
         }
+    }
+
+    private static func requireCandidate(
+        recordingID: UUID,
+        store: RecordingJournalStore
+    ) throws -> InflightRecordingRecoveryCandidate {
+        guard let candidate = InflightRecordingRecovery(store: store)
+            .scan()
+            .first(where: { $0.recordingID == recordingID }) else {
+            throw TestFailure("missing combined recovery candidate")
+        }
+        return candidate
     }
 
     private static func combinedRequest(


### PR DESCRIPTION
## Summary

- validate the two-source `combined` recording manifest shape
- create microphone and System Audio journals atomically under one recording ID
- checkpoint both durable source boundaries in a single manifest generation
- add a combined journal lifecycle controller for checkpoint, stop, recovery preservation, and discard
- preserve valid and degraded combined journals as explicit manual recovery candidates until Phase 3B-2 connects mixdown and startup recovery

## Scope

This PR adds the durable journal foundation only. It does not connect the controller to `AppState` or `SystemDefaultAndSystemAudioRecorder`, and it does not mix, promote, or create history entries for combined journals yet.

Refs #181

## Test plan

- `make check-test-wiring`
- `make test`
- `make all APP_NAME=\"Quill Dev\" BUNDLE_ID=\"com.woosublee.quill.dev\" CODESIGN_IDENTITY=Quill`
- `xattr -cr build/`
- `codesign --verify --deep --strict --verbose=2 \"build/Quill Dev.app\"`
- `git diff --check`

## Follow-up

- #208 tracks the pre-existing Core Data and AVFoundation test-suite warnings.
- Phase 3B-2 will connect the combined controller to the real recorders and add mixed/degraded startup recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 마이크와 시스템 오디오를 하나의 녹음 세션으로 함께 기록할 수 있습니다.
  - 두 오디오 소스를 동시에 체크포인트하고 안전하게 종료하거나 복구 상태로 보존할 수 있습니다.
  - 녹음 중 문제가 발생해도 복구 가능한 기록을 식별하고 관련 파일을 보존합니다.

- **버그 수정**
  - 결합 녹음 생성 실패 시 불완전한 파일이 남지 않도록 정리합니다.
  - 녹음 구성과 소스 정보의 유효성 검사를 강화했습니다.
  - 복구 과정에서 손상되거나 누락된 소스를 삭제하지 않고 진단 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->