### PR TITLE
Fix note action hover and reminder localization

### DIFF
--- a/Sources/CalendarRecordingReminderScheduler.swift
+++ b/Sources/CalendarRecordingReminderScheduler.swift
@@ -404,6 +404,27 @@ final class CalendarRecordingReminderScheduler {
         )
     }
 
+    nonisolated static func leadTimeOptionTitle(_ minutes: Int) -> String {
+        leadTimeOptionTitle(
+            minutes,
+            language: preferredLocalizedStringLanguage(),
+            bundle: .main
+        )
+    }
+
+    nonisolated static func leadTimeOptionTitle(
+        _ minutes: Int,
+        language: String,
+        bundle: Bundle
+    ) -> String {
+        localizedCatalogFormat(
+            "%@ min before",
+            String(minutes),
+            language: language,
+            bundle: bundle
+        )
+    }
+
     nonisolated static func notificationTitle(for schedule: CalendarRecordingReminderSchedule, now: Date) -> String {
         notificationTitle(for: schedule, now: now, language: preferredLocalizedStringLanguage(), bundle: .main)
     }

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -1647,7 +1647,7 @@ private struct NoteDetailView: View {
                 help: "Save Files"
             )
 
-            Menu {
+            ToolbarIconMenu(help: "More Actions") {
                 Button("Export to Obsidian") {
                     showObsidianExportSheet = true
                 }
@@ -1656,13 +1656,7 @@ private struct NoteDetailView: View {
                 Image(systemName: "ellipsis")
                     .font(.system(size: 13, weight: .medium))
                     .accessibilityLabel(Text("More Actions"))
-                    .frame(width: 36, height: 36)
-                    .contentShape(Circle())
             }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .fixedSize()
-            .help("More Actions")
 
             toolbarDivider
 
@@ -2181,6 +2175,50 @@ private struct ToolbarIconButton<Label: View>: View {
             isHovered = hovering && !disabled
         }
         .overrideCursor(.arrow)
+    }
+}
+
+private struct ToolbarIconMenu<Content: View, Label: View>: View {
+    let help: LocalizedStringKey
+    @ViewBuilder let content: () -> Content
+    @ViewBuilder let label: () -> Label
+
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var isHovered = false
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(isHovered ? hoverFillColor : Color.clear)
+                .allowsHitTesting(false)
+            Circle()
+                .strokeBorder(hoverStrokeColor.opacity(isHovered ? 1 : 0), lineWidth: 0.5)
+                .allowsHitTesting(false)
+            Menu(content: content) {
+                label()
+                    .frame(width: 36, height: 36)
+                    .contentShape(Circle())
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+        }
+        .frame(width: 36, height: 36)
+        .contentShape(Circle())
+        .animation(.easeInOut(duration: 0.12), value: isHovered)
+        .help(help)
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .overrideCursor(.arrow)
+    }
+
+    private var hoverFillColor: Color {
+        colorScheme == .dark ? Color.white.opacity(0.08) : Color.primary.opacity(0.07)
+    }
+
+    private var hoverStrokeColor: Color {
+        colorScheme == .dark ? Color.white.opacity(0.16) : Color.primary.opacity(0.12)
     }
 }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1102,7 +1102,7 @@ struct CalendarSettingsView: View {
                             appState.setCalendarRecordingReminderLeadTime(minutes, isSelected: !isSelected)
                         } label: {
                             Label(
-                                "\(minutes) min before",
+                                CalendarRecordingReminderScheduler.leadTimeOptionTitle(minutes),
                                 systemImage: isSelected ? "checkmark.circle.fill" : "circle"
                             )
                             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Tests/CalendarRecordingReminderSchedulerTests.swift
+++ b/Tests/CalendarRecordingReminderSchedulerTests.swift
@@ -17,6 +17,7 @@ struct CalendarRecordingReminderSchedulerTests {
         testCalendarReminderIdentifierFilteringUsesPrefix()
         testNotificationTitleDescribesRelativeStartTime()
         try testNotificationCopyLocalizesWrapperAndPreservesEventTitle()
+        try testLeadTimeOptionTitleLocalizes()
         testNormalizesLeadMinutes()
         testNormalizesLeadMinuteSelections()
         testNormalizesRefreshIntervalMinutesToSupportedOptions()
@@ -233,6 +234,25 @@ struct CalendarRecordingReminderSchedulerTests {
         assert(CalendarRecordingReminderScheduler.notificationTitle(for: schedule, now: now, language: "en", bundle: bundle) == "Meeting starts in 10 minutes")
         assert(CalendarRecordingReminderScheduler.notificationTitle(for: schedule, now: now, language: "ko", bundle: bundle) == "회의가 10분 후 시작됩니다")
         assert(CalendarRecordingReminderScheduler.notificationBody(for: event, language: "ko", bundle: bundle) == "눌러서 녹음 시작: Quarterly Review: Q3")
+    }
+
+    private static func testLeadTimeOptionTitleLocalizes() throws {
+        let bundle = try compiledLocalizationBundle()
+
+        assert(
+            CalendarRecordingReminderScheduler.leadTimeOptionTitle(
+                10,
+                language: "en",
+                bundle: bundle
+            ) == "10 min before"
+        )
+        assert(
+            CalendarRecordingReminderScheduler.leadTimeOptionTitle(
+                10,
+                language: "ko",
+                bundle: bundle
+            ) == "10분 전"
+        )
     }
 
     private static func compiledLocalizationBundle() throws -> Bundle {

--- a/Tests/NoteFileExportUIContractTests.swift
+++ b/Tests/NoteFileExportUIContractTests.swift
@@ -45,11 +45,51 @@ struct NoteFileExportUIContractTests {
             noteBrowser.contains("Image(systemName: \"ellipsis\")"),
             "more-actions menu uses the approved symbol"
         )
+        try expect(
+            noteBrowser.contains("ToolbarIconMenu(help: \"More Actions\")"),
+            "more-actions menu uses the toolbar hover control"
+        )
+        let toolbarIconMenu = try sourceSection(
+            noteBrowser,
+            from: "private struct ToolbarIconMenu",
+            to: "// MARK: - Obsidian Export Sheet"
+        )
+        for marker in [
+            "@State private var isHovered = false",
+            "ZStack {",
+            ".fill(isHovered ? hoverFillColor : Color.clear)",
+            ".strokeBorder(hoverStrokeColor.opacity(isHovered ? 1 : 0), lineWidth: 0.5)",
+            "Menu(content: content)",
+            ".contentShape(Circle())",
+            ".onHover { hovering in",
+            "isHovered = hovering"
+        ] {
+            try expect(toolbarIconMenu.contains(marker), "toolbar menu hover control contains \(marker)")
+        }
+        let disabledHitTestingCount = toolbarIconMenu.components(
+            separatedBy: ".allowsHitTesting(false)"
+        ).count - 1
+        try expect(
+            disabledHitTestingCount == 2,
+            "both decorative hover circles leave menu hit testing enabled"
+        )
         print("NoteFileExportUIContractTests passed")
     }
 
     private static func source(_ path: String) throws -> String {
         try String(contentsOfFile: path, encoding: .utf8)
+    }
+
+    private static func sourceSection(
+        _ source: String,
+        from startMarker: String,
+        to endMarker: String
+    ) throws -> Substring {
+        guard let start = source.range(of: startMarker)?.lowerBound,
+              let end = source.range(of: endMarker, range: start..<source.endIndex)?.lowerBound else {
+            throw TestFailure("Unable to locate source section from \(startMarker) to \(endMarker)")
+        }
+        return source[start..<end]
     }
 
     private static func expect(

--- a/Tests/SettingsLocalizationTests.swift
+++ b/Tests/SettingsLocalizationTests.swift
@@ -9,6 +9,7 @@ struct SettingsLocalizationTests {
         try testAudioImportDisplayKeepsModelIDAndLocalizesStaticLabels()
         try testSettingsSectionTitlePolicy()
         try testGoogleCalendarHealthMessagesLocalizeWithoutChangingDetail()
+        try testCalendarReminderLeadTimeUsesLocalizedCopy()
         try testRecordingOverlaySettingsCopyLocalizes()
         try testModelFirstSettingsCopyLocalizes()
         print("SettingsLocalizationTests passed")
@@ -110,6 +111,17 @@ struct SettingsLocalizationTests {
                 bundle: bundle
             ) == "Google Calendar를 새로 고치지 못했습니다: \(detail)"
         )
+    }
+
+    private static func testCalendarReminderLeadTimeUsesLocalizedCopy() throws {
+        let settingsSource = try String(contentsOfFile: "Sources/SettingsView.swift", encoding: .utf8)
+
+        assert(
+            settingsSource.contains(
+                "CalendarRecordingReminderScheduler.leadTimeOptionTitle(minutes)"
+            )
+        )
+        assert(!settingsSource.contains("\"\\(minutes) min before\""))
     }
 
     private static func testRecordingOverlaySettingsCopyLocalizes() throws {


### PR DESCRIPTION
## Summary

- apply the Note Browser toolbar hover treatment to the more-actions menu without blocking menu hit testing
- format meeting reminder lead-time options through the localization catalog for English and Korean
- add regression coverage for the hover visuals, hit-testing contract, and localized lead-time copy

## Testing

- `make test`
- Quill Dev build
- manual verification of the more-actions hover effect and Korean reminder-time labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 캘린더 녹화 미리 알림의 리드 타임 표시가 언어 설정에 맞게 현지화됩니다.
  - “더 보기” 메뉴의 아이콘 버튼에 일관된 호버 효과, 도움말, 클릭 영역이 제공됩니다.
- **개선 사항**
  - 설정 화면의 리드 타임 문구가 통일된 형식으로 표시됩니다.
- **테스트**
  - 영어·한국어 현지화와 메뉴 호버·히트테스팅 동작에 대한 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->