### PR TITLE
Enable Note Browser by default for new installs

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1811,7 +1811,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let disableAutoPaste = UserDefaults.standard.bool(forKey: disableAutoPasteStorageKey)
         let disablePostProcessing = UserDefaults.standard.bool(forKey: disablePostProcessingStorageKey)
         let preserveExactWording = UserDefaults.standard.bool(forKey: preserveExactWordingStorageKey)
-        let noteBrowserEnabled = UserDefaults.standard.bool(forKey: noteBrowserEnabledStorageKey)
+        let noteBrowserEnabled = UserDefaults.standard.object(forKey: noteBrowserEnabledStorageKey) == nil
+            ? true
+            : UserDefaults.standard.bool(forKey: noteBrowserEnabledStorageKey)
         let transcriptionLanguage = TranscriptionLanguage.find(
             code: UserDefaults.standard.string(forKey: transcriptionLanguageStorageKey) ?? "ko"
         )

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -32,6 +32,8 @@ struct AppStateTranscriptionConfigurationTests {
         testPostProcessingCooldownDispositionDefaultsToProcessed()
         testPostProcessingCooldownDispositionCanBeMarkedSkipped()
         testPreserveExactWordingDefaultsOffAndPersists()
+        testNoteBrowserDefaultsOnWhenPreferenceIsMissing()
+        testNoteBrowserPreservesExplicitOptOut()
         testVerbatimTranslationPromptAndSanitizer()
         testVerbatimTranslationRejectsOutputThatSanitizesToEmpty()
         try testPreserveExactWordingSettingsAndPipelineWiring()
@@ -325,6 +327,25 @@ struct AppStateTranscriptionConfigurationTests {
         assert(!appState.preserveExactWording)
         appState.preserveExactWording = true
         assert(defaults.bool(forKey: "preserve_exact_wording"))
+    }
+
+    private static func testNoteBrowserDefaultsOnWhenPreferenceIsMissing() {
+        resetDefaults()
+        let defaults = UserDefaults.standard
+
+        assert(defaults.object(forKey: "note_browser_enabled") == nil)
+        assert(AppState().noteBrowserEnabled)
+    }
+
+    private static func testNoteBrowserPreservesExplicitOptOut() {
+        resetDefaults()
+        let defaults = UserDefaults.standard
+        let appState = AppState()
+
+        appState.noteBrowserEnabled = false
+
+        assert(defaults.object(forKey: "note_browser_enabled") as? Bool == false)
+        assert(!AppState().noteBrowserEnabled)
     }
 
     private static func testVerbatimTranslationPromptAndSanitizer() {
@@ -1695,6 +1716,7 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.removeObject(forKey: "transcription_language")
         defaults.removeObject(forKey: "context_model")
         defaults.removeObject(forKey: "preserve_exact_wording")
+        defaults.removeObject(forKey: "note_browser_enabled")
         defaults.removeObject(forKey: "selected_microphone_id")
         defaults.removeObject(forKey: "realtime_streaming_enabled")
         defaults.removeObject(forKey: "hold_shortcut")


### PR DESCRIPTION
## Summary

- enable Note Browser when `note_browser_enabled` has never been stored
- preserve an existing user’s explicit opt-out
- keep the existing launch, Dock reopen, and Appearance settings paths unchanged

## Validation

- `make test`
- verified with an isolated runtime-test bundle that a missing preference opens one Note Browser window
- verified reopening the app does not create a duplicate window
- verified an explicitly stored `false` keeps Note Browser closed

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 노트 브라우저 설정이 저장되지 않은 경우 기본적으로 활성화되도록 변경했습니다.
  * 노트 브라우저를 명시적으로 비활성화하면 해당 설정이 유지됩니다.

* **테스트**
  * 노트 브라우저 설정의 기본값과 저장 동작을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->