### PR TITLE
Add optional transcription and record-only audio notes

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -44,7 +44,7 @@
     <key>GoogleCalendarOAuthClientSecret</key>
     <string></string>
     <key>NSMicrophoneUsageDescription</key>
-    <string>Quill needs microphone access to transcribe your speech.</string>
+    <string>Quill needs microphone access to record audio.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>Quill needs speech recognition to convert your voice to text.</string>
     <key>NSAccessibilityUsageDescription</key>

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -12692,6 +12692,134 @@
           }
         }
       }
+    },
+    "Record only": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Record only"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음만"
+          }
+        }
+      }
+    },
+    "No transcription · No model download": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No transcription · No model download"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사 없음 · 모델 다운로드 없음"
+          }
+        }
+      }
+    },
+    "Save audio notes now. Transcribe them later if needed. No model download or API key required.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save audio notes now. Transcribe them later if needed. No model download or API key required."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지금 오디오 노트를 저장하고 필요할 때 나중에 전사하세요. 모델 다운로드나 API 키가 필요하지 않습니다."
+          }
+        }
+      }
+    },
+    "Record only · Audio notes": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Record only · Audio notes"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음만 · 오디오 노트"
+          }
+        }
+      }
+    },
+    "Enables automatic paste and Edit Mode when you turn them on.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enables automatic paste and Edit Mode when you turn them on."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동 붙여넣기와 편집 모드를 켜면 사용할 수 있습니다."
+          }
+        }
+      }
+    },
+    "Record your voice and other selected audio inputs.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Record your voice and other selected audio inputs."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성과 선택한 다른 오디오 입력을 녹음합니다."
+          }
+        }
+      }
+    },
+    "Screen & System Audio Recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screen & System Audio Recording"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "화면 및 시스템 오디오 녹음"
+          }
+        }
+      }
+    },
+    "Enables System Audio recording and optional screen context.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enables System Audio recording and optional screen context."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 오디오 녹음과 선택적 화면 컨텍스트를 사용할 수 있습니다."
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -1265,6 +1265,102 @@
         }
       }
     },
+    "Applies to recordings when Transcription is enabled.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applies to recordings when Transcription is enabled."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사가 활성화된 녹음에 적용됩니다."
+          }
+        }
+      }
+    },
+    "Record audio without creating a transcript.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Record audio without creating a transcript."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사본을 만들지 않고 오디오를 녹음합니다."
+          }
+        }
+      }
+    },
+    "Recording saved": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording saved"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 저장됨"
+          }
+        }
+      }
+    },
+    "Saved without transcription. You can transcribe it later.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saved without transcription. You can transcribe it later."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사 없이 저장되었습니다. 나중에 전사할 수 있습니다."
+          }
+        }
+      }
+    },
+    "Start Recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start Recording"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 시작"
+          }
+        }
+      }
+    },
+    "Transcribe audio": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcribe audio"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오 전사"
+          }
+        }
+      }
+    },
     "No content": {
       "localizations": {
         "en": {

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -1281,6 +1281,54 @@
         }
       }
     },
+    "Audio recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio recording"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오 녹음"
+          }
+        }
+      }
+    },
+    "Audio only": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio only"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오만"
+          }
+        }
+      }
+    },
+    "Not transcribed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not transcribed"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사되지 않음"
+          }
+        }
+      }
+    },
     "Transcription failed": {
       "localizations": {
         "en": {

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -1409,6 +1409,22 @@
         }
       }
     },
