### PR TITLE
Enforce Native Whisper Metal artifact contract

### DIFF
--- a/BuildSupport/WhisperRuntime/build-whisper.cpp.sh
+++ b/BuildSupport/WhisperRuntime/build-whisper.cpp.sh
@@ -5,6 +5,7 @@ repo_url="${1:?repo url required}"
 version="${2:?version required}"
 checkout_dir="${3:?checkout dir required}"
 arch="${4:-$(uname -m)}"
+verify_script="$(cd "$(dirname "$0")" && pwd)/verify-whisper-helper.sh"
 
 mkdir -p "$(dirname "$checkout_dir")"
 
@@ -27,35 +28,10 @@ cmake -S "$checkout_dir" -B "$checkout_dir/build" \
   -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=OFF \
   -DWHISPER_BUILD_TESTS=OFF \
-  -DWHISPER_BUILD_EXAMPLES=ON
+  -DWHISPER_BUILD_EXAMPLES=ON \
+  -DGGML_METAL=ON \
+  -DGGML_METAL_EMBED_LIBRARY=ON
 cmake --build "$checkout_dir/build" --target whisper-cli --config Release -j "$(sysctl -n hw.ncpu)"
 
 helper="$checkout_dir/build/bin/whisper-cli"
-test -x "$helper"
-
-if otool -L "$helper" | grep -E '(@rpath/)?lib(whisper|ggml)' >/dev/null; then
-  echo "whisper-cli still links whisper.cpp/ggml dylibs; expected a self-contained helper." >&2
-  otool -L "$helper" >&2
-  exit 1
-fi
-
-helper_archs="$(lipo -archs "$helper")"
-if [ "$arch" = "universal" ]; then
-  for required_arch in arm64 x86_64; do
-    case " $helper_archs " in
-      *" $required_arch "*) ;;
-      *)
-        echo "whisper-cli is not universal; missing $required_arch; found architectures: $helper_archs" >&2
-        exit 1
-        ;;
-    esac
-  done
-else
-  case " $helper_archs " in
-    *" $arch "*) ;;
-    *)
-      echo "whisper-cli missing requested architecture $arch; found architectures: $helper_archs" >&2
-      exit 1
-      ;;
-  esac
-fi
+"$verify_script" "$helper" "$arch"

--- a/BuildSupport/WhisperRuntime/verify-whisper-helper.sh
+++ b/BuildSupport/WhisperRuntime/verify-whisper-helper.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+helper="${1:?helper path required}"
+expected_arch="${2:?expected architecture required}"
+
+fail() {
+  printf 'Native Whisper helper verification failed: %s\n' "$1" >&2
+  exit 1
+}
+
+[ -x "$helper" ] || fail "helper is missing or not executable: $helper"
+[ "$(stat -f %z "$helper")" -gt 0 ] || fail "helper is empty: $helper"
+
+helper_archs="$(lipo -archs "$helper")"
+case "$expected_arch" in
+  universal)
+    required_archs=(arm64 x86_64)
+    ;;
+  arm64|x86_64)
+    required_archs=("$expected_arch")
+    ;;
+  *)
+    fail "unsupported expected architecture: $expected_arch"
+    ;;
+esac
+
+for required_arch in "${required_archs[@]}"; do
+  case " $helper_archs " in
+    *" $required_arch "*) ;;
+    *) fail "missing required architecture $required_arch; found: $helper_archs" ;;
+  esac
+
+  linked_libraries="$(otool -arch "$required_arch" -L "$helper")"
+  grep -F 'Metal.framework' <<<"$linked_libraries" >/dev/null \
+    || fail "missing Metal.framework linkage for $required_arch"
+  grep -F 'MetalKit.framework' <<<"$linked_libraries" >/dev/null \
+    || fail "missing MetalKit.framework linkage for $required_arch"
+  if grep -E '(@rpath/)?lib(whisper|ggml)' <<<"$linked_libraries" >/dev/null; then
+    fail "helper links dynamic whisper.cpp/ggml libraries for $required_arch"
+  fi
+
+  symbols="$(nm -arch "$required_arch" -gU "$helper")"
+  for symbol in ggml_metallib_start ggml_metallib_end; do
+    grep -F "$symbol" <<<"$symbols" >/dev/null \
+      || fail "missing embedded Metal kernel symbol $symbol for $required_arch"
+  done
+done
+
+printf 'Verified Native Whisper Metal helper: %s (%s)\n' \
+  "$helper" "$helper_archs"

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ WHISPER_CPP_DIR = .build/checkouts/whisper.cpp
 WHISPER_HELPER = $(WHISPER_CPP_DIR)/build/bin/whisper-cli
 WHISPER_STAMP = $(BUILD_DIR)/.whisper-helper
 WHISPER_BUILD_SETTINGS = $(BUILD_DIR)/.whisper-build-settings
+WHISPER_VERIFY_SCRIPT = BuildSupport/WhisperRuntime/verify-whisper-helper.sh
 empty :=
 space := $(empty) $(empty)
 APP_EXECUTABLE = $(MACOS_DIR)/$(APP_NAME)
@@ -54,7 +55,7 @@ ICON_ICNS = Resources/AppIcon.icns
 endif
 
 # Usage: make install CODESIGN_IDENTITY="Apple Development: you@example.com (TEAMID)"
-.PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run check-test-wiring test localization-bundle-test print-app-version print-build-number print-build-tag print-version-metadata FORCE /tmp/LocalizationResourceTests
+.PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run check-test-wiring test localization-bundle-test native-whisper-helper-test print-app-version print-build-number print-build-tag print-version-metadata FORCE /tmp/LocalizationResourceTests
 
 all: $(APP_EXECUTABLE_TARGET)
 
@@ -78,10 +79,14 @@ $(WHISPER_BUILD_SETTINGS): FORCE
 	@printf '%s\n%s\n%s\n' "$(WHISPER_CPP_REPO)" "$(WHISPER_CPP_VERSION)" "$(ARCH)" > "$@.tmp"
 	@if [ ! -f "$@" ] || ! cmp -s "$@.tmp" "$@"; then mv "$@.tmp" "$@"; else rm "$@.tmp"; fi
 
-$(WHISPER_STAMP): BuildSupport/WhisperRuntime/build-whisper.cpp.sh $(WHISPER_BUILD_SETTINGS)
+$(WHISPER_STAMP): BuildSupport/WhisperRuntime/build-whisper.cpp.sh $(WHISPER_VERIFY_SCRIPT) $(WHISPER_BUILD_SETTINGS)
 	@BuildSupport/WhisperRuntime/build-whisper.cpp.sh "$(WHISPER_CPP_REPO)" "$(WHISPER_CPP_VERSION)" "$(WHISPER_CPP_DIR)" "$(ARCH)"
 	@mkdir -p "$(BUILD_DIR)"
 	@printf '%s\n' "$(WHISPER_HELPER)" > "$@"
+
+native-whisper-helper-test: $(WHISPER_STAMP)
+	@helper="$$(cat "$(WHISPER_STAMP)")"; \
+		$(WHISPER_VERIFY_SCRIPT) "$$helper" "$(ARCH)"
 
 $(LOCALIZATION_STAMP): $(LOCALIZATION_CATALOG) $(LOCALIZATION_INFO_DIR)/en.lproj/InfoPlist.strings $(LOCALIZATION_INFO_DIR)/ko.lproj/InfoPlist.strings
 	@rm -rf "$(LOCALIZATION_BUILD_DIR)"
@@ -324,6 +329,8 @@ test: check-test-wiring $(SPARKLE_STAMP) $(LOCALIZATION_STAMP)
 	@/tmp/LegacyNoteTitleMigrationTests
 	@swiftc -parse-as-library Tests/ManualReleaseWorkflowTests.swift -o /tmp/ManualReleaseWorkflowTests
 	@/tmp/ManualReleaseWorkflowTests
+	@swiftc -parse-as-library Tests/NativeWhisperBuildContractTests.swift -o /tmp/NativeWhisperBuildContractTests
+	@/tmp/NativeWhisperBuildContractTests
 	@framework="$$(cat "$(SPARKLE_STAMP)")"; framework_parent="$$(dirname "$$framework")"; swiftc -parse-as-library -F "$$framework_parent" -framework Sparkle -Xlinker -rpath -Xlinker "$$framework_parent" Sources/LocalizedStringLookup.swift Sources/LocalizedUserMessage.swift Sources/UpdateManager.swift Tests/UpdateManagerSafetyTests.swift -o /tmp/UpdateManagerSafetyTests
 	@/tmp/UpdateManagerSafetyTests
 	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Tests/LocalizedStringLookupTests.swift -o /tmp/LocalizedStringLookupTests