+    "Audio-only recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio-only recording"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오 전용 녹음"
+          }
+        }
+      }
+    },
     "Not transcribed": {
       "localizations": {
         "en": {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -4317,7 +4317,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     postProcessingEnabled: snapshot.postProcessingEnabled,
                     preserveExactWording: snapshot.preserveExactWording
                 )
-                let transcriptFileName = snapshot.item.machineStatus == .audioOnly
+                let transcriptFileName = snapshot.item.transcriptFileName == nil
                     ? Self.saveTranscriptFile(
                         rawTranscript: parsedTranscript.transcript,
                         postProcessedTranscript: result.finalTranscript

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1259,17 +1259,22 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @MainActor
     func applySetupProcessingPreset(_ preset: SetupFlow.ProcessingPreset) {
         switch preset {
+        case .recordOnly:
+            transcriptionEnabled = false
         case .localAppleSpeech:
+            transcriptionEnabled = true
             setNoteBrowserTranscriptionChoice(.appleLive)
             disablePostProcessing = true
             disableContextCapture = true
         case .localNativeWhisper:
+            transcriptionEnabled = true
             setNoteBrowserTranscriptionChoice(
                 .nativeWhisper(modelID: NativeWhisperModelCatalog.recommended.id)
             )
             disablePostProcessing = true
             disableContextCapture = true
         case .apiStandard:
+            transcriptionEnabled = true
             setNoteBrowserTranscriptionChoice(
                 .apiStandard(modelID: transcriptionModel)
             )

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2656,6 +2656,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         case audioOnly(UUID)
     }
 
+    enum MCPStopRecordingOutcome {
+        case notRecording
+        case transcribing
+        case savingAudioOnly
+    }
+
     static func audioStorageDirectory() -> URL {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "Quill"
@@ -5241,9 +5247,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
-    func stopRecordingFromMCP() {
-        guard isRecording else { return }
+    func stopRecordingFromMCP() -> MCPStopRecordingOutcome {
+        guard isRecording else { return .notRecording }
+        let shouldTranscribe = shouldTranscribeActiveRecording
         stopAndTranscribe()
+        return shouldTranscribe ? .transcribing : .savingAudioOnly
     }
 
     @MainActor
@@ -8024,6 +8032,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 )
             }
         } catch {
+            if journalRecordingID == nil,
+               !pipelineHistoryStore.loadAllHistory().contains(where: { $0.id == recordingID }) {
+                Self.deleteStoredFiles(
+                    audioFileName: audioFileName,
+                    transcriptFileName: nil
+                )
+            }
             let message = userIssue(for: error).record.presentation().compactMessage
             completeStoppedRecording(
                 .audioOnly(recordingID),

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -6816,10 +6816,30 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let jobID = currentRecordingLiveNoteID ?? activeRecordingID ?? UUID()
         let liveNoteID = currentRecordingLiveNoteID
         currentRecordingLiveNoteID = nil
+        let shouldTranscribe = shouldTranscribeActiveRecording
+        activeRecordingTranscriptionEnabled = nil
+        let recordingCalendarSnapshot = activeRecordingCalendarSnapshot
         let recordingStartedAt = activeRecordingStartedAt
         let recordingEndedAt = Date()
         activeRecordingStartedAt = nil
         activeRecordingCalendarSnapshot = nil
+
+        if !shouldTranscribe {
+            capturedContext = nil
+            contextCaptureTask?.cancel()
+            contextCaptureTask = nil
+            liveTranscriber?.cancel()
+            liveTranscriber = nil
+            setActiveRecorderPCMHandler(nil)
+            stopAndSaveAudioOnly(
+                recordingID: jobID,
+                recordingStartedAt: recordingStartedAt,
+                recordingEndedAt: recordingEndedAt,
+                calendarSnapshot: recordingCalendarSnapshot
+            )
+            return
+        }
+
         let startedAt = recordingEndedAt
         registerTranscriptionJob(
             id: jobID,
@@ -7241,6 +7261,73 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 historyID: cloudHistoryID,
                 context: cloudExecutionContext
             )
+        }
+    }
+
+    @MainActor
+    private func stopAndSaveAudioOnly(
+        recordingID: UUID,
+        recordingStartedAt: Date?,
+        recordingEndedAt: Date,
+        calendarSnapshot: RecordingCalendarSnapshot?
+    ) {
+        isRecording = false
+        restoreAudioInterruptionIfNeeded()
+        refreshTranscribingState()
+        errorMessage = nil
+        tearDownRealtimeService()
+
+        stopActiveAudioRecorder { [weak self] stoppedRecording in
+            guard let self else { return }
+            switch stoppedRecording {
+            case .transcribable(let fileURL, _):
+                guard let savedAudioFile = Self.savedAudioFileForStoppedRecording(fileURL) else {
+                    self.errorMessage = localizedCatalogString("No audio recorded")
+                    self.statusText = localizedCatalogString("Error")
+                    self.dismissTranscribingOverlay()
+                    self.cleanupActiveAudioRecordersIfIdle()
+                    return
+                }
+
+                Task { [weak self] in
+                    guard let self else { return }
+                    let calendarMatch = await self.calendarMatchForStoppedRecording(
+                        recordingStartedAt: recordingStartedAt,
+                        recordingEndedAt: recordingEndedAt,
+                        calendarSnapshot: calendarSnapshot
+                    )
+                    await MainActor.run {
+                        // persistAudioOnlyRecording creates PipelineHistoryItem.audioOnly(...).
+                        self.persistAudioOnlyRecording(
+                            recordingID: recordingID,
+                            recordingStartedAt: recordingStartedAt,
+                            recordingEndedAt: recordingEndedAt,
+                            calendarMatch: calendarMatch,
+                            audioFileName: savedAudioFile.fileName
+                        )
+                    }
+                }
+
+            case .recoveredWithoutTranscription(let recovered):
+                self.persistRecoveredRecordingWithoutTranscription(
+                    recovered,
+                    jobID: recordingID,
+                    overlayID: self.overlayTranscriptionID
+                )
+
+            case .preservedForRecovery(_, let message):
+                self.errorMessage = localizedCatalogString("Audio was preserved for recovery.") + " " + message
+                self.statusText = localizedCatalogString("Error")
+                self.dismissTranscribingOverlay()
+                self.cleanupActiveAudioRecordersIfIdle()
+
+            case .empty:
+                self.errorMessage = localizedCatalogString("No audio recorded")
+                self.statusText = localizedCatalogString("Error")
+                self.mcpLastRecordingFailed = true
+                self.dismissTranscribingOverlay()
+                self.cleanupActiveAudioRecordersIfIdle()
+            }
         }
     }
 
@@ -7809,6 +7896,56 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
+    private func persistAudioOnlyRecording(
+        recordingID: UUID,
+        recordingStartedAt: Date?,
+        recordingEndedAt: Date,
+        calendarMatch: CalendarEventMatch?,
+        audioFileName: String
+    ) {
+        let item = PipelineHistoryItem.audioOnly(
+            id: recordingID,
+            timestamp: recordingEndedAt,
+            recordingStartedAt: recordingStartedAt,
+            recordingEndedAt: recordingEndedAt,
+            calendarMatch: calendarMatch,
+            audioFileName: audioFileName,
+            transcriptionLanguageCode: transcriptionLanguage.code,
+            localTranscriptionModelID: localTranscriptionModel.id
+        )
+        let journalRecordingID = recordingJournalID(
+            forAudioFileName: audioFileName
+        )
+
+        do {
+            let removed = try appendPipelineHistoryItem(item)
+            for assets in removed {
+                cleanupDeletedPipelineHistoryAssets(assets)
+            }
+            if let journalRecordingID {
+                completePromotedRecordingJournal(
+                    recordingID: journalRecordingID
+                )
+            }
+            statusText = localizedCatalogString("Recording saved")
+            debugStatusMessage = "Recording saved"
+            errorMessage = nil
+            mcpLastRecordingFailed = false
+            dismissTranscribingOverlay()
+            cleanupActiveAudioRecordersIfIdle()
+            scheduleReadyStatusReset(
+                after: 3,
+                matching: [localizedCatalogString("Recording saved")]
+            )
+        } catch {
+            errorMessage = userIssue(for: error).record.presentation().compactMessage
+            statusText = localizedCatalogString("Error")
+            dismissTranscribingOverlay()
+            cleanupActiveAudioRecordersIfIdle()
+        }
+    }
+
+    @MainActor
     private func updatePipelineHistoryItem(_ item: PipelineHistoryItem) {
         if let index = pipelineHistory.firstIndex(where: { $0.id == item.id }) {
             pipelineHistory[index] = item
@@ -7930,8 +8067,111 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    private static func logTimestamp(_ date: Date) -> String {
-        ISO8601DateFormatter().string(from: date)
+    private func calendarMatchForStoppedRecording(
+        recordingStartedAt: Date?,
+        recordingEndedAt: Date,
+        calendarSnapshot: RecordingCalendarSnapshot?
+    ) async -> CalendarEventMatch? {
+        if let calendarSnapshot,
+           let calendarID = calendarSnapshot.calendarID,
+           let eventID = calendarSnapshot.eventID,
+           let title = calendarSnapshot.title,
+           let start = calendarSnapshot.startDate,
+           let end = calendarSnapshot.endDate {
+            let matchSource = CalendarMatchSource(
+                rawValue: calendarSnapshot.matchSource ?? ""
+            ) ?? .calendarNotification
+            let attendees = calendarSnapshot.attendeeNames.map {
+                CalendarEventAttendee(
+                    displayName: $0,
+                    email: nil,
+                    responseStatus: nil,
+                    isOptional: false,
+                    isSelf: false
+                )
+            }
+            return CalendarEventMatch(
+                calendarID: calendarID,
+                eventID: eventID,
+                title: title,
+                start: start,
+                end: end,
+                attendees: attendees,
+                matchSource: matchSource,
+                titleState: .applied
+            )
+        }
+
+        guard let recordingStartedAt else { return nil }
+        return await calendarEventMatch(
+            recordingStartedAt: recordingStartedAt,
+            recordingEndedAt: recordingEndedAt
+        )
+    }
+
+    private func calendarEventMatch(
+        recordingStartedAt: Date,
+        recordingEndedAt: Date
+    ) async -> CalendarEventMatch? {
+        guard recordingEndedAt > recordingStartedAt else { return nil }
+        let selectedCalendarIDs = await MainActor.run {
+            googleCalendarConnection.selectedCalendarIDs
+        }
+        guard !selectedCalendarIDs.isEmpty else { return nil }
+
+        do {
+            guard let token = try await validGoogleCalendarToken() else {
+                await MainActor.run {
+                    markGoogleCalendarNeedsReconnect(
+                        feature: .recordingMatch,
+                        message: localizedCatalogString("Google Calendar needs reconnecting. Calendar-based note titles may be unavailable.")
+                    )
+                }
+                return nil
+            }
+            let fetchResult = await Self.googleCalendarServiceFactory()
+                .fetchEventsWithDiagnostics(
+                    accessToken: token.accessToken,
+                    calendarIDs: Array(selectedCalendarIDs),
+                    timeMin: recordingStartedAt,
+                    timeMax: recordingEndedAt
+                )
+            await MainActor.run {
+                if fetchResult.failedCalendarIDs.isEmpty {
+                    markGoogleCalendarHealthy(feature: .recordingMatch)
+                } else {
+                    markGoogleCalendarTemporarilyUnavailable(
+                        feature: .recordingMatch,
+                        message: localizedCatalogString("Some Google calendars could not be refreshed. Calendar-based note titles may be incomplete.")
+                    )
+                }
+            }
+            guard let event = CalendarEventMatcher.bestMatch(
+                recordingStartedAt: recordingStartedAt,
+                recordingEndedAt: recordingEndedAt,
+                events: fetchResult.events
+            ) else { return nil }
+            return event.match(
+                accountID: token.accountEmail,
+                source: .overlapSuggestion,
+                titleState: .suggested
+            )
+        } catch {
+            await MainActor.run {
+                if Self.isGoogleCalendarReconnectError(error) {
+                    markGoogleCalendarNeedsReconnect(
+                        feature: .recordingMatch,
+                        message: localizedCatalogString("Google Calendar needs reconnecting. Calendar-based note titles may be unavailable.")
+                    )
+                } else {
+                    markGoogleCalendarTemporarilyUnavailable(
+                        feature: .recordingMatch,
+                        message: localizedCatalogFormat("Unable to refresh Google Calendar for note titles: %@", error.localizedDescription)
+                    )
+                }
+            }
+            return nil
+        }
     }
 
     private func calendarMatchForHistoryItem(jobID: UUID) async -> CalendarEventMatch? {
@@ -7948,136 +8188,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
             os_log(.info, log: calendarLog, "Calendar match skipped: missing recording interval for job %{public}@", jobID.uuidString)
             return nil
         }
-        guard recordingEndedAt > recordingStartedAt else {
-            os_log(
-                .info,
-                log: calendarLog,
-                "Calendar match skipped: invalid recording interval for job %{public}@ start=%{public}@ end=%{public}@",
-                jobID.uuidString,
-                Self.logTimestamp(recordingStartedAt),
-                Self.logTimestamp(recordingEndedAt)
-            )
-            return nil
-        }
-        let selectedCalendarIDs = await MainActor.run { googleCalendarConnection.selectedCalendarIDs }
-        guard !selectedCalendarIDs.isEmpty else {
-            os_log(
-                .info,
-                log: calendarLog,
-                "Calendar match skipped: no selected calendars for job %{public}@ start=%{public}@ end=%{public}@",
-                jobID.uuidString,
-                Self.logTimestamp(recordingStartedAt),
-                Self.logTimestamp(recordingEndedAt)
-            )
-            return nil
-        }
-        do {
-            guard let token = try await validGoogleCalendarToken() else {
-                os_log(.info, log: calendarLog, "Calendar match skipped: no valid Google Calendar token for job %{public}@", jobID.uuidString)
-                await MainActor.run {
-                    markGoogleCalendarNeedsReconnect(
-                        feature: .recordingMatch,
-                        message: localizedCatalogString("Google Calendar needs reconnecting. Calendar-based note titles may be unavailable.")
-                    )
-                }
-                return nil
-            }
-            os_log(
-                .info,
-                log: calendarLog,
-                "Calendar match fetch started: job=%{public}@ calendars=%d start=%{public}@ end=%{public}@",
-                jobID.uuidString,
-                selectedCalendarIDs.count,
-                Self.logTimestamp(recordingStartedAt),
-                Self.logTimestamp(recordingEndedAt)
-            )
-            let fetchResult = await Self.googleCalendarServiceFactory().fetchEventsWithDiagnostics(
-                accessToken: token.accessToken,
-                calendarIDs: Array(selectedCalendarIDs),
-                timeMin: recordingStartedAt,
-                timeMax: recordingEndedAt
-            )
-            if !fetchResult.failedCalendarIDs.isEmpty {
-                await MainActor.run {
-                    markGoogleCalendarTemporarilyUnavailable(
-                        feature: .recordingMatch,
-                        message: localizedCatalogString("Some Google calendars could not be refreshed. Calendar-based note titles may be incomplete.")
-                    )
-                }
-                os_log(
-                    .error,
-                    log: calendarLog,
-                    "Calendar match fetch had failures: job=%{public}@ failedCalendars=%{private}@ fetchedEvents=%d",
-                    jobID.uuidString,
-                    fetchResult.failedCalendarIDs.joined(separator: ","),
-                    fetchResult.events.count
-                )
-            } else {
-                await MainActor.run {
-                    markGoogleCalendarHealthy(feature: .recordingMatch)
-                }
-                os_log(
-                    .info,
-                    log: calendarLog,
-                    "Calendar match fetch succeeded: job=%{public}@ fetchedEvents=%d",
-                    jobID.uuidString,
-                    fetchResult.events.count
-                )
-            }
-            guard let event = CalendarEventMatcher.bestMatch(
-                recordingStartedAt: recordingStartedAt,
-                recordingEndedAt: recordingEndedAt,
-                events: fetchResult.events
-            ) else {
-                os_log(
-                    .info,
-                    log: calendarLog,
-                    "Calendar match not found: job=%{public}@ fetchedEvents=%d failedCalendars=%d",
-                    jobID.uuidString,
-                    fetchResult.events.count,
-                    fetchResult.failedCalendarIDs.count
-                )
-                return nil
-            }
-            os_log(
-                .info,
-                log: calendarLog,
-                "Calendar match found: job=%{public}@ calendar=%{private}@ event=%{private}@ title=%{private}@ start=%{public}@ end=%{public}@",
-                jobID.uuidString,
-                event.calendarID,
-                event.id,
-                event.title,
-                Self.logTimestamp(event.start),
-                Self.logTimestamp(event.end)
-            )
-            return event.match(
-                accountID: token.accountEmail,
-                source: .overlapSuggestion,
-                titleState: .suggested
-            )
-        } catch {
-            os_log(
-                .error,
-                log: calendarLog,
-                "Calendar match failed: job=%{public}@ error=%{public}@",
-                jobID.uuidString,
-                error.localizedDescription
-            )
-            await MainActor.run {
-                if Self.isGoogleCalendarReconnectError(error) {
-                    markGoogleCalendarNeedsReconnect(
-                        feature: .recordingMatch,
-                        message: localizedCatalogString("Google Calendar needs reconnecting. Calendar-based note titles may be unavailable.")
-                    )
-                } else {
-                    markGoogleCalendarTemporarilyUnavailable(
-                        feature: .recordingMatch,
-                        message: localizedCatalogFormat("Unable to refresh Google Calendar for note titles: %@", error.localizedDescription)
-                    )
-                }
-            }
-            return nil
-        }
+        return await calendarEventMatch(
+            recordingStartedAt: recordingStartedAt,
+            recordingEndedAt: recordingEndedAt
+        )
     }
 
     @MainActor

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -5951,7 +5951,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
             case .authorized:
                 break
             case .notDetermined:
-                guard let triggerMode = activeRecordingTriggerMode else { return }
+                guard let triggerMode = activeRecordingTriggerMode else {
+                    activeRecordingTranscriptionEnabled = nil
+                    return
+                }
                 prepareForSpeechRecognitionPermissionPrompt(
                     triggerMode: triggerMode,
                     selectionSnapshot: pendingSelectionSnapshot,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1731,6 +1731,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var isEscapeCancelAlertPresented = false
     private var isNativeWhisperQuitAlertPresented = false
     private var shouldTerminateAfterTranscription = false
+    private var pendingAudioOnlyStopIDs: Set<UUID> = []
     private var audioDeviceObservers: [NSObjectProtocol] = []
     private var needsMicrophoneRefreshAfterRecording = false
     private let pipelineHistoryStore = PipelineHistoryStore()
@@ -2648,6 +2649,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         case recoveredWithoutTranscription(RecoveredRecordingArtifact)
         case preservedForRecovery(recordingID: UUID, message: String)
         case empty
+    }
+
+    private enum StoppedRecordingCompletion {
+        case transcriptionJob(UUID)
+        case audioOnly(UUID)
     }
 
     static func audioStorageDirectory() -> URL {
@@ -5248,6 +5254,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func requestTerminationWhileRecording() -> NSApplication.TerminateReply {
+        if !pendingAudioOnlyStopIDs.isEmpty, !shouldConfirmTermination {
+            shouldTerminateAfterTranscription = true
+            return .terminateLater
+        }
         guard shouldConfirmTermination else { return .terminateNow }
         guard !isEscapeCancelAlertPresented else { return .terminateCancel }
 
@@ -5311,7 +5321,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func terminateIfReady() {
-        guard shouldTerminateAfterTranscription, !isRecording, !isTranscribing else { return }
+        guard shouldTerminateAfterTranscription,
+              !isRecording,
+              !isTranscribing,
+              pendingAudioOnlyStopIDs.isEmpty else { return }
         shouldTerminateAfterTranscription = false
         NSApp.reply(toApplicationShouldTerminate: true)
     }
@@ -5962,6 +5975,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func beginRecording(triggerMode: RecordingTriggerMode, onStarted: (@MainActor () -> Void)? = nil) {
         os_log(.info, log: recordingLog, "beginRecording() entered")
         clearPendingOverlayDismissToken()
+        overlayTranscriptionID = UUID()
         errorMessage = nil
         let audioInputID = selectedMicrophoneID
         activeRecordingID = AudioInputDevice.isSingleSource(audioInputID)
@@ -6829,6 +6843,26 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
+    private func completeStoppedRecording(
+        _ completion: StoppedRecordingCompletion,
+        overlayID: UUID,
+        updateOwnedUI: () -> Void
+    ) {
+        cleanupActiveAudioRecordersIfIdle()
+        if overlayTranscriptionID == overlayID {
+            updateOwnedUI()
+        }
+
+        switch completion {
+        case .transcriptionJob(let jobID):
+            finishTranscriptionJob(jobID, overlayID: overlayID)
+        case .audioOnly(let recordingID):
+            pendingAudioOnlyStopIDs.remove(recordingID)
+            terminateIfReady()
+        }
+    }
+
+    @MainActor
     private func stopAndTranscribe() {
         guard activeRecordingStorageFailureID == nil else { return }
         cancelPendingShortcutStart()
@@ -6855,6 +6889,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         activeRecordingCalendarSnapshot = nil
 
         if !shouldTranscribe {
+            let audioOnlyOverlayID = overlayTranscriptionID
             capturedContext = nil
             contextCaptureTask?.cancel()
             contextCaptureTask = nil
@@ -6865,7 +6900,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 recordingID: jobID,
                 recordingStartedAt: recordingStartedAt,
                 recordingEndedAt: recordingEndedAt,
-                calendarSnapshot: recordingCalendarSnapshot
+                calendarSnapshot: recordingCalendarSnapshot,
+                overlayID: audioOnlyOverlayID
             )
             return
         }
@@ -7057,7 +7093,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             case .recoveredWithoutTranscription(let recovered):
                 self.persistRecoveredRecordingWithoutTranscription(
                     recovered,
-                    jobID: jobID,
+                    completion: .transcriptionJob(jobID),
                     overlayID: myOverlayID
                 )
                 return
@@ -7299,8 +7335,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         recordingID: UUID,
         recordingStartedAt: Date?,
         recordingEndedAt: Date,
-        calendarSnapshot: RecordingCalendarSnapshot?
+        calendarSnapshot: RecordingCalendarSnapshot?,
+        overlayID: UUID
     ) {
+        pendingAudioOnlyStopIDs.insert(recordingID)
         isRecording = false
         restoreAudioInterruptionIfNeeded()
         refreshTranscribingState()
@@ -7312,10 +7350,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
             switch stoppedRecording {
             case .transcribable(let fileURL, _):
                 guard let savedAudioFile = Self.savedAudioFileForStoppedRecording(fileURL) else {
-                    self.errorMessage = localizedCatalogString("No audio recorded")
-                    self.statusText = localizedCatalogString("Error")
-                    self.dismissTranscribingOverlay()
-                    self.cleanupActiveAudioRecordersIfIdle()
+                    self.completeStoppedRecording(
+                        .audioOnly(recordingID),
+                        overlayID: overlayID
+                    ) {
+                        self.errorMessage = localizedCatalogString("No audio recorded")
+                        self.statusText = localizedCatalogString("Error")
+                        self.dismissTranscribingOverlay()
+                    }
                     return
                 }
 
@@ -7327,13 +7369,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         calendarSnapshot: calendarSnapshot
                     )
                     await MainActor.run {
-                        // persistAudioOnlyRecording creates PipelineHistoryItem.audioOnly(...).
                         self.persistAudioOnlyRecording(
                             recordingID: recordingID,
                             recordingStartedAt: recordingStartedAt,
                             recordingEndedAt: recordingEndedAt,
                             calendarMatch: calendarMatch,
-                            audioFileName: savedAudioFile.fileName
+                            audioFileName: savedAudioFile.fileName,
+                            overlayID: overlayID
                         )
                     }
                 }
@@ -7341,22 +7383,30 @@ final class AppState: ObservableObject, @unchecked Sendable {
             case .recoveredWithoutTranscription(let recovered):
                 self.persistRecoveredRecordingWithoutTranscription(
                     recovered,
-                    jobID: recordingID,
-                    overlayID: self.overlayTranscriptionID
+                    completion: .audioOnly(recordingID),
+                    overlayID: overlayID
                 )
 
             case .preservedForRecovery(_, let message):
-                self.errorMessage = localizedCatalogString("Audio was preserved for recovery.") + " " + message
-                self.statusText = localizedCatalogString("Error")
-                self.dismissTranscribingOverlay()
-                self.cleanupActiveAudioRecordersIfIdle()
+                self.completeStoppedRecording(
+                    .audioOnly(recordingID),
+                    overlayID: overlayID
+                ) {
+                    self.errorMessage = localizedCatalogString("Audio was preserved for recovery.") + " " + message
+                    self.statusText = localizedCatalogString("Error")
+                    self.dismissTranscribingOverlay()
+                }
 
             case .empty:
-                self.errorMessage = localizedCatalogString("No audio recorded")
-                self.statusText = localizedCatalogString("Error")
                 self.mcpLastRecordingFailed = true
-                self.dismissTranscribingOverlay()
-                self.cleanupActiveAudioRecordersIfIdle()
+                self.completeStoppedRecording(
+                    .audioOnly(recordingID),
+                    overlayID: overlayID
+                ) {
+                    self.errorMessage = localizedCatalogString("No audio recorded")
+                    self.statusText = localizedCatalogString("Error")
+                    self.dismissTranscribingOverlay()
+                }
             }
         }
     }
@@ -7932,7 +7982,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         recordingStartedAt: Date?,
         recordingEndedAt: Date,
         calendarMatch: CalendarEventMatch?,
-        audioFileName: String
+        audioFileName: String,
+        overlayID: UUID
     ) {
         let item = PipelineHistoryItem.audioOnly(
             id: recordingID,
@@ -7958,21 +8009,30 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     recordingID: journalRecordingID
                 )
             }
-            statusText = localizedCatalogString("Recording saved")
-            debugStatusMessage = "Recording saved"
-            errorMessage = nil
             mcpLastRecordingFailed = false
-            dismissTranscribingOverlay()
-            cleanupActiveAudioRecordersIfIdle()
-            scheduleReadyStatusReset(
-                after: 3,
-                matching: [localizedCatalogString("Recording saved")]
-            )
+            completeStoppedRecording(
+                .audioOnly(recordingID),
+                overlayID: overlayID
+            ) {
+                self.statusText = localizedCatalogString("Recording saved")
+                self.debugStatusMessage = "Recording saved"
+                self.errorMessage = nil
+                self.dismissTranscribingOverlay()
+                self.scheduleReadyStatusReset(
+                    after: 3,
+                    matching: [localizedCatalogString("Recording saved")]
+                )
+            }
         } catch {
-            errorMessage = userIssue(for: error).record.presentation().compactMessage
-            statusText = localizedCatalogString("Error")
-            dismissTranscribingOverlay()
-            cleanupActiveAudioRecordersIfIdle()
+            let message = userIssue(for: error).record.presentation().compactMessage
+            completeStoppedRecording(
+                .audioOnly(recordingID),
+                overlayID: overlayID
+            ) {
+                self.errorMessage = message
+                self.statusText = localizedCatalogString("Error")
+                self.dismissTranscribingOverlay()
+            }
         }
     }
 
@@ -7991,9 +8051,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @MainActor
     private func persistRecoveredRecordingWithoutTranscription(
         _ recovered: RecoveredRecordingArtifact,
-        jobID: UUID,
+        completion: StoppedRecordingCompletion,
         overlayID: UUID
     ) {
+        let presentation: (errorMessage: String, statusText: String)
         do {
             let removedAssets = try RecordingRecoveryHistory(
                 journalStore: recordingJournalStore,
@@ -8016,23 +8077,28 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 in: pipelineHistoryStore.loadAllHistory(),
                 store: pipelineHistoryStore
             )
-            errorMessage = localizedCatalogString(
-                recovered.mode.descriptionLocalizationKey
-            )
-            statusText = localizedCatalogString(
-                recovered.mode.titleLocalizationKey
+            presentation = (
+                localizedCatalogString(recovered.mode.descriptionLocalizationKey),
+                localizedCatalogString(recovered.mode.titleLocalizationKey)
             )
         } catch {
-            errorMessage = LocalizedUserMessage.providerFailure(
-                prefix: localizedCatalogString("Unable to save recovery entry"),
-                providerDetail: error.localizedDescription
+            presentation = (
+                LocalizedUserMessage.providerFailure(
+                    prefix: localizedCatalogString("Unable to save recovery entry"),
+                    providerDetail: error.localizedDescription
+                ),
+                localizedCatalogString("Error")
             )
-            statusText = localizedCatalogString("Error")
         }
         tearDownRealtimeService()
-        cleanupActiveAudioRecordersIfIdle()
-        dismissTranscribingOverlay()
-        finishTranscriptionJob(jobID, overlayID: overlayID)
+        completeStoppedRecording(
+            completion,
+            overlayID: overlayID
+        ) {
+            self.errorMessage = presentation.errorMessage
+            self.statusText = presentation.statusText
+            self.dismissTranscribingOverlay()
+        }
     }
 
     @MainActor

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1702,6 +1702,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var currentRecordingLiveNoteID: UUID?
     private var activeRecordingStartedAt: Date?
     private var activeRecordingCalendarSnapshot: RecordingCalendarSnapshot?
+    private var activeRecordingTranscriptionEnabled: Bool?
+
+    private var shouldTranscribeActiveRecording: Bool {
+        activeRecordingTranscriptionEnabled ?? transcriptionEnabled
+    }
     private var activeAudioInputID: String?
     private var activeInputSwitchToken: UUID?
     private var isActiveInputSwitchPhysicalStopInProgress = false
@@ -3194,6 +3199,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         currentSessionIntent = .dictation
         activeRecordingStartedAt = nil
         activeRecordingCalendarSnapshot = nil
+        activeRecordingTranscriptionEnabled = nil
         isRecording = false
         restoreAudioInterruptionIfNeeded()
         syncCriticalDictationActivity()
@@ -3575,12 +3581,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 ).isEmpty ? .defaultConfiguration : .transcriptionOverride
             ),
             processing: RecordingProcessingSnapshot(
-                postProcessingEnabled: !disablePostProcessing,
+                postProcessingEnabled: shouldTranscribeActiveRecording && !disablePostProcessing,
                 preferredModelID: postProcessingModel,
                 fallbackModelID: postProcessingFallbackModel,
                 outputLanguage: outputLanguage,
                 preserveExactWording: preserveExactWording,
-                contextCaptureEnabled: !disableContextCapture,
+                contextCaptureEnabled: shouldTranscribeActiveRecording && !disableContextCapture,
                 instructionExecutionGuardEnabled: instructionExecutionGuardEnabled,
                 customVocabulary: customVocabulary
                     .split(whereSeparator: \.isNewline)
@@ -5162,7 +5168,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
     // MCP public interface
     @MainActor
     func startRecordingFromMCP() {
-        lastTranscript = ""
+        if transcriptionEnabled {
+            lastTranscript = ""
+        }
         mcpLastRecordingFailed = false
         shortcutSessionController.beginManual(mode: .toggle)
         startRecording(triggerMode: .toggle)
@@ -5189,7 +5197,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
             activeRecordingCalendarSnapshot = nil
             return
         }
-        lastTranscript = ""
+        if transcriptionEnabled {
+            lastTranscript = ""
+        }
         shortcutSessionController.beginManual(mode: .toggle)
         startRecording(triggerMode: .toggle, onStarted: onStarted)
     }
@@ -5336,6 +5346,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         capturedContext = nil
         activeRecordingStartedAt = nil
         activeRecordingCalendarSnapshot = nil
+        activeRecordingTranscriptionEnabled = nil
         currentSessionIntent = .dictation
         isRecording = false
         errorMessage = nil
@@ -5564,7 +5575,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     /// Note: the global hotkey's event tap also needs AX, but that is a separate
     /// concern — we intentionally don't gate on whether a shortcut is bound here.
     var requiresAccessibility: Bool {
-        !disableAutoPaste || isCommandModeEnabled
+        transcriptionEnabled && (!disableAutoPaste || isCommandModeEnabled)
     }
 
     @MainActor
@@ -5576,6 +5587,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         startedAt: CFAbsoluteTime? = nil
     ) async -> Bool {
         activeRecordingTriggerMode = triggerMode
+        if !transcriptionEnabled {
+            currentSessionIntent = .dictation
+            overlayManager.setRecordingTriggerMode(triggerMode, animated: false)
+            return true
+        }
+
         let isAccessibilityTrusted = AXIsProcessTrusted()
         hasAccessibility = isAccessibilityTrusted
         guard isAccessibilityTrusted || !requiresAccessibility else {
@@ -5690,6 +5707,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         hotkeyManager.stop()
         shortcutSessionController.reset()
         activeRecordingTriggerMode = nil
+        activeRecordingTranscriptionEnabled = nil
         cancelRecordingInitializationTimer()
         clearAudioRecorderCallbacks()
         audioLevelCancellable?.cancel()
@@ -5921,8 +5939,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
             ? UUID()
             : nil
         let supportsLiveTranscription = !AudioInputDevice.isSystemDefaultAndSystemAudio(audioInputID)
+        activeRecordingTranscriptionEnabled = transcriptionEnabled
+        let shouldTranscribe = shouldTranscribeActiveRecording
 
-        if supportsLiveTranscription && useLocalTranscription && localTranscriptionModel.isAppleSpeech {
+        if shouldTranscribe,
+           supportsLiveTranscription,
+           useLocalTranscription,
+           localTranscriptionModel.isAppleSpeech {
             refreshSpeechRecognitionAuthorizationStatus()
             switch speechRecognitionAuthorizationStatus {
             case .authorized:
@@ -5987,6 +6010,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             default:
                 isRecording = false
                 activeRecordingCalendarSnapshot = nil
+                activeRecordingTranscriptionEnabled = nil
                 syncCriticalDictationActivity()
                 restoreAudioInterruptionIfNeeded()
                 activeRecordingTriggerMode = nil
@@ -6061,12 +6085,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
         )
 
-        if supportsLiveTranscription {
+        if shouldTranscribe, supportsLiveTranscription {
             startRealtimeStreamingIfEnabled()
         }
 
         // Start engine on background thread so UI isn't blocked
-        if supportsLiveTranscription, useLocalTranscription, let transcriber = localTranscriptionModel.makeLiveTranscriber() {
+        if shouldTranscribe,
+           supportsLiveTranscription,
+           useLocalTranscription,
+           let transcriber = localTranscriptionModel.makeLiveTranscriber() {
             // Live transcription: initialize before recording starts so the request is ready
             // to receive buffers from the very first sample
             Task { [weak self] in
@@ -6123,7 +6150,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     }
                     await MainActor.run {
                         guard self.isRecording, self.activeRecordingTriggerMode != nil else { return }
-                        self.startContextCapture()
+                        if shouldTranscribe {
+                            self.startContextCapture()
+                        }
                         if !transcriber.handlesRecording {
                             self.audioLevelCancellable = self.activeRecorderAudioLevelPublisher(inputID: audioInputID)
                                 .receive(on: DispatchQueue.main)
@@ -6152,7 +6181,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.markRecordingStarted(actualRecordingStartedAt)
                         guard self.isRecording, self.activeRecordingTriggerMode != nil else { return }
                         onStarted?()
-                        self.startContextCapture()
+                        if shouldTranscribe {
+                            self.startContextCapture()
+                        }
                         self.audioLevelCancellable = self.activeRecorderAudioLevelPublisher(inputID: audioInputID)
                             .receive(on: DispatchQueue.main)
                             .sink { [weak self] level in
@@ -6182,6 +6213,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         capturedContext = nil
         activeRecordingStartedAt = nil
         activeRecordingCalendarSnapshot = nil
+        activeRecordingTranscriptionEnabled = nil
         if let liveNoteID = currentRecordingLiveNoteID {
             currentRecordingLiveNoteID = nil
             pipelineHistory.removeAll { $0.id == liveNoteID }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -4366,6 +4366,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     context: snapshot.cloudExecutionContext,
                     requiresCloudExecution: snapshot.requiresCloudExecution
                 ) else {
+                    if snapshot.item.transcriptFileName == nil,
+                       let transcriptFileName = updatedItem.transcriptFileName {
+                        Self.deleteTranscriptFile(transcriptFileName)
+                    }
                     self.retryingItemIDs.remove(snapshot.item.id)
                     return
                 }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -361,6 +361,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private let apiKeyStorageKey = "groq_api_key"
     private let apiBaseURLStorageKey = "api_base_url"
+    private let transcriptionEnabledStorageKey = "transcription_enabled"
     private let transcriptionModelStorageKey = AppState.transcriptionModelStorageKeyName
     private let transcriptionAPIURLStorageKey = "transcription_api_url"
     private let transcriptionAPIKeyStorageKey = "transcription_api_key"
@@ -454,9 +455,54 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    private static let firstInstallDefaultsVersion = 1
+    private static let firstInstallDefaultsVersionKey = "first_install_defaults_version"
+
+    private static func seedFirstInstallDefaultsIfNeeded(
+        defaults: UserDefaults,
+        hasCompletedSetup: Bool
+    ) {
+        guard defaults.integer(forKey: firstInstallDefaultsVersionKey)
+                < firstInstallDefaultsVersion else { return }
+
+        if hasCompletedSetup {
+            defaults.set(firstInstallDefaultsVersion, forKey: firstInstallDefaultsVersionKey)
+            return
+        }
+
+        if defaults.object(forKey: "disable_auto_paste") == nil {
+            defaults.set(true, forKey: "disable_auto_paste")
+        }
+        if defaults.object(forKey: "transcription_language") == nil {
+            defaults.set("auto", forKey: "transcription_language")
+        }
+        if defaults.object(forKey: "recording_overlay_layout") == nil {
+            defaults.set(RecordingOverlayLayout.notchSides.rawValue, forKey: "recording_overlay_layout")
+        }
+        if defaults.object(forKey: "overlay_waveform_display_mode") == nil {
+            defaults.set(OverlayWaveformDisplayMode.hoverTime.rawValue, forKey: "overlay_waveform_display_mode")
+        }
+        if defaults.object(forKey: "press_enter_voice_command_enabled") == nil {
+            defaults.set(false, forKey: "press_enter_voice_command_enabled")
+        }
+
+        defaults.set(firstInstallDefaultsVersion, forKey: firstInstallDefaultsVersionKey)
+    }
+
     @Published var hasCompletedSetup: Bool {
         didSet {
             UserDefaults.standard.set(hasCompletedSetup, forKey: "hasCompletedSetup")
+        }
+    }
+
+    @Published var transcriptionEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(
+                transcriptionEnabled,
+                forKey: transcriptionEnabledStorageKey
+            )
+            guard transcriptionEnabled, oldValue != transcriptionEnabled else { return }
+            scheduleNoteBrowserTranscriptionModeNormalizationForProviderConfiguration()
         }
     }
 
@@ -1235,12 +1281,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func scheduleNoteBrowserTranscriptionModeNormalizationForSelectedInput() {
         if Thread.isMainThread {
             MainActor.assumeIsolated {
-                guard !isApplyingNoteBrowserTranscriptionChoice else { return }
+                guard transcriptionEnabled,
+                      !isApplyingNoteBrowserTranscriptionChoice else { return }
                 normalizeNoteBrowserTranscriptionMode()
             }
         } else {
             Task { @MainActor [weak self] in
-                guard let self, !self.isApplyingNoteBrowserTranscriptionChoice else { return }
+                guard let self,
+                      self.transcriptionEnabled,
+                      !self.isApplyingNoteBrowserTranscriptionChoice else { return }
                 self.normalizeNoteBrowserTranscriptionMode()
             }
         }
@@ -1249,7 +1298,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func scheduleNoteBrowserTranscriptionModeNormalizationForProviderConfiguration() {
         if Thread.isMainThread {
             MainActor.assumeIsolated {
-                guard !isApplyingNoteBrowserTranscriptionChoice,
+                guard transcriptionEnabled,
+                      !isApplyingNoteBrowserTranscriptionChoice,
                       !isRecording,
                       !isTranscribing else { return }
                 normalizeNoteBrowserTranscriptionMode()
@@ -1257,6 +1307,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         } else {
             Task { @MainActor [weak self] in
                 guard let self,
+                      self.transcriptionEnabled,
                       !self.isApplyingNoteBrowserTranscriptionChoice,
                       !self.isRecording,
                       !self.isTranscribing else { return }
@@ -1565,6 +1616,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var isRecording = false
     @Published var isTranscribing = false
     @Published var retryingItemIDs: Set<UUID> = []
+
+    var isTranscriptionConfigurationLocked: Bool {
+        isRecording || isTranscribing || !retryingItemIDs.isEmpty
+    }
     @Published private(set) var cloudTranscriptionProgressByHistoryID:
         [UUID: CloudTranscriptionDisplayProgress] = [:]
     @Published var lastTranscript: String = ""
@@ -1730,6 +1785,19 @@ final class AppState: ObservableObject, @unchecked Sendable {
         UserDefaults.standard.removeObject(forKey: "force_http2_transcription")
         Self.migrateModelStorageKeys()
         let hasCompletedSetup = UserDefaults.standard.bool(forKey: "hasCompletedSetup")
+        Self.seedFirstInstallDefaultsIfNeeded(
+            defaults: .standard,
+            hasCompletedSetup: hasCompletedSetup
+        )
+        let hasStoredTranscriptionEnabled = UserDefaults.standard.object(
+            forKey: transcriptionEnabledStorageKey
+        ) != nil
+        let transcriptionEnabled = hasStoredTranscriptionEnabled
+            ? UserDefaults.standard.bool(forKey: transcriptionEnabledStorageKey)
+            : true
+        if hasCompletedSetup && !hasStoredTranscriptionEnabled {
+            UserDefaults.standard.set(true, forKey: transcriptionEnabledStorageKey)
+        }
         let apiKey = Self.loadStoredAPIKey(account: apiKeyStorageKey)
         let apiBaseURL = Self.loadStoredAPIBaseURL(account: "api_base_url")
         let transcriptionModel = UserDefaults.standard.string(forKey: transcriptionModelStorageKey) ?? Self.defaultTranscriptionModel
@@ -1944,6 +2012,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             contextScreenshotMaxDimension: contextScreenshotMaxDimension
         )
         self.hasCompletedSetup = hasCompletedSetup
+        self.transcriptionEnabled = transcriptionEnabled
         self.apiKey = apiKey
         self.apiBaseURL = apiBaseURL
         self.transcriptionAPIURL = transcriptionAPIURL

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -4317,6 +4317,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     postProcessingEnabled: snapshot.postProcessingEnabled,
                     preserveExactWording: snapshot.preserveExactWording
                 )
+                let transcriptFileName = snapshot.item.machineStatus == .audioOnly
+                    ? Self.saveTranscriptFile(
+                        rawTranscript: parsedTranscript.transcript,
+                        postProcessedTranscript: result.finalTranscript
+                    )
+                    : snapshot.item.transcriptFileName
                 updatedItem = self.makeRetryHistoryItem(
                     from: snapshot,
                     rawTranscript: parsedTranscript.transcript,
@@ -4328,7 +4334,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             parsedTranscript: parsedTranscript,
                             isRetry: true
                         ),
-                    debugStatus: "Retried"
+                    debugStatus: "Retried",
+                    transcriptFileName: transcriptFileName
                 )
                 retrySucceeded = true
             } catch {
@@ -4347,7 +4354,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     postProcessedTranscript: snapshot.item.postProcessedTranscript,
                     postProcessingPrompt: snapshot.item.postProcessingPrompt,
                     postProcessingStatus: issue.persistedStatus,
-                    debugStatus: "Retry failed"
+                    debugStatus: "Retry failed",
+                    transcriptFileName: snapshot.item.transcriptFileName
                 )
                 retrySucceeded = false
             }
@@ -4382,6 +4390,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.copyRetryTranscriptToPasteboardIfNeeded(updatedItem.postProcessedTranscript)
                     }
                 } catch {
+                    if snapshot.item.transcriptFileName == nil,
+                       let transcriptFileName = updatedItem.transcriptFileName {
+                        Self.deleteTranscriptFile(transcriptFileName)
+                    }
                     let issue = self.userIssue(for: error)
                     self.errorMessage = issue.record.presentation().compactMessage
                 }
@@ -4426,8 +4438,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
             throw TranscriptionError.submissionFailed(reason)
         }
         let configuration = audioImportConfiguration(for: retryChoice)
+        let isAudioOnly = item.machineStatus == .audioOnly
+        let retryPostProcessingEnabled = isAudioOnly ? !disablePostProcessing : item.usedPostProcessing
+        let retryCustomVocabulary = isAudioOnly ? customVocabulary : item.customVocabulary
+        let retryCustomSystemPrompt = isAudioOnly ? customSystemPrompt : item.customSystemPrompt
         let completionSnapshot = TranscriptionCompletionSnapshot(
-            postProcessingEnabled: item.usedPostProcessing,
+            postProcessingEnabled: retryPostProcessingEnabled,
             preserveExactWording: preserveExactWording,
             outputLanguage: outputLanguage,
             pressEnterCommandEnabled: isPressEnterVoiceCommandEnabled
@@ -4473,15 +4489,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
             item: item,
             audioURL: audioURL,
             restoredContext: AppContext(
-                appName: nil,
-                bundleIdentifier: nil,
-                windowTitle: nil,
-                selectedText: nil,
-                currentActivity: item.contextSummary,
-                contextSystemPrompt: item.contextSystemPrompt,
-                contextPrompt: item.contextPrompt,
-                screenshotDataURL: item.contextScreenshotDataURL,
-                screenshotMimeType: item.contextScreenshotDataURL != nil ? "image/jpeg" : nil,
+                appName: isAudioOnly ? nil : item.contextAppName,
+                bundleIdentifier: isAudioOnly ? nil : item.contextBundleIdentifier,
+                windowTitle: isAudioOnly ? nil : item.contextWindowTitle,
+                selectedText: isAudioOnly ? nil : item.capturedSelection,
+                currentActivity: isAudioOnly ? "" : item.contextSummary,
+                contextSystemPrompt: isAudioOnly ? nil : item.contextSystemPrompt,
+                contextPrompt: isAudioOnly ? nil : item.contextPrompt,
+                screenshotDataURL: isAudioOnly ? nil : item.contextScreenshotDataURL,
+                screenshotMimeType: !isAudioOnly && item.contextScreenshotDataURL != nil
+                    ? "image/jpeg"
+                    : nil,
                 screenshotError: nil
             ),
             restoredIntent: SessionIntent.fromPersisted(intent: item.intent, selectedText: item.selectedText),
@@ -4490,10 +4508,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
             transcriptionLanguage: TranscriptionLanguage.find(code: item.transcriptionLanguageCode),
             localTranscriptionModel: configuration.localTranscriptionModel,
             useLocalTranscription: configuration.useLocalTranscription,
-            customVocabulary: item.customVocabulary,
-            customSystemPrompt: item.customSystemPrompt,
+            customVocabulary: retryCustomVocabulary,
+            customSystemPrompt: retryCustomSystemPrompt,
             outputLanguage: outputLanguage,
-            postProcessingEnabled: item.usedPostProcessing,
+            postProcessingEnabled: retryPostProcessingEnabled,
             preserveExactWording: preserveExactWording,
             localWhisperPath: localWhisperPath.isEmpty ? nil : localWhisperPath,
             useLegacyMlxWhisper: configuration.useLegacyMlxWhisper,
@@ -4508,11 +4526,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         postProcessedTranscript: String,
         postProcessingPrompt: String?,
         postProcessingStatus: String,
-        debugStatus: String
+        debugStatus: String,
+        transcriptFileName: String?
     ) -> PipelineHistoryItem {
         PipelineHistoryItem(
             intent: snapshot.item.intent,
             selectedText: snapshot.item.selectedText,
+            capturedSelection: snapshot.item.capturedSelection,
             id: snapshot.item.id,
             timestamp: snapshot.item.timestamp,
             recordingStartedAt: snapshot.item.recordingStartedAt,
@@ -4521,7 +4541,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
             rawTranscript: rawTranscript,
             postProcessedTranscript: postProcessedTranscript,
             postProcessingPrompt: postProcessingPrompt,
+            systemPrompt: snapshot.item.systemPrompt,
             contextSummary: snapshot.item.contextSummary,
+            contextSystemPrompt: snapshot.item.contextSystemPrompt,
             contextPrompt: snapshot.item.contextPrompt,
             contextScreenshotDataURL: snapshot.item.contextScreenshotDataURL,
             contextScreenshotStatus: snapshot.item.contextScreenshotStatus,
@@ -4535,7 +4557,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
             usedPostProcessing: snapshot.postProcessingEnabled,
             transcriptionLanguageCode: snapshot.transcriptionLanguage.code,
             localTranscriptionModelID: snapshot.localTranscriptionModel.id,
-            transcriptFileName: snapshot.item.transcriptFileName
+            transcriptFileName: transcriptFileName,
+            contextAppName: snapshot.item.contextAppName,
+            contextBundleIdentifier: snapshot.item.contextBundleIdentifier,
+            contextWindowTitle: snapshot.item.contextWindowTitle,
+            customTitle: snapshot.item.customTitle
         )
     }
 
@@ -7505,7 +7531,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             parsedTranscript: parsed,
                             isRetry: true
                         ),
-                    debugStatus: "Resumed after relaunch"
+                    debugStatus: "Resumed after relaunch",
+                    transcriptFileName: item.transcriptFileName
                 )
                 try pipelineHistoryStore.update(updated)
                 pipelineHistory = pipelineHistoryStore.loadAllHistory()

--- a/Sources/MCPServer.swift
+++ b/Sources/MCPServer.swift
@@ -296,7 +296,12 @@ final class MCPServer {
                 return textContent("Not currently recording.")
             }
             appState.stopRecordingFromMCP()
-            return textContent("Recording stopped. Transcription in progress — listen for recording/completed event.")
+            if appState.transcriptionEnabled {
+                return textContent(
+                    "Recording stopped. Transcription in progress — listen for recording/completed event."
+                )
+            }
+            return textContent("Recording stopped. Audio note is being saved.")
 
         case "get_status":
             let status: String

--- a/Sources/MCPServer.swift
+++ b/Sources/MCPServer.swift
@@ -202,7 +202,7 @@ final class MCPServer {
             ],
             [
                 "name": "stop_recording",
-                "description": "Stop the current recording and trigger transcription.",
+                "description": "Stop the current recording; transcribe it if transcription was enabled when recording began, otherwise save an audio-only note.",
                 "inputSchema": [
                     "type": "object",
                     "properties": [:]
@@ -292,16 +292,16 @@ final class MCPServer {
             return textContent("Context added: \(text)")
 
         case "stop_recording":
-            guard appState.isRecording else {
+            switch appState.stopRecordingFromMCP() {
+            case .notRecording:
                 return textContent("Not currently recording.")
-            }
-            appState.stopRecordingFromMCP()
-            if appState.transcriptionEnabled {
+            case .transcribing:
                 return textContent(
                     "Recording stopped. Transcription in progress — listen for recording/completed event."
                 )
+            case .savingAudioOnly:
+                return textContent("Recording stopped. Audio note is being saved.")
             }
-            return textContent("Recording stopped. Audio note is being saved.")
 
         case "get_status":
             let status: String

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -46,6 +46,15 @@ struct MenuBarView: View {
         NotificationCenter.default.post(name: .showSettings, object: nil)
     }
 
+    private var recordingButtonTitle: String {
+        if appState.isRecording {
+            return String(localized: "Stop Recording")
+        }
+        return appState.transcriptionEnabled
+            ? String(localized: "Start Dictating")
+            : String(localized: "Start Recording")
+    }
+
     var body: some View {
         VStack(spacing: 4) {
             Text("\(AppName.displayName) v\(appVersion)")
@@ -113,7 +122,7 @@ struct MenuBarView: View {
             Divider()
 
             // Manual toggle
-            Button(appState.isRecording ? String(localized: "Stop Recording") : String(localized: "Start Dictating")) {
+            Button(recordingButtonTitle) {
                 appState.toggleRecording()
             }
             .disabled(appState.isTranscribing)

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -1046,7 +1046,7 @@ private struct NoteListRow: View {
                     .lineLimit(1)
 
                 if displayData.status == .audioOnly {
-                    Text("Audio only")
+                    Text(localizedCatalogString("Audio only"))
                         .font(.system(size: 9, weight: .semibold))
                         .foregroundStyle(.blue)
                         .padding(.horizontal, 6)
@@ -1466,7 +1466,7 @@ private struct NoteDetailView: View {
         HStack(spacing: 5) {
             if isAudioOnly {
                 metaTag(
-                    "Audio only",
+                    localizedCatalogString("Audio only"),
                     active: true,
                     help: "Audio-only recording"
                 )

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -1114,6 +1114,8 @@ private struct NoteListRow: View {
                 .frame(width: 6, height: 6)
         case .recording, .transcribing:
             YellowSpinner(color: .orange)
+        case .audioOnly:
+            EmptyView()
         case .recovered:
             Image(systemName: "arrow.clockwise.circle")
                 .font(.system(size: 9, weight: .medium))

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -1045,6 +1045,15 @@ private struct NoteListRow: View {
                     .foregroundStyle(selectedTitleColor)
                     .lineLimit(1)
 
+                if displayData.status == .audioOnly {
+                    Text("Audio only")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.blue)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.blue.opacity(0.10), in: Capsule())
+                }
+
                 Text(displayData.preview.isEmpty ? " " : displayData.preview)
                     .font(.system(size: 11.5))
                     .foregroundStyle(selectedPreviewColor)
@@ -1115,7 +1124,9 @@ private struct NoteListRow: View {
         case .recording, .transcribing:
             YellowSpinner(color: .orange)
         case .audioOnly:
-            EmptyView()
+            Circle()
+                .fill(Color.blue)
+                .frame(width: 6, height: 6)
         case .recovered:
             Image(systemName: "arrow.clockwise.circle")
                 .font(.system(size: 9, weight: .medium))
@@ -1151,6 +1162,12 @@ private struct NoteDetailView: View {
     private var isError: Bool {
         if case .failed = item.machineStatus { return true }
         return false
+    }
+    private var isAudioOnly: Bool {
+        item.machineStatus == .audioOnly
+    }
+    private var transcriptionActionHelp: LocalizedStringKey {
+        isAudioOnly ? "Transcribe audio" : "Retry transcription"
     }
     private var isCloudTranscribing: Bool {
         item.machineStatus == .cloudTranscribing
@@ -1447,11 +1464,19 @@ private struct NoteDetailView: View {
     @ViewBuilder
     private var statusBadges: some View {
         HStack(spacing: 5) {
-            metaTag(
-                item.usedLocalTranscription ? "LOCAL" : "CLOUD",
-                active: item.usedLocalTranscription,
-                help: item.usedLocalTranscription ? "Local transcription" : "Cloud transcription"
-            )
+            if isAudioOnly {
+                metaTag(
+                    "Audio only",
+                    active: true,
+                    help: "Audio-only recording"
+                )
+            } else {
+                metaTag(
+                    item.usedLocalTranscription ? "LOCAL" : "CLOUD",
+                    active: item.usedLocalTranscription,
+                    help: item.usedLocalTranscription ? "Local transcription" : "Cloud transcription"
+                )
+            }
             metaDot
             metaTag(
                 item.usedContextCapture ? "CTX" : "NO CTX",
@@ -1558,6 +1583,22 @@ private struct NoteDetailView: View {
                     .foregroundStyle(.tertiary)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 60)
+            } else if isAudioOnly {
+                ZStack {
+                    Circle()
+                        .fill(Color.blue.opacity(0.08))
+                        .frame(width: 80, height: 80)
+                    Image(systemName: "waveform")
+                        .font(.system(size: 30, weight: .ultraLight))
+                        .foregroundStyle(.blue.opacity(0.75))
+                }
+                Text("Audio recording")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Text("Saved without transcription. You can transcribe it later.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.tertiary)
+                    .multilineTextAlignment(.center)
             } else if isError {
                 if let issuePresentation {
                     QuillUserIssueView(
@@ -1607,7 +1648,7 @@ private struct NoteDetailView: View {
                         }
                     },
                     disabled: isRetrying,
-                    help: "Retry transcription"
+                    help: transcriptionActionHelp
                 )
                 toolbarDivider
             }
@@ -2171,6 +2212,7 @@ private struct ToolbarIconButton<Label: View>: View {
         .buttonStyle(ToolbarButtonStyle(isHovered: isHovered))
         .disabled(disabled)
         .help(help)
+        .accessibilityLabel(Text(help))
         .contentShape(Circle())
         .allowsHitTesting(true)
         .onHover { hovering in

--- a/Sources/NoteListRowDisplayData.swift
+++ b/Sources/NoteListRowDisplayData.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum TranscriptStatus: Equatable {
-    case done, recording, transcribing, recovered, fail
+    case done, recording, transcribing, audioOnly, recovered, fail
 }
 
 struct CloudTranscriptionDisplayProgress: Equatable, Sendable {
@@ -17,6 +17,8 @@ func transcriptStatus(for item: PipelineHistoryItem, retrying: Set<UUID>) -> Tra
         return .recording
     case .importing, .cloudTranscribing:
         return .transcribing
+    case .audioOnly:
+        return .audioOnly
     case .recovered:
         return .recovered
     case .failed:
@@ -131,6 +133,13 @@ struct NoteListRowDisplayData: Equatable {
             _ arguments: [CVarArg]
         ) -> String
     ) -> String {
+        if status == .audioOnly {
+            return localizedCatalogString(
+                "Not transcribed",
+                language: localizationLanguage,
+                bundle: localizationBundle
+            )
+        }
         if status == .fail {
             return item.userIssuePresentation(
                 language: localizationLanguage,

--- a/Sources/NoteTitleResolver.swift
+++ b/Sources/NoteTitleResolver.swift
@@ -43,6 +43,13 @@ enum NoteTitleResolver {
         let content = item.postProcessedTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
         if content.isEmpty {
             if isTranscribing { return "Transcribing..." }
+            if item.machineStatus == .audioOnly {
+                return localizedCatalogString(
+                    "Audio recording",
+                    language: language,
+                    bundle: bundle
+                )
+            }
             if case .failed = item.machineStatus {
                 return item.userIssuePresentation(
                     language: language,

--- a/Sources/PipelineHistoryItem.swift
+++ b/Sources/PipelineHistoryItem.swift
@@ -10,6 +10,7 @@ enum PipelineHistoryMachineStatus: Equatable {
     case importing
     case liveRecording
     case cloudTranscribing
+    case audioOnly
     case recovered(RecoveredRecordingContext)
     case failed(QuillUserIssueRecord)
     case completed
@@ -21,12 +22,16 @@ struct PipelineHistoryItem: Identifiable, Codable {
     static let recoveredRecordingStatus =
         RecoveredRecordingMode.complete.recoveredStatus
     static let cloudTranscribingStatus = "cloud-transcribing"
+    static let audioOnlyStatus = "audio-only"
 
     var machineStatus: PipelineHistoryMachineStatus {
         if postProcessingStatus == "importing" { return .importing }
         if postProcessingStatus == "live-recording" { return .liveRecording }
         if postProcessingStatus == Self.cloudTranscribingStatus {
             return .cloudTranscribing
+        }
+        if postProcessingStatus == Self.audioOnlyStatus {
+            return .audioOnly
         }
         if let context = recoveredRecordingContext {
             return .recovered(context)
@@ -247,6 +252,52 @@ struct PipelineHistoryItem: Identifiable, Codable {
             contextAppName: contextAppName,
             contextBundleIdentifier: contextBundleIdentifier,
             contextWindowTitle: contextWindowTitle,
+            customTitle: nil
+        )
+    }
+
+    static func audioOnly(
+        id: UUID = UUID(),
+        timestamp: Date,
+        recordingStartedAt: Date?,
+        recordingEndedAt: Date?,
+        calendarMatch: CalendarEventMatch?,
+        audioFileName: String,
+        transcriptionLanguageCode: String,
+        localTranscriptionModelID: String
+    ) -> PipelineHistoryItem {
+        PipelineHistoryItem(
+            intent: .dictation,
+            selectedText: nil,
+            capturedSelection: nil,
+            id: id,
+            timestamp: timestamp,
+            recordingStartedAt: recordingStartedAt,
+            recordingEndedAt: recordingEndedAt,
+            calendarMatch: calendarMatch,
+            rawTranscript: "",
+            postProcessedTranscript: "",
+            postProcessingPrompt: nil,
+            systemPrompt: nil,
+            contextSummary: "",
+            contextSystemPrompt: nil,
+            contextPrompt: nil,
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "No screenshot",
+            postProcessingStatus: Self.audioOnlyStatus,
+            debugStatus: "Audio only",
+            customVocabulary: "",
+            customSystemPrompt: "",
+            audioFileName: audioFileName,
+            usedLocalTranscription: false,
+            usedContextCapture: false,
+            usedPostProcessing: false,
+            transcriptionLanguageCode: transcriptionLanguageCode,
+            localTranscriptionModelID: localTranscriptionModelID,
+            transcriptFileName: nil,
+            contextAppName: nil,
+            contextBundleIdentifier: nil,
+            contextWindowTitle: nil,
             customTitle: nil
         )
     }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1734,6 +1734,13 @@ struct ModelsSettingsView: View {
         )
     }
 
+    private var transcriptionEnabled: Binding<Bool> {
+        Binding(
+            get: { appState.transcriptionEnabled },
+            set: { appState.transcriptionEnabled = $0 }
+        )
+    }
+
     private var managedNativeModel: NativeWhisperModel? {
         guard let pendingNativeModelID else { return nil }
         return NativeWhisperModelCatalog.all.first { $0.id == pendingNativeModelID }
@@ -1845,52 +1852,70 @@ struct ModelsSettingsView: View {
 
     private var transcriptionFeatureSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Convert speech to text.")
+            HStack {
+                Text(
+                    appState.transcriptionEnabled
+                        ? "Convert speech to text."
+                        : "Record audio without creating a transcript."
+                )
                 .font(.caption)
                 .foregroundStyle(.secondary)
-
-            transcriptionChoicePicker
-
-            if let model = managedNativeModel {
-                NativeWhisperModelRowView(
-                    model: model,
-                    isSelected: appState.currentNoteBrowserTranscriptionChoice == .nativeWhisper(modelID: model.id),
-                    onSelect: {
-                        handleTranscriptionChoiceSelection(.nativeWhisper(modelID: model.id))
-                    },
-                    showsSelectionControl: false
-                )
-
-                Text("The download continues in the background while Quill is running.")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
+                Spacer()
+                Toggle("", isOn: transcriptionEnabled)
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                    .accessibilityLabel("Transcription")
+                    .disabled(appState.isTranscriptionConfigurationLocked)
             }
 
-            if currentTranscriptionUsesAPI && !appState.hasTranscriptionAPIKey {
-                Label(
-                    "Cloud transcription requires an API key. Add one in Cloud Provider or use the transcription override in Details.",
-                    systemImage: "exclamationmark.triangle"
-                )
-                .font(.caption)
-                .foregroundStyle(.orange)
-            } else if let reason = currentTranscriptionDisplay.localizedUnavailableReason() {
-                Label(reason, systemImage: "exclamationmark.triangle")
+            VStack(alignment: .leading, spacing: 12) {
+                transcriptionChoicePicker
+
+                if let model = managedNativeModel {
+                    NativeWhisperModelRowView(
+                        model: model,
+                        isSelected: appState.currentNoteBrowserTranscriptionChoice == .nativeWhisper(modelID: model.id),
+                        onSelect: {
+                            handleTranscriptionChoiceSelection(.nativeWhisper(modelID: model.id))
+                        },
+                        showsSelectionControl: false
+                    )
+
+                    Text("The download continues in the background while Quill is running.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
+                if appState.transcriptionEnabled,
+                   currentTranscriptionUsesAPI,
+                   !appState.hasTranscriptionAPIKey {
+                    Label(
+                        "Cloud transcription requires an API key. Add one in Cloud Provider or use the transcription override in Details.",
+                        systemImage: "exclamationmark.triangle"
+                    )
                     .font(.caption)
                     .foregroundStyle(.orange)
-            }
-
-            DisclosureGroup("Details") {
-                VStack(alignment: .leading, spacing: 14) {
-                    transcriptionLanguageSetting
-                    Divider()
-                    standardAPITranscriptionSetting
-                    realtimeTranscriptionSetting
-                    transcriptionProviderOverrideSetting
-                    Divider()
-                    legacyTranscriptionSettings
+                } else if let reason = currentTranscriptionDisplay.localizedUnavailableReason() {
+                    Label(reason, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
                 }
-                .padding(.top, 8)
+
+                DisclosureGroup("Details") {
+                    VStack(alignment: .leading, spacing: 14) {
+                        transcriptionLanguageSetting
+                        Divider()
+                        standardAPITranscriptionSetting
+                        realtimeTranscriptionSetting
+                        transcriptionProviderOverrideSetting
+                        Divider()
+                        legacyTranscriptionSettings
+                    }
+                    .padding(.top, 8)
+                }
             }
+            .disabled(!appState.transcriptionEnabled)
+            .opacity(appState.transcriptionEnabled ? 1 : 0.45)
         }
     }
 
@@ -1945,6 +1970,12 @@ struct ModelsSettingsView: View {
             if appState.disablePostProcessing {
                 Text("Normal dictation uses the raw transcript while Post-processing is off. Edit Mode still uses this model configuration.")
                     .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if !appState.transcriptionEnabled {
+                Text("Applies to recordings when Transcription is enabled.")
+                    .font(.caption2)
                     .foregroundStyle(.secondary)
             }
 
@@ -2006,6 +2037,12 @@ struct ModelsSettingsView: View {
             if appState.disableContextCapture {
                 Text("Context capture is off. Quill skips app context and screenshots for normal dictation.")
                     .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if !appState.transcriptionEnabled {
+                Text("Applies to recordings when Transcription is enabled.")
+                    .font(.caption2)
                     .foregroundStyle(.secondary)
             }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1895,7 +1895,8 @@ struct ModelsSettingsView: View {
                     )
                     .font(.caption)
                     .foregroundStyle(.orange)
-                } else if let reason = currentTranscriptionDisplay.localizedUnavailableReason() {
+                } else if appState.transcriptionEnabled,
+                          let reason = currentTranscriptionDisplay.localizedUnavailableReason() {
                     Label(reason, systemImage: "exclamationmark.triangle")
                         .font(.caption)
                         .foregroundStyle(.orange)

--- a/Sources/SetupFlow.swift
+++ b/Sources/SetupFlow.swift
@@ -2,6 +2,7 @@ import UserNotifications
 
 enum SetupFlow {
     enum ProcessingLocation: Equatable {
+        case recordOnly
         case onThisMac
         case apiProvider
     }
@@ -14,6 +15,7 @@ enum SetupFlow {
     }
 
     enum ProcessingPreset: Equatable {
+        case recordOnly
         case localAppleSpeech
         case localNativeWhisper
         case apiStandard
@@ -30,6 +32,8 @@ enum SetupFlow {
         localModel: LocalModel
     ) -> ProcessingPreset? {
         switch location {
+        case .recordOnly:
+            return .recordOnly
         case .onThisMac:
             switch localModel {
             case .appleSpeech:
@@ -45,11 +49,12 @@ enum SetupFlow {
     }
 
     static func requiredPermissions(for preset: ProcessingPreset) -> Set<Permission> {
-        var permissions: Set<Permission> = [.microphone, .accessibility]
-        if preset == .localAppleSpeech {
-            permissions.insert(.speechRecognition)
+        switch preset {
+        case .recordOnly, .localNativeWhisper, .apiStandard:
+            return [.microphone]
+        case .localAppleSpeech:
+            return [.microphone, .speechRecognition]
         }
-        return permissions
     }
 
     static func isNotificationAuthorizationGranted(_ status: UNAuthorizationStatus) -> Bool {

--- a/Sources/SetupView.swift
+++ b/Sources/SetupView.swift
@@ -189,6 +189,12 @@ struct SetupView: View {
 
             HStack(spacing: 12) {
                 processingChoiceCard(
+                    location: .recordOnly,
+                    icon: "waveform",
+                    title: "Record only",
+                    detail: "No transcription · No model download"
+                )
+                processingChoiceCard(
                     location: .onThisMac,
                     icon: "desktopcomputer",
                     title: "On this Mac",
@@ -202,7 +208,19 @@ struct SetupView: View {
                 )
             }
 
-            if processingLocation == .onThisMac {
+            if processingLocation == .recordOnly {
+                Label(
+                    "Save audio notes now. Transcribe them later if needed. No model download or API key required.",
+                    systemImage: "checkmark.circle"
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+                .cornerRadius(12)
+            } else if processingLocation == .onThisMac {
                 localProcessingDetails
                     .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .top)))
             } else if processingLocation == .apiProvider {
@@ -366,20 +384,11 @@ struct SetupView: View {
 
                 permissionRow(
                     title: "Microphone",
-                    description: "Record your voice for transcription.",
+                    description: "Record your voice and other selected audio inputs.",
                     icon: "mic.fill",
                     granted: micPermissionGranted,
                     actionTitle: String(localized: "Grant Access"),
                     action: requestMicrophonePermission
-                )
-
-                permissionRow(
-                    title: "Accessibility",
-                    description: "Paste transcribed text into your apps.",
-                    icon: "hand.raised.fill",
-                    granted: accessibilityGranted,
-                    actionTitle: String(localized: "Open Settings"),
-                    action: appState.openAccessibilitySettings
                 )
 
                 if selectedPreset == .localAppleSpeech {
@@ -404,8 +413,17 @@ struct SetupView: View {
                 }
 
                 permissionRow(
-                    title: "Screen Recording",
-                    description: "Adds screen context and enables System Audio when you choose it.",
+                    title: "Accessibility",
+                    description: "Enables automatic paste and Edit Mode when you turn them on.",
+                    icon: "hand.raised.fill",
+                    granted: accessibilityGranted,
+                    actionTitle: String(localized: "Open Settings"),
+                    action: appState.openAccessibilitySettings
+                )
+
+                permissionRow(
+                    title: "Screen & System Audio Recording",
+                    description: "Enables System Audio recording and optional screen context.",
                     icon: "camera.viewfinder",
                     granted: appState.hasScreenRecordingPermission,
                     actionTitle: String(localized: "Grant Access"),
@@ -711,6 +729,8 @@ struct SetupView: View {
         case .processing:
             guard let selectedPreset else { return false }
             switch selectedPreset {
+            case .recordOnly:
+                return true
             case .localAppleSpeech:
                 return true
             case .localNativeWhisper:
@@ -729,6 +749,8 @@ struct SetupView: View {
 
     private var processingSummary: String {
         switch selectedPreset {
+        case .recordOnly:
+            return localizedCatalogString("Record only · Audio notes")
         case .localAppleSpeech:
             if appState.willAutoSelectNativeWhisperWhenReady {
                 return localizedCatalogString(
@@ -814,6 +836,8 @@ struct SetupView: View {
     }
 
     private func handleNativeWhisperStatusChange(_ status: NativeWhisperInstallStatus) {
+        guard processingLocation != .recordOnly else { return }
+
         if status == .ready,
            case .nativeWhisper = appState.currentNoteBrowserTranscriptionChoice {
             processingLocation = .onThisMac

--- a/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
+++ b/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
@@ -241,6 +241,7 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         precondition(preserveBody.contains("controller.preserveForRecovery()"))
 
         try testRecordOnlySessionSnapshotsAndGatesAIComponents()
+        try testAppleSpeechStartWithoutTriggerModeClearsSessionSnapshot()
         try testRecordOnlyStillStartsSelectedAudioRecorder()
 
         print("AppStateRecordingJournalIntegrationSourceTests passed")
@@ -256,6 +257,18 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         assert(begin.contains("startRealtimeStreamingIfEnabled()"))
         assert(begin.contains("startContextCapture()"))
         assert(begin.contains("localTranscriptionModel.makeLiveTranscriber()"))
+    }
+
+    private static func testAppleSpeechStartWithoutTriggerModeClearsSessionSnapshot() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let begin = try body(startingWith: "private func beginRecording(", in: source)
+
+        assert(begin.contains("""
+                guard let triggerMode = activeRecordingTriggerMode else {
+                    activeRecordingTranscriptionEnabled = nil
+                    return
+                }
+"""))
     }
 
     private static func testRecordOnlyStillStartsSelectedAudioRecorder() throws {

--- a/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
+++ b/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
@@ -243,8 +243,70 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         try testRecordOnlySessionSnapshotsAndGatesAIComponents()
         try testAppleSpeechStartWithoutTriggerModeClearsSessionSnapshot()
         try testRecordOnlyStillStartsSelectedAudioRecorder()
+        try testRecordOnlyBranchesBeforeTranscriptionJobCreation()
+        try testAudioOnlyStopUsesExistingRecorderFinalizationCases()
+        try testAudioOnlyStopDismissesRecordingOverlayOnErrors()
 
         print("AppStateRecordingJournalIntegrationSourceTests passed")
+    }
+
+    private static func testRecordOnlyBranchesBeforeTranscriptionJobCreation() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let stop = try body(startingWith: "private func stopAndTranscribe()", in: source)
+
+        let branch = try requiredRange(of: "if !shouldTranscribe", in: stop)
+        let register = try requiredRange(of: "registerTranscriptionJob(", in: stop)
+        let overlay = try requiredRange(of: "overlayManager.showTranscribing()", in: stop)
+        let service = try requiredRange(of: "PostProcessingService(", in: stop)
+
+        assert(branch.lowerBound < register.lowerBound)
+        assert(branch.lowerBound < overlay.lowerBound)
+        assert(branch.lowerBound < service.lowerBound)
+        assert(stop.contains("stopAndSaveAudioOnly("))
+    }
+
+    private static func testAudioOnlyStopUsesExistingRecorderFinalizationCases() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let helper = try body(startingWith: "private func stopAndSaveAudioOnly(", in: source)
+
+        assert(helper.contains("stopActiveAudioRecorder"))
+        assert(helper.contains("case .transcribable"))
+        assert(helper.contains("case .recoveredWithoutTranscription"))
+        assert(helper.contains("case .preservedForRecovery"))
+        assert(helper.contains("case .empty"))
+        assert(helper.contains("savedAudioFileForStoppedRecording"))
+        assert(helper.contains("PipelineHistoryItem.audioOnly("))
+        assert(!helper.contains("saveTranscriptFile("))
+        assert(!helper.contains("registerTranscriptionJob("))
+        assert(!helper.contains("overlayManager.showTranscribing()"))
+        assert(!helper.contains("writeTranscriptToPasteboard("))
+        assert(!helper.contains("pasteAtCursorWhenShortcutReleased"))
+        assert(!helper.contains("lastTranscript = \"\""))
+    }
+
+    private static func testAudioOnlyStopDismissesRecordingOverlayOnErrors() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let helper = try body(startingWith: "private func stopAndSaveAudioOnly(", in: source)
+        let transcribable = try switchCaseBody(
+            startingWith: "case .transcribable",
+            endingBefore: "case .recoveredWithoutTranscription",
+            in: helper
+        )
+        let preserved = try switchCaseBody(
+            startingWith: "case .preservedForRecovery",
+            endingBefore: "case .empty",
+            in: helper
+        )
+        let emptyRange = try requiredRange(of: "case .empty:", in: helper)
+        let empty = String(helper[emptyRange.upperBound...])
+        let persist = try body(startingWith: "private func persistAudioOnlyRecording(", in: source)
+        let catchRange = try requiredRange(of: "} catch {", in: persist)
+        let persistCatch = String(persist[catchRange.upperBound...])
+
+        assert(transcribable.contains("self.dismissTranscribingOverlay()"))
+        assert(preserved.contains("self.dismissTranscribingOverlay()"))
+        assert(empty.contains("self.dismissTranscribingOverlay()"))
+        assert(persistCatch.contains("dismissTranscribingOverlay()"))
     }
 
     private static func testRecordOnlySessionSnapshotsAndGatesAIComponents() throws {

--- a/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
+++ b/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
@@ -246,6 +246,7 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         try testRecordOnlyBranchesBeforeTranscriptionJobCreation()
         try testAudioOnlyStopUsesExistingRecorderFinalizationCases()
         try testAudioOnlyStopDismissesRecordingOverlayOnErrors()
+        try testAudioOnlyCompletionOwnsForegroundUIAndTermination()
 
         print("AppStateRecordingJournalIntegrationSourceTests passed")
     }
@@ -254,20 +255,27 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
         let stop = try body(startingWith: "private func stopAndTranscribe()", in: source)
 
-        let branch = try requiredRange(of: "if !shouldTranscribe", in: stop)
+        let branchRange = try requiredRange(of: "if !shouldTranscribe", in: stop)
+        let branch = try body(startingWith: "if !shouldTranscribe", in: stop)
         let register = try requiredRange(of: "registerTranscriptionJob(", in: stop)
         let overlay = try requiredRange(of: "overlayManager.showTranscribing()", in: stop)
         let service = try requiredRange(of: "PostProcessingService(", in: stop)
 
-        assert(branch.lowerBound < register.lowerBound)
-        assert(branch.lowerBound < overlay.lowerBound)
-        assert(branch.lowerBound < service.lowerBound)
-        assert(stop.contains("stopAndSaveAudioOnly("))
+        assert(branchRange.lowerBound < register.lowerBound)
+        assert(branchRange.lowerBound < overlay.lowerBound)
+        assert(branchRange.lowerBound < service.lowerBound)
+        assert(branch.contains("let audioOnlyOverlayID = overlayTranscriptionID"))
+        assert(branch.contains("stopAndSaveAudioOnly("))
+        assert(branch.contains("overlayID: audioOnlyOverlayID"))
+        assert(!branch.contains("registerTranscriptionJob("))
+        assert(!branch.contains("overlayManager.showTranscribing()"))
+        assert(!branch.contains("PostProcessingService("))
     }
 
     private static func testAudioOnlyStopUsesExistingRecorderFinalizationCases() throws {
         let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
         let helper = try body(startingWith: "private func stopAndSaveAudioOnly(", in: source)
+        let persist = try body(startingWith: "private func persistAudioOnlyRecording(", in: source)
 
         assert(helper.contains("stopActiveAudioRecorder"))
         assert(helper.contains("case .transcribable"))
@@ -275,7 +283,9 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         assert(helper.contains("case .preservedForRecovery"))
         assert(helper.contains("case .empty"))
         assert(helper.contains("savedAudioFileForStoppedRecording"))
-        assert(helper.contains("PipelineHistoryItem.audioOnly("))
+        assert(helper.contains("persistAudioOnlyRecording("))
+        assert(persist.contains("PipelineHistoryItem.audioOnly("))
+        assert(!helper.contains("PipelineHistoryItem.audioOnly("))
         assert(!helper.contains("saveTranscriptFile("))
         assert(!helper.contains("registerTranscriptionJob("))
         assert(!helper.contains("overlayManager.showTranscribing()"))
@@ -300,13 +310,53 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         let emptyRange = try requiredRange(of: "case .empty:", in: helper)
         let empty = String(helper[emptyRange.upperBound...])
         let persist = try body(startingWith: "private func persistAudioOnlyRecording(", in: source)
-        let catchRange = try requiredRange(of: "} catch {", in: persist)
-        let persistCatch = String(persist[catchRange.upperBound...])
 
-        assert(transcribable.contains("self.dismissTranscribingOverlay()"))
-        assert(preserved.contains("self.dismissTranscribingOverlay()"))
-        assert(empty.contains("self.dismissTranscribingOverlay()"))
-        assert(persistCatch.contains("dismissTranscribingOverlay()"))
+        for terminalPath in [transcribable, preserved, empty, persist] {
+            assert(terminalPath.contains("completeStoppedRecording("))
+            assert(terminalPath.contains("dismissTranscribingOverlay()"))
+        }
+    }
+
+    private static func testAudioOnlyCompletionOwnsForegroundUIAndTermination() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let begin = try body(startingWith: "private func beginRecording(", in: source)
+        let stop = try body(startingWith: "private func stopAndSaveAudioOnly(", in: source)
+        let persist = try body(startingWith: "private func persistAudioOnlyRecording(", in: source)
+        let completion = try body(startingWith: "private func completeStoppedRecording(", in: source)
+        let terminate = try body(startingWith: "private func terminateIfReady()", in: source)
+        let requestTermination = try body(
+            startingWith: "func requestTerminationWhileRecording()",
+            in: source
+        )
+
+        let overlayOwner = try requiredRange(of: "overlayTranscriptionID = UUID()", in: begin)
+        let clearedError = try requiredRange(of: "errorMessage = nil", in: begin)
+        let pendingInsert = try requiredRange(
+            of: "pendingAudioOnlyStopIDs.insert(recordingID)",
+            in: stop
+        )
+        let recordingStopped = try requiredRange(of: "isRecording = false", in: stop)
+        let historyAppend = try requiredRange(of: "appendPipelineHistoryItem(item)", in: persist)
+        let persistenceCompletion = try requiredRange(of: "completeStoppedRecording(", in: persist)
+
+        assert(source.contains("private var pendingAudioOnlyStopIDs: Set<UUID> = []"))
+        assert(source.contains("private enum StoppedRecordingCompletion"))
+        assert(begin.contains("overlayTranscriptionID = UUID()"))
+        assert(overlayOwner.lowerBound < clearedError.lowerBound)
+        assert(stop.contains("pendingAudioOnlyStopIDs.insert(recordingID)"))
+        assert(pendingInsert.lowerBound < recordingStopped.lowerBound)
+        assert(source.contains("calendarSnapshot: RecordingCalendarSnapshot?,\n        overlayID: UUID"))
+        assert(source.contains("audioFileName: String,\n        overlayID: UUID"))
+        assert(source.contains("completion: StoppedRecordingCompletion,\n        overlayID: UUID"))
+        assert(completion.contains("cleanupActiveAudioRecordersIfIdle()"))
+        assert(completion.contains("if overlayTranscriptionID == overlayID"))
+        assert(completion.contains("updateOwnedUI()"))
+        assert(completion.contains("pendingAudioOnlyStopIDs.remove(recordingID)"))
+        assert(completion.contains("finishTranscriptionJob(jobID, overlayID: overlayID)"))
+        assert(completion.contains("terminateIfReady()"))
+        assert(terminate.contains("pendingAudioOnlyStopIDs.isEmpty"))
+        assert(requestTermination.contains("pendingAudioOnlyStopIDs.isEmpty"))
+        assert(historyAppend.lowerBound < persistenceCompletion.lowerBound)
     }
 
     private static func testRecordOnlySessionSnapshotsAndGatesAIComponents() throws {

--- a/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
+++ b/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
@@ -240,7 +240,30 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         precondition(preserveBody.contains("detachSegmentedJournalSinks()"))
         precondition(preserveBody.contains("controller.preserveForRecovery()"))
 
+        try testRecordOnlySessionSnapshotsAndGatesAIComponents()
+        try testRecordOnlyStillStartsSelectedAudioRecorder()
+
         print("AppStateRecordingJournalIntegrationSourceTests passed")
+    }
+
+    private static func testRecordOnlySessionSnapshotsAndGatesAIComponents() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let begin = try body(startingWith: "private func beginRecording(", in: source)
+
+        assert(source.contains("private var activeRecordingTranscriptionEnabled: Bool?"))
+        assert(begin.contains("activeRecordingTranscriptionEnabled = transcriptionEnabled"))
+        assert(begin.contains("if shouldTranscribe"))
+        assert(begin.contains("startRealtimeStreamingIfEnabled()"))
+        assert(begin.contains("startContextCapture()"))
+        assert(begin.contains("localTranscriptionModel.makeLiveTranscriber()"))
+    }
+
+    private static func testRecordOnlyStillStartsSelectedAudioRecorder() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let begin = try body(startingWith: "private func beginRecording(", in: source)
+
+        assert(begin.contains("try await self.startSelectedAudioRecorder(inputID: audioInputID)"))
+        assert(begin.contains("self.audioLevelCancellable = self.activeRecorderAudioLevelPublisher"))
     }
 
     private static func switchCaseBody(

--- a/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
+++ b/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
@@ -243,12 +243,29 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         try testRecordOnlySessionSnapshotsAndGatesAIComponents()
         try testAppleSpeechStartWithoutTriggerModeClearsSessionSnapshot()
         try testRecordOnlyStillStartsSelectedAudioRecorder()
+        try testMCPStopUsesRecordingSessionSnapshot()
         try testRecordOnlyBranchesBeforeTranscriptionJobCreation()
         try testAudioOnlyStopUsesExistingRecorderFinalizationCases()
         try testAudioOnlyStopDismissesRecordingOverlayOnErrors()
+        try testAudioOnlyHistoryFailureCleansOnlyUnreferencedNonJournalAudio()
         try testAudioOnlyCompletionOwnsForegroundUIAndTermination()
 
         print("AppStateRecordingJournalIntegrationSourceTests passed")
+    }
+
+    private static func testMCPStopUsesRecordingSessionSnapshot() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let stop = try body(startingWith: "func stopRecordingFromMCP()", in: source)
+        let snapshot = try requiredRange(
+            of: "let shouldTranscribe = shouldTranscribeActiveRecording",
+            in: stop
+        )
+        let stopCall = try requiredRange(of: "stopAndTranscribe()", in: stop)
+
+        assert(source.contains("enum MCPStopRecordingOutcome"))
+        assert(stop.contains("guard isRecording else { return .notRecording }"))
+        assert(snapshot.lowerBound < stopCall.lowerBound)
+        assert(stop.contains("return shouldTranscribe ? .transcribing : .savingAudioOnly"))
     }
 
     private static func testRecordOnlyBranchesBeforeTranscriptionJobCreation() throws {
@@ -315,6 +332,20 @@ struct AppStateRecordingJournalIntegrationSourceTests {
             assert(terminalPath.contains("completeStoppedRecording("))
             assert(terminalPath.contains("dismissTranscribingOverlay()"))
         }
+    }
+
+    private static func testAudioOnlyHistoryFailureCleansOnlyUnreferencedNonJournalAudio() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let persist = try body(startingWith: "private func persistAudioOnlyRecording(", in: source)
+        let catchRange = try requiredRange(of: "} catch {", in: persist)
+        let catchBody = String(persist[catchRange.upperBound...])
+
+        assert(catchBody.contains("journalRecordingID == nil"))
+        assert(catchBody.contains("!pipelineHistoryStore.loadAllHistory().contains(where: { $0.id == recordingID })"))
+        assert(catchBody.contains("Self.deleteStoredFiles("))
+        assert(catchBody.contains("audioFileName: audioFileName"))
+        assert(catchBody.contains("transcriptFileName: nil"))
+        assert(!catchBody.contains("Self.deleteAudioFile(audioFileName)"))
     }
 
     private static func testAudioOnlyCompletionOwnsForegroundUIAndTermination() throws {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -124,6 +124,8 @@ struct AppStateTranscriptionConfigurationTests {
         await testRetryAvailabilityRequiresModelSetup()
         await testRetryAvailabilityRequiresModelSelection()
         await testRetryAvailabilityAcceptsConfiguredAPIStandard()
+        try testAudioOnlyRetryUsesCurrentProcessingSettings()
+        try testAudioOnlyRetryCreatesTranscriptFileAndPreservesMetadata()
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
@@ -2182,6 +2184,41 @@ struct AppStateTranscriptionConfigurationTests {
             precondition(appState.noteBrowserStoredAudioURL(for: item) == audioURL)
             precondition(appState.noteBrowserRetryAvailability(for: item) == .ready)
         }
+    }
+
+    private static func testAudioOnlyRetryUsesCurrentProcessingSettings() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let retrySnapshot = sourceBlock(
+            in: source,
+            from: "private func makeRetrySnapshot(for item: PipelineHistoryItem)",
+            to: "\n    private func makeRetryHistoryItem("
+        )
+
+        assert(retrySnapshot.contains("let isAudioOnly = item.machineStatus == .audioOnly"))
+        assert(retrySnapshot.contains("isAudioOnly ? !disablePostProcessing : item.usedPostProcessing"))
+        assert(retrySnapshot.contains("isAudioOnly ? customVocabulary : item.customVocabulary"))
+        assert(retrySnapshot.contains("isAudioOnly ? customSystemPrompt : item.customSystemPrompt"))
+        assert(retrySnapshot.contains("currentActivity: isAudioOnly ? \"\" : item.contextSummary"))
+    }
+
+    private static func testAudioOnlyRetryCreatesTranscriptFileAndPreservesMetadata() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let retry = sourceBlock(
+            in: source,
+            from: "func retryTranscription(item: PipelineHistoryItem)",
+            to: "\n    @MainActor\n    private func copyRetryTranscriptToPasteboardIfNeeded"
+        )
+        let history = sourceBlock(
+            in: source,
+            from: "private func makeRetryHistoryItem(",
+            to: "\n    func updatePermissionStatus"
+        )
+
+        assert(retry.contains("saveTranscriptFile("))
+        assert(history.contains("capturedSelection: snapshot.item.capturedSelection"))
+        assert(history.contains("systemPrompt: snapshot.item.systemPrompt"))
+        assert(history.contains("contextSystemPrompt: snapshot.item.contextSystemPrompt"))
+        assert(history.contains("customTitle: snapshot.item.customTitle"))
     }
 
     private static func retryHistoryItem(audioFileName: String?) -> PipelineHistoryItem {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -2215,7 +2215,9 @@ struct AppStateTranscriptionConfigurationTests {
             to: "\n    func updatePermissionStatus"
         )
 
+        assert(retry.contains("let transcriptFileName = snapshot.item.transcriptFileName == nil"))
         assert(retry.contains("saveTranscriptFile("))
+        assert(!retry.contains("let transcriptFileName = snapshot.item.machineStatus == .audioOnly"))
         assert(history.contains("capturedSelection: snapshot.item.capturedSelection"))
         assert(history.contains("systemPrompt: snapshot.item.systemPrompt"))
         assert(history.contains("contextSystemPrompt: snapshot.item.contextSystemPrompt"))
@@ -2234,10 +2236,17 @@ struct AppStateTranscriptionConfigurationTests {
             from: "guard self.isCurrentCloudTranscriptionExecution(",
             to: "\n                do {"
         )
+        let storeUpdate = sourceBlock(
+            in: retry,
+            from: "try self.pipelineHistoryStore.update(updatedItem)",
+            to: "\n                if !retrySucceeded"
+        )
 
-        assert(staleGuard.contains("snapshot.item.transcriptFileName == nil"))
-        assert(staleGuard.contains("let transcriptFileName = updatedItem.transcriptFileName"))
-        assert(staleGuard.contains("Self.deleteTranscriptFile(transcriptFileName)"))
+        for cleanup in [staleGuard, storeUpdate] {
+            assert(cleanup.contains("snapshot.item.transcriptFileName == nil"))
+            assert(cleanup.contains("let transcriptFileName = updatedItem.transcriptFileName"))
+            assert(cleanup.contains("Self.deleteTranscriptFile(transcriptFileName)"))
+        }
     }
 
     private static func retryHistoryItem(audioFileName: String?) -> PipelineHistoryItem {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -126,6 +126,7 @@ struct AppStateTranscriptionConfigurationTests {
         await testRetryAvailabilityAcceptsConfiguredAPIStandard()
         try testAudioOnlyRetryUsesCurrentProcessingSettings()
         try testAudioOnlyRetryCreatesTranscriptFileAndPreservesMetadata()
+        try testAudioOnlyRetryDeletesNewTranscriptFileWhenStale()
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
@@ -2219,6 +2220,24 @@ struct AppStateTranscriptionConfigurationTests {
         assert(history.contains("systemPrompt: snapshot.item.systemPrompt"))
         assert(history.contains("contextSystemPrompt: snapshot.item.contextSystemPrompt"))
         assert(history.contains("customTitle: snapshot.item.customTitle"))
+    }
+
+    private static func testAudioOnlyRetryDeletesNewTranscriptFileWhenStale() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let retry = sourceBlock(
+            in: source,
+            from: "func retryTranscription(item: PipelineHistoryItem)",
+            to: "\n    @MainActor\n    private func copyRetryTranscriptToPasteboardIfNeeded"
+        )
+        let staleGuard = sourceBlock(
+            in: retry,
+            from: "guard self.isCurrentCloudTranscriptionExecution(",
+            to: "\n                do {"
+        )
+
+        assert(staleGuard.contains("snapshot.item.transcriptFileName == nil"))
+        assert(staleGuard.contains("let transcriptFileName = updatedItem.transcriptFileName"))
+        assert(staleGuard.contains("Self.deleteTranscriptFile(transcriptFileName)"))
     }
 
     private static func retryHistoryItem(audioFileName: String?) -> PipelineHistoryItem {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -1314,6 +1314,13 @@ struct AppStateTranscriptionConfigurationTests {
             precondition(!appState.disablePostProcessing)
             precondition(!appState.disableContextCapture)
             assertProviderState(appState, equals: expectedProviderState)
+
+            appState.disablePostProcessing = false
+            appState.disableContextCapture = true
+            appState.applySetupProcessingPreset(.recordOnly)
+            precondition(!appState.transcriptionEnabled)
+            precondition(!appState.disablePostProcessing)
+            precondition(appState.disableContextCapture)
         }
     }
 

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -38,6 +38,7 @@ struct AppStateTranscriptionConfigurationTests {
         testNoteBrowserPreservesExplicitOptOut()
         await testExistingInstallMigratesMissingTranscriptionPreferenceOn()
         await testStoredTranscriptionPreferenceIsPreserved()
+        await testRecordOnlyDoesNotRequireAccessibility()
         await testTranscriptionOffPreservesRememberedBackend()
         await testTranscriptionOnRenormalizesRememberedBackend()
         await testFreshInstallSeedsNewHiddenDefaultsOnce()
@@ -396,6 +397,20 @@ struct AppStateTranscriptionConfigurationTests {
             appState.transcriptionEnabled = true
         }
         precondition(defaults.bool(forKey: "transcription_enabled"))
+    }
+
+    private static func testRecordOnlyDoesNotRequireAccessibility() async {
+        resetDefaults()
+        let appState = await MainActor.run { AppState() }
+        await MainActor.run {
+            appState.disableAutoPaste = false
+            appState.isCommandModeEnabled = true
+            appState.transcriptionEnabled = false
+            precondition(!appState.requiresAccessibility)
+
+            appState.transcriptionEnabled = true
+            precondition(appState.requiresAccessibility)
+        }
     }
 
     private static func testTranscriptionOffPreservesRememberedBackend() async {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -36,6 +36,13 @@ struct AppStateTranscriptionConfigurationTests {
         testPreserveExactWordingDefaultsOffAndPersists()
         testNoteBrowserDefaultsOnWhenPreferenceIsMissing()
         testNoteBrowserPreservesExplicitOptOut()
+        await testExistingInstallMigratesMissingTranscriptionPreferenceOn()
+        await testStoredTranscriptionPreferenceIsPreserved()
+        await testTranscriptionOffPreservesRememberedBackend()
+        await testTranscriptionOnRenormalizesRememberedBackend()
+        await testFreshInstallSeedsNewHiddenDefaultsOnce()
+        await testCompletedInstallKeepsLegacyFallbacksWhenKeysAreMissing()
+        await testStoredUserDefaultsBeatFirstInstallSeed()
         testVerbatimTranslationPromptAndSanitizer()
         testVerbatimTranslationRejectsOutputThatSanitizesToEmpty()
         try testPreserveExactWordingSettingsAndPipelineWiring()
@@ -359,6 +366,121 @@ struct AppStateTranscriptionConfigurationTests {
 
         assert(defaults.object(forKey: "note_browser_enabled") as? Bool == false)
         assert(!AppState().noteBrowserEnabled)
+    }
+
+    private static func testExistingInstallMigratesMissingTranscriptionPreferenceOn() async {
+        resetDefaults()
+        let defaults = UserDefaults.standard
+        defaults.set(true, forKey: "hasCompletedSetup")
+        defaults.removeObject(forKey: "transcription_enabled")
+
+        let appState = await MainActor.run { AppState() }
+
+        await MainActor.run {
+            precondition(appState.transcriptionEnabled)
+        }
+        precondition(defaults.object(forKey: "transcription_enabled") != nil)
+        precondition(defaults.bool(forKey: "transcription_enabled"))
+    }
+
+    private static func testStoredTranscriptionPreferenceIsPreserved() async {
+        resetDefaults()
+        let defaults = UserDefaults.standard
+        defaults.set(true, forKey: "hasCompletedSetup")
+        defaults.set(false, forKey: "transcription_enabled")
+
+        let appState = await MainActor.run { AppState() }
+
+        await MainActor.run {
+            precondition(!appState.transcriptionEnabled)
+            appState.transcriptionEnabled = true
+        }
+        precondition(defaults.bool(forKey: "transcription_enabled"))
+    }
+
+    private static func testTranscriptionOffPreservesRememberedBackend() async {
+        resetDefaults()
+        let appState = await MainActor.run { AppState() }
+
+        await MainActor.run {
+            appState.apiKey = "global-key"
+            appState.setNoteBrowserTranscriptionChoice(.apiStandard(modelID: "remembered-model"))
+            appState.transcriptionEnabled = false
+            appState.apiKey = ""
+
+            precondition(!appState.transcriptionEnabled)
+            precondition(appState.currentNoteBrowserTranscriptionChoice == .apiStandard(modelID: "remembered-model"))
+        }
+    }
+
+    private static func testTranscriptionOnRenormalizesRememberedBackend() async {
+        resetDefaults()
+        let appState = await MainActor.run { AppState() }
+
+        await MainActor.run {
+            appState.apiKey = "global-key"
+            appState.setNoteBrowserTranscriptionChoice(.apiStandard(modelID: "remembered-model"))
+            appState.transcriptionEnabled = false
+            appState.apiKey = ""
+            appState.transcriptionEnabled = true
+
+            precondition(appState.currentNoteBrowserTranscriptionMode == .localAppleLive)
+        }
+    }
+
+    private static func testFreshInstallSeedsNewHiddenDefaultsOnce() async {
+        resetDefaults()
+        let defaults = UserDefaults.standard
+        defaults.set(false, forKey: "hasCompletedSetup")
+        defaults.removeObject(forKey: "first_install_defaults_version")
+
+        _ = await MainActor.run { AppState() }
+
+        precondition(defaults.bool(forKey: "disable_auto_paste"))
+        precondition(defaults.string(forKey: "transcription_language") == "auto")
+        precondition(defaults.string(forKey: "recording_overlay_layout") == "notchSides")
+        precondition(defaults.string(forKey: "overlay_waveform_display_mode") == "hoverTime")
+        precondition(!defaults.bool(forKey: "press_enter_voice_command_enabled"))
+        precondition(defaults.integer(forKey: "first_install_defaults_version") == 1)
+    }
+
+    private static func testCompletedInstallKeepsLegacyFallbacksWhenKeysAreMissing() async {
+        resetDefaults()
+        let defaults = UserDefaults.standard
+        defaults.set(true, forKey: "hasCompletedSetup")
+        defaults.removeObject(forKey: "first_install_defaults_version")
+
+        let appState = await MainActor.run { AppState() }
+
+        await MainActor.run {
+            precondition(!appState.disableAutoPaste)
+            precondition(appState.transcriptionLanguage.code == "ko")
+            precondition(appState.recordingOverlayLayout == .centered)
+            precondition(appState.overlayWaveformDisplayMode == .waveformOnly)
+            precondition(appState.isPressEnterVoiceCommandEnabled)
+        }
+        precondition(defaults.integer(forKey: "first_install_defaults_version") == 1)
+    }
+
+    private static func testStoredUserDefaultsBeatFirstInstallSeed() async {
+        resetDefaults()
+        let defaults = UserDefaults.standard
+        defaults.set(false, forKey: "hasCompletedSetup")
+        defaults.set(false, forKey: "disable_auto_paste")
+        defaults.set("en", forKey: "transcription_language")
+        defaults.set("centered", forKey: "recording_overlay_layout")
+        defaults.set("timeOnly", forKey: "overlay_waveform_display_mode")
+        defaults.set(true, forKey: "press_enter_voice_command_enabled")
+
+        let appState = await MainActor.run { AppState() }
+
+        await MainActor.run {
+            precondition(!appState.disableAutoPaste)
+            precondition(appState.transcriptionLanguage.code == "en")
+            precondition(appState.recordingOverlayLayout == .centered)
+            precondition(appState.overlayWaveformDisplayMode == .timeOnly)
+            precondition(appState.isPressEnterVoiceCommandEnabled)
+        }
     }
 
     private static func testVerbatimTranslationPromptAndSanitizer() {
@@ -1258,9 +1380,11 @@ struct AppStateTranscriptionConfigurationTests {
         )
 
         precondition(!selectedInputScheduler.contains("guard !isApplyingNoteBrowserTranscriptionChoice else { return }\n        if Thread.isMainThread"))
-        precondition(selectedInputScheduler.contains("MainActor.assumeIsolated {\n                guard !isApplyingNoteBrowserTranscriptionChoice else { return }"))
+        precondition(selectedInputScheduler.contains("MainActor.assumeIsolated {\n                guard transcriptionEnabled,\n                      !isApplyingNoteBrowserTranscriptionChoice else { return }"))
+        precondition(selectedInputScheduler.contains("guard let self,\n                      self.transcriptionEnabled,\n                      !self.isApplyingNoteBrowserTranscriptionChoice else { return }"))
         precondition(!providerScheduler.contains("guard !isApplyingNoteBrowserTranscriptionChoice else { return }\n        if Thread.isMainThread"))
-        precondition(providerScheduler.contains("MainActor.assumeIsolated {\n                guard !isApplyingNoteBrowserTranscriptionChoice,"))
+        precondition(providerScheduler.contains("MainActor.assumeIsolated {\n                guard transcriptionEnabled,\n                      !isApplyingNoteBrowserTranscriptionChoice,"))
+        precondition(providerScheduler.contains("guard let self,\n                      self.transcriptionEnabled,\n                      !self.isApplyingNoteBrowserTranscriptionChoice,"))
         precondition(!legacyObserver.contains("!isApplyingNoteBrowserTranscriptionChoice"))
     }
 
@@ -2069,6 +2193,12 @@ struct AppStateTranscriptionConfigurationTests {
         for key in defaults.dictionaryRepresentation().keys where key.hasPrefix("app_state_transcription_test_") {
             defaults.removeObject(forKey: key)
         }
+        defaults.removeObject(forKey: "transcription_enabled")
+        defaults.removeObject(forKey: "first_install_defaults_version")
+        defaults.removeObject(forKey: "disable_auto_paste")
+        defaults.removeObject(forKey: "recording_overlay_layout")
+        defaults.removeObject(forKey: "overlay_waveform_display_mode")
+        defaults.removeObject(forKey: "press_enter_voice_command_enabled")
         defaults.removeObject(forKey: "use_local_transcription")
         defaults.removeObject(forKey: "use_legacy_mlx_whisper")
         defaults.removeObject(forKey: "show_legacy_mlx_whisper_options")

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -2280,6 +2280,7 @@ struct AppStateTranscriptionConfigurationTests {
         for key in defaults.dictionaryRepresentation().keys where key.hasPrefix("app_state_transcription_test_") {
             defaults.removeObject(forKey: key)
         }
+        defaults.removeObject(forKey: "hasCompletedSetup")
         defaults.removeObject(forKey: "transcription_enabled")
         defaults.removeObject(forKey: "first_install_defaults_version")
         defaults.removeObject(forKey: "disable_auto_paste")

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -220,6 +220,7 @@ struct LocalizationResourceTests {
             "Export to Obsidian",
             "More Actions",
             "Audio only",
+            "Audio-only recording",
             "Audio recording",
             "Not transcribed",
             "Saved without transcription. You can transcribe it later.",
@@ -234,6 +235,14 @@ struct LocalizationResourceTests {
                 assert(!value.isEmpty, "Missing \(language) Note Browser key: \(key)")
             }
         }
+        let audioOnlyTooltip = (strings["Audio-only recording"] as? [String: Any])?["localizations"]
+            as? [String: Any]
+        let audioOnlyTooltipEnglish = (((audioOnlyTooltip?["en"] as? [String: Any])?["stringUnit"]
+            as? [String: Any])?["value"] as? String) ?? ""
+        let audioOnlyTooltipKorean = (((audioOnlyTooltip?["ko"] as? [String: Any])?["stringUnit"]
+            as? [String: Any])?["value"] as? String) ?? ""
+        assert(audioOnlyTooltipEnglish == "Audio-only recording")
+        assert(audioOnlyTooltipKorean == "오디오 전용 녹음")
 
         let hangulPattern = try NSRegularExpression(pattern: "[가-힣]")
         let sourceFiles = [

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -218,7 +218,12 @@ struct LocalizationResourceTests {
             "The transcript text could not be saved.",
             "The recording file could not be saved.",
             "Export to Obsidian",
-            "More Actions"
+            "More Actions",
+            "Audio only",
+            "Audio recording",
+            "Not transcribed",
+            "Saved without transcription. You can transcribe it later.",
+            "Transcribe audio"
         ]
         for key in noteBrowserKeys {
             let localizations = (strings[key] as? [String: Any])?["localizations"]

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -64,7 +64,18 @@ struct LocalizationResourceTests {
                 "Local Whisper를 다운로드하는 중에 종료할까요?",
             "Quill will cancel the download and delete the partial file if you quit now.":
                 "지금 종료하면 Quill이 다운로드를 취소하고 partial 파일을 삭제합니다.",
-            "Quit and Cancel Download": "종료하고 다운로드 취소"
+            "Quit and Cancel Download": "종료하고 다운로드 취소",
+            "Record only": "녹음만",
+            "No transcription · No model download": "전사 없음 · 모델 다운로드 없음",
+            "Save audio notes now. Transcribe them later if needed. No model download or API key required.":
+                "지금 오디오 노트를 저장하고 필요할 때 나중에 전사하세요. 모델 다운로드나 API 키가 필요하지 않습니다.",
+            "Record only · Audio notes": "녹음만 · 오디오 노트",
+            "Enables automatic paste and Edit Mode when you turn them on.":
+                "자동 붙여넣기와 편집 모드를 켜면 사용할 수 있습니다.",
+            "Record your voice and other selected audio inputs.": "음성과 선택한 다른 오디오 입력을 녹음합니다.",
+            "Screen & System Audio Recording": "화면 및 시스템 오디오 녹음",
+            "Enables System Audio recording and optional screen context.":
+                "시스템 오디오 녹음과 선택적 화면 컨텍스트를 사용할 수 있습니다."
         ]
         for (key, expected) in onboardingKorean {
             let english = try localizedValue(key: key, language: "en", root: root)

--- a/Tests/MCPLocalAccessPolicyTests.swift
+++ b/Tests/MCPLocalAccessPolicyTests.swift
@@ -93,8 +93,23 @@ struct MCPLocalAccessPolicyTests {
 
     private static func testMCPStopRecordingCopySupportsRecordOnly() throws {
         let source = try String(contentsOfFile: "Sources/MCPServer.swift", encoding: .utf8)
-        assertContains(source, "appState.transcriptionEnabled")
-        assertContains(source, "Recording stopped. Audio note is being saved.")
+        guard let start = source.range(of: "case \"stop_recording\":"),
+              let end = source.range(
+                of: "case \"get_status\":",
+                range: start.upperBound..<source.endIndex
+              ) else {
+            fatalError("Unable to locate stop_recording handler")
+        }
+        let handler = String(source[start.lowerBound..<end.lowerBound])
+
+        assertContains(handler, "switch appState.stopRecordingFromMCP()")
+        assertContains(handler, "case .notRecording:")
+        assertContains(handler, "case .transcribing:")
+        assertContains(handler, "case .savingAudioOnly:")
+        assertContains(handler, "Not currently recording.")
+        assertContains(handler, "Recording stopped. Transcription in progress — listen for recording/completed event.")
+        assertContains(handler, "Recording stopped. Audio note is being saved.")
+        assertDoesNotContain(handler, "appState.transcriptionEnabled")
     }
 
     private static func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {

--- a/Tests/MCPLocalAccessPolicyTests.swift
+++ b/Tests/MCPLocalAccessPolicyTests.swift
@@ -10,6 +10,7 @@ struct MCPLocalAccessPolicyTests {
         testAcceptsOnlyNumericLoopbackPeers()
         testListenerIsRestrictedToLoopback()
         try testMCPServerUsesPolicyAndDoesNotEmitCORSHeaders()
+        try testMCPStopRecordingCopySupportsRecordOnly()
         print("MCPLocalAccessPolicyTests passed")
     }
 
@@ -88,6 +89,12 @@ struct MCPLocalAccessPolicyTests {
         assertContains(source, "MCPLocalAccessPolicy.allowsRequest(headers: request.headers, port: Self.port)")
         assertDoesNotContain(source, "Access-Control-Allow-Origin")
         assertDoesNotContain(source, "corsHeaders()")
+    }
+
+    private static func testMCPStopRecordingCopySupportsRecordOnly() throws {
+        let source = try String(contentsOfFile: "Sources/MCPServer.swift", encoding: .utf8)
+        assertContains(source, "appState.transcriptionEnabled")
+        assertContains(source, "Recording stopped. Audio note is being saved.")
     }
 
     private static func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {

--- a/Tests/ModelsSettingsUIContractTests.swift
+++ b/Tests/ModelsSettingsUIContractTests.swift
@@ -26,6 +26,8 @@ struct ModelsSettingsUIContractTests {
         try testAutoPasteLivesInShortcutsClipboard(settings)
         testTranscriptionDetailsAreManagementOnly(settings)
         testManagementRowsKeepSelectionAsDefaultBehavior(settings)
+        try testTranscriptionCardHasIndependentToggle()
+        try testMenuBarUsesRecordingCopyWhenTranscriptionIsOff()
         testCurrentSpecDocumentsCorrectedLayout(currentSpec)
         print("ModelsSettingsUIContractTests passed")
     }
@@ -511,6 +513,24 @@ struct ModelsSettingsUIContractTests {
             precondition(row.contains("showsSelectionControl: Bool = true"))
             precondition(row.contains("if showsSelectionControl"))
         }
+    }
+
+    private static func testTranscriptionCardHasIndependentToggle() throws {
+        let source = try String(contentsOfFile: "Sources/SettingsView.swift", encoding: .utf8)
+
+        precondition(source.contains("private var transcriptionEnabled: Binding<Bool>"))
+        precondition(source.contains("Toggle(\"\", isOn: transcriptionEnabled)"))
+        precondition(source.contains(".accessibilityLabel(\"Transcription\")"))
+        precondition(source.contains("appState.isTranscriptionConfigurationLocked"))
+        precondition(source.contains("Record audio without creating a transcript."))
+        precondition(source.contains(".disabled(!appState.transcriptionEnabled)"))
+    }
+
+    private static func testMenuBarUsesRecordingCopyWhenTranscriptionIsOff() throws {
+        let source = try String(contentsOfFile: "Sources/MenuBarView.swift", encoding: .utf8)
+        precondition(source.contains("appState.transcriptionEnabled"))
+        precondition(source.contains("String(localized: \"Start Recording\")"))
+        precondition(source.contains("String(localized: \"Start Dictating\")"))
     }
 
     private static func testCurrentSpecDocumentsCorrectedLayout(_ source: String) {

--- a/Tests/ModelsSettingsUIContractTests.swift
+++ b/Tests/ModelsSettingsUIContractTests.swift
@@ -522,8 +522,17 @@ struct ModelsSettingsUIContractTests {
         precondition(source.contains("Toggle(\"\", isOn: transcriptionEnabled)"))
         precondition(source.contains(".accessibilityLabel(\"Transcription\")"))
         precondition(source.contains("appState.isTranscriptionConfigurationLocked"))
+        let section = block(
+            in: source,
+            from: "private var transcriptionFeatureSection",
+            to: "private var postProcessingEnabled"
+        )
+
         precondition(source.contains("Record audio without creating a transcript."))
         precondition(source.contains(".disabled(!appState.transcriptionEnabled)"))
+        precondition(section.contains("} else if appState.transcriptionEnabled,"))
+        precondition(section.contains("let reason = currentTranscriptionDisplay.localizedUnavailableReason()"))
+        precondition(!section.contains("} else if let reason = currentTranscriptionDisplay.localizedUnavailableReason()"))
     }
 
     private static func testMenuBarUsesRecordingCopyWhenTranscriptionIsOff() throws {

--- a/Tests/NoteListRowDisplayDataTests.swift
+++ b/Tests/NoteListRowDisplayDataTests.swift
@@ -28,6 +28,7 @@ struct NoteListRowDisplayDataTests {
         testRestoredCloudProgressDisplaysWaitingCopy()
         testCloudProgressCopyLocalizesInKorean()
         testRetryingItemHidesExistingPreview()
+        testAudioOnlyRowUsesBlueStateAndNotTranscribedPreview()
         print("NoteListRowDisplayDataTests passed")
     }
 
@@ -439,6 +440,28 @@ struct NoteListRowDisplayDataTests {
 
         assert(data.status == .transcribing)
         assert(data.preview.isEmpty, "Expected retrying item to hide stale preview, got: \(data.preview)")
+    }
+
+    private static func testAudioOnlyRowUsesBlueStateAndNotTranscribedPreview() {
+        let item = PipelineHistoryItem.audioOnly(
+            timestamp: Date(timeIntervalSince1970: 10),
+            recordingStartedAt: Date(timeIntervalSince1970: 1),
+            recordingEndedAt: Date(timeIntervalSince1970: 10),
+            calendarMatch: nil,
+            audioFileName: "recording.wav",
+            transcriptionLanguageCode: "auto",
+            localTranscriptionModelID: "remembered-model"
+        )
+        let data = NoteListRowDisplayData(
+            item: item,
+            retryingIDs: [],
+            localization: { key, _ in key }
+        )
+
+        assert(data.status == .audioOnly)
+        assert(data.displayTitle == "Audio recording")
+        assert(data.preview == "Not transcribed")
+        assert(transcriptStatus(for: item, retrying: [item.id]) == .transcribing)
     }
 
     private static func historyItem(

--- a/Tests/NoteTitleResolutionTests.swift
+++ b/Tests/NoteTitleResolutionTests.swift
@@ -12,6 +12,7 @@ struct NoteTitleResolutionTests {
         testCalendarAppliedTitleIncludesRecordingDate()
         testRecoveredRecordingTitlesNameAvailableSource()
         testStorageInterruptionReasonWinsRecoveredTitle()
+        testAudioOnlyTitleUsesNormalPrecedence()
         print("NoteTitleResolutionTests passed")
     }
 
@@ -99,6 +100,44 @@ struct NoteTitleResolutionTests {
             )
             assert(NoteTitleResolver.displayTitle(for: recovered) == expected)
         }
+    }
+
+    private static func testAudioOnlyTitleUsesNormalPrecedence() {
+        let audioOnly = PipelineHistoryItem.audioOnly(
+            timestamp: Date(timeIntervalSince1970: 10),
+            recordingStartedAt: Date(timeIntervalSince1970: 1),
+            recordingEndedAt: Date(timeIntervalSince1970: 10),
+            calendarMatch: nil,
+            audioFileName: "recording.wav",
+            transcriptionLanguageCode: "auto",
+            localTranscriptionModelID: "remembered-model"
+        )
+        assert(NoteTitleResolver.displayTitle(for: audioOnly) == "Audio recording")
+
+        let calendarMatch = CalendarEventMatch(
+            calendarID: "calendar",
+            eventID: "event",
+            title: "Weekly Sync",
+            start: Date(timeIntervalSince1970: 1),
+            end: Date(timeIntervalSince1970: 10),
+            matchSource: .overlapSuggestion,
+            titleState: .applied
+        )
+        let calendar = PipelineHistoryItem.audioOnly(
+            timestamp: Date(timeIntervalSince1970: 10),
+            recordingStartedAt: Date(timeIntervalSince1970: 1),
+            recordingEndedAt: Date(timeIntervalSince1970: 10),
+            calendarMatch: calendarMatch,
+            audioFileName: "recording.wav",
+            transcriptionLanguageCode: "auto",
+            localTranscriptionModelID: "remembered-model"
+        )
+        assert(NoteTitleResolver.displayTitle(for: calendar) == "Weekly Sync")
+        assert(
+            NoteTitleResolver.displayTitle(
+                for: audioOnly.withCustomTitle("My recording")
+            ) == "My recording"
+        )
     }
 
     private static func item(

--- a/Tests/PipelineHistoryCalendarMetadataTests.swift
+++ b/Tests/PipelineHistoryCalendarMetadataTests.swift
@@ -311,12 +311,21 @@ struct PipelineHistoryCalendarMetadataTests {
         let id = UUID()
         let start = Date(timeIntervalSince1970: 100)
         let end = Date(timeIntervalSince1970: 200)
+        let calendarMatch = CalendarEventMatch(
+            calendarID: "calendar-id",
+            eventID: "event-id",
+            title: "Weekly Sync",
+            start: start,
+            end: end,
+            matchSource: .calendarNotification,
+            titleState: .applied
+        )
         let item = PipelineHistoryItem.audioOnly(
             id: id,
             timestamp: end,
             recordingStartedAt: start,
             recordingEndedAt: end,
-            calendarMatch: nil,
+            calendarMatch: calendarMatch,
             audioFileName: "audio.wav",
             transcriptionLanguageCode: "auto",
             localTranscriptionModelID: "remembered-model"
@@ -328,10 +337,12 @@ struct PipelineHistoryCalendarMetadataTests {
         assert(loaded.count == 1)
         assert(loaded[0].id == id)
         assert(loaded[0].machineStatus == .audioOnly)
-        assert(loaded[0].audioFileName == "audio.wav")
-        assert(loaded[0].transcriptFileName == nil)
+        assert(loaded[0].calendarMatch?.eventID == "event-id")
+        assert(loaded[0].calendarMatch?.appliedTitle == "Weekly Sync")
         assert(loaded[0].recordingStartedAt == start)
         assert(loaded[0].recordingEndedAt == end)
+        assert(loaded[0].audioFileName == "audio.wav")
+        assert(loaded[0].transcriptFileName == nil)
     }
 
     private static func testUpsertKeepsOneRowAndUpdatesAllFields() throws {

--- a/Tests/PipelineHistoryCalendarMetadataTests.swift
+++ b/Tests/PipelineHistoryCalendarMetadataTests.swift
@@ -9,6 +9,7 @@ struct PipelineHistoryCalendarMetadataTests {
         try testLegacyEncodedHistoryItemDecodesMissingCalendarMetadataAsNil()
         try testCustomTitlePersistsThroughPipelineHistoryStore()
         try testCalendarMetadataPersistsThroughPipelineHistoryStore()
+        try testAudioOnlyRoundTripPreservesRecordingMetadata()
         try testUpsertKeepsOneRowAndUpdatesAllFields()
         try testDeletedAssetsIncludeHistoryIDForDeleteClearAndTrim()
         testGoogleCalendarConnectionMetadataBuildsConnectedState()
@@ -303,6 +304,34 @@ struct PipelineHistoryCalendarMetadataTests {
         assert(loaded[0].recordingStartedAt == recordingStart)
         assert(loaded[0].recordingEndedAt == recordingEnd)
         assert(loaded[0].calendarMatch == match)
+    }
+
+    private static func testAudioOnlyRoundTripPreservesRecordingMetadata() throws {
+        let store = PipelineHistoryStore(inMemory: true)
+        let id = UUID()
+        let start = Date(timeIntervalSince1970: 100)
+        let end = Date(timeIntervalSince1970: 200)
+        let item = PipelineHistoryItem.audioOnly(
+            id: id,
+            timestamp: end,
+            recordingStartedAt: start,
+            recordingEndedAt: end,
+            calendarMatch: nil,
+            audioFileName: "audio.wav",
+            transcriptionLanguageCode: "auto",
+            localTranscriptionModelID: "remembered-model"
+        )
+
+        _ = try store.append(item, maxCount: 100)
+        let loaded = store.loadAllHistory()
+
+        assert(loaded.count == 1)
+        assert(loaded[0].id == id)
+        assert(loaded[0].machineStatus == .audioOnly)
+        assert(loaded[0].audioFileName == "audio.wav")
+        assert(loaded[0].transcriptFileName == nil)
+        assert(loaded[0].recordingStartedAt == start)
+        assert(loaded[0].recordingEndedAt == end)
     }
 
     private static func testUpsertKeepsOneRowAndUpdatesAllFields() throws {

--- a/Tests/PipelineHistoryUserIssueTests.swift
+++ b/Tests/PipelineHistoryUserIssueTests.swift
@@ -9,6 +9,7 @@ struct PipelineHistoryUserIssueTests {
         try testLegacyErrorUsesGenericSafePresentation(bundle: bundle)
         try testStoredRecordRerendersForCurrentLanguage(bundle: bundle)
         try testExistingMachineTokensRemainUnchanged()
+        testAudioOnlyIsACompletedNormalState()
         print("PipelineHistoryUserIssueTests passed")
     }
 
@@ -134,6 +135,30 @@ struct PipelineHistoryUserIssueTests {
         guard case .recovered = recovered.machineStatus else {
             throw TestFailure("Expected recovered token")
         }
+    }
+
+    private static func testAudioOnlyIsACompletedNormalState() {
+        let item = PipelineHistoryItem.audioOnly(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 10),
+            recordingStartedAt: Date(timeIntervalSince1970: 1),
+            recordingEndedAt: Date(timeIntervalSince1970: 10),
+            calendarMatch: nil,
+            audioFileName: "recording.wav",
+            transcriptionLanguageCode: "auto",
+            localTranscriptionModelID: "remembered-model"
+        )
+
+        assert(item.machineStatus == .audioOnly)
+        assert(!item.isIncompleteTranscription)
+        assert(item.userIssueRecord == nil)
+        assert(item.rawTranscript.isEmpty)
+        assert(item.postProcessedTranscript.isEmpty)
+        assert(item.transcriptFileName == nil)
+        assert(item.audioFileName == "recording.wav")
+        assert(!item.usedLocalTranscription)
+        assert(!item.usedContextCapture)
+        assert(!item.usedPostProcessing)
     }
 
     private static func historyItem(

--- a/Tests/RecoveredRecordingNoteBrowserSourceTests.swift
+++ b/Tests/RecoveredRecordingNoteBrowserSourceTests.swift
@@ -48,6 +48,7 @@ struct RecoveredRecordingNoteBrowserSourceTests {
         precondition(source.contains("help: \"Audio-only recording\""))
         precondition(source.contains("Saved without transcription. You can transcribe it later."))
         precondition(source.contains("Transcribe audio"))
-        precondition(source.contains("Color.blue"))
+        precondition(source.contains(".fill(Color.blue.opacity(0.08))"))
+        precondition(source.contains(".foregroundStyle(.blue.opacity(0.75))"))
     }
 }

--- a/Tests/RecoveredRecordingNoteBrowserSourceTests.swift
+++ b/Tests/RecoveredRecordingNoteBrowserSourceTests.swift
@@ -40,8 +40,12 @@ struct RecoveredRecordingNoteBrowserSourceTests {
     private static func testAudioOnlyNoteUsesDedicatedNormalState() throws {
         let source = try String(contentsOfFile: "Sources/NoteBrowserView.swift", encoding: .utf8)
         precondition(source.contains("item.machineStatus == .audioOnly"))
-        precondition(source.contains("Text(\"Audio only\")"))
+        precondition(
+            source.components(separatedBy: "localizedCatalogString(\"Audio only\")").count >= 3
+        )
+        precondition(!source.contains("Text(\"Audio only\")"))
         precondition(source.contains("Text(\"Audio recording\")"))
+        precondition(source.contains("help: \"Audio-only recording\""))
         precondition(source.contains("Saved without transcription. You can transcribe it later."))
         precondition(source.contains("Transcribe audio"))
         precondition(source.contains("Color.blue"))

--- a/Tests/RecoveredRecordingNoteBrowserSourceTests.swift
+++ b/Tests/RecoveredRecordingNoteBrowserSourceTests.swift
@@ -32,7 +32,18 @@ struct RecoveredRecordingNoteBrowserSourceTests {
         precondition(source.contains("NoteFileExportView("))
         precondition(source.contains("Image(systemName: \"square.and.arrow.down\")"))
         precondition(source.contains("Image(systemName: \"ellipsis\")"))
+        try testAudioOnlyNoteUsesDedicatedNormalState()
 
         print("RecoveredRecordingNoteBrowserSourceTests passed")
+    }
+
+    private static func testAudioOnlyNoteUsesDedicatedNormalState() throws {
+        let source = try String(contentsOfFile: "Sources/NoteBrowserView.swift", encoding: .utf8)
+        precondition(source.contains("item.machineStatus == .audioOnly"))
+        precondition(source.contains("Text(\"Audio only\")"))
+        precondition(source.contains("Text(\"Audio recording\")"))
+        precondition(source.contains("Saved without transcription. You can transcribe it later."))
+        precondition(source.contains("Transcribe audio"))
+        precondition(source.contains("Color.blue"))
     }
 }

--- a/Tests/SetupFlowTests.swift
+++ b/Tests/SetupFlowTests.swift
@@ -6,7 +6,9 @@ struct SetupFlowTests {
     static func main() throws {
         testProcessingStartsWithoutSelection()
         testLocalDefaultsToAppleSpeech()
-        testRequiredPermissionsAdaptToPreset()
+        testRecordOnlyPresetAndPermissions()
+        try testProcessingOffersRecordOnlyAlongsideLocalAndAPI()
+        try testAccessibilityPermissionIsOptional()
         testNotificationAuthorizationGrantedStates()
         testNotificationActionTitles()
         try testSetupContainsExactlyFiveScrollableSteps()
@@ -47,15 +49,61 @@ struct SetupFlowTests {
         )
     }
 
-    private static func testRequiredPermissionsAdaptToPreset() {
-        let common: Set<SetupFlow.Permission> = [.microphone, .accessibility]
-
+    private static func testRecordOnlyPresetAndPermissions() {
+        assert(
+            SetupFlow.processingPreset(
+                location: .recordOnly,
+                localModel: .appleSpeech
+            ) == .recordOnly
+        )
+        assert(
+            SetupFlow.requiredPermissions(for: .recordOnly) == [.microphone]
+        )
         assert(
             SetupFlow.requiredPermissions(for: .localAppleSpeech)
-                == common.union([.speechRecognition])
+                == [.microphone, .speechRecognition]
         )
-        assert(SetupFlow.requiredPermissions(for: .localNativeWhisper) == common)
-        assert(SetupFlow.requiredPermissions(for: .apiStandard) == common)
+        assert(
+            SetupFlow.requiredPermissions(for: .localNativeWhisper)
+                == [.microphone]
+        )
+        assert(
+            SetupFlow.requiredPermissions(for: .apiStandard)
+                == [.microphone]
+        )
+    }
+
+    private static func testProcessingOffersRecordOnlyAlongsideLocalAndAPI() throws {
+        let source = try String(contentsOfFile: "Sources/SetupView.swift", encoding: .utf8)
+        let processing = sourceBlock(
+            in: source,
+            from: "var processingStep: some View",
+            to: "\n    private var localProcessingDetails"
+        )
+
+        assert(processing.contains("location: .recordOnly"))
+        assert(processing.contains("title: \"Record only\""))
+        assert(processing.contains("location: .onThisMac"))
+        assert(processing.contains("location: .apiProvider"))
+        assert(source.contains("case .recordOnly:\n                return true"))
+    }
+
+    private static func testAccessibilityPermissionIsOptional() throws {
+        let source = try String(contentsOfFile: "Sources/SetupView.swift", encoding: .utf8)
+        let permissions = sourceBlock(
+            in: source,
+            from: "var permissionsStep: some View",
+            to: "\n    var shortcutStep: some View"
+        )
+        let required = sourceBlock(
+            in: permissions,
+            from: "Text(\"Required\")",
+            to: "Text(\"Optional\")"
+        )
+        let optional = String(permissions.dropFirst(required.count))
+
+        assert(!required.contains("title: \"Accessibility\""))
+        assert(optional.contains("title: \"Accessibility\""))
     }
 
     private static func testNotificationAuthorizationGrantedStates() {

--- a/Tests/SetupFlowTests.swift
+++ b/Tests/SetupFlowTests.swift
@@ -100,7 +100,11 @@ struct SetupFlowTests {
             from: "Text(\"Required\")",
             to: "Text(\"Optional\")"
         )
-        let optional = String(permissions.dropFirst(required.count))
+        let optional = sourceBlock(
+            in: permissions,
+            from: "Text(\"Optional\")",
+            to: "\n        .onAppear"
+        )
 
         assert(!required.contains("title: \"Accessibility\""))
         assert(optional.contains("title: \"Accessibility\""))

--- a/Tests/SystemAudioAppStateRoutingTests.swift
+++ b/Tests/SystemAudioAppStateRoutingTests.swift
@@ -20,7 +20,7 @@ struct SystemAudioAppStateRoutingTests {
         precondition(source.contains("AudioInputDevice.isMicrophoneOnly(audioInputID)"))
         precondition(source.contains("private func ensureSystemDefaultAndSystemAudioAccess() async -> Bool"))
         precondition(source.contains("let supportsLiveTranscription = !AudioInputDevice.isSystemDefaultAndSystemAudio(audioInputID)"))
-        precondition(source.contains("if supportsLiveTranscription {\n            startRealtimeStreamingIfEnabled()\n        }"))
+        precondition(source.contains("if shouldTranscribe, supportsLiveTranscription {\n            startRealtimeStreamingIfEnabled()\n        }"))
         precondition(source.contains("func isNoteBrowserTranscriptionModeAvailable(_ mode: NoteBrowserTranscriptionMode) -> Bool"))
         precondition(source.contains("scheduleNoteBrowserTranscriptionModeNormalizationForSelectedInput()"))
         precondition(noteBrowserSource.contains("ForEach(transcriptionChoiceDisplays(in: \"API\"))"))

--- a/docs/superpowers/specs/2026-07-22-optional-transcription-record-only-design.md
+++ b/docs/superpowers/specs/2026-07-22-optional-transcription-record-only-design.md
@@ -1,0 +1,456 @@
+# 선택형 전사와 녹음 전용 모드 설계
+
+## 배경
+
+Quill의 현재 녹음 흐름은 모든 녹음이 전사된다고 가정한다. 녹음 종료 진입점도 `stopAndTranscribe()`이며, Setup의 Processing 단계는 Local 또는 API 전사 방식을 반드시 선택하게 한다.
+
+이 구조에서는 System Audio나 System Default + System Audio를 녹음하려는 사용자가 전사 결과를 원하지 않더라도 Native Whisper 모델을 내려받거나 API Provider를 설정해야 한다. 녹음 자체보다 전사 준비가 먼저 필요해 초기 사용 허들이 커진다.
+
+Quill은 이미 오디오 파일 저장, 빈 전사문을 가진 기록, 재전사 가용성 판단, 모델이 없을 때의 안내 토스트를 지원한다. 이번 변경은 이 기존 경로를 확장해 전사를 독립적으로 끌 수 있게 하고, 녹음 전용 결과를 정상적인 Note Browser 상태로 표현한다.
+
+## 목표
+
+- Transcription을 Post-processing 및 Context처럼 독립적으로 켜고 끌 수 있게 한다.
+- Transcription이 꺼진 녹음은 모델이나 API 키 없이 오디오 노트로 저장한다.
+- 오디오 전용 노트를 실패나 미완료 전사가 아닌 정상 콘텐츠로 표시한다.
+- 기존 재전사 버튼, 모델 가용성 판단, 안내 토스트를 재사용한다.
+- 전사를 다시 켜면 마지막으로 선택했던 전사 백엔드를 복원한다.
+- 기존 사용자의 녹음 동작은 업데이트 후에도 전사가 켜진 상태로 유지한다.
+- 신규 설치에만 적용되는 앱 내부 기본값을 조정한다.
+- 자동 붙여넣기 기본값 변경에 맞춰 Accessibility 권한을 Setup의 선택 권한으로 이동한다.
+
+## 비목표
+
+- 녹음별 일회성 전사 override를 추가하지 않는다.
+- 녹음 종료 때마다 전사 여부를 묻지 않는다.
+- 새로운 모델 설치 관리자나 다운로드 재개 기능을 만들지 않는다.
+- Apple Speech가 저장된 오디오 파일을 전사하도록 확장하지 않는다.
+- 전사가 꺼진 동안 Context를 별도로 수집하거나 분석하지 않는다.
+- 오디오 전용 노트에 새로운 파일 형식이나 저장 위치를 도입하지 않는다.
+- 이번 작업에서 Settings의 Sound Volume 카드 위치를 변경하지 않는다.
+
+## 핵심 결정
+
+### 전사 여부와 백엔드 선택 분리
+
+`transcriptionEnabled`를 전사 백엔드 선택과 독립된 영구 설정으로 추가한다.
+
+전사 Off를 `TranscriptionBackendChoice.none`으로 모델링하지 않는다. `None`을 백엔드로 취급하면 다음 문제가 생긴다.
+
+- 현재의 backend fallback 및 normalization 로직이 사용자 의도를 덮어쓸 수 있다.
+- Audio Import와 재전사에서는 `None`이 유효한 실행 백엔드가 아니다.
+- 전사를 다시 켤 때 복원할 마지막 백엔드를 별도로 기억해야 한다.
+- 모델 가용성과 사용자의 전사 의도가 하나의 enum에 섞인다.
+
+독립 토글은 다음 세 상태를 분리한다.
+
+1. 사용자가 향후 녹음에서 전사를 원하는가
+2. 전사할 때 어떤 백엔드를 사용할 것인가
+3. 개별 노트가 현재 어떤 처리 상태인가
+
+## 상태와 저장
+
+### `AppState.transcriptionEnabled`
+
+새로운 `@Published var transcriptionEnabled: Bool`을 추가한다.
+
+- 저장 키: `transcription_enabled`
+- Settings에서 토글하면 즉시 저장한다.
+- Off로 바꿔도 전사 모델, API 설정, Local Whisper 선택을 변경하지 않는다.
+- On으로 바꾸면 마지막 백엔드 선택을 사용한다.
+- On으로 전환하는 시점에 현재 입력과 Provider 상태를 기준으로 기존 normalization을 실행한다.
+- Off인 동안에는 입력 변경이나 API 키 변경 때문에 기억된 백엔드가 자동으로 다른 백엔드로 바뀌지 않게 한다.
+- 녹음 또는 전사 진행 중에는 Settings 토글을 비활성화한다.
+
+### 세션 snapshot
+
+녹음 시작 시 `transcriptionEnabled`를 세션 상태로 snapshot한다. 녹음 종료 처리는 이 snapshot만 사용한다.
+
+- 녹음 도중 설정이 외부에서 바뀌어도 현재 녹음의 처리 방식은 변하지 않는다.
+- 다음 녹음부터 새 값이 적용된다.
+- 녹음 시작 전까지만 전사 여부를 바꿀 수 있다는 사용자 경험을 보장한다.
+
+### 기존 사용자 마이그레이션
+
+`transcription_enabled`가 없는 기존 설치는 `true`로 해석하고 저장한다.
+
+- `hasCompletedSetup == true`
+- `transcription_enabled`가 없음
+- 결과: 기존 동작을 보존하기 위해 Transcription On
+
+신규 설치는 Setup의 Processing 카드 선택이 값을 저장한다.
+
+- Record only: Off
+- On this Mac: On
+- API Provider: On
+
+Setup을 다시 실행하더라도 사용자가 선택한 Processing 카드 외의 신규 설치 공통 기본값은 다시 덮어쓰지 않는다.
+
+## Setup 설계
+
+### Processing 카드
+
+Processing 화면의 최상위 선택지는 세 개다.
+
+1. Record only
+2. On this Mac
+3. API Provider
+
+처음 화면에 들어왔을 때는 현재처럼 아무 카드도 미리 선택하지 않는다. 사용자가 하나를 선택해야 Continue가 활성화된다.
+
+Record only 설명:
+
+> Save audio notes now. Transcribe them later if needed. No model download or API key required.
+
+`SetupFlow.ProcessingPreset`에 `recordOnly`를 추가한다.
+
+- `recordOnly`: `transcriptionEnabled = false`
+- `localAppleSpeech`: `transcriptionEnabled = true`, Apple Speech 선택
+- `localNativeWhisper`: `transcriptionEnabled = true`, Native Whisper 선택
+- `apiStandard`: `transcriptionEnabled = true`, API Standard 선택
+
+Record only는 Post-processing과 Context의 저장된 토글 값을 바꾸지 않는다. 해당 녹음에서만 두 기능을 실행하지 않는다.
+
+### 권한
+
+신규 기본값에서 자동 붙여넣기와 Command Mode가 모두 Off이므로 Accessibility는 기본 녹음에 필수가 아니다.
+
+필수 권한:
+
+- Record only: Microphone
+- Local Apple Speech: Microphone + Speech Recognition
+- Local Native Whisper: Microphone
+- API Standard: Microphone
+
+선택 권한:
+
+- Accessibility
+- Screen & System Audio Recording
+- Notifications
+
+Accessibility는 사용자가 나중에 자동 붙여넣기 또는 Command Mode를 켤 때 기존 앱 내 권한 요청 흐름으로 안내한다.
+
+System Audio는 여전히 Screen & System Audio Recording 권한이 필요하다. 기본 오디오 소스는 System Default이므로 Setup 완료 자체는 이 권한으로 막지 않는다.
+
+## Settings 설계
+
+### Transcription 카드
+
+`ModelsSettingsView`의 Transcription 카드를 Post-processing 및 Context 카드와 같은 패턴으로 맞춘다.
+
+- 설명 오른쪽에 switch-style Toggle 배치
+- 접근성 label: `Transcription`
+- 녹음 또는 전사 중에는 토글 비활성화
+
+On 상태:
+
+- 기존 Model picker와 세부 설정 사용
+- 현재 백엔드의 가용성 경고 사용
+- 마지막으로 저장된 백엔드를 기준으로 동작
+
+Off 상태:
+
+- 안내 문구: `Record audio without creating a transcript.`
+- 모델 선택과 Details를 흐리게 비활성화
+- 모델, 언어, API override 값은 삭제하지 않음
+- Post-processing과 Context는 실행하지 않음
+
+Post-processing 및 Context 카드의 저장값은 유지하고 계속 편집할 수 있게 한다. Transcription Off 상태에서는 두 카드에 해당 기능이 전사가 켜진 녹음에 적용된다는 보조 설명을 표시한다.
+
+### 메뉴 막대 문구
+
+Transcription Off 상태에서는 메뉴 막대의 수동 시작 문구를 바꾼다.
+
+- On: `Start Dictating`
+- Off: `Start Recording`
+
+녹음 완료 상태도 전사 완료 문구 대신 `Recording saved`를 사용한다.
+
+별도의 `Next recording` 메뉴나 일회성 toggle은 추가하지 않는다.
+
+## 녹음 실행 흐름
+
+### 녹음 시작
+
+세션 snapshot이 Off이면 물리적 녹음 장치와 녹음 저널만 시작한다.
+
+시작하지 않는 구성 요소:
+
+- Apple Speech `LiveTranscriber`
+- Realtime transcription service
+- Context capture task
+- Post-processing service snapshot
+- Cloud transcription job 및 checkpoint
+
+오디오 소스 접근 권한과 녹음 저장 안정성 검사는 기존 경로를 그대로 사용한다.
+
+### 정상 종료
+
+기존의 단일 종료 진입점은 유지하되, 내부에서 세션 snapshot에 따라 분기한다. 필요하면 `stopAndTranscribe()`처럼 전사를 전제로 한 helper 이름을 녹음 종료와 후처리를 포괄하는 이름으로 제한적으로 정리한다.
+
+전사 Off 정상 종료 순서:
+
+1. 녹음 초기화 timer와 recorder callback 정리
+2. 물리적 녹음 장치 정지
+3. 기존 recording journal finalization 수행
+4. 기존 영구 오디오 파일 저장 경로 사용
+5. 캘린더 snapshot 및 녹음 시작·종료 시각 해석
+6. 같은 녹음 ID로 audio-only history item 저장
+7. `Recording saved` 상태 표시
+8. Note Browser에 파란색 Audio only 상태 표시
+
+실행하지 않는 동작:
+
+- Transcribing overlay
+- Local 또는 Cloud transcription
+- Post-processing
+- Context 수집 및 분석
+- 클립보드 write
+- 자동 붙여넣기
+- 기존 `lastTranscript` 또는 Paste Again 대상 삭제
+
+### 저장 실패 및 복구
+
+정상적으로 오디오 파일이 저장된 경우에만 audio-only 상태를 만든다.
+
+- 녹음 저장 실패: 기존 recording storage failure 흐름
+- journal finalization 실패: 기존 preserved-for-recovery 흐름
+- 비정상 종료 후 복구: 기존 recovered recording 상태
+- 빈 녹음: 기존 no-audio 오류
+
+저장 실패나 복구 상태를 audio-only 정상 상태로 위장하지 않는다.
+
+## 오디오 전용 노트 모델
+
+### 명시적 machine status
+
+`PipelineHistoryItem`에 audio-only 상태를 명시적으로 표현한다.
+
+권장 표현:
+
+- persisted `postProcessingStatus`: `audio-only`
+- `PipelineHistoryMachineStatus.audioOnly`
+- Note Browser 표시 상태에도 별도 audio-only case 추가
+
+audio-only는 다음 범주에 포함되지 않는다.
+
+- failed
+- recovered
+- importing
+- live recording
+- cloud transcribing
+- incomplete transcription
+
+audio-only item의 기본 필드:
+
+- `rawTranscript = ""`
+- `postProcessedTranscript = ""`
+- `transcriptFileName = nil`
+- `audioFileName` 존재
+- `usedContextCapture = false`
+- `usedPostProcessing = false`
+- `usedLocalTranscription = false`
+- 녹음 시작·종료 시각 저장
+- 캘린더 match 저장
+- 현재 전사 언어 코드는 진단 및 향후 기본값 참고용으로 저장 가능하지만, 실제 전사를 수행한 것으로 표시하지 않는다.
+
+### 제목과 미리보기
+
+파란색 A안의 시각 톤을 사용한다.
+
+- 상태 점: 파란색
+- 배지: `Audio only`
+- 캘린더 적용 제목이 있으면 해당 제목 사용
+- custom title이 있으면 custom title 우선
+- 그 외 기본 제목: `Audio recording`
+- 목록 미리보기: `Not transcribed`
+
+오디오 전용은 경고색이나 오류 아이콘을 사용하지 않는다.
+
+### 상세 화면
+
+전사문이 없는 일반 `No content` 화면을 재사용하지 않는다.
+
+- 파란색 waveform 계열 아이콘
+- 제목: `Audio recording`
+- 설명: `Saved without transcription. You can transcribe it later.`
+- 저장된 오디오 player 표시
+- toolbar의 재전사 action 표시
+- audio-only action 도움말: `Transcribe audio`
+
+## 후속 전사
+
+### 기존 가용성 판단 재사용
+
+오디오 전용 노트의 `Transcribe audio` action은 기존 `noteBrowserRetryAvailability(for:)`와 재전사 분기를 사용한다.
+
+- `.ready`: 현재 선택된 실행 가능한 백엔드로 즉시 전사
+- `.needsModelSelection`: 기존 모델 선택 안내 toast
+- `.needsModelSetup`: 기존 Local Whisper 또는 API 설정 안내 toast
+- `.noAudio`: action 비활성화
+
+새로운 모델 설치 sheet나 다운로드 owner를 만들지 않는다.
+
+Apple Speech는 저장된 오디오 파일 전사를 지원하지 않으므로 후속 전사의 실행 가능한 선택지에 포함하지 않는다.
+
+### 글로벌 토글과의 관계
+
+사용자가 audio-only 노트에서 명시적으로 Transcribe audio를 누른 경우에는 글로벌 `transcriptionEnabled == false`여도 해당 노트의 전사를 실행한다.
+
+- 글로벌 토글 값은 바꾸지 않는다.
+- 이후 새 녹음은 계속 audio-only로 저장된다.
+- 수동 전사 성공 시 같은 note ID를 일반 완료 상태로 갱신한다.
+
+### Post-processing과 Context
+
+오디오 전용 녹음 당시 Context는 수집하지 않았으므로 후속 전사에서도 당시 화면 Context를 재구성하지 않는다.
+
+Post-processing은 수동 전사를 실행하는 시점의 현재 설정을 따른다.
+
+- 현재 Post-processing On: 새 전사문에 후처리 적용
+- 현재 Post-processing Off: raw transcript 사용
+- 출력 언어, vocabulary, prompt, preserve exact wording도 전사 시점의 현재 설정 사용
+- 현재 앱 화면을 과거 녹음의 Context로 사용하지 않는다.
+
+### 성공과 실패
+
+성공:
+
+- 동일한 history item ID 유지
+- raw 및 final transcript 저장
+- transcript file 생성
+- audio-only machine status를 completed로 전환
+- 오디오 파일 유지
+- 기존 retry 성공 clipboard 동작 재사용
+
+실패:
+
+- 오디오 파일 유지
+- 기존 구조화된 Quill user issue 저장
+- 기존 retry action 유지
+- audio-only 정상 상태 대신 실패 상태를 표시해 실제 실행 실패임을 구분
+
+모델이 준비되지 않아 toast만 표시된 경우에는 실행을 시작하지 않았으므로 audio-only 상태를 그대로 유지한다.
+
+## 신규 설치 공통 기본값
+
+아래 값은 Setup 화면에 추가 질문으로 노출하지 않는다. 신규 설치에서만 앱 내부 기본값으로 적용한다.
+
+| 설정 | 신규 설치 기본값 | 기존 설치의 누락 키 동작 |
+|---|---|---|
+| Audio Source | System Default | System Default 유지 |
+| Paste Automatically | Off | 이전 기본값 On 유지 |
+| Preserve Clipboard | On | On 유지 |
+| Keep Dictations in Clipboard History | Off | Off 유지 |
+| Dictation Audio Interruption | Off | Off 유지 |
+| Note Browser | On | On 유지 |
+| Transcription Language | Auto Detect | 이전 기본값 Korean 유지 |
+| Output Language | Same as spoken language | 유지 |
+| Preserve Exact Wording | Off | Off 유지 |
+| Recording Overlay Layout | Notch Sides | 이전 기본값 Centered 유지 |
+| Waveform Display | Hover Time | 이전 기본값 Waveform Only 유지 |
+| Alert Sounds | On | On 유지 |
+| Command Mode | Off | Off 유지 |
+| Calendar Recording Reminders | Off | Off 유지 |
+| Launch at Login | Off | 기존 시스템 등록 상태 유지 |
+| Press Enter Voice Command | Off | 이전 기본값 On 유지 |
+| Realtime Transcription | Off | Off 유지 |
+
+### 신규 설치와 기존 설치 구분
+
+변경되는 기본값은 단순히 `UserDefaults.bool(forKey:)`의 fallback만 바꾸지 않는다. 그렇게 하면 저장 키가 없는 기존 사용자도 새 기본값으로 바뀐다.
+
+초기화 규칙:
+
+1. 저장 키가 있으면 항상 저장값 사용
+2. 저장 키가 없고 `hasCompletedSetup == false`이면 새 기본값 사용 및 명시적으로 저장
+3. 저장 키가 없고 `hasCompletedSetup == true`이면 이전 기본값 사용
+
+신규 설치 시 초기화 단계에서 값을 저장해야 한다. 그렇지 않으면 Setup 완료 후 다음 실행에서 누락 키가 기존 설치로 해석되어 이전 기본값으로 되돌아갈 수 있다.
+
+Setup 재실행은 Processing 카드가 직접 다루는 전사 preset과 사용자가 편집한 shortcut만 변경하며, 위 공통 기본값을 다시 seed하지 않는다.
+
+## UI 및 접근성
+
+- Transcription toggle에 명확한 accessibility label 제공
+- audio-only 상태 점만으로 의미를 전달하지 않고 `Audio only` 텍스트 배지 병행
+- `Transcribe audio` action에 tooltip 및 accessibility label 제공
+- toast는 기존 `NSAccessibility.announcementRequested` 경로 재사용
+- 영어 및 한국어 localization catalog에 신규 문자열 추가
+- 진행 중인 녹음과 전사에서는 Transcription toggle이 비활성화되었다는 상태를 시각적으로 표현
+
+## 테스트 계획
+
+### AppState 및 저장
+
+- `transcription_enabled`가 없는 기존 완료 설치는 On으로 마이그레이션된다.
+- 저장된 Off 및 On 값은 그대로 복원된다.
+- Transcription Off가 마지막 백엔드 선택을 변경하지 않는다.
+- Off 상태의 입력 및 Provider 변경은 remembered backend를 normalization하지 않는다.
+- 다시 On하면 현재 환경에 맞춰 기존 normalization이 실행된다.
+- 녹음 시작 snapshot 이후 설정 변경이 현재 녹음에 영향을 주지 않는다.
+
+### 신규 설치 기본값
+
+- 신규 설치는 자동 붙여넣기 Off, 언어 Auto, Notch Sides, Hover Time, press-enter Off를 명시적으로 저장한다.
+- 완료된 기존 설치의 누락 키는 이전 기본값을 유지한다.
+- 저장된 사용자 값은 신규 기본값 로직이 덮어쓰지 않는다.
+- Setup 재실행은 공통 기본값을 다시 seed하지 않는다.
+
+### Setup
+
+- Processing 화면에 정확히 Record only, On this Mac, API Provider가 표시된다.
+- 아무 카드도 선택하지 않으면 Continue가 비활성화된다.
+- Record only는 모델 및 API 키 없이 Continue가 가능하다.
+- Record only는 `transcriptionEnabled = false`를 저장한다.
+- Local 및 API preset은 `transcriptionEnabled = true`를 저장한다.
+- Accessibility가 선택 권한으로 이동한다.
+- Apple Speech만 Speech Recognition을 필수로 요구한다.
+
+### 녹음 흐름
+
+- Transcription Off에서 Apple Speech, Realtime, Context가 시작되지 않는다.
+- 정상 종료 시 기존 finalizer를 거쳐 영구 오디오 파일이 저장된다.
+- audio-only history item이 같은 recording ID와 정확한 시간 범위로 생성된다.
+- 캘린더 match 및 제목 정보가 보존된다.
+- Transcribing overlay가 표시되지 않는다.
+- clipboard와 Paste Again 대상이 변경되지 않는다.
+- 저장 실패 및 journal 복구가 기존 오류 상태로 유지된다.
+
+### Note Browser
+
+- audio-only가 별도 정상 machine status로 해석된다.
+- 파란색 Audio only 상태, 제목, 미리보기가 표시된다.
+- 상세 화면에 오디오 player와 전용 empty state가 표시된다.
+- audio-only가 failed, recovered, transcribing으로 표시되지 않는다.
+- 앱 재실행 후 상태가 보존된다.
+
+### 후속 전사
+
+- 실행 가능한 현재 backend가 있으면 기존 retry path로 전사한다.
+- 모델 선택이 필요하면 기존 selection toast가 표시된다.
+- usable backend가 없으면 기존 setup toast가 표시된다.
+- toast만 표시된 경우 audio-only 상태가 유지된다.
+- 글로벌 Transcription Off에서도 명시적 수동 전사는 실행된다.
+- 성공 시 같은 item ID가 completed transcript 상태로 갱신된다.
+- 전사 시점의 현재 Post-processing 설정이 적용된다.
+- 과거 녹음 Context는 생성하거나 현재 화면으로 대체하지 않는다.
+- 실패 시 오디오는 유지되고 기존 structured issue 및 retry action이 표시된다.
+
+### UI 및 localization
+
+- Transcription 카드가 Post-processing 및 Context와 같은 toggle 구조를 사용한다.
+- 녹음 또는 전사 중 toggle이 비활성화된다.
+- Off 상태에서 모델 설정이 비활성화되지만 값은 보존된다.
+- 메뉴 막대 문구가 Transcription 상태에 따라 Start Recording 또는 Start Dictating으로 바뀐다.
+- 신규 영어 및 한국어 문자열이 localization validation을 통과한다.
+
+## 성공 기준
+
+- 신규 사용자가 모델 다운로드나 API 키 없이 Record only로 Setup을 완료할 수 있다.
+- System Audio를 포함한 모든 기존 오디오 소스를 전사 없이 녹음하고 재생 가능한 노트로 저장할 수 있다.
+- 전사를 꺼도 마지막 모델 설정이 손실되지 않는다.
+- 기존 사용자의 전사는 업데이트 후 자동으로 꺼지지 않는다.
+- 오디오-only 노트는 실패가 아닌 정상 저장 상태로 명확히 보인다.
+- 모델이 없어도 재전사 action은 crash나 빈 UI 없이 기존 toast로 안내한다.
+- 전사를 다시 켜거나 개별 오디오 노트를 수동 전사할 때 기존 전사 파이프라인을 재사용한다.


### PR DESCRIPTION
## Summary

This draft adds an optional transcription mode so Quill can record and save audio notes without requiring a downloaded transcription model or an API key.

### Included

- Adds an independent, persisted **Transcription** switch while preserving the remembered transcription backend.
- Keeps existing users on Transcription On when migrating from installations without the new preference.
- Adds one-time new-install defaults without reapplying them when Setup is rerun.
- Adds **Record only** as a Setup processing option.
- Moves Accessibility from required to optional Setup permissions; only Apple Speech requires Speech Recognition.
- Snapshots the transcription preference at recording start so changing settings cannot alter an active session.
- Prevents Apple Speech, realtime transcription, Context capture, post-processing snapshots, and cloud transcription checkpoints from starting for record-only sessions.
- Reuses the existing audio recorder, recording journal, finalizer, permanent audio storage, and recovery paths.
- Persists record-only results as a first-class `audio-only` note state rather than a failed or incomplete transcription.
- Adds the blue **Audio only** Note Browser state, dedicated detail copy, audio playback, and a **Transcribe audio** action.
- Reuses the existing backend availability and toast flow for later transcription.
- Allows explicit retranscription while the global Transcription switch remains Off.
- Applies current post-processing settings to audio-only retranscription and preserves note, audio, calendar, and title metadata.
- Adds English and Korean localization for the new Setup, Settings, menu, and Note Browser copy.

## Final-review follow-up fixes

The Important and Minor issues found by the broad branch review have now been addressed in code.

### Resolved: transcript artifact after a failed audio-only retry

A successful retry now creates a transcript file whenever the stored note does not already have one, instead of requiring the current machine status to remain `.audioOnly`.

This covers the full transition:

```text
audio-only → retry failure → failed state → retry success
```

The existing cleanup remains intact:

- stale retry completion removes only the file created by that attempt
- history-store update failure removes only the file created by that attempt
- an existing transcript file is never deleted by retry rollback

### Resolved: deferred termination for record-only finalization

Record-only stops now use a shared terminal-completion lifecycle.

- Every success, persistence failure, empty-audio, preserved-for-recovery, and recovered-without-transcription branch reaches a terminal completion.
- Pending audio-only finalizations are tracked separately without exposing them as Transcribing state.
- Application termination waits until all audio-only history, calendar, journal, or recovery work has reached a terminal result.
- A quit request made after recording has stopped but while audio-only persistence is still pending is also deferred correctly.
- Existing transcription jobs continue to use their original completion path.

### Resolved: stale audio-only completion overwriting a newer recording

Recording UI ownership is now tied to the existing overlay operation token.

- Starting a new recording rotates the foreground owner.
- Record-only stop captures the current owner and passes it through calendar lookup and persistence.
- Durable history and journal operations still complete even if the result becomes stale.
- Only the current owner may change status text, error text, ready-reset scheduling, or dismiss the overlay.
- A delayed previous save therefore cannot hide or relabel a newer recording.

### Resolved: backend warning while Transcription is Off

The generic unavailable-backend warning is now guarded by the Transcription switch, matching the existing API-key warning. Record only no longer presents a disabled model/API warning.

### Resolved: audio-only localization gaps

- Audio-only row and detail labels use explicit catalog lookup.
- `Audio-only recording` is registered in English and Korean.
- Korean tooltip value: `오디오 전용 녹음`.

### Resolved: source-contract test relying on a comment

The recording source-contract tests now inspect the actual `if !shouldTranscribe` branch and the real audio-only persistence helper. They no longer pass because a production comment contains the factory name.

## Automated verification

The following completed successfully after the follow-up fixes:

- `make test-core test-recording test-transcription localization-bundle-test`
  - core shard: status 0
  - recording shard: status 0
  - transcription shard: status 0
  - localization bundle validation: passed
- `make test`
  - core shard: status 0
  - recording shard: status 0
  - transcription shard: status 0
- `git diff --check`: passed
- Ad-hoc development app bundle build: passed
- Deep/strict signature validation on an xattr-clean copy in a non-synced temporary path: passed
- Working tree was clean before push

Existing non-fatal Core Data entity-description warnings and the existing non-interleaved audio warning still appear in test output.

### Signing environment note

The configured development signing identity was visible, but its private key was not accessible to the current non-interactive session, and even signing a temporary binary returned `errSecInternalComponent`. Compilation completed, and the same app bundle built and passed deep/strict validation with ad-hoc signing. A configured-identity build should be rerun from an interactive Keychain-unlocked environment before the PR leaves draft.

## Manual UI and device verification — owner follow-up

Automated code-based verification is complete. The following interactive checks are intentionally left for the PR owner:

### Settings and Setup

- [ ] Independent Transcription switch behaves correctly.
- [ ] Turning Transcription Off disables model controls without losing the selected model.
- [ ] Post-processing and Context retain their saved switch values.
- [ ] Record only completes Setup without a model or API key.
- [ ] Accessibility appears under Optional permissions.
- [ ] Menu bar copy changes to **Start Recording** when Transcription is Off.
- [ ] No backend availability warning appears while Transcription is Off.

### Record-only audio sources

Verify each available source:

- [ ] System Default
- [ ] System Audio
- [ ] System Default + System Audio

For each source:

- [ ] Recording starts without a Transcribing state.
- [ ] Stop finishes with **Recording saved**.
- [ ] One blue Audio only note appears.
- [ ] Detail audio playback works.
- [ ] No transcript artifact is created before manual transcription.
- [ ] Clipboard and Paste Again remain unchanged.

### Retranscription

- [ ] No usable backend shows the existing setup toast.
- [ ] An unavailable remembered backend shows the existing selection toast.
- [ ] A usable remembered backend converts the same note successfully.
- [ ] Note ID and audio file remain unchanged.
- [ ] A transcript file exists after success.
- [ ] Current Post-processing settings are respected.
- [ ] Global Transcription remains Off.
- [ ] A first failed retry followed by a successful retry still creates the transcript file.

### Lifecycle interactions

- [ ] **Stop Recording and Quit** waits for record-only persistence and then exits.
- [ ] Quitting immediately after manually stopping a record-only recording waits for pending persistence.
- [ ] Starting a second recording before the previous record-only save completes does not lose the new overlay or status.
- [ ] Actual Microphone and Screen & System Audio Recording permission prompts work as expected.

## Merge readiness

- [x] Feature implementation committed
- [x] Broad-review Important issues fixed
- [x] Broad-review Minor issues fixed
- [x] Full automated test suite passed
- [x] Localization bundle validation passed
- [x] Development app compiled and ad-hoc bundle verification passed
- [ ] Configured-identity build rerun in an interactive Keychain-unlocked environment
- [ ] Owner interactive UI/audio/permission verification completed

The PR remains draft until the two unchecked verification items are complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 전사를 끄고 오디오만 녹음·저장하는 **Record only** 모드를 추가했습니다.
  * 설정에서 전사를 독립적으로 켜고 끌 수 있습니다.
  * 오디오 전용 노트에 상태 배지, 안내 문구, 오디오 재전사 기능을 제공합니다.
  * 녹음 상태와 메뉴 표시가 전사 설정에 맞게 변경됩니다.

* **개선 사항**
  * 오디오 전용 녹음의 캘린더 정보와 녹음 메타데이터를 보존합니다.
  * 마이크 권한 안내와 관련 화면 문구를 보다 정확하게 수정했습니다.
  * 영어와 한국어 안내 문구를 추가 및 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->