--- a/Tests/BuildMetadataTests.swift
+++ b/Tests/BuildMetadataTests.swift
@@ -49,7 +49,7 @@ struct BuildMetadataTests {
     private static func testMakefilePrintsVersionMetadata() throws {
         let makefile = try String(contentsOfFile: "Makefile", encoding: .utf8)
 
-        assertContains(makefile, ".PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run check-test-wiring test localization-bundle-test print-app-version print-build-number print-build-tag print-version-metadata FORCE /tmp/LocalizationResourceTests")
+        assertContains(makefile, ".PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run check-test-wiring test localization-bundle-test native-whisper-helper-test print-app-version print-build-number print-build-tag print-version-metadata FORCE /tmp/LocalizationResourceTests")
         assertContains(makefile, "print-app-version:")
         assertContains(makefile, "print-build-number:")
         assertContains(makefile, "print-build-tag:")

--- a/Tests/NativeWhisperBuildContractTests.swift
+++ b/Tests/NativeWhisperBuildContractTests.swift
@@ -1,0 +1,333 @@
+import Foundation
+
+@main
+struct NativeWhisperBuildContractTests {
+    static func main() throws {
+        let buildScriptPath = "BuildSupport/WhisperRuntime/build-whisper.cpp.sh"
+        let verifierPath = "BuildSupport/WhisperRuntime/verify-whisper-helper.sh"
+        let makefilePath = "Makefile"
+
+        let buildScript = try String(
+            contentsOfFile: buildScriptPath,
+            encoding: .utf8
+        )
+        try expect(
+            FileManager.default.fileExists(atPath: verifierPath),
+            "native whisper helper verifier exists"
+        )
+        let verifier = try String(
+            contentsOfFile: verifierPath,
+            encoding: .utf8
+        )
+        let makefile = try String(
+            contentsOfFile: makefilePath,
+            encoding: .utf8
+        )
+
+        try expect(
+            buildScript.contains("-DGGML_METAL=ON"),
+            "build explicitly enables Metal"
+        )
+        try expect(
+            buildScript.contains("-DGGML_METAL_EMBED_LIBRARY=ON"),
+            "build explicitly embeds Metal kernels"
+        )
+        try expect(
+            buildScript.contains(
+                #"verify_script="$(cd "$(dirname "$0")" && pwd)/verify-whisper-helper.sh""#
+            ),
+            "build resolves the shared verifier"
+        )
+        try expect(
+            buildScript.contains(#""$verify_script" "$helper" "$arch""#),
+            "build invokes the shared verifier"
+        )
+        try expect(
+            !buildScript.contains("otool -L \"$helper\" | grep"),
+            "build script no longer duplicates verifier implementation"
+        )
+
+        for marker in [
+            "lipo -archs",
+            "otool -arch",
+            "Metal.framework",
+            "MetalKit.framework",
+            "lib(whisper|ggml)",
+            "nm -arch",
+            "ggml_metallib_start",
+            "ggml_metallib_end"
+        ] {
+            try expect(
+                verifier.contains(marker),
+                "verifier contains contract marker: \(marker)"
+            )
+        }
+
+        try expect(
+            makefile.contains(
+                "WHISPER_VERIFY_SCRIPT = BuildSupport/WhisperRuntime/verify-whisper-helper.sh"
+            ),
+            "Makefile names the shared verifier"
+        )
+        try expect(
+            makefile.contains(
+                "$(WHISPER_STAMP): BuildSupport/WhisperRuntime/build-whisper.cpp.sh $(WHISPER_VERIFY_SCRIPT) $(WHISPER_BUILD_SETTINGS)"
+            ),
+            "verifier changes invalidate the helper stamp"
+        )
+        try expect(
+            makefile.contains("native-whisper-helper-test: $(WHISPER_STAMP)"),
+            "Makefile exposes actual helper validation"
+        )
+        try expect(
+            makefile.contains(
+                "$(WHISPER_VERIFY_SCRIPT) \"$$helper\" \"$(ARCH)\""
+            ),
+            "Make target invokes the shared verifier"
+        )
+
+        try verifierAcceptsUniversalMetalHelper(verifierPath: verifierPath)
+        try verifierRejectsMissingUniversalSlice(verifierPath: verifierPath)
+        try verifierRejectsMissingMetalKit(verifierPath: verifierPath)
+        try verifierRejectsDynamicGGMLDependency(verifierPath: verifierPath)
+        try verifierRejectsMissingEmbeddedKernelBoundary(verifierPath: verifierPath)
+        try verifierRejectsEmptyHelper(verifierPath: verifierPath)
+
+        print("NativeWhisperBuildContractTests passed")
+    }
+
+    private static func verifierAcceptsUniversalMetalHelper(
+        verifierPath: String
+    ) throws {
+        let result = try runVerifier(
+            verifierPath: verifierPath,
+            expectedArch: "universal",
+            archs: "x86_64 arm64",
+            linkedLibraries: metalLibraries,
+            symbols: embeddedSymbols
+        )
+        try expect(result.status == 0, "valid universal Metal helper passes")
+    }
+
+    private static func verifierRejectsMissingUniversalSlice(
+        verifierPath: String
+    ) throws {
+        let result = try runVerifier(
+            verifierPath: verifierPath,
+            expectedArch: "universal",
+            archs: "arm64",
+            linkedLibraries: metalLibraries,
+            symbols: embeddedSymbols
+        )
+        try expect(result.status != 0, "missing x86_64 slice fails")
+        try expect(
+            result.stderr.contains("missing required architecture x86_64"),
+            "missing architecture diagnostic"
+        )
+    }
+
+    private static func verifierRejectsMissingMetalKit(
+        verifierPath: String
+    ) throws {
+        let result = try runVerifier(
+            verifierPath: verifierPath,
+            expectedArch: "arm64",
+            archs: "arm64",
+            linkedLibraries: metalLibraries.replacingOccurrences(
+                of: metalKitLine,
+                with: ""
+            ),
+            symbols: embeddedSymbols
+        )
+        try expect(result.status != 0, "missing MetalKit fails")
+        try expect(
+            result.stderr.contains("missing MetalKit.framework linkage for arm64"),
+            "missing MetalKit diagnostic"
+        )
+    }
+
+    private static func verifierRejectsDynamicGGMLDependency(
+        verifierPath: String
+    ) throws {
+        let result = try runVerifier(
+            verifierPath: verifierPath,
+            expectedArch: "arm64",
+            archs: "arm64",
+            linkedLibraries: metalLibraries
+                + "\t@rpath/libggml.dylib (compatibility version 0.0.0)\n",
+            symbols: embeddedSymbols
+        )
+        try expect(result.status != 0, "dynamic ggml dependency fails")
+        try expect(
+            result.stderr.contains("links dynamic whisper.cpp/ggml libraries"),
+            "dynamic dependency diagnostic"
+        )
+    }
+
+    private static func verifierRejectsMissingEmbeddedKernelBoundary(
+        verifierPath: String
+    ) throws {
+        let result = try runVerifier(
+            verifierPath: verifierPath,
+            expectedArch: "arm64",
+            archs: "arm64",
+            linkedLibraries: metalLibraries,
+            symbols: "000000 T _ggml_metallib_start\n"
+        )
+        try expect(result.status != 0, "missing kernel end symbol fails")
+        try expect(
+            result.stderr.contains("missing embedded Metal kernel symbol ggml_metallib_end for arm64"),
+            "missing kernel diagnostic"
+        )
+    }
+
+    private static func verifierRejectsEmptyHelper(
+        verifierPath: String
+    ) throws {
+        let result = try runVerifier(
+            verifierPath: verifierPath,
+            expectedArch: "arm64",
+            archs: "arm64",
+            linkedLibraries: metalLibraries,
+            symbols: embeddedSymbols,
+            helperData: Data()
+        )
+        try expect(result.status != 0, "empty helper fails")
+        try expect(
+            result.stderr.contains("helper is empty"),
+            "empty helper diagnostic"
+        )
+    }
+
+    private static func runVerifier(
+        verifierPath: String,
+        expectedArch: String,
+        archs: String,
+        linkedLibraries: String,
+        symbols: String,
+        helperData: Data = Data([0x01])
+    ) throws -> ProcessResult {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let bin = root.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: bin,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let helper = root.appendingPathComponent("whisper-cli")
+        FileManager.default.createFile(
+            atPath: helper.path,
+            contents: helperData
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: helper.path
+        )
+
+        let librariesFile = root.appendingPathComponent("libraries.txt")
+        let symbolsFile = root.appendingPathComponent("symbols.txt")
+        try linkedLibraries.write(
+            to: librariesFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        try symbols.write(
+            to: symbolsFile,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        try writeTool(
+            named: "lipo",
+            in: bin,
+            body: "printf '%s\\n' \"$FAKE_ARCHS\""
+        )
+        try writeTool(
+            named: "otool",
+            in: bin,
+            body: "cat \"$FAKE_LIBRARIES_FILE\""
+        )
+        try writeTool(
+            named: "nm",
+            in: bin,
+            body: "cat \"$FAKE_SYMBOLS_FILE\""
+        )
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [verifierPath, helper.path, expectedArch]
+        process.environment = [
+            "PATH": "\(bin.path):/usr/bin:/bin",
+            "FAKE_ARCHS": archs,
+            "FAKE_LIBRARIES_FILE": librariesFile.path,
+            "FAKE_SYMBOLS_FILE": symbolsFile.path
+        ]
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        try process.run()
+        process.waitUntilExit()
+        return ProcessResult(
+            status: process.terminationStatus,
+            stdout: String(
+                data: stdout.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            ) ?? "",
+            stderr: String(
+                data: stderr.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            ) ?? ""
+        )
+    }
+
+    private static func writeTool(
+        named name: String,
+        in directory: URL,
+        body: String
+    ) throws {
+        let url = directory.appendingPathComponent(name)
+        try "#!/bin/sh\nset -eu\n\(body)\n".write(
+            to: url,
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: url.path
+        )
+    }
+
+    private static let metalLine =
+        "\t/System/Library/Frameworks/Metal.framework/Versions/A/Metal\n"
+    private static let metalKitLine =
+        "\t/System/Library/Frameworks/MetalKit.framework/Versions/A/MetalKit\n"
+    private static let metalLibraries = metalLine + metalKitLine
+    private static let embeddedSymbols = """
+    000000 T _ggml_metallib_start
+    000001 T _ggml_metallib_end
+    """
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ label: String
+    ) throws {
+        guard condition() else { throw TestFailure(label) }
+    }
+}
+
+private struct ProcessResult {
+    let status: Int32
+    let stdout: String
+    let stderr: String
+}
+
+private struct TestFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/Tests/NativeWhisperBuildContractTests.swift
+++ b/Tests/NativeWhisperBuildContractTests.swift
@@ -273,11 +273,11 @@ struct NativeWhisperBuildContractTests {
         return ProcessResult(
             status: process.terminationStatus,
             stdout: String(
-                data: stdout.fileHandleForReading.readDataToEndOfFile(),
+                data: try stdout.fileHandleForReading.readToEnd() ?? Data(),
                 encoding: .utf8
             ) ?? "",
             stderr: String(
-                data: stderr.fileHandleForReading.readDataToEndOfFile(),
+                data: try stderr.fileHandleForReading.readToEnd() ?? Data(),
                 encoding: .utf8
             ) ?? ""
         )

--- a/Tests/NativeWhisperRuntimeTests.swift
+++ b/Tests/NativeWhisperRuntimeTests.swift
@@ -5,7 +5,7 @@ struct NativeWhisperRuntimeTests {
     static func main() async throws {
         try await testRuntimeReturnsStdoutTranscript()
         try await testRuntimeReadsOutputJSONTextField()
-        try await testRuntimeDisablesTextContext()
+        try await testRuntimeKeepsGPUEnabledAndDisablesTextContext()
         try await testRuntimeRejectsMissingRunner()
         try await testRuntimeRejectsMissingModel()
         try await testRuntimeRejectsMissingAudio()
@@ -55,7 +55,7 @@ struct NativeWhisperRuntimeTests {
         assert(transcript == "json transcript")
     }
 
-    private static func testRuntimeDisablesTextContext() async throws {
+    private static func testRuntimeKeepsGPUEnabledAndDisablesTextContext() async throws {
         let root = try temporaryRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let argsFile = root.appendingPathComponent("args.txt")
@@ -74,6 +74,9 @@ struct NativeWhisperRuntimeTests {
         let maxContextIndex = args.firstIndex(of: "-mc")
         assert(maxContextIndex != nil, "Expected native whisper runtime to set max context")
         assert(args.dropFirst(maxContextIndex! + 1).first == "0", "Expected native whisper runtime to disable previous text conditioning")
+        assert(!args.contains("-ng"), "Expected Native Whisper to keep GPU enabled")
+        assert(!args.contains("--no-gpu"), "Expected Native Whisper to keep GPU enabled")
+        assert(!args.contains("-ngl"), "Expected whisper-cli GPU policy, not generic layer offload")
     }
 
     private static func testRuntimeRejectsMissingRunner() async throws {

--- a/docs/superpowers/plans/2026-07-20-native-whisper-metal-contract.md
+++ b/docs/superpowers/plans/2026-07-20-native-whisper-metal-contract.md
@@ -1,0 +1,976 @@
+# Native Whisper Metal Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Quill's existing whisper.cpp Metal acceleration an explicit, build-breaking artifact contract and preserve the current GPU-enabled runtime invocation.
+
+**Architecture:** Keep the existing whisper.cpp v1.9.1 subprocess architecture and embedded Metal kernel mode. Add a shared shell verifier that the build script and a focused Make target both invoke, then lock the build and runtime contracts with fast Swift tests that do not rebuild whisper.cpp during `make test`.
+
+**Tech Stack:** Bash, CMake, Make, Swift 5.10 executable tests, whisper.cpp v1.9.1, macOS `lipo`/`otool`/`nm`/`codesign`, Metal and MetalKit.
+
+## Global Constraints
+
+- Work only in the existing harness-owned worktree on branch `issue-184-whisper-metal-contract`; do not create or remove another worktree.
+- Use test-driven development for production changes: write the failing contract test, run it, implement the minimum change, and run it again.
+- Keep whisper.cpp pinned to `v1.9.1`.
+- Keep `BUILD_SHARED_LIBS=OFF`, `WHISPER_BUILD_TESTS=OFF`, and `WHISPER_BUILD_EXAMPLES=ON`.
+- Explicitly build with `GGML_METAL=ON` and `GGML_METAL_EMBED_LIBRARY=ON`.
+- Keep the universal release helper as `arm64;x86_64`; do not remove Intel support.
+- Do not bundle a separate `default.metallib` while embedded kernel mode is selected.
+- Do not add `GGML_METAL_PATH_RESOURCES`, `-ngl`, a user-facing Metal toggle, or automatic GPU-to-CPU retry.
+- Do not change Native Whisper model metadata, installer behavior, Settings UI, Legacy mlx-whisper, cloud transcription, or post-processing.
+- Never modify or overwrite `/Applications/Quill.app`; build and inspect only `build/Quill Dev.app` with bundle ID `com.woosublee.quill.dev`.
+- Never put signing identity details, credentials, API keys, or OAuth values in source, tests, logs, docs, commits, issues, or PR text.
+- Try `CODESIGN_IDENTITY=Quill` for the authorized final build. If Keychain returns `errSecInternalComponent`, report that exact limitation and use `CODESIGN_IDENTITY=-` only as an additional compile/bundle verification, not as evidence that the configured identity succeeded.
+- Do not push, open a PR, merge, close #184, or edit Roadmap #176 until explicitly requested after implementation verification.
+
+---
+
+## File structure
+
+- Create `BuildSupport/WhisperRuntime/verify-whisper-helper.sh`: the single executable artifact verifier shared by the helper build and focused Make target.
+- Modify `BuildSupport/WhisperRuntime/build-whisper.cpp.sh`: explicitly request Metal and embedded kernels, then delegate all helper artifact checks to the shared verifier.
+- Modify `Makefile`: invalidate the whisper stamp when the verifier changes, expose `native-whisper-helper-test`, and wire the fast contract test into `make test`.
+- Create `Tests/NativeWhisperBuildContractTests.swift`: verify source wiring and exercise the verifier with controlled fake `lipo`, `otool`, and `nm` commands.
+- Modify `Tests/NativeWhisperRuntimeTests.swift`: characterize and lock the existing rule that Quill does not pass no-GPU flags.
+
+---
+
+### Task 1: Add the shared Metal helper verifier and explicit build contract
+
+**Files:**
+- Create: `BuildSupport/WhisperRuntime/verify-whisper-helper.sh`
+- Modify: `BuildSupport/WhisperRuntime/build-whisper.cpp.sh:18-61`
+- Modify: `Makefile:30-31,57,81-84,286-298,306-326`
+- Create: `Tests/NativeWhisperBuildContractTests.swift`
+
+**Interfaces:**
+- Consumes: `build-whisper.cpp.sh <repo-url> <version> <checkout-dir> <arch>` and the existing `ARCH` values `arm64`, `x86_64`, or `universal`.
+- Produces: `verify-whisper-helper.sh <helper-path> <expected-arch>` with exit status 0 only when every requested slice links Metal/MetalKit, embeds the Metal kernel boundaries, and avoids dynamic whisper/ggml libraries.
+- Produces: Make target `native-whisper-helper-test`, which validates the helper path stored in `build/.whisper-helper` for the current `ARCH`.
+
+- [ ] **Step 1: Write the failing build-contract and verifier behavior test**
+
+Create `Tests/NativeWhisperBuildContractTests.swift`:
+
+```swift
+import Foundation
+
+@main
+struct NativeWhisperBuildContractTests {
+    static func main() throws {
+        let buildScriptPath = "BuildSupport/WhisperRuntime/build-whisper.cpp.sh"
+        let verifierPath = "BuildSupport/WhisperRuntime/verify-whisper-helper.sh"
+        let makefilePath = "Makefile"
+
+        let buildScript = try String(
+            contentsOfFile: buildScriptPath,
+            encoding: .utf8
+        )
+        try expect(
+            FileManager.default.fileExists(atPath: verifierPath),
+            "native whisper helper verifier exists"
+        )
+        let verifier = try String(
+            contentsOfFile: verifierPath,
+            encoding: .utf8
+        )
+        let makefile = try String(
+            contentsOfFile: makefilePath,
+            encoding: .utf8
+        )
+
+        try expect(
+            buildScript.contains("-DGGML_METAL=ON"),
+            "build explicitly enables Metal"
+        )
+        try expect(
+            buildScript.contains("-DGGML_METAL_EMBED_LIBRARY=ON"),
+            "build explicitly embeds Metal kernels"
+        )
+        try expect(
+            buildScript.contains(
+                #"verify_script="$(cd "$(dirname "$0")" && pwd)/verify-whisper-helper.sh""#
+            ),
+            "build resolves the shared verifier"
+        )
+        try expect(
+            buildScript.contains(#""$verify_script" "$helper" "$arch""#),
+            "build invokes the shared verifier"
+        )
+        try expect(
+            !buildScript.contains("otool -L \"$helper\" | grep"),
+            "build script no longer duplicates verifier implementation"
+        )
+
+        for marker in [
+            "lipo -archs",
+            "otool -arch",
+            "Metal.framework",
+            "MetalKit.framework",
+            "lib(whisper|ggml)",
+            "nm -arch",
+            "ggml_metallib_start",
+            "ggml_metallib_end"
+        ] {
+            try expect(
+                verifier.contains(marker),
+                "verifier contains contract marker: \(marker)"
+            )
+        }
+
+        try expect(
+            makefile.contains(
+                "WHISPER_VERIFY_SCRIPT = BuildSupport/WhisperRuntime/verify-whisper-helper.sh"
+            ),
+            "Makefile names the shared verifier"
+        )
+        try expect(
+            makefile.contains(
+                "$(WHISPER_STAMP): BuildSupport/WhisperRuntime/build-whisper.cpp.sh $(WHISPER_VERIFY_SCRIPT) $(WHISPER_BUILD_SETTINGS)"
+            ),
+            "verifier changes invalidate the helper stamp"
+        )
+        try expect(
+            makefile.contains("native-whisper-helper-test: $(WHISPER_STAMP)"),
+            "Makefile exposes actual helper validation"
+        )
+        try expect(
+            makefile.contains(
+                "$(WHISPER_VERIFY_SCRIPT) \"$$helper\" \"$(ARCH)\""
+            ),
+            "Make target invokes the shared verifier"
+        )
+
+        try verifierAcceptsUniversalMetalHelper(verifierPath: verifierPath)
+        try verifierRejectsMissingUniversalSlice(verifierPath: verifierPath)
+        try verifierRejectsMissingMetalKit(verifierPath: verifierPath)
+        try verifierRejectsDynamicGGMLDependency(verifierPath: verifierPath)
+        try verifierRejectsMissingEmbeddedKernelBoundary(verifierPath: verifierPath)
+        try verifierRejectsEmptyHelper(verifierPath: verifierPath)
+
+        print("NativeWhisperBuildContractTests passed")
+    }
+
+    private static func verifierAcceptsUniversalMetalHelper(
+        verifierPath: String
+    ) throws {
+        let result = try runVerifier(
+            verifierPath: verifierPath,
+            expectedArch: "universal",
+            archs: "x86_64 arm64",
+            linkedLibraries: metalLibraries,
+            symbols: embeddedSymbols
+        )
+        try expect(result.status == 0, "valid universal Metal helper passes")
+    }
+
+    private static func verifierRejectsMissingUniversalSlice(
+        verifierPath: String
+    ) throws {
+        let result = try runVerifier(
+            verifierPath: verifierPath,
+            expectedArch: "universal",
+            archs: "arm64",
+            linkedLibraries: metalLibraries,
+            symbols: embeddedSymbols
+        )
+        try expect(result.status != 0, "missing x86_64 slice fails")
+        try expect(
+            result.stderr.contains("missing required architecture x86_64"),
+            "missing architecture diagnostic"
+        )
+    }
+
+    private static func verifierRejectsMissingMetalKit(
+        verifierPath: String
+    ) throws {
+        let result = try runVerifier(
+            verifierPath: verifierPath,
+            expectedArch: "arm64",
+            archs: "arm64",
+            linkedLibraries: metalLibraries.replacingOccurrences(
+                of: metalKitLine,
+                with: ""
+            ),
+            symbols: embeddedSymbols
+        )
+        try expect(result.status != 0, "missing MetalKit fails")
+        try expect(
+            result.stderr.contains("missing MetalKit.framework linkage for arm64"),
+            "missing MetalKit diagnostic"
+        )
+    }
+
+    private static func verifierRejectsDynamicGGMLDependency(
+        verifierPath: String
+    ) throws {
+        let result = try runVerifier(
+            verifierPath: verifierPath,
+            expectedArch: "arm64",
+            archs: "arm64",
+            linkedLibraries: metalLibraries
+                + "\t@rpath/libggml.dylib (compatibility version 0.0.0)\n",
+            symbols: embeddedSymbols
+        )
+        try expect(result.status != 0, "dynamic ggml dependency fails")
+        try expect(
+            result.stderr.contains("links dynamic whisper.cpp/ggml libraries"),
+            "dynamic dependency diagnostic"
+        )
+    }
+
+    private static func verifierRejectsMissingEmbeddedKernelBoundary(
+        verifierPath: String
+    ) throws {
+        let result = try runVerifier(
+            verifierPath: verifierPath,
+            expectedArch: "arm64",
+            archs: "arm64",
+            linkedLibraries: metalLibraries,
+            symbols: "000000 T _ggml_metallib_start\n"
+        )
+        try expect(result.status != 0, "missing kernel end symbol fails")
+        try expect(
+            result.stderr.contains("missing embedded Metal kernel symbol ggml_metallib_end for arm64"),
+            "missing kernel diagnostic"
+        )
+    }
+
+    private static func verifierRejectsEmptyHelper(
+        verifierPath: String
+    ) throws {
+        let result = try runVerifier(
+            verifierPath: verifierPath,
+            expectedArch: "arm64",
+            archs: "arm64",
+            linkedLibraries: metalLibraries,
+            symbols: embeddedSymbols,
+            helperData: Data()
+        )
+        try expect(result.status != 0, "empty helper fails")
+        try expect(
+            result.stderr.contains("helper is empty"),
+            "empty helper diagnostic"
+        )
+    }
+
+    private static func runVerifier(
+        verifierPath: String,
+        expectedArch: String,
+        archs: String,
+        linkedLibraries: String,
+        symbols: String,
+        helperData: Data = Data([0x01])
+    ) throws -> ProcessResult {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let bin = root.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: bin,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let helper = root.appendingPathComponent("whisper-cli")
+        FileManager.default.createFile(
+            atPath: helper.path,
+            contents: helperData
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: helper.path
+        )
+
+        let librariesFile = root.appendingPathComponent("libraries.txt")
+        let symbolsFile = root.appendingPathComponent("symbols.txt")
+        try linkedLibraries.write(
+            to: librariesFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        try symbols.write(
+            to: symbolsFile,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        try writeTool(
+            named: "lipo",
+            in: bin,
+            body: "printf '%s\\n' \"$FAKE_ARCHS\""
+        )
+        try writeTool(
+            named: "otool",
+            in: bin,
+            body: "cat \"$FAKE_LIBRARIES_FILE\""
+        )
+        try writeTool(
+            named: "nm",
+            in: bin,
+            body: "cat \"$FAKE_SYMBOLS_FILE\""
+        )
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [verifierPath, helper.path, expectedArch]
+        process.environment = [
+            "PATH": "\(bin.path):/usr/bin:/bin",
+            "FAKE_ARCHS": archs,
+            "FAKE_LIBRARIES_FILE": librariesFile.path,
+            "FAKE_SYMBOLS_FILE": symbolsFile.path
+        ]
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        try process.run()
+        process.waitUntilExit()
+        return ProcessResult(
+            status: process.terminationStatus,
+            stdout: String(
+                data: stdout.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            ) ?? "",
+            stderr: String(
+                data: stderr.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            ) ?? ""
+        )
+    }
+
+    private static func writeTool(
+        named name: String,
+        in directory: URL,
+        body: String
+    ) throws {
+        let url = directory.appendingPathComponent(name)
+        try "#!/bin/sh\nset -eu\n\(body)\n".write(
+            to: url,
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: url.path
+        )
+    }
+
+    private static let metalLine =
+        "\t/System/Library/Frameworks/Metal.framework/Versions/A/Metal\n"
+    private static let metalKitLine =
+        "\t/System/Library/Frameworks/MetalKit.framework/Versions/A/MetalKit\n"
+    private static let metalLibraries = metalLine + metalKitLine
+    private static let embeddedSymbols = """
+    000000 T _ggml_metallib_start
+    000001 T _ggml_metallib_end
+    """
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ label: String
+    ) throws {
+        guard condition() else { throw TestFailure(label) }
+    }
+}
+
+private struct ProcessResult {
+    let status: Int32
+    let stdout: String
+    let stderr: String
+}
+
+private struct TestFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}
+```
+
+- [ ] **Step 2: Compile and run the focused test to verify RED**
+
+Run:
+
+```bash
+swiftc -parse-as-library \
+  Tests/NativeWhisperBuildContractTests.swift \
+  -o /tmp/NativeWhisperBuildContractTests
+/tmp/NativeWhisperBuildContractTests
+```
+
+Expected: FAIL with `native whisper helper verifier exists` because `BuildSupport/WhisperRuntime/verify-whisper-helper.sh` does not exist. If it fails for a Swift syntax error instead, fix only the test and rerun until the missing verifier is the failure.
+
+- [ ] **Step 3: Create the minimal shared verifier**
+
+Create `BuildSupport/WhisperRuntime/verify-whisper-helper.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+helper="${1:?helper path required}"
+expected_arch="${2:?expected architecture required}"
+
+fail() {
+  printf 'Native Whisper helper verification failed: %s\n' "$1" >&2
+  exit 1
+}
+
+[ -x "$helper" ] || fail "helper is missing or not executable: $helper"
+[ "$(stat -f %z "$helper")" -gt 0 ] || fail "helper is empty: $helper"
+
+helper_archs="$(lipo -archs "$helper")"
+case "$expected_arch" in
+  universal)
+    required_archs=(arm64 x86_64)
+    ;;
+  arm64|x86_64)
+    required_archs=("$expected_arch")
+    ;;
+  *)
+    fail "unsupported expected architecture: $expected_arch"
+    ;;
+esac
+
+for required_arch in "${required_archs[@]}"; do
+  case " $helper_archs " in
+    *" $required_arch "*) ;;
+    *) fail "missing required architecture $required_arch; found: $helper_archs" ;;
+  esac
+
+  linked_libraries="$(otool -arch "$required_arch" -L "$helper")"
+  grep -F 'Metal.framework' <<<"$linked_libraries" >/dev/null \
+    || fail "missing Metal.framework linkage for $required_arch"
+  grep -F 'MetalKit.framework' <<<"$linked_libraries" >/dev/null \
+    || fail "missing MetalKit.framework linkage for $required_arch"
+  if grep -E '(@rpath/)?lib(whisper|ggml)' <<<"$linked_libraries" >/dev/null; then
+    fail "helper links dynamic whisper.cpp/ggml libraries for $required_arch"
+  fi
+
+  symbols="$(nm -arch "$required_arch" -gU "$helper")"
+  for symbol in ggml_metallib_start ggml_metallib_end; do
+    grep -F "$symbol" <<<"$symbols" >/dev/null \
+      || fail "missing embedded Metal kernel symbol $symbol for $required_arch"
+  done
+done
+
+printf 'Verified Native Whisper Metal helper: %s (%s)\n' \
+  "$helper" "$helper_archs"
+```
+
+Then make it executable:
+
+```bash
+chmod 755 BuildSupport/WhisperRuntime/verify-whisper-helper.sh
+```
+
+- [ ] **Step 4: Make Metal configuration explicit and delegate artifact checks**
+
+Modify `BuildSupport/WhisperRuntime/build-whisper.cpp.sh`.
+
+After the argument declarations, add:
+
+```bash
+verify_script="$(cd "$(dirname "$0")" && pwd)/verify-whisper-helper.sh"
+```
+
+Change the CMake invocation to:
+
+```bash
+cmake -S "$checkout_dir" -B "$checkout_dir/build" \
+  "${cmake_arch_args[@]}" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DWHISPER_BUILD_TESTS=OFF \
+  -DWHISPER_BUILD_EXAMPLES=ON \
+  -DGGML_METAL=ON \
+  -DGGML_METAL_EMBED_LIBRARY=ON
+```
+
+Replace the current helper existence, `otool`, and `lipo` verification block after `helper=...` with:
+
+```bash
+"$verify_script" "$helper" "$arch"
+```
+
+Do not retain the old duplicated verification block.
+
+- [ ] **Step 5: Wire the verifier and focused target into Makefile**
+
+Near the existing whisper variables, add:
+
+```make
+WHISPER_VERIFY_SCRIPT = BuildSupport/WhisperRuntime/verify-whisper-helper.sh
+```
+
+Add `native-whisper-helper-test` to `.PHONY`:
+
+```make
+.PHONY: all clean run icon dmg codesign-dmg notarize install reset-permissions install-and-run check-test-wiring test localization-bundle-test native-whisper-helper-test print-app-version print-build-number print-build-tag print-version-metadata FORCE /tmp/LocalizationResourceTests
+```
+
+Change the helper stamp prerequisite line to:
+
+```make
+$(WHISPER_STAMP): BuildSupport/WhisperRuntime/build-whisper.cpp.sh $(WHISPER_VERIFY_SCRIPT) $(WHISPER_BUILD_SETTINGS)
+```
+
+After the stamp recipe, add:
+
+```make
+native-whisper-helper-test: $(WHISPER_STAMP)
+	@helper="$$(cat "$(WHISPER_STAMP)")"; \
+		$(WHISPER_VERIFY_SCRIPT) "$$helper" "$(ARCH)"
+```
+
+Wire the new fast test into `make test`, near `ManualReleaseWorkflowTests`:
+
+```make
+	@swiftc -parse-as-library Tests/NativeWhisperBuildContractTests.swift -o /tmp/NativeWhisperBuildContractTests
+	@/tmp/NativeWhisperBuildContractTests
+```
+
+- [ ] **Step 6: Run focused tests and wiring to verify GREEN**
+
+Run:
+
+```bash
+swiftc -parse-as-library \
+  Tests/NativeWhisperBuildContractTests.swift \
+  -o /tmp/NativeWhisperBuildContractTests
+/tmp/NativeWhisperBuildContractTests
+make check-test-wiring
+git diff --check
+```
+
+Expected:
+
+```text
+NativeWhisperBuildContractTests passed
+```
+
+`make check-test-wiring` and `git diff --check` must exit 0.
+
+- [ ] **Step 7: Verify the current arm64 helper with the real verifier**
+
+Run:
+
+```bash
+make native-whisper-helper-test ARCH="$(uname -m)"
+```
+
+Expected output includes:
+
+```text
+Verified Native Whisper Metal helper:
+```
+
+On Apple Silicon, the architecture list must include `arm64`. This step may rebuild the helper if its build stamp is stale.
+
+- [ ] **Step 8: Commit the build contract**
+
+Run:
+
+```bash
+git add \
+  BuildSupport/WhisperRuntime/build-whisper.cpp.sh \
+  BuildSupport/WhisperRuntime/verify-whisper-helper.sh \
+  Makefile \
+  Tests/NativeWhisperBuildContractTests.swift
+git commit -m "Enforce Native Whisper Metal artifacts
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Lock the GPU-enabled runtime invocation
+
+**Files:**
+- Modify: `Tests/NativeWhisperRuntimeTests.swift:5-15,58-77`
+
+**Interfaces:**
+- Consumes: the existing `NativeWhisperRuntime.transcribe(audioURL:modelURL:languageCode:)` subprocess invocation.
+- Produces: a characterization contract proving that Quill preserves `-mc 0` while omitting `-ng`, `--no-gpu`, and `-ngl`.
+
+This is a test-only characterization of behavior already verified in whisper.cpp v1.9.1. It does not require or justify a production runtime change.
+
+- [ ] **Step 1: Rename and strengthen the existing argument-recording test**
+
+In `main()`, replace:
+
+```swift
+try await testRuntimeDisablesTextContext()
+```
+
+with:
+
+```swift
+try await testRuntimeKeepsGPUEnabledAndDisablesTextContext()
+```
+
+Rename the function to:
+
+```swift
+private static func testRuntimeKeepsGPUEnabledAndDisablesTextContext() async throws {
+```
+
+After the existing `-mc 0` assertions, add:
+
+```swift
+assert(!args.contains("-ng"), "Expected Native Whisper to keep GPU enabled")
+assert(!args.contains("--no-gpu"), "Expected Native Whisper to keep GPU enabled")
+assert(!args.contains("-ngl"), "Expected whisper-cli GPU policy, not generic layer offload")
+```
+
+- [ ] **Step 2: Run the focused characterization test**
+
+Run:
+
+```bash
+swiftc -parse-as-library \
+  Sources/LocalizedStringLookup.swift \
+  Sources/NativeWhisperModel.swift \
+  Sources/NativeWhisperRuntime.swift \
+  Tests/NativeWhisperRuntimeTests.swift \
+  -o /tmp/NativeWhisperRuntimeTests
+/tmp/NativeWhisperRuntimeTests
+```
+
+Expected:
+
+```text
+NativeWhisperRuntimeTests passed
+```
+
+The test is expected to pass immediately because it records an intentional existing runtime contract. If it fails, do not add GPU flags; investigate the actual current arguments before changing production code.
+
+- [ ] **Step 3: Run the build-contract test together with runtime tests**
+
+Run:
+
+```bash
+/tmp/NativeWhisperBuildContractTests
+/tmp/NativeWhisperRuntimeTests
+git diff --check
+```
+
+Expected: both test executables pass and `git diff --check` exits 0.
+
+- [ ] **Step 4: Commit the runtime contract test**
+
+Run:
+
+```bash
+git add Tests/NativeWhisperRuntimeTests.swift
+git commit -m "Lock Native Whisper GPU invocation
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Verify universal artifacts, app signing, and performance evidence
+
+**Files:**
+- Modify only if a focused verification exposes a reproducible contract defect and a failing regression test is added first.
+- Do not commit generated helpers, app bundles, DMGs, WAV fixtures, model files, benchmark logs, or credentials.
+
+**Interfaces:**
+- Consumes: `native-whisper-helper-test`, `build/Quill Dev.app`, the installed `ggml-large-v3-turbo` model, and the bundled or stamped `whisper-cli`.
+- Produces: fresh verification evidence for architecture, Metal initialization, runtime correctness, signing, bundle size, and comparative performance.
+
+- [ ] **Step 1: Run all fast automated tests**
+
+Run:
+
+```bash
+make check-test-wiring
+make test
+git diff --check
+```
+
+Expected: every test passes, including:
+
+```text
+NativeWhisperBuildContractTests passed
+NativeWhisperRuntimeTests passed
+```
+
+Known Core Data entity warnings and AVFoundation non-interleaved warnings may still appear; do not treat pre-existing warnings as evidence of a new failure. Any nonzero exit is a blocker.
+
+- [ ] **Step 2: Build and verify the universal helper**
+
+Run:
+
+```bash
+make native-whisper-helper-test ARCH=universal
+helper="$(cat build/.whisper-helper)"
+lipo -archs "$helper"
+stat -f 'helper_bytes=%z' "$helper"
+```
+
+Expected:
+
+```text
+Verified Native Whisper Metal helper:
+x86_64 arm64
+```
+
+The `lipo` output may list the two architectures in either order. Record the helper size but do not commit it.
+
+- [ ] **Step 3: Build and strictly verify the universal Quill Dev app**
+
+First try the configured development identity:
+
+```bash
+make all \
+  ARCH=universal \
+  APP_NAME="Quill Dev" \
+  BUNDLE_ID="com.woosublee.quill.dev" \
+  CODESIGN_IDENTITY=Quill
+xattr -cr build/
+codesign --verify --deep --strict --verbose=2 "build/Quill Dev.app"
+```
+
+Expected: build exit 0 and `build/Quill Dev.app: valid on disk`.
+
+If and only if the local Keychain rejects nested Sparkle signing with `errSecInternalComponent`, preserve that output and run this additional compile/bundle check:
+
+```bash
+rm -rf build/codesign-staging
+rm -f "build/Quill Dev.app/Contents/MacOS/Quill Dev"
+make all \
+  ARCH=universal \
+  APP_NAME="Quill Dev" \
+  BUNDLE_ID="com.woosublee.quill.dev" \
+  CODESIGN_IDENTITY=-
+xattr -cr build/
+codesign --verify --deep --strict --verbose=2 "build/Quill Dev.app"
+```
+
+Report the configured-identity failure separately. Do not claim the ad hoc result as a successful `Quill` identity build.
+
+Then verify the bundled helper with the same contract:
+
+```bash
+BuildSupport/WhisperRuntime/verify-whisper-helper.sh \
+  "build/Quill Dev.app/Contents/Resources/whisper/whisper-cli" \
+  universal
+plutil -extract CFBundleIdentifier raw \
+  "build/Quill Dev.app/Contents/Info.plist"
+```
+
+Expected bundle ID:
+
+```text
+com.woosublee.quill.dev
+```
+
+- [ ] **Step 4: Generate a deterministic local benchmark WAV outside the repository**
+
+Run:
+
+```bash
+python3 - <<'PY'
+import math
+import struct
+import wave
+
+path = "/tmp/quill-whisper-metal-benchmark.wav"
+rate = 16_000
+seconds = 30
+with wave.open(path, "wb") as output:
+    output.setnchannels(1)
+    output.setsampwidth(2)
+    output.setframerate(rate)
+    frames = bytearray()
+    for index in range(rate * seconds):
+        sample = int(900 * math.sin(2 * math.pi * 220 * index / rate))
+        frames += struct.pack("<h", sample)
+    output.writeframes(frames)
+print(path)
+PY
+```
+
+Expected: `/tmp/quill-whisper-metal-benchmark.wav` is a 30-second, 16 kHz, mono PCM16 WAV. Never add it to git.
+
+- [ ] **Step 5: Run one warm-up and three measured Metal/CPU runs**
+
+Use the installed Quill Dev model and stamped helper:
+
+```bash
+bash <<'SH'
+set -euo pipefail
+
+helper="$(cat build/.whisper-helper)"
+model="$HOME/Library/Application Support/Quill Dev/LocalWhisper/Models/ggml-large-v3-turbo.bin"
+audio="/tmp/quill-whisper-metal-benchmark.wav"
+root="/tmp/quill-whisper-metal-benchmark"
+
+test -x "$helper"
+test -s "$model"
+test -s "$audio"
+rm -rf "$root"
+mkdir -p "$root"
+
+run_once() {
+  local mode="$1"
+  local run="$2"
+  local no_gpu=()
+  if [ "$mode" = cpu ]; then
+    no_gpu=(-ng)
+  fi
+  /usr/bin/time -p "$helper" \
+    "${no_gpu[@]}" \
+    -m "$model" \
+    -f "$audio" \
+    -nt \
+    -mc 0 \
+    -oj \
+    -of "$root/${mode}-${run}" \
+    >"$root/${mode}-${run}.stdout" \
+    2>"$root/${mode}-${run}.stderr"
+}
+
+run_once metal warmup
+run_once cpu warmup
+for run in 1 2 3; do
+  run_once metal "$run"
+  run_once cpu "$run"
+done
+SH
+```
+
+Expected: all eight runs exit 0 and produce JSON outputs. The Metal stderr must contain device initialization evidence; the CPU run may still enumerate Metal devices during backend registration, so performance and `use gpu`/execution context must be interpreted together rather than using framework loading alone.
+
+- [ ] **Step 6: Summarize median performance and transcript equivalence**
+
+Run:
+
+```bash
+python3 - <<'PY'
+import json
+import pathlib
+import statistics
+
+root = pathlib.Path("/tmp/quill-whisper-metal-benchmark")
+
+def real_times(mode):
+    values = []
+    for run in (1, 2, 3):
+        lines = (root / f"{mode}-{run}.stderr").read_text().splitlines()
+        values.append(float(next(line.split()[1] for line in lines if line.startswith("real "))))
+    return values
+
+def transcript(mode, run):
+    value = json.loads((root / f"{mode}-{run}.json").read_text())
+    return " ".join(str(value.get("text", "")).split())
+
+metal = real_times("metal")
+cpu = real_times("cpu")
+metal_median = statistics.median(metal)
+cpu_median = statistics.median(cpu)
+print(f"metal_runs={metal}")
+print(f"cpu_runs={cpu}")
+print(f"metal_median={metal_median:.3f}")
+print(f"cpu_median={cpu_median:.3f}")
+print(f"speedup={cpu_median / metal_median:.2f}x")
+print(f"transcripts_equal={transcript('metal', 1) == transcript('cpu', 1)}")
+if not metal_median < cpu_median:
+    raise SystemExit("Metal median was not faster than CPU median")
+PY
+
+rg -n \
+  'ggml_metal_init: found device|ggml_metal_init: picking default device|use gpu' \
+  /tmp/quill-whisper-metal-benchmark/metal-1.stderr
+```
+
+Expected:
+
+- Metal median is lower than CPU median.
+- `transcripts_equal=true` for the deterministic fixture.
+- The Metal log identifies an Apple GPU and default device selection.
+- Record the speedup as machine-specific evidence, not a universal guarantee.
+
+- [ ] **Step 7: Build a Quill Dev DMG and enforce the size ceiling**
+
+Use the same signing result as Step 3. If the configured identity succeeded:
+
+```bash
+make dmg \
+  ARCH=universal \
+  APP_NAME="Quill Dev" \
+  BUNDLE_ID="com.woosublee.quill.dev" \
+  CODESIGN_IDENTITY=Quill
+```
+
+If only the ad hoc verification path was available:
+
+```bash
+make dmg \
+  ARCH=universal \
+  APP_NAME="Quill Dev" \
+  BUNDLE_ID="com.woosublee.quill.dev" \
+  CODESIGN_IDENTITY=-
+```
+
+Then run:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+path = Path("build/Quill Dev.dmg")
+size = path.stat().st_size
+limit = 150 * 1024 * 1024
+print(f"dmg_bytes={size}")
+print(f"dmg_mib={size / 1024 / 1024:.2f}")
+if size > limit:
+    raise SystemExit("Quill Dev DMG exceeds 150 MiB")
+PY
+```
+
+Expected: the model-free DMG remains at or below 150 MiB. Do not add the DMG to git.
+
+- [ ] **Step 8: Review architectural boundaries**
+
+Run:
+
+```bash
+changed_files="$(git diff --name-only origin/main...HEAD)"
+printf '%s\n' "$changed_files"
+```
+
+Confirm the implementation changes are limited to:
+
+```text
+BuildSupport/WhisperRuntime/build-whisper.cpp.sh
+BuildSupport/WhisperRuntime/verify-whisper-helper.sh
+Makefile
+Tests/NativeWhisperBuildContractTests.swift
+Tests/NativeWhisperRuntimeTests.swift
+docs/superpowers/specs/2026-07-20-native-whisper-metal-contract-design.md
+docs/superpowers/plans/2026-07-20-native-whisper-metal-contract.md
+```
+
+If another file changed, explain why it is required by the approved design or revert it. Confirm there are no changes to `NativeWhisperInstaller`, `NativeWhisperModel`, Settings UI, transcription backend selection, cloud transcription, or `/Applications/Quill.app`.
+
+- [ ] **Step 9: Record evidence and stop before external publication**
+
+Prepare a concise completion report containing:
+
+- focused RED/GREEN evidence,
+- `make test` result,
+- actual arm64 and universal helper verification,
+- configured-identity codesign result and any Keychain limitation,
+- ad hoc result if used,
+- helper and DMG sizes,
+- Metal and CPU medians,
+- measured speedup,
+- transcript equivalence,
+- clean git status,
+- commits created.
+
+Do not push, create a PR, merge, edit #184, edit Roadmap #176, or close the issue until the user explicitly requests those actions.

--- a/docs/superpowers/specs/2026-07-20-native-whisper-metal-contract-design.md
+++ b/docs/superpowers/specs/2026-07-20-native-whisper-metal-contract-design.md
@@ -1,0 +1,334 @@
+# Native Whisper Metal Contract Design
+
+## Context
+
+Issue #184 was opened under the assumption that Quill's bundled whisper.cpp v1.9.1 helper was built without Metal and therefore ran local transcription on CPU only. Investigation against the current `origin/main`, the checked-out whisper.cpp source, the built helper, and an installed `ggml-large-v3-turbo` model showed that this assumption is no longer correct.
+
+On macOS, whisper.cpp v1.9.1 defaults to:
+
+- `GGML_METAL=ON`
+- `GGML_METAL_EMBED_LIBRARY=ON`
+- `whisper-cli` GPU use enabled unless `-ng` or `--no-gpu` is passed
+- flash attention enabled by default
+
+Quill's current helper contains the Metal backend, links Metal and MetalKit, and embeds the Metal kernel source inside the executable. `NativeWhisperRuntime` does not pass the no-GPU flag, so the normal local transcription path already uses Metal when available.
+
+A local probe on an Apple M4 Max using the bundled arm64 helper, the installed `ggml-large-v3-turbo` model, and a deterministic 30-second 16 kHz mono WAV measured:
+
+- default Metal path: 0.89 seconds wall-clock
+- explicit CPU path with `-ng`: 2.49 seconds wall-clock
+- observed speedup: approximately 2.8×
+
+The probe also logged Metal initialization and selection of the Apple M4 Max device. This is preliminary engineering evidence rather than a portable benchmark guarantee.
+
+The remaining product risk is not absent acceleration. It is that Quill relies on upstream defaults and does not enforce or continuously validate its Metal artifact contract. A future whisper.cpp update or build change could silently produce a CPU-only helper.
+
+## Goal
+
+Make Quill's existing Native Whisper Metal support explicit, reproducible, and regression-resistant without changing local transcription behavior, model installation, UI, or backend selection.
+
+## Product decision
+
+Issue #184 will be completed as a build and validation hardening task rather than as a new acceleration feature.
+
+Quill will:
+
+- explicitly request the Metal backend and embedded Metal kernels when building whisper.cpp on macOS,
+- fail the build if the helper no longer satisfies the expected Metal artifact contract,
+- retain the current GPU-enabled `whisper-cli` runtime behavior,
+- retain the x86_64 slice in universal releases,
+- document and measure the existing acceleration,
+- avoid adding an unproven automatic GPU-to-CPU retry path.
+
+## Non-goals
+
+- Replacing the `whisper-cli` subprocess with a direct whisper.cpp library integration
+- Changing the recommended Native Whisper model or its checksum
+- Adding a model quantization or model-selection feature
+- Changing Legacy mlx-whisper behavior
+- Changing cloud transcription or post-processing
+- Adding a user-facing Metal toggle
+- Adding automatic CPU retry after a Metal failure without a reproduced failure case
+- Guaranteeing a fixed performance multiplier on every Apple Silicon generation
+- Adding a separate `default.metallib` while embedded Metal kernels remain the selected build mode
+- Removing x86_64 support from the universal release
+
+## Verified current behavior
+
+### Build configuration
+
+`BuildSupport/WhisperRuntime/build-whisper.cpp.sh` builds whisper.cpp v1.9.1 with static whisper and ggml libraries. The script already:
+
+- builds `whisper-cli`,
+- rejects dynamic `libwhisper` and `libggml` dependencies,
+- validates requested architectures,
+- supports a universal `arm64;x86_64` build.
+
+It does not explicitly pass the Metal CMake options. Metal is enabled only because whisper.cpp currently sets the macOS default to ON.
+
+### Embedded Metal resource model
+
+With `GGML_METAL_EMBED_LIBRARY=ON`, whisper.cpp v1.9.1 does not require Quill to bundle a separate `.metallib`. It combines the Metal source and required headers and embeds them in the executable's `__DATA,__ggml_metallib` section, exposing `ggml_metallib_start` and `ggml_metallib_end` symbols.
+
+At runtime, ggml compiles the embedded Metal source through Metal. `GGML_METAL_PATH_RESOURCES` belongs to the non-embedded source fallback and is not needed for Quill's selected mode.
+
+### Runtime behavior
+
+`NativeWhisperRuntime` executes the bundled helper with the current arguments:
+
+```text
+-m <model>
+-f <audio>
+-nt
+-mc 0
+-oj
+-of <temporary-output-base>
+[-l <language>]
+```
+
+The helper's GPU behavior is enabled by default. Quill does not pass `-ng` or `--no-gpu`, so no new runtime argument is necessary to enable Metal.
+
+The generic `-ngl` option found in whisper.cpp's shared example utilities does not control `whisper-cli`. The transcription CLI uses a `use_gpu` boolean and exposes `-ng` only for disabling GPU execution.
+
+## Architecture
+
+### 1. Explicit build contract
+
+`BuildSupport/WhisperRuntime/build-whisper.cpp.sh` will pass these CMake options explicitly:
+
+```text
+-DGGML_METAL=ON
+-DGGML_METAL_EMBED_LIBRARY=ON
+```
+
+This records Quill's intent independently of upstream defaults. The existing static library, examples, tests, architecture, and release settings remain unchanged.
+
+The build remains a single CMake invocation. For `ARCH=universal`, CMake continues to build `arm64;x86_64`, and the resulting helper must contain both slices.
+
+### 2. Helper artifact verifier
+
+The whisper helper's artifact checks will be represented by a focused shell verifier in `BuildSupport/WhisperRuntime/`. The build script will invoke this verifier after creating `whisper-cli`, and Makefile targets may invoke the same verifier against the helper copied into an app bundle.
+
+The verifier consumes:
+
+- helper path,
+- expected architecture mode (`arm64`, `x86_64`, or `universal`).
+
+It validates:
+
+1. The helper exists and is executable.
+2. The helper has nonzero physical size.
+3. `lipo -archs` contains the requested architecture or both `arm64` and `x86_64` for a universal build.
+4. `otool -L` shows Metal and MetalKit framework dependencies.
+5. `otool -L` does not show dynamic `libwhisper` or `libggml` dependencies.
+6. `nm` finds both `ggml_metallib_start` and `ggml_metallib_end`, proving that the selected embedded-kernel contract is present.
+
+Each failure emits a specific diagnostic and exits nonzero. Quill must not silently package a CPU-only or incomplete helper.
+
+The verifier uses only macOS command-line tools already required by the build: `test`, `stat`, `lipo`, `otool`, `nm`, and `grep`.
+
+### 3. Makefile integration
+
+The existing `.whisper-helper` build remains the source of the helper path. Its dependencies will include the new verifier so verifier changes invalidate the stamp.
+
+A focused target, `native-whisper-helper-test`, will validate the built helper without rebuilding the full app when the current stamp is fresh. It accepts the existing `ARCH` setting and applies the same architecture expectation as the build script.
+
+The app build will continue to:
+
+- copy the verified helper to `Contents/Resources/whisper/whisper-cli`,
+- mark it executable,
+- sign the helper before signing the outer app.
+
+No extra Metal resource file is copied.
+
+### 4. Runtime contract
+
+`NativeWhisperRuntime` keeps its current arguments and environment. It will not add:
+
+- `-ng`,
+- `--no-gpu`,
+- `-ngl`,
+- `GGML_METAL_PATH_RESOURCES`,
+- a Metal resource path.
+
+A runtime unit test will record helper arguments and assert that Quill does not disable GPU execution. Existing assertions for `-mc 0`, JSON output, language handling, process failure, and cancellation remain intact.
+
+### 5. Release contract
+
+Official universal release builds must produce:
+
+- a universal app executable,
+- a universal `whisper-cli` with arm64 and x86_64 slices,
+- Metal and MetalKit dependencies in the helper,
+- embedded Metal kernel boundary symbols,
+- no dynamic whisper/ggml libraries,
+- a valid deeply signed app and DMG.
+
+The model remains downloaded after installation and is not included in the app or DMG.
+
+## Data flow
+
+```text
+Makefile
+  -> build-whisper.cpp.sh
+      -> checkout whisper.cpp v1.9.1
+      -> CMake with explicit Metal + embedded kernels
+      -> build whisper-cli
+      -> verify-native-whisper-helper.sh
+  -> copy verified helper into app Resources/whisper
+  -> sign helper
+  -> sign app
+
+NativeWhisperRuntime
+  -> locate bundled helper
+  -> validate helper and downloaded model
+  -> execute whisper-cli without --no-gpu
+  -> whisper.cpp selects Metal when available
+  -> read JSON transcript
+```
+
+## Error handling
+
+### Build-time failures
+
+Artifact contract failures are release engineering errors, not user-facing runtime errors. The build stops with a targeted message when:
+
+- the helper is missing, empty, or not executable,
+- an expected architecture is absent,
+- Metal or MetalKit linkage is absent,
+- an embedded kernel symbol is absent,
+- a dynamic whisper or ggml dependency is present.
+
+There is no CPU-only packaging fallback. A release that unexpectedly loses Metal support must fail visibly.
+
+### Runtime failures
+
+Existing `NativeWhisperRuntimeError` behavior remains unchanged. This task does not add a second automatic CPU execution after a failed Metal run.
+
+An automatic fallback is intentionally excluded because:
+
+- no Metal execution failure has been reproduced,
+- a second full transcription changes latency and cancellation semantics,
+- duplicate execution could obscure the actual artifact or hardware problem,
+- Intel and Apple Silicon fallback policy should be based on concrete failure evidence.
+
+If a reproducible Metal-only failure appears later, it should receive a separate runtime fallback design and tests.
+
+## Test strategy
+
+### Fast source and unit tests
+
+Add `Tests/NativeWhisperBuildContractTests.swift` to verify that:
+
+- the CMake invocation explicitly enables `GGML_METAL`,
+- embedded kernels are explicitly enabled,
+- the helper verifier is invoked,
+- the verifier contains architecture, Metal framework, embedded symbol, and dynamic dependency checks,
+- the Makefile exposes and wires `native-whisper-helper-test`.
+
+Extend `Tests/NativeWhisperRuntimeTests.swift` so a fake helper records its arguments and the test asserts:
+
+- `-ng` is absent,
+- `--no-gpu` is absent,
+- the existing `-mc 0` contract remains present.
+
+These tests run under `make test` and do not rebuild whisper.cpp.
+
+### Actual artifact validation
+
+Run:
+
+```bash
+make native-whisper-helper-test ARCH=$(uname -m)
+```
+
+For release validation, run:
+
+```bash
+make native-whisper-helper-test ARCH=universal
+```
+
+The universal invocation may rebuild the helper when its current build settings do not match `ARCH=universal`.
+
+### App validation
+
+Build only the development bundle and never modify `/Applications/Quill.app`:
+
+```bash
+make all APP_NAME="Quill Dev" BUNDLE_ID="com.woosublee.quill.dev" CODESIGN_IDENTITY=Quill
+xattr -cr build/
+codesign --verify --deep --strict --verbose=2 "build/Quill Dev.app"
+```
+
+When local Keychain access prevents the configured identity from signing, an ad hoc build may verify compile and bundle structure, but that does not replace the required release-identity CI or release verification.
+
+### Performance smoke
+
+Performance is measured manually on Apple Silicon because wall-clock thresholds are unsuitable for shared CI.
+
+Use:
+
+- the same helper,
+- the same installed model,
+- the same canonical WAV,
+- one warm-up run per mode,
+- at least three measured runs per mode,
+- median wall-clock time.
+
+Compare:
+
+```text
+Metal: whisper-cli <normal Quill arguments>
+CPU:   whisper-cli -ng <normal Quill arguments>
+```
+
+Record:
+
+- hardware and macOS version,
+- model identity,
+- audio duration and format,
+- Metal initialization/device-selection evidence,
+- Metal median,
+- CPU median,
+- relative speedup,
+- transcript equivalence,
+- helper size,
+- final DMG size.
+
+Metal must be faster than CPU on the measured Apple Silicon machine. The issue's 2× target remains a product performance target, not an automated build gate.
+
+## Acceptance criteria
+
+- CMake explicitly sets `GGML_METAL=ON`.
+- CMake explicitly sets `GGML_METAL_EMBED_LIBRARY=ON`.
+- The helper verifier rejects missing architectures, missing Metal linkage, missing embedded kernels, and dynamic whisper/ggml dependencies.
+- `make test` includes the fast build-contract and runtime-argument tests.
+- `native-whisper-helper-test` validates the actual helper.
+- Native Whisper continues to transcribe through the existing helper and model paths.
+- Quill does not pass a no-GPU argument.
+- No separate `.metallib` is added in embedded mode.
+- A universal release helper contains both arm64 and x86_64.
+- Quill Dev and release artifacts pass deep strict code-sign verification in their authorized signing environments.
+- Apple Silicon manual smoke demonstrates Metal initialization and a performance advantage over explicit CPU mode.
+- Issue #184 is updated to correct its original premise and closed with the artifact and performance evidence.
+
+## Delivery strategy
+
+Implement this as one focused PR from current `origin/main`.
+
+Expected files:
+
+- Modify `BuildSupport/WhisperRuntime/build-whisper.cpp.sh`
+- Create `BuildSupport/WhisperRuntime/verify-whisper-helper.sh`
+- Modify `Makefile`
+- Modify `Tests/NativeWhisperRuntimeTests.swift`
+- Create `Tests/NativeWhisperBuildContractTests.swift`
+- Modify release/build contract tests only if necessary to wire the new target
+
+Do not modify `NativeWhisperInstaller`, model metadata, Settings UI, transcription backend selection, or cloud transcription.
+
+After merge:
+
+1. Post the corrected technical findings and benchmark evidence on Issue #184.
+2. Mark #184 complete in Roadmap #176.
+3. Close #184 if the PR does not close it automatically.


### PR DESCRIPTION
## Summary

- explicitly enable `GGML_METAL` and embedded Metal kernels when building whisper.cpp
- verify every requested helper slice links Metal/MetalKit, embeds kernel boundary symbols, and avoids dynamic whisper/ggml libraries
- add `make native-whisper-helper-test` and fast build/runtime contract tests
- preserve the existing GPU-enabled runtime invocation without adding a Metal toggle or CPU fallback

This corrects the original premise of #184: Native Whisper already uses Metal with whisper.cpp v1.9.1. The change makes that behavior explicit and build-breaking if it regresses.

## Verification

- `make check-test-wiring`
- `make test`
- `git diff --check`
- universal helper verification: `x86_64 arm64`
- bundled universal helper verification in `build/Quill Dev.app`
- ad hoc development app: deep strict code-sign verification passed
- development DMG: 17.31 MiB, below the 150 MiB ceiling

Apple M4 Max / macOS 27.0, `ggml-large-v3-turbo`, deterministic 30-second 16 kHz mono PCM16 WAV:

- Metal runs: 0.69s, 0.72s, 0.69s; median 0.690s
- explicit CPU `-ng` runs: 2.48s, 2.50s, 2.49s; median 2.490s
- measured speedup: 3.61×
- transcript equivalence: true
- runtime log confirmed `use gpu = 1` and selected the Apple M4 Max device

The configured local signing identity could not complete nested Sparkle signing because the local Keychain returned `errSecInternalComponent`. The additional ad hoc build verifies compilation, universal bundle structure, and strict nested signatures; release-identity verification remains the responsibility of the authorized release environment.

Closes #184
