### PR TITLE
Align Note Browser / Models settings consistency and context handling

### DIFF
--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -11461,6 +11461,54 @@
         }
       }
     },
+    "Context wasn't available": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Context wasn't available"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "컨텍스트를 사용할 수 없었습니다"
+          }
+        }
+      }
+    },
+    "Continued with text-only post-processing.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continued with text-only post-processing."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "텍스트만으로 처리를 계속했습니다."
+          }
+        }
+      }
+    },
+    "No action needed. Context capture will be attempted again next time.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No action needed. Context capture will be attempted again next time."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "별도 조치가 필요 없습니다. 다음번에 컨텍스트 캡처를 다시 시도합니다."
+          }
+        }
+      }
+    },
     "Quill could not complete this transcription.": {
       "localizations": {
         "en": {

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -481,6 +481,22 @@
         }
       }
     },
+    "Switch the active recording's audio input": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch the active recording's audio input"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "진행 중인 녹음의 오디오 입력 전환"
+          }
+        }
+      }
+    },
     "Cloud transcription": {
       "localizations": {
         "en": {
@@ -6299,6 +6315,38 @@
           "stringUnit": {
             "state": "translated",
             "value": "Apple 라이브"
+          }
+        }
+      }
+    },
+    "Apple Live is unavailable with System Default + System Audio": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Live is unavailable with System Default + System Audio"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple 라이브는 시스템 기본값 + 시스템 오디오에서 사용할 수 없습니다"
+          }
+        }
+      }
+    },
+    "Realtime is unavailable with System Default + System Audio": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Realtime is unavailable with System Default + System Audio"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실시간은 시스템 기본값 + 시스템 오디오에서 사용할 수 없습니다"
           }
         }
       }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -8016,13 +8016,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
         sessionContext: AppContext?,
         inFlightContextTask: Task<AppContext?, Never>?
     ) async -> AppContext {
+        let resolvedContext: AppContext
         if let sessionContext {
-            return sessionContext
+            resolvedContext = sessionContext
+        } else if let inFlightContext = await inFlightContextTask?.value {
+            resolvedContext = inFlightContext
+        } else {
+            resolvedContext = fallbackContextAtStop()
         }
-        if let inFlightContext = await inFlightContextTask?.value {
-            return inFlightContext
-        }
-        return fallbackContextAtStop()
+        return Self.sanitizedCapturedContext(
+            resolvedContext,
+            contextCaptureDisabled: disableContextCapture
+        )
     }
 
     @MainActor
@@ -9853,6 +9858,50 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
             return context
         }
+    }
+
+    // Old notes may still carry the stop-time placeholder sentence in their
+    // stored contextSummary; both that literal and a genuinely empty summary
+    // count as "no usable context" rather than real captured activity.
+    private static func isPlaceholderContextSummary(_ summary: String) -> Bool {
+        let trimmed = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return true }
+        return trimmed == "Could not refresh app context at stop time; using text-only post-processing."
+    }
+
+    // Context is only worth injecting into post-processing when it was
+    // successfully captured: real (non-placeholder) activity text, and no
+    // error-severity issue was recorded while collecting it.
+    private static func isUsableCapturedContext(_ context: AppContext) -> Bool {
+        guard !isPlaceholderContextSummary(context.currentActivity) else { return false }
+        guard context.userIssueRecord?.severity != .error else { return false }
+        return true
+    }
+
+    // Context capture being turned off is intentional and already produces an
+    // empty, issue-free context (see fallbackContextAtStop). Only sanitize
+    // when capture is enabled but did not actually succeed: drop the
+    // placeholder/error text instead of injecting it, and surface a warning
+    // (not an error) so the note still shows as completed.
+    private static func sanitizedCapturedContext(
+        _ context: AppContext,
+        contextCaptureDisabled: Bool
+    ) -> AppContext {
+        guard !contextCaptureDisabled else { return context }
+        guard !isUsableCapturedContext(context) else { return context }
+        return AppContext(
+            appName: context.appName,
+            bundleIdentifier: context.bundleIdentifier,
+            windowTitle: context.windowTitle,
+            selectedText: context.selectedText,
+            currentActivity: "",
+            contextSystemPrompt: context.contextSystemPrompt,
+            contextPrompt: context.contextPrompt,
+            screenshotDataURL: context.screenshotDataURL,
+            screenshotMimeType: context.screenshotMimeType,
+            screenshotError: context.screenshotError,
+            userIssueRecord: QuillUserIssueRecord(code: .contextUnavailable)
+        )
     }
 
     private func fallbackContextAtStop() -> AppContext {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1842,6 +1842,73 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var isTranscribing = false
     @Published var retryingItemIDs: Set<UUID> = []
 
+    // MARK: Warning banner dismissal (per note + issue code, invalidated by retry)
+
+    // A per-note counter bumped every time that note is retried. Dismissals
+    // are recorded against the generation they were dismissed at, so a later
+    // retry (which may produce a different outcome) makes the banner
+    // reappear if the warning condition still holds.
+    @Published private(set) var noteRetryGenerationByID: [String: Int] = AppState.loadIntDictionary(
+        forKey: AppState.noteRetryGenerationDefaultsKey
+    )
+    @Published private(set) var dismissedWarningBannerGeneration: [String: Int] = AppState.loadIntDictionary(
+        forKey: AppState.dismissedWarningBannerGenerationDefaultsKey
+    )
+
+    private static let noteRetryGenerationDefaultsKey = "note_retry_generation_by_id"
+    private static let dismissedWarningBannerGenerationDefaultsKey = "dismissed_warning_banner_generation_by_key"
+
+    private static func loadIntDictionary(forKey key: String) -> [String: Int] {
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let values = try? JSONDecoder().decode([String: Int].self, from: data) else {
+            return [:]
+        }
+        return values
+    }
+
+    private static func saveIntDictionary(_ values: [String: Int], forKey key: String) {
+        guard !values.isEmpty else {
+            UserDefaults.standard.removeObject(forKey: key)
+            return
+        }
+        if let data = try? JSONEncoder().encode(values) {
+            UserDefaults.standard.set(data, forKey: key)
+        }
+    }
+
+    private static func dismissalKey(noteID: UUID, code: QuillUserIssueCode) -> String {
+        "\(noteID.uuidString):\(code.rawValue)"
+    }
+
+    func noteRetryGeneration(for noteID: UUID) -> Int {
+        noteRetryGenerationByID[noteID.uuidString] ?? 0
+    }
+
+    @MainActor
+    func incrementNoteRetryGeneration(for noteID: UUID) {
+        let key = noteID.uuidString
+        noteRetryGenerationByID[key] = (noteRetryGenerationByID[key] ?? 0) + 1
+        Self.saveIntDictionary(noteRetryGenerationByID, forKey: Self.noteRetryGenerationDefaultsKey)
+    }
+
+    func isWarningBannerDismissed(noteID: UUID, code: QuillUserIssueCode) -> Bool {
+        let key = Self.dismissalKey(noteID: noteID, code: code)
+        guard let dismissedGeneration = dismissedWarningBannerGeneration[key] else {
+            return false
+        }
+        return dismissedGeneration == noteRetryGeneration(for: noteID)
+    }
+
+    @MainActor
+    func dismissWarningBanner(noteID: UUID, code: QuillUserIssueCode) {
+        let key = Self.dismissalKey(noteID: noteID, code: code)
+        dismissedWarningBannerGeneration[key] = noteRetryGeneration(for: noteID)
+        Self.saveIntDictionary(
+            dismissedWarningBannerGeneration,
+            forKey: Self.dismissedWarningBannerGenerationDefaultsKey
+        )
+    }
+
     var isTranscriptionConfigurationLocked: Bool {
         isRecording || isTranscribing || !retryingItemIDs.isEmpty
     }
@@ -5665,6 +5732,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         retryingItemIDs.insert(item.id)
+        incrementNoteRetryGeneration(for: item.id)
 
         let postProcessingService = makePostProcessingService()
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -5121,7 +5121,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let switchToken = UUID()
         activeInputSwitchToken = switchToken
         isActiveInputSwitchPhysicalStopInProgress = true
-        liveTranscriber = nil
+        tearDownLiveTranscriberOffMainThread()
         tearDownRealtimeService()
         setActiveRecorderPCMHandler(nil)
         audioLevelCancellable?.cancel()
@@ -9897,6 +9897,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
         setActiveRecorderPCMHandler(nil)
         realtimeService?.cancel()
         realtimeService = nil
+    }
+
+    /// Detaches the active live transcriber and tears it down off the main
+    /// thread. Cancelling/deallocating an Apple Speech session is synchronous
+    /// and can stall for a few hundred ms; doing it inline (e.g. from the
+    /// audio-source menu action that triggers a mid-recording input switch)
+    /// keeps the menu open and freezes the UI. The reference is dropped from
+    /// AppState immediately; cancel() and dealloc run on a background queue.
+    @MainActor
+    private func tearDownLiveTranscriberOffMainThread() {
+        guard let transcriber = liveTranscriber else { return }
+        liveTranscriber = nil
+        DispatchQueue.global(qos: .utility).async {
+            transcriber.cancel()
+        }
     }
 
     private func startContextCapture() {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1909,6 +1909,39 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
     }
 
+    /// Drops the per-note retry generation and any banner dismissals for a
+    /// deleted note so these side-store dictionaries don't grow unbounded.
+    @MainActor
+    private func forgetWarningBannerState(for noteID: UUID) {
+        let dismissalPrefix = "\(noteID.uuidString):"
+        let hadState = noteRetryGenerationByID[noteID.uuidString] != nil
+            || dismissedWarningBannerGeneration.keys.contains { $0.hasPrefix(dismissalPrefix) }
+        guard hadState else { return }
+        noteRetryGenerationByID.removeValue(forKey: noteID.uuidString)
+        dismissedWarningBannerGeneration = dismissedWarningBannerGeneration.filter {
+            !$0.key.hasPrefix(dismissalPrefix)
+        }
+        Self.saveIntDictionary(noteRetryGenerationByID, forKey: Self.noteRetryGenerationDefaultsKey)
+        Self.saveIntDictionary(
+            dismissedWarningBannerGeneration,
+            forKey: Self.dismissedWarningBannerGenerationDefaultsKey
+        )
+    }
+
+    /// Clears all banner dismissal / retry-generation side state, e.g. when the
+    /// entire run history is cleared.
+    @MainActor
+    private func forgetAllWarningBannerState() {
+        guard !noteRetryGenerationByID.isEmpty || !dismissedWarningBannerGeneration.isEmpty else { return }
+        noteRetryGenerationByID = [:]
+        dismissedWarningBannerGeneration = [:]
+        Self.saveIntDictionary(noteRetryGenerationByID, forKey: Self.noteRetryGenerationDefaultsKey)
+        Self.saveIntDictionary(
+            dismissedWarningBannerGeneration,
+            forKey: Self.dismissedWarningBannerGenerationDefaultsKey
+        )
+    }
+
     var isTranscriptionConfigurationLocked: Bool {
         isRecording || isTranscribing || !retryingItemIDs.isEmpty
     }
@@ -5324,6 +5357,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 cleanupDeletedPipelineHistoryAssets(removedAssets)
             }
             pipelineHistory = []
+            forgetAllWarningBannerState()
         } catch {
             errorMessage = LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Unable to clear run history"), providerDetail: error.localizedDescription)
         }
@@ -5349,6 +5383,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 cleanupDeletedPipelineHistoryAssets(deletedAssets)
             }
             pipelineHistory.remove(at: index)
+            forgetWarningBannerState(for: id)
         } catch {
             errorMessage = LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Unable to delete run history entry"), providerDetail: error.localizedDescription)
         }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -5706,6 +5706,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     postProcessedTranscript: result.finalTranscript.trimmingCharacters(in: .whitespacesAndNewlines),
                     postProcessingPrompt: result.prompt,
                     postProcessingStatus: result.userIssueRecord?.persistedStatus
+                        ?? snapshot.restoredContext.userIssueRecord?.persistedStatus
                         ?? Self.statusMessage(
                             for: result.outcome,
                             parsedTranscript: parsedTranscript,
@@ -5820,6 +5821,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
         let configuration = audioImportConfiguration(for: retryChoice)
         let isAudioOnly = item.machineStatus == .audioOnly
+        // Retry never re-captures context; it only reuses what was stored,
+        // gated by the CURRENT context toggle (not whatever was in effect
+        // when the note was first recorded). Old notes may still carry the
+        // stop-time placeholder sentence, which counts as no usable context.
+        let usesStoredContext = !isAudioOnly && !disableContextCapture
+        let storedContextIsUsable = usesStoredContext
+            && !Self.isPlaceholderContextSummary(item.contextSummary)
+        let restoredCurrentActivity = storedContextIsUsable ? item.contextSummary : ""
+        let restoredContextUserIssueRecord: QuillUserIssueRecord? = usesStoredContext && !storedContextIsUsable
+            ? QuillUserIssueRecord(code: .contextUnavailable)
+            : nil
         let retryCustomVocabulary = isAudioOnly ? customVocabulary : item.customVocabulary
         let retryCustomSystemPrompt = isAudioOnly ? customSystemPrompt : item.customSystemPrompt
         let completionSnapshot = TranscriptionCompletionSnapshot(
@@ -5872,14 +5884,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 bundleIdentifier: isAudioOnly ? nil : item.contextBundleIdentifier,
                 windowTitle: isAudioOnly ? nil : item.contextWindowTitle,
                 selectedText: isAudioOnly ? nil : item.capturedSelection,
-                currentActivity: isAudioOnly ? "" : item.contextSummary,
+                currentActivity: restoredCurrentActivity,
                 contextSystemPrompt: isAudioOnly ? nil : item.contextSystemPrompt,
                 contextPrompt: isAudioOnly ? nil : item.contextPrompt,
                 screenshotDataURL: isAudioOnly ? nil : item.contextScreenshotDataURL,
                 screenshotMimeType: !isAudioOnly && item.contextScreenshotDataURL != nil
                     ? "image/jpeg"
                     : nil,
-                screenshotError: nil
+                screenshotError: nil,
+                userIssueRecord: restoredContextUserIssueRecord
             ),
             restoredIntent: SessionIntent.fromPersisted(intent: item.intent, selectedText: item.selectedText),
             transcriptionChoice: retryChoice,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -472,6 +472,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let commandModeManualModifierStorageKey = "command_mode_manual_modifier"
     private let realtimeStreamingEnabledStorageKey = "realtime_streaming_enabled"
     private let realtimeStreamingModelStorageKey = "realtime_streaming_model"
+    private let showRealtimeTranscriptionOptionStorageKey = "show_realtime_transcription_option"
     private let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
     private let recordingOverlayLayoutStorageKey = "recording_overlay_layout"
     private let overlayWaveformDisplayModeStorageKey = "overlay_waveform_display_mode"
@@ -801,6 +802,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    /// Whether Realtime should appear as a selectable transcription option in
+    /// Settings and the Note Browser. Realtime otherwise stays hidden from
+    /// both pickers unless it is already the active choice.
+    @Published var showRealtimeTranscriptionOption: Bool {
+        didSet {
+            UserDefaults.standard.set(
+                showRealtimeTranscriptionOption,
+                forKey: showRealtimeTranscriptionOptionStorageKey
+            )
+        }
+    }
+
     /// Model ID the realtime WebSocket should transcribe with. Empty means
     /// "use the server's default".
     @Published var realtimeStreamingModel: String {
@@ -1019,11 +1032,30 @@ final class AppState: ObservableObject, @unchecked Sendable {
         currentNoteBrowserTranscriptionChoice.mode
     }
 
+    /// Predefined Standard API model IDs, plus the current custom model ID if
+    /// it isn't already one of them. Shared by Settings and the Note Browser
+    /// so both list the same Cloud Standard models.
+    var standardAPIModelIDs: [String] {
+        var modelIDs: [String] = []
+        for modelID in ModelConfiguration.transcriptionModels where !modelIDs.contains(modelID) {
+            modelIDs.append(modelID)
+        }
+        let currentModelID = transcriptionModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !currentModelID.isEmpty && !modelIDs.contains(currentModelID) {
+            modelIDs.append(currentModelID)
+        }
+        return modelIDs
+    }
+
     @MainActor
     var noteBrowserTranscriptionChoiceDisplays: [TranscriptionChoiceDisplay] {
-        [
-            noteBrowserTranscriptionDisplay(for: apiStandardChoice),
-            noteBrowserTranscriptionDisplay(for: apiRealtimeChoice),
+        let standardDisplays = standardAPIModelIDs.map { modelID in
+            noteBrowserTranscriptionDisplay(for: .apiStandard(modelID: modelID))
+        }
+        let realtimeDisplays = (showRealtimeTranscriptionOption || realtimeStreamingEnabled)
+            ? [noteBrowserTranscriptionDisplay(for: apiRealtimeChoice)]
+            : []
+        return standardDisplays + realtimeDisplays + [
             noteBrowserTranscriptionDisplay(for: nativeWhisperChoice),
             noteBrowserTranscriptionDisplay(for: .appleLive)
         ] + installedLegacyLocalWhisperModels.map { model in
@@ -1397,6 +1429,50 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
+    func setNoteBrowserTranscriptionSelection(
+        _ choice: TranscriptionBackendChoice?
+    ) {
+        guard let choice else {
+            transcriptionEnabled = false
+            return
+        }
+        guard isNoteBrowserTranscriptionChoiceReady(choice) else { return }
+        setNoteBrowserTranscriptionChoice(choice)
+        transcriptionEnabled = true
+    }
+
+    @MainActor
+    func setSettingsTranscriptionEnabled(_ isEnabled: Bool) {
+        guard isEnabled else {
+            transcriptionEnabled = false
+            return
+        }
+        guard let readyChoice = readyNoteBrowserTranscriptionChoice(
+            preferred: currentNoteBrowserTranscriptionChoice
+        ) else {
+            transcriptionEnabled = false
+            return
+        }
+        applyNoteBrowserTranscriptionChoice(readyChoice)
+        transcriptionEnabled = true
+    }
+
+    @MainActor
+    private func readyNoteBrowserTranscriptionChoice(
+        preferred: TranscriptionBackendChoice
+    ) -> TranscriptionBackendChoice? {
+        if isNoteBrowserTranscriptionChoiceReady(preferred) {
+            return preferred
+        }
+        let currentChoice = currentNoteBrowserTranscriptionChoice
+        if isNoteBrowserTranscriptionChoiceReady(currentChoice) {
+            return currentChoice
+        }
+        return noteBrowserFallbackChoices(for: preferred)
+            .first(where: isNoteBrowserTranscriptionChoiceReady)
+    }
+
+    @MainActor
     func applySetupProcessingPreset(_ preset: SetupFlow.ProcessingPreset) {
         switch preset {
         case .recordOnly:
@@ -1466,6 +1542,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let currentChoice = currentNoteBrowserTranscriptionChoice
         let normalizedChoice = normalizedNoteBrowserTranscriptionChoice(currentChoice)
         guard normalizedChoice != currentChoice else { return }
+        guard isNoteBrowserTranscriptionChoiceReady(normalizedChoice) else {
+            transcriptionEnabled = false
+            return
+        }
         applyNoteBrowserTranscriptionChoice(normalizedChoice)
     }
 
@@ -1847,6 +1927,47 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var shouldTranscribeActiveRecording: Bool {
         activeRecordingTranscriptionEnabled ?? transcriptionEnabled
     }
+
+    /// Whether the transcription choice that would actually run right now
+    /// (the active recording's choice while recording, otherwise the choice
+    /// queued up for the next recording) streams live audio (Apple Live,
+    /// API Realtime) and therefore cannot tolerate the combined System
+    /// Default + System Audio source.
+    @MainActor
+    private var currentNoteBrowserTranscriptionChoiceIsLiveOnly: Bool {
+        switch currentNoteBrowserTranscriptionChoice {
+        case .appleLive, .apiRealtime:
+            return true
+        case .apiStandard, .nativeWhisper, .legacyMlxWhisper:
+            return false
+        }
+    }
+
+    /// Whether the currently active recording is relying on a transcriber
+    /// that streams live audio (Apple Live, API Realtime) and therefore
+    /// cannot tolerate a mid-recording switch to the combined
+    /// System Default + System Audio source.
+    @MainActor
+    private var isActiveRecordingUsingLiveOnlyTranscription: Bool {
+        guard isRecording, shouldTranscribeActiveRecording else { return false }
+        return currentNoteBrowserTranscriptionChoiceIsLiveOnly
+    }
+
+    /// Whether `inputID` can be selected right now without breaking live
+    /// transcription: during an active recording, without breaking the
+    /// active recording's live transcriber; otherwise, without queueing up
+    /// a source that would immediately force the next recording's live-only
+    /// transcription choice to turn off. Used by both the recording
+    /// overlay's input switcher and the Note Browser's input picker.
+    @MainActor
+    func isAudioInputSelectable(_ inputID: String) -> Bool {
+        guard AudioInputDevice.isSystemDefaultAndSystemAudio(inputID) else { return true }
+        if isRecording {
+            return !isActiveRecordingUsingLiveOnlyTranscription
+        }
+        return !(transcriptionEnabled && currentNoteBrowserTranscriptionChoiceIsLiveOnly)
+    }
+
     private var activeAudioInputID: String?
     private var activeInputSwitchToken: UUID?
     private var isActiveInputSwitchPhysicalStopInProgress = false
@@ -2130,6 +2251,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let keepDictationInClipboardHistory = UserDefaults.standard.bool(forKey: keepDictationInClipboardHistoryStorageKey)
         let realtimeStreamingEnabled = UserDefaults.standard.bool(forKey: realtimeStreamingEnabledStorageKey)
         let realtimeStreamingModel = UserDefaults.standard.string(forKey: realtimeStreamingModelStorageKey) ?? ""
+        let showRealtimeTranscriptionOption = UserDefaults.standard.bool(
+            forKey: showRealtimeTranscriptionOptionStorageKey
+        )
         let dictationAudioInterruptionEnabled = UserDefaults.standard.bool(
             forKey: dictationAudioInterruptionEnabledStorageKey
         )
@@ -2312,6 +2436,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.keepDictationInClipboardHistory = keepDictationInClipboardHistory
         self.realtimeStreamingEnabled = realtimeStreamingEnabled
         self.realtimeStreamingModel = realtimeStreamingModel
+        self.showRealtimeTranscriptionOption = showRealtimeTranscriptionOption
         self.dictationAudioInterruptionEnabled = dictationAudioInterruptionEnabled
         self.recordingOverlayLayout = recordingOverlayLayout
         self.overlayWaveformDisplayMode = overlayWaveformDisplayMode
@@ -2684,6 +2809,100 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
+    func discardPendingLocalAISelection(for feature: AIProcessingFeature) {
+        setPendingLocalAIModelID(nil, for: feature)
+    }
+
+    @MainActor
+    func discardUndownloadedLocalAISelections() {
+        let retainedSelections = pendingLocalAISelections.filter { _, modelID in
+            guard let model = LocalAIModelCatalog.model(id: modelID) else {
+                return false
+            }
+            let state = localAIInstallState(for: model)
+            return state.isInstalling
+                || state.progress.isCancelled
+                || state.issue != nil
+        }
+        guard retainedSelections != pendingLocalAISelections else { return }
+        pendingLocalAISelections = retainedSelections
+    }
+
+    @MainActor
+    func commitModelSettingsDrafts(
+        transcriptionEnabled requestedTranscriptionEnabled: Bool,
+        transcriptionChoice: TranscriptionBackendChoice,
+        postProcessingEnabled requestedPostProcessingEnabled: Bool,
+        postProcessingChoice: AIProcessingBackendChoice,
+        contextEnabled requestedContextEnabled: Bool,
+        contextChoice: AIProcessingBackendChoice
+    ) {
+        discardUndownloadedLocalAISelections()
+
+        if requestedTranscriptionEnabled,
+           let readyChoice = readyNoteBrowserTranscriptionChoice(
+                preferred: transcriptionChoice
+           ) {
+            applyNoteBrowserTranscriptionChoice(readyChoice)
+            transcriptionEnabled = true
+        } else {
+            transcriptionEnabled = false
+        }
+
+        commitAIProcessingSettingsDraft(
+            feature: .postProcessing,
+            isEnabled: requestedPostProcessingEnabled,
+            preferredChoice: postProcessingChoice
+        )
+        commitAIProcessingSettingsDraft(
+            feature: .context,
+            isEnabled: requestedContextEnabled,
+            preferredChoice: contextChoice
+        )
+    }
+
+    @MainActor
+    func reconcileModelSelectionsAfterSettingsDismissal() {
+        commitModelSettingsDrafts(
+            transcriptionEnabled: transcriptionEnabled,
+            transcriptionChoice: currentNoteBrowserTranscriptionChoice,
+            postProcessingEnabled: !disablePostProcessing,
+            postProcessingChoice: postProcessingBackendChoice,
+            contextEnabled: !disableContextCapture,
+            contextChoice: contextBackendChoice
+        )
+    }
+
+    @MainActor
+    private func commitAIProcessingSettingsDraft(
+        feature: AIProcessingFeature,
+        isEnabled: Bool,
+        preferredChoice: AIProcessingBackendChoice
+    ) {
+        guard isEnabled,
+              let readyChoice = readyAIProcessingChoice(
+                preferred: preferredChoice,
+                for: feature
+              ) else {
+            switch feature {
+            case .postProcessing:
+                disablePostProcessing = true
+            case .context:
+                disableContextCapture = true
+            }
+            return
+        }
+
+        applyAIProcessingChoice(readyChoice, for: feature)
+        switch feature {
+        case .postProcessing:
+            disablePostProcessing = false
+        case .context:
+            disableContextCapture = false
+        }
+    }
+
+    @MainActor
     func isAIProcessingChoiceAvailable(
         _ choice: AIProcessingBackendChoice
     ) -> Bool {
@@ -2700,7 +2919,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
     func isAIProcessingBackendReady(
         for feature: AIProcessingFeature
     ) -> Bool {
-        switch currentAIProcessingChoice(for: feature) {
+        isAIProcessingChoiceReady(currentAIProcessingChoice(for: feature))
+    }
+
+    @MainActor
+    func isAIProcessingChoiceReady(
+        _ choice: AIProcessingBackendChoice
+    ) -> Bool {
+        switch choice {
         case .cloud:
             return !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         case .localAI(let modelID):
@@ -2711,6 +2937,41 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
             return localAIInstallState(for: model).status == .ready
         }
+    }
+
+    @MainActor
+    private func readyAIProcessingChoice(
+        preferred: AIProcessingBackendChoice? = nil,
+        for feature: AIProcessingFeature
+    ) -> AIProcessingBackendChoice? {
+        if let preferred, isAIProcessingChoiceReady(preferred) {
+            return preferred
+        }
+        let currentChoice = currentAIProcessingChoice(for: feature)
+        if isAIProcessingChoiceReady(currentChoice) {
+            return currentChoice
+        }
+
+        let availability = Self.localAIProcessingAvailabilityProvider()
+        if hasCompletedLocalAIStatusRefresh, availability.isSupported {
+            let readyModels = LocalAIModelCatalog.all.filter {
+                localAIInstallState(for: $0).status == .ready
+            }
+            let preferredModel = readyModels.first {
+                $0.id == availability.recommendedModel.id
+            } ?? readyModels.first
+            if let preferredModel {
+                return .localAI(modelID: preferredModel.id)
+            }
+        }
+
+        guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        let modelID = feature == .postProcessing
+            ? resolvedPostProcessingCloudModelID
+            : resolvedContextCloudModelID
+        return .cloud(modelID: modelID)
     }
 
     @MainActor
@@ -4783,6 +5044,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
             )
             return
         }
+        // Combined-source selection is already disabled in both input pickers
+        // while a live-only transcriber is active; this is a silent defensive
+        // guard against any bypass, not a user-facing error path.
+        guard isAudioInputSelectable(newInputID) else {
+            return
+        }
 
         let switchToken = UUID()
         activeInputSwitchToken = switchToken
@@ -4944,14 +5211,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
     /// Audio source choices shown in the recording overlay's input switcher.
     /// Limited to the source modes — the meaningful mid-recording choice — rather
     /// than the full hardware microphone list.
+    @MainActor
     private func recordingOverlayInputOptions() -> [RecordingOverlayInputOption] {
         [
             RecordingOverlayInputOption(id: AudioInputDevice.defaultMicrophoneID, name: "System Default", isStaticQuillName: true),
             RecordingOverlayInputOption(id: AudioInputDevice.systemAudioID, name: "System Audio", isStaticQuillName: true),
-            RecordingOverlayInputOption(id: AudioInputDevice.systemDefaultAndSystemAudioID, name: "System Default + System Audio", isStaticQuillName: true)
+            RecordingOverlayInputOption(
+                id: AudioInputDevice.systemDefaultAndSystemAudioID,
+                name: "System Default + System Audio",
+                isStaticQuillName: true,
+                isEnabled: isAudioInputSelectable(AudioInputDevice.systemDefaultAndSystemAudioID)
+            )
         ]
     }
 
+    @MainActor
     private func refreshOverlayInputOptions() {
         overlayManager.updateInputOptions(
             recordingOverlayInputOptions(),
@@ -5376,10 +5650,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @MainActor
     func retryTranscription(item: PipelineHistoryItem) {
         guard !retryingItemIDs.contains(item.id) else { return }
-        if noteBrowserRetryAvailability(for: item) == .needsProviderConfiguration {
-            openProviderSettings()
-            return
-        }
+        guard noteBrowserRetryAvailability(for: item) == .ready else { return }
 
         let snapshot: RetrySnapshot
         do {
@@ -9587,17 +9858,28 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func fallbackContextAtStop() -> AppContext {
         let frontmostApp = NSWorkspace.shared.frontmostApplication
         let windowTitle = focusedWindowTitle(for: frontmostApp)
+        // Context capture being off is an intentional setting, not a failure.
+        // Leave currentActivity empty so post-processing runs genuinely
+        // text-only (empty CONTEXT in the prompt, nothing to echo back) and the
+        // note shows no context line — instead of injecting a placeholder
+        // sentence that reads like an error.
+        let currentActivity = disableContextCapture
+            ? ""
+            : "Could not refresh app context at stop time; using text-only post-processing."
+        let screenshotError = disableContextCapture
+            ? "Context capture disabled"
+            : "No app context captured before stop"
         return AppContext(
             appName: frontmostApp?.localizedName,
             bundleIdentifier: frontmostApp?.bundleIdentifier,
             windowTitle: windowTitle,
             selectedText: nil,
-            currentActivity: "Could not refresh app context at stop time; using text-only post-processing.",
+            currentActivity: currentActivity,
             contextSystemPrompt: resolvedContextSystemPrompt(),
             contextPrompt: nil,
             screenshotDataURL: nil,
             screenshotMimeType: nil,
-            screenshotError: "No app context captured before stop"
+            screenshotError: screenshotError
         )
     }
 

--- a/Sources/NoteBrowserRecovery.swift
+++ b/Sources/NoteBrowserRecovery.swift
@@ -38,6 +38,21 @@ enum NoteBrowserRecoveryPresentation {
         bundle: Bundle = .main
     ) -> QuillUserIssuePresentation {
         let original = record.presentation(language: language, bundle: bundle)
+
+        // Local backend/model IDs are debugging detail, not something a
+        // typical user acts on for a plain transcription-process failure.
+        if record.code == .localTranscriptionFailed {
+            return QuillUserIssuePresentation(
+                title: original.title,
+                body: original.body,
+                suggestion: original.suggestion,
+                compactMessage: original.compactMessage,
+                detailsRows: [],
+                recoveryAction: original.recoveryAction,
+                severity: original.severity
+            )
+        }
+
         guard record.code == .localModelMissing,
               actionState.hasStoredAudio else {
             return original

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -1302,6 +1302,13 @@ private struct NoteDetailView: View {
         }
         return issuePresentation
     }
+    private var warningBannerCode: QuillUserIssueCode? {
+        item.userIssueRecord?.code
+    }
+    private var isWarningBannerDismissed: Bool {
+        guard let warningBannerCode else { return false }
+        return appState.isWarningBannerDismissed(noteID: item.id, code: warningBannerCode)
+    }
 
     private var suggestedCalendarTitle: String? {
         guard item.customTitle == nil,
@@ -1600,7 +1607,7 @@ private struct NoteDetailView: View {
                 emptyContentState
             } else {
                 VStack(spacing: 0) {
-                    if let warningPresentation {
+                    if let warningPresentation, !isWarningBannerDismissed {
                         QuillUserIssueView(
                             presentation: warningPresentation,
                             style: .warningBanner,
@@ -1608,6 +1615,14 @@ private struct NoteDetailView: View {
                                 performRecoveryAction(
                                     warningPresentation.recoveryAction
                                 )
+                            },
+                            onDismiss: {
+                                if let warningBannerCode {
+                                    appState.dismissWarningBanner(
+                                        noteID: item.id,
+                                        code: warningBannerCode
+                                    )
+                                }
                             }
                         )
                         .padding(.horizontal, 40)

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -434,14 +434,44 @@ struct NoteBrowserView: View {
 
     private func transcriptionChoiceMenuItem(_ display: TranscriptionChoiceDisplay) -> some View {
         Toggle(isOn: Binding<Bool>(
-            get: { appState.currentNoteBrowserTranscriptionChoice == display.choice },
+            get: {
+                appState.transcriptionEnabled
+                    && appState.currentNoteBrowserTranscriptionChoice == display.choice
+            },
             set: { isSelected in
-                if isSelected { appState.setNoteBrowserTranscriptionChoice(display.choice) }
+                if isSelected {
+                    appState.setNoteBrowserTranscriptionSelection(display.choice)
+                }
             }
         )) {
             Text(display.localizedCompactLabel())
         }
-        .disabled(!display.isAvailable)
+        .disabled(!appState.isNoteBrowserTranscriptionChoiceReady(display.choice))
+    }
+
+    private var transcriptionOffMenuItem: some View {
+        Toggle(isOn: Binding<Bool>(
+            get: { !appState.transcriptionEnabled },
+            set: { isSelected in
+                if isSelected {
+                    appState.setNoteBrowserTranscriptionSelection(nil)
+                }
+            }
+        )) {
+            Text(localizedCatalogString("Off"))
+        }
+    }
+
+    private var transcriptionSelectionLabel: String {
+        appState.transcriptionEnabled
+            ? appState.noteBrowserTranscriptionChoiceLabel
+            : localizedCatalogString("Off")
+    }
+
+    private var transcriptionSelectionDetailLabel: String {
+        appState.transcriptionEnabled
+            ? appState.noteBrowserTranscriptionChoiceDetailLabel
+            : localizedCatalogString("Off")
     }
 
     private func transcriptionChoiceDisplays(in section: String) -> [TranscriptionChoiceDisplay] {
@@ -490,9 +520,10 @@ struct NoteBrowserView: View {
 
     // MARK: - Sidebar
 
-    // Down-chevron beside the Rec button to choose the audio input for the next
-    // recording (mirrors the menu bar Microphone submenu). Disabled while
-    // recording — switching the live input is done from the recording overlay.
+    // Down-chevron beside the Rec button to choose the audio input. Mirrors the
+    // menu bar Microphone submenu. While recording, selecting an input switches
+    // the active recording's input (same capability as the recording overlay's
+    // switcher) instead of only setting the preference for the next recording.
     // Starts/stops the Rec dot pulse. Stopping is wrapped in a finite animation
     // so the repeatForever context is cleanly torn down (no idle CPU), and this
     // is also called from onAppear so the pulse runs if the view opens while a
@@ -520,22 +551,34 @@ struct NoteBrowserView: View {
             .frame(width: 11, height: 22)
             .contentShape(Rectangle())
             .padding(.leading, -2)
-            .opacity(appState.isRecording ? 0.3 : 1.0)
             .overlay {
-                if !appState.isRecording {
-                    InputMenuCatcher(
-                        sources: [
-                            (AudioInputDevice.defaultMicrophoneID, "System Default"),
-                            (AudioInputDevice.systemAudioID, "System Audio"),
-                            (AudioInputDevice.systemDefaultAndSystemAudioID, "System Default + System Audio")
-                        ],
-                        mics: appState.availableMicrophones.map { ($0.uid, $0.name) },
-                        selectedID: appState.selectedMicrophoneID,
-                        onSelect: { appState.selectedMicrophoneID = $0 }
-                    )
-                }
+                InputMenuCatcher(
+                    sources: [
+                        (AudioInputDevice.defaultMicrophoneID, "System Default"),
+                        (AudioInputDevice.systemAudioID, "System Audio"),
+                        (AudioInputDevice.systemDefaultAndSystemAudioID, "System Default + System Audio")
+                    ],
+                    disabledSourceIDs: appState.isAudioInputSelectable(
+                        AudioInputDevice.systemDefaultAndSystemAudioID
+                    ) ? [] : [AudioInputDevice.systemDefaultAndSystemAudioID],
+                    mics: appState.isRecording
+                        ? []
+                        : appState.availableMicrophones.map { ($0.uid, $0.name) },
+                    selectedID: appState.selectedMicrophoneID,
+                    onSelect: { newInputID in
+                        if appState.isRecording {
+                            appState.switchActiveRecordingInput(to: newInputID)
+                        } else {
+                            appState.selectedMicrophoneID = newInputID
+                        }
+                    }
+                )
             }
-            .help("Choose audio input for the next recording")
+            .help(
+                appState.isRecording
+                    ? "Switch the active recording's audio input"
+                    : "Choose audio input for the next recording"
+            )
             .overrideCursor(.arrow)
     }
 
@@ -623,6 +666,8 @@ struct NoteBrowserView: View {
                 Spacer()
 
                 Menu {
+                    transcriptionOffMenuItem
+                    Divider()
                     Section("Cloud") {
                         ForEach(transcriptionChoiceDisplays(in: "Cloud")) { display in
                             transcriptionChoiceMenuItem(display)
@@ -634,7 +679,7 @@ struct NoteBrowserView: View {
                         }
                     }
                 } label: {
-                    Text(appState.noteBrowserTranscriptionChoiceLabel)
+                    Text(transcriptionSelectionLabel)
                         .font(.system(size: 11, weight: .semibold))
                         .lineLimit(1)
                         .truncationMode(.middle)
@@ -643,7 +688,11 @@ struct NoteBrowserView: View {
                         .background(Color.primary.opacity(0.06), in: Capsule())
                 }
                 .menuStyle(.borderlessButton)
-                .accessibilityLabel(String(localized: "Transcription method: \(appState.noteBrowserTranscriptionChoiceDetailLabel)"))
+                .accessibilityLabel(
+                    String(
+                        localized: "Transcription method: \(transcriptionSelectionDetailLabel)"
+                    )
+                )
                 .disabled(appState.isRecording || appState.isTranscribing)
             }
             .padding(.horizontal, 12)
@@ -1054,6 +1103,14 @@ private struct NoteListRow: View {
                                 .foregroundStyle(isSelected ? selectedMetaColor : .orange)
                         }
                     }
+                    if displayData.status == .audioOnly {
+                        Text(localizedCatalogString("Audio only"))
+                            .font(.system(size: 8, weight: .semibold))
+                            .foregroundStyle(selectedMetaColor)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Color.primary.opacity(0.08), in: Capsule())
+                    }
                     Spacer()
                     statusIndicator
                 }
@@ -1062,15 +1119,6 @@ private struct NoteListRow: View {
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(selectedTitleColor)
                     .lineLimit(1)
-
-                if displayData.status == .audioOnly {
-                    Text(localizedCatalogString("Audio only"))
-                        .font(.system(size: 9, weight: .semibold))
-                        .foregroundStyle(.blue)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(Color.blue.opacity(0.10), in: Capsule())
-                }
 
                 Text(displayData.preview.isEmpty ? " " : displayData.preview)
                     .font(.system(size: 11.5))
@@ -1143,7 +1191,7 @@ private struct NoteListRow: View {
             YellowSpinner(color: .orange)
         case .audioOnly:
             Circle()
-                .fill(Color.blue)
+                .fill(Color.green)
                 .frame(width: 6, height: 6)
         case .recovered:
             Image(systemName: "arrow.clockwise.circle")
@@ -1838,7 +1886,11 @@ private struct NoteDetailView: View {
                 )
             )
         case .needsProviderConfiguration:
-            appState.openProviderSettings()
+            showToast(
+                localizedCatalogString(
+                    "No transcription method is available. Configure an API key or install a Local Whisper model, then try again."
+                )
+            )
         case .noAudio:
             break
         }
@@ -2624,22 +2676,24 @@ private struct LiveRecordingBadge: View {
 /// input shows a native checkmark.
 private struct InputMenuCatcher: NSViewRepresentable {
     let sources: [(id: String, name: String)]
+    let disabledSourceIDs: Set<String>
     let mics: [(id: String, name: String)]
     let selectedID: String
     let onSelect: (String) -> Void
 
     func makeNSView(context: Context) -> CatcherView {
         let view = CatcherView()
-        view.apply(sources: sources, mics: mics, selectedID: selectedID, onSelect: onSelect)
+        view.apply(sources: sources, disabledSourceIDs: disabledSourceIDs, mics: mics, selectedID: selectedID, onSelect: onSelect)
         return view
     }
 
     func updateNSView(_ nsView: CatcherView, context: Context) {
-        nsView.apply(sources: sources, mics: mics, selectedID: selectedID, onSelect: onSelect)
+        nsView.apply(sources: sources, disabledSourceIDs: disabledSourceIDs, mics: mics, selectedID: selectedID, onSelect: onSelect)
     }
 
     final class CatcherView: NSView {
         private var sources: [(id: String, name: String)] = []
+        private var disabledSourceIDs: Set<String> = []
         private var mics: [(id: String, name: String)] = []
         private var selectedID = ""
         private var onSelect: ((String) -> Void)?
@@ -2650,11 +2704,13 @@ private struct InputMenuCatcher: NSViewRepresentable {
 
         func apply(
             sources: [(id: String, name: String)],
+            disabledSourceIDs: Set<String>,
             mics: [(id: String, name: String)],
             selectedID: String,
             onSelect: @escaping (String) -> Void
         ) {
             self.sources = sources
+            self.disabledSourceIDs = disabledSourceIDs
             self.mics = mics
             self.selectedID = selectedID
             self.onSelect = onSelect
@@ -2662,13 +2718,18 @@ private struct InputMenuCatcher: NSViewRepresentable {
 
         override func mouseDown(with event: NSEvent) {
             let menu = NSMenu()
+            // Honor our per-item isEnabled; otherwise AppKit auto-enables every
+            // item whose target responds to the action, masking the disabled state.
+            menu.autoenablesItems = false
             for option in sources {
-                menu.addItem(makeItem(option))
+                let item = makeItem(option, isStaticQuillName: true)
+                item.isEnabled = !disabledSourceIDs.contains(option.id)
+                menu.addItem(item)
             }
             if !mics.isEmpty {
                 menu.addItem(.separator())
                 for option in mics {
-                    menu.addItem(makeItem(option))
+                    menu.addItem(makeItem(option, isStaticQuillName: false))
                 }
             }
             // Flipped view: y == bounds.height is the bottom edge, so the menu
@@ -2676,8 +2737,12 @@ private struct InputMenuCatcher: NSViewRepresentable {
             menu.popUp(positioning: nil, at: NSPoint(x: 0, y: bounds.height + 2), in: self)
         }
 
-        private func makeItem(_ option: (id: String, name: String)) -> NSMenuItem {
-            let item = NSMenuItem(title: option.name, action: #selector(pick(_:)), keyEquivalent: "")
+        // `sources` entries are Quill-authored labels ("System Default", etc.)
+        // and need localizing; `mics` entries are real device names from the
+        // system and must be shown verbatim.
+        private func makeItem(_ option: (id: String, name: String), isStaticQuillName: Bool) -> NSMenuItem {
+            let title = isStaticQuillName ? String(localized: String.LocalizationValue(option.name)) : option.name
+            let item = NSMenuItem(title: title, action: #selector(pick(_:)), keyEquivalent: "")
             item.target = self
             item.representedObject = option.id
             item.state = AudioInputDevice.isSameInput(option.id, selectedID) ? .on : .off

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -864,6 +864,9 @@ Model: \(model)
         }
 
         let sanitizedTranscript = sanitizePostProcessedTranscript(content)
+        guard !Self.leaksRawTranscriptionPromptTemplate(sanitizedTranscript) else {
+            throw PostProcessingError.suspectedInstructionExecution
+        }
         if instructionExecutionGuardEnabled && appearsToHaveExecutedInstruction(
             rawTranscript: transcript,
             cleanedTranscript: sanitizedTranscript,
@@ -875,6 +878,14 @@ Model: \(model)
             transcript: sanitizedTranscript,
             prompt: promptForDisplay
         )
+    }
+
+    /// Detects the model echoing this service's own RAW_TRANSCRIPTION prompt
+    /// wrapper back as its "cleaned" output instead of actually cleaning the
+    /// text. Independent of `instructionExecutionGuardEnabled` since this is a
+    /// plain correctness failure, not a prompt-injection concern.
+    static func leaksRawTranscriptionPromptTemplate(_ value: String) -> Bool {
+        value.contains("RAW_TRANSCRIPTION")
     }
 
     private func processCommandTransform(

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -884,8 +884,13 @@ Model: \(model)
     /// wrapper back as its "cleaned" output instead of actually cleaning the
     /// text. Independent of `instructionExecutionGuardEnabled` since this is a
     /// plain correctness failure, not a prompt-injection concern.
+    ///
+    /// Matches on the wrapper's opening delimiter (`<<<RAW_TRANSCRIPTION`) — the
+    /// triple-angle marker only ever appears in the template, so legitimately
+    /// dictated text that merely mentions the word "RAW_TRANSCRIPTION" (an
+    /// identifier, variable name, or the word itself) is not rejected.
     static func leaksRawTranscriptionPromptTemplate(_ value: String) -> Bool {
-        value.contains("RAW_TRANSCRIPTION")
+        value.contains("<<<RAW_TRANSCRIPTION")
     }
 
     private func processCommandTransform(

--- a/Sources/QuillUserIssue.swift
+++ b/Sources/QuillUserIssue.swift
@@ -26,6 +26,7 @@ enum QuillUserIssueCode: String, Codable, CaseIterable, Sendable {
     case localAIModelUnavailable = "local-ai-model-unavailable"
     case localAIStartFailed = "local-ai-start-failed"
     case localAIProcessExited = "local-ai-process-exited"
+    case contextUnavailable = "context-unavailable"
     case unknown
     case legacy
 }
@@ -134,7 +135,7 @@ struct QuillUserIssueRecord: Codable, Equatable, Sendable {
             return .openSpeechRecognitionSettings
         case .screenRecordingPermissionDenied:
             return .openScreenRecordingSettings
-        case .postProcessingGuardFallback:
+        case .postProcessingGuardFallback, .contextUnavailable:
             return .none
         case .networkUnavailable, .requestTimedOut, .rateLimited,
              .providerUnavailable, .audioFileTooLarge,
@@ -369,7 +370,8 @@ private extension QuillUserIssueCode {
         switch self {
         case .postProcessingFailed, .postProcessingRateLimited,
              .postProcessingGuardFallback, .localAIModelUnavailable,
-             .localAIStartFailed, .localAIProcessExited:
+             .localAIStartFailed, .localAIProcessExited,
+             .contextUnavailable:
             return .warning
         default:
             return .error
@@ -527,6 +529,12 @@ private extension QuillUserIssueCode {
                 titleKey: "Original transcript kept",
                 bodyKey: "Quill detected that cleanup may have changed the intended meaning.",
                 suggestionKey: "Review the original transcript before using it."
+            )
+        case .contextUnavailable:
+            return QuillUserIssueCopy(
+                titleKey: "Context wasn't available",
+                bodyKey: "Continued with text-only post-processing.",
+                suggestionKey: "No action needed. Context capture will be attempted again next time."
             )
         case .unknown:
             return QuillUserIssueCopy(

--- a/Sources/QuillUserIssueView.swift
+++ b/Sources/QuillUserIssueView.swift
@@ -10,6 +10,10 @@ struct QuillUserIssueView: View {
     let presentation: QuillUserIssuePresentation
     var style: QuillUserIssueViewStyle = .full
     var action: (() -> Void)?
+    // Only meaningful for .warningBanner: when non-nil, a small close button
+    // renders top-right of the banner. The centered error card (.full /
+    // .inline styles) never passes this, so it never gets a dismiss control.
+    var onDismiss: (() -> Void)?
 
     var body: some View {
         switch style {
@@ -68,6 +72,7 @@ struct QuillUserIssueView: View {
 
             Spacer(minLength: 8)
             actionButton
+            dismissButton
         }
         .padding(10)
         .background(
@@ -78,6 +83,19 @@ struct QuillUserIssueView: View {
             RoundedRectangle(cornerRadius: 10)
                 .stroke(accentColor.opacity(0.15), lineWidth: 1)
         )
+    }
+
+    @ViewBuilder
+    private var dismissButton: some View {
+        if let onDismiss {
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(localizedCatalogString("Dismiss"))
+        }
     }
 
     private var inlineView: some View {

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -5,13 +5,15 @@ import AppKit
 
 struct RecordingOverlayInputOption: Identifiable, Equatable {
     let id: String
+    let isEnabled: Bool
     private let name: String
     private let isStaticQuillName: Bool
 
-    init(id: String, name: String, isStaticQuillName: Bool = false) {
+    init(id: String, name: String, isStaticQuillName: Bool = false, isEnabled: Bool = true) {
         self.id = id
         self.name = name
         self.isStaticQuillName = isStaticQuillName
+        self.isEnabled = isEnabled
     }
 
     var displayName: String {
@@ -1331,11 +1333,15 @@ private struct InputMenuClickCatcher: NSViewRepresentable {
         override func mouseDown(with event: NSEvent) {
             guard !options.isEmpty else { return }
             let menu = NSMenu()
+            // Honor our per-item isEnabled; otherwise AppKit auto-enables every
+            // item whose target responds to the action, masking the disabled state.
+            menu.autoenablesItems = false
             for option in options {
                 let item = NSMenuItem(title: option.displayName, action: #selector(selectOption(_:)), keyEquivalent: "")
                 item.target = self
                 item.representedObject = option.id
                 item.state = AudioInputDevice.isSameInput(option.id, selectedID) ? .on : .off
+                item.isEnabled = option.isEnabled
                 menu.addItem(item)
             }
             // Anchor just below the view's bottom-left so the menu drops downward

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1512,11 +1512,16 @@ struct ModelsSettingsView: View {
     @State private var transcriptionAPIURLInput: String = ""
     @State private var transcriptionAPIKeyInput: String = ""
     @State private var transcriptionModelDraft = ""
+    @State private var transcriptionEnabledDraft = false
+    @State private var transcriptionChoiceDraft: TranscriptionBackendChoice?
     @State private var pendingNativeModelID: String?
-    @State private var showRealtimeTranscriptionOption = false
     @State private var realtimeStreamingModelDraft = ""
+    @State private var postProcessingEnabledDraft = false
+    @State private var postProcessingChoiceDraft: AIProcessingBackendChoice?
     @State private var postProcessingModelDraft = ""
     @State private var postProcessingFallbackModelDraft = ""
+    @State private var contextEnabledDraft = false
+    @State private var contextChoiceDraft: AIProcessingBackendChoice?
     @State private var contextModelDraft = ""
     @State private var retainedPostProcessingLocalModelID: String?
     @State private var retainedContextLocalModelID: String?
@@ -1587,10 +1592,15 @@ struct ModelsSettingsView: View {
             transcriptionAPIURLInput = appState.transcriptionAPIURL
             transcriptionAPIKeyInput = appState.transcriptionAPIKey
             transcriptionModelDraft = customStandardAPIModelDraft(for: appState.transcriptionModel)
-            showRealtimeTranscriptionOption = appState.realtimeStreamingEnabled
+            transcriptionEnabledDraft = appState.transcriptionEnabled
+            transcriptionChoiceDraft = appState.currentNoteBrowserTranscriptionChoice
             realtimeStreamingModelDraft = appState.realtimeStreamingModel
+            postProcessingEnabledDraft = !appState.disablePostProcessing
+            postProcessingChoiceDraft = appState.postProcessingBackendChoice
             postProcessingModelDraft = customAIProcessingModelDraft(for: appState.postProcessingModel)
             postProcessingFallbackModelDraft = appState.postProcessingFallbackModel
+            contextEnabledDraft = !appState.disableContextCapture
+            contextChoiceDraft = appState.contextBackendChoice
             contextModelDraft = customAIProcessingModelDraft(for: appState.contextModel)
             customVocabularyInput = appState.customVocabulary
             customSystemPromptInput = appState.customSystemPrompt.isEmpty
@@ -1601,6 +1611,24 @@ struct ModelsSettingsView: View {
                 : appState.customContextPrompt
             initializeManagedNativeModel()
             reconcileRetainedLocalAIModels()
+        }
+        .onChange(of: appState.currentNoteBrowserTranscriptionChoice) { value in
+            if transcriptionChoiceDraft != value { transcriptionChoiceDraft = value }
+        }
+        .onChange(of: appState.transcriptionEnabled) { value in
+            if transcriptionEnabledDraft != value { transcriptionEnabledDraft = value }
+        }
+        .onChange(of: appState.postProcessingBackendChoice) { value in
+            if postProcessingChoiceDraft != value { postProcessingChoiceDraft = value }
+        }
+        .onChange(of: appState.disablePostProcessing) { value in
+            if postProcessingEnabledDraft != !value { postProcessingEnabledDraft = !value }
+        }
+        .onChange(of: appState.contextBackendChoice) { value in
+            if contextChoiceDraft != value { contextChoiceDraft = value }
+        }
+        .onChange(of: appState.disableContextCapture) { value in
+            if contextEnabledDraft != !value { contextEnabledDraft = !value }
         }
         .onChange(of: appState.transcriptionAPIURL) { value in
             if transcriptionAPIURLInput != value { transcriptionAPIURLInput = value }
@@ -1625,6 +1653,18 @@ struct ModelsSettingsView: View {
         }
         .onChange(of: managedLocalAIReconciliationInputs) { _ in
             reconcileRetainedLocalAIModels()
+        }
+        .onDisappear {
+            appState.commitModelSettingsDrafts(
+                transcriptionEnabled: transcriptionEnabledDraft,
+                transcriptionChoice: settingsTranscriptionChoice,
+                postProcessingEnabled: postProcessingEnabledDraft,
+                postProcessingChoice: settingsAIProcessingChoice(
+                    for: .postProcessing
+                ),
+                contextEnabled: contextEnabledDraft,
+                contextChoice: settingsAIProcessingChoice(for: .context)
+            )
         }
     }
 
@@ -1704,42 +1744,34 @@ struct ModelsSettingsView: View {
         }
     }
 
+    private var settingsTranscriptionChoice: TranscriptionBackendChoice {
+        transcriptionChoiceDraft ?? appState.currentNoteBrowserTranscriptionChoice
+    }
+
     private var currentTranscriptionDisplay: TranscriptionChoiceDisplay {
         appState.noteBrowserTranscriptionDisplay(
-            for: appState.currentNoteBrowserTranscriptionChoice
+            for: settingsTranscriptionChoice
         )
     }
 
-    private var standardAPIModelIDs: [String] {
-        var modelIDs: [String] = []
-        for modelID in ModelConfiguration.transcriptionModels where !modelIDs.contains(modelID) {
-            modelIDs.append(modelID)
-        }
-
-        let currentModelID = appState.transcriptionModel.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !currentModelID.isEmpty && !modelIDs.contains(currentModelID) {
-            modelIDs.append(currentModelID)
-        }
-        return modelIDs
-    }
-
     private var transcriptionChoiceDisplays: [TranscriptionChoiceDisplay] {
-        let standardDisplays = standardAPIModelIDs.map { modelID in
+        let standardDisplays = appState.standardAPIModelIDs.map { modelID in
             appState.noteBrowserTranscriptionDisplay(for: .apiStandard(modelID: modelID))
         }
         let nativeDisplays = NativeWhisperModelCatalog.all.map { model in
             appState.noteBrowserTranscriptionDisplay(for: .nativeWhisper(modelID: model.id))
         }
+        // appState.noteBrowserTranscriptionChoiceDisplays already gates Realtime
+        // on showRealtimeTranscriptionOption / realtimeStreamingEnabled, so
+        // apiRealtime only appears here when it's already meant to be shown.
         let otherDisplays = appState.noteBrowserTranscriptionChoiceDisplays.filter { display in
             switch display.choice {
             case .apiStandard, .nativeWhisper:
                 return false
-            case .apiRealtime:
-                return showRealtimeTranscriptionOption || appState.realtimeStreamingEnabled
+            case .apiRealtime, .appleLive:
+                return true
             case .legacyMlxWhisper:
                 return display.isAvailable
-            case .appleLive:
-                return true
             }
         }
         return standardDisplays + nativeDisplays + otherDisplays
@@ -1747,15 +1779,26 @@ struct ModelsSettingsView: View {
 
     private var transcriptionChoice: Binding<TranscriptionBackendChoice> {
         Binding(
-            get: { appState.currentNoteBrowserTranscriptionChoice },
+            get: { settingsTranscriptionChoice },
             set: { handleTranscriptionChoiceSelection($0) }
         )
     }
 
     private var transcriptionEnabled: Binding<Bool> {
         Binding(
-            get: { appState.transcriptionEnabled },
-            set: { appState.transcriptionEnabled = $0 }
+            get: { transcriptionEnabledDraft },
+            set: { newValue in
+                transcriptionEnabledDraft = newValue
+                guard newValue else {
+                    appState.transcriptionEnabled = false
+                    return
+                }
+                guard appState.isNoteBrowserTranscriptionChoiceReady(settingsTranscriptionChoice) else {
+                    return
+                }
+                appState.setNoteBrowserTranscriptionChoice(settingsTranscriptionChoice)
+                appState.transcriptionEnabled = true
+            }
         )
     }
 
@@ -1765,29 +1808,34 @@ struct ModelsSettingsView: View {
     }
 
     private func initializeManagedNativeModel() {
-        guard case .nativeWhisper(let modelID) =
-            appState.currentNoteBrowserTranscriptionChoice else { return }
+        guard case .nativeWhisper(let modelID) = settingsTranscriptionChoice else {
+            return
+        }
         pendingNativeModelID = modelID
     }
 
     private func handleTranscriptionChoiceSelection(_ choice: TranscriptionBackendChoice) {
+        transcriptionChoiceDraft = choice
         switch choice {
         case .nativeWhisper(let modelID):
             pendingNativeModelID = modelID
-            if appState.isNoteBrowserTranscriptionChoiceAvailable(choice) {
-                appState.cancelNativeWhisperAutoSelection()
-                appState.setNoteBrowserTranscriptionChoice(choice)
-            }
         case .apiStandard, .apiRealtime, .legacyMlxWhisper, .appleLive:
             pendingNativeModelID = nil
             appState.cancelNativeWhisperAutoSelection()
+        }
+        if appState.isNoteBrowserTranscriptionChoiceReady(choice) {
             appState.setNoteBrowserTranscriptionChoice(choice)
+            appState.transcriptionEnabled = true
         }
     }
 
     private func canSelectTranscriptionDisplay(_ display: TranscriptionChoiceDisplay) -> Bool {
-        if case .nativeWhisper = display.choice { return true }
-        return display.isAvailable
+        // Settings always lets any model be selected, independent of the audio
+        // input source or install state — this is a temporary selection. When
+        // the picked model can't actually run right now, the warning below the
+        // picker explains why, and the Note Browser stays on the last ready
+        // model until Settings resolves to a usable one.
+        true
     }
 
     private func transcriptionChoiceMenuLabel(_ display: TranscriptionChoiceDisplay) -> String {
@@ -1839,7 +1887,7 @@ struct ModelsSettingsView: View {
 
     private func transcriptionChoiceMenuItem(_ display: TranscriptionChoiceDisplay) -> some View {
         Toggle(isOn: Binding(
-            get: { appState.currentNoteBrowserTranscriptionChoice == display.choice },
+            get: { settingsTranscriptionChoice == display.choice },
             set: { isSelected in
                 if isSelected { handleTranscriptionChoiceSelection(display.choice) }
             }
@@ -1859,22 +1907,64 @@ struct ModelsSettingsView: View {
         }
     }
 
+    private func settingsAIProcessingChoice(
+        for feature: AIProcessingFeature
+    ) -> AIProcessingBackendChoice {
+        switch feature {
+        case .postProcessing:
+            postProcessingChoiceDraft
+                ?? appState.currentAIProcessingChoice(for: feature)
+        case .context:
+            contextChoiceDraft
+                ?? appState.currentAIProcessingChoice(for: feature)
+        }
+    }
+
+    private func setAIProcessingChoiceDraft(
+        _ choice: AIProcessingBackendChoice,
+        for feature: AIProcessingFeature
+    ) {
+        switch feature {
+        case .postProcessing:
+            postProcessingChoiceDraft = choice
+        case .context:
+            contextChoiceDraft = choice
+        }
+    }
+
     private func aiProcessingChoiceBinding(
         for feature: AIProcessingFeature
     ) -> Binding<AIProcessingBackendChoice> {
         Binding(
-            get: { appState.currentAIProcessingChoice(for: feature) },
+            get: { settingsAIProcessingChoice(for: feature) },
             set: { handleAIProcessingChoiceSelection($0, for: feature) }
         )
+    }
+
+    private func setAIProcessingFeatureEnabled(
+        _ isEnabled: Bool,
+        for feature: AIProcessingFeature
+    ) {
+        switch feature {
+        case .postProcessing:
+            appState.disablePostProcessing = !isEnabled
+        case .context:
+            appState.disableContextCapture = !isEnabled
+        }
     }
 
     private func handleAIProcessingChoiceSelection(
         _ choice: AIProcessingBackendChoice,
         for feature: AIProcessingFeature
     ) {
+        setAIProcessingChoiceDraft(choice, for: feature)
         switch choice {
         case .cloud(let modelID):
-            appState.selectAIProcessingBackendChoice(choice, for: feature)
+            appState.discardPendingLocalAISelection(for: feature)
+            if appState.isAIProcessingChoiceReady(choice) {
+                appState.selectAIProcessingBackendChoice(choice, for: feature)
+                setAIProcessingFeatureEnabled(true, for: feature)
+            }
             syncCloudModelDraft(modelID, for: feature)
             reconcileRetainedLocalAIModel(for: feature)
         case .localAI(let modelID):
@@ -1884,6 +1974,9 @@ struct ModelsSettingsView: View {
                 || appState.currentAIProcessingChoice(for: feature) == choice
             if wasAccepted {
                 setRetainedLocalAIModelID(modelID, for: feature)
+                if appState.currentAIProcessingChoice(for: feature) == choice {
+                    setAIProcessingFeatureEnabled(true, for: feature)
+                }
             } else {
                 reconcileRetainedLocalAIModel(for: feature)
             }
@@ -1939,7 +2032,7 @@ struct ModelsSettingsView: View {
         return LocalAIManagedModelResolver.Input(
             pendingModelID: appState.pendingLocalAIModelID(for: feature),
             retainedModelID: retainedModelID,
-            currentChoice: appState.currentAIProcessingChoice(for: feature),
+            currentChoice: settingsAIProcessingChoice(for: feature),
             retainedIsInstalling: retainedState?.isInstalling ?? false,
             retainedProgressIsCancelled: retainedState?.progress.isCancelled ?? false,
             retainedHasIssue: retainedState?.issue != nil
@@ -2060,11 +2153,11 @@ struct ModelsSettingsView: View {
                     }
                 } label: {
                     if let currentDisplay = displays.first(where: {
-                        $0.choice == appState.currentAIProcessingChoice(for: feature)
+                        $0.choice == settingsAIProcessingChoice(for: feature)
                     }) {
                         Text(aiProcessingChoiceMenuLabel(currentDisplay))
                     } else {
-                        Text(verbatim: appState.currentAIProcessingChoice(for: feature).modelID)
+                        Text(verbatim: settingsAIProcessingChoice(for: feature).modelID)
                     }
                 }
                 .menuStyle(.borderlessButton)
@@ -2074,7 +2167,7 @@ struct ModelsSettingsView: View {
     }
 
     private var currentTranscriptionUsesAPI: Bool {
-        switch appState.currentNoteBrowserTranscriptionChoice {
+        switch settingsTranscriptionChoice {
         case .apiStandard, .apiRealtime:
             true
         case .nativeWhisper, .legacyMlxWhisper, .appleLive:
@@ -2089,38 +2182,27 @@ struct ModelsSettingsView: View {
         switch issue.recoveryAction {
         case .retryTranscription:
             return retry
-        case .openProviderSettings:
-            return { appState.openProviderSettings() }
-        case .openModelsSettings, .openMicrophoneSettings,
-             .openSpeechRecognitionSettings, .openScreenRecordingSettings,
-             .none:
+        case .openProviderSettings, .openModelsSettings,
+             .openMicrophoneSettings, .openSpeechRecognitionSettings,
+             .openScreenRecordingSettings, .none:
             return nil
         }
     }
 
     private func providerConfigurationWarning(_ message: String) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Label(
-                localizedCatalogString(message),
-                systemImage: "exclamationmark.triangle"
-            )
-            .font(.caption)
-            .foregroundStyle(.orange)
-
-            Button("Open Provider Settings") {
-                appState.openProviderSettings()
-            }
-            .font(.caption)
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-        }
+        Label(
+            localizedCatalogString(message),
+            systemImage: "exclamationmark.triangle"
+        )
+        .font(.caption)
+        .foregroundStyle(.orange)
     }
 
     private var transcriptionFeatureSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
                 Text(
-                    appState.transcriptionEnabled
+                    transcriptionEnabledDraft
                         ? "Convert speech to text."
                         : "Record audio without creating a transcript."
                 )
@@ -2140,7 +2222,7 @@ struct ModelsSettingsView: View {
                 if let model = managedNativeModel {
                     NativeWhisperModelRowView(
                         model: model,
-                        isSelected: appState.currentNoteBrowserTranscriptionChoice == .nativeWhisper(modelID: model.id),
+                        isSelected: settingsTranscriptionChoice == .nativeWhisper(modelID: model.id),
                         onSelect: {
                             handleTranscriptionChoiceSelection(.nativeWhisper(modelID: model.id))
                         },
@@ -2152,13 +2234,13 @@ struct ModelsSettingsView: View {
                         .foregroundStyle(.secondary)
                 }
 
-                if appState.transcriptionEnabled,
+                if transcriptionEnabledDraft,
                    currentTranscriptionUsesAPI,
                    !appState.hasTranscriptionAPIKey {
                     providerConfigurationWarning(
                         "Cloud transcription requires an API key. Add one in Cloud Provider or use the transcription override in Details."
                     )
-                } else if appState.transcriptionEnabled,
+                } else if transcriptionEnabledDraft,
                           let reason = currentTranscriptionDisplay.localizedUnavailableReason() {
                     Label(reason, systemImage: "exclamationmark.triangle")
                         .font(.caption)
@@ -2178,20 +2260,38 @@ struct ModelsSettingsView: View {
                     .padding(.top, 8)
                 }
             }
-            .disabled(!appState.transcriptionEnabled)
-            .opacity(appState.transcriptionEnabled ? 1 : 0.45)
+            .disabled(!transcriptionEnabledDraft)
+            .opacity(transcriptionEnabledDraft ? 1 : 0.45)
         }
     }
 
     private var postProcessingEnabled: Binding<Bool> {
         Binding(
-            get: { !appState.disablePostProcessing },
-            set: { appState.disablePostProcessing = !$0 }
+            get: { postProcessingEnabledDraft },
+            set: { newValue in
+                postProcessingEnabledDraft = newValue
+                guard newValue else {
+                    appState.disablePostProcessing = true
+                    return
+                }
+                guard appState.isAIProcessingChoiceReady(
+                    settingsAIProcessingChoice(for: .postProcessing)
+                ) else {
+                    return
+                }
+                appState.selectAIProcessingBackendChoice(
+                    settingsAIProcessingChoice(for: .postProcessing),
+                    for: .postProcessing
+                )
+                appState.disablePostProcessing = false
+            }
         )
     }
 
     private var postProcessingUsesCloud: Bool {
-        if case .cloud = appState.postProcessingBackendChoice { return true }
+        if case .cloud = settingsAIProcessingChoice(for: .postProcessing) {
+            return true
+        }
         return false
     }
 
@@ -2212,53 +2312,74 @@ struct ModelsSettingsView: View {
                     .accessibilityLabel("Post-processing")
             }
 
-            aiProcessingChoicePicker(for: .postProcessing)
+            VStack(alignment: .leading, spacing: 12) {
+                aiProcessingChoicePicker(for: .postProcessing)
 
-            if let model = managedLocalAIModel(for: .postProcessing) {
-                LocalAIModelRowView(
-                    feature: .postProcessing,
-                    model: model,
-                    isSelected: appState.postProcessingBackendChoice
-                        == .localAI(modelID: model.id)
-                )
-            }
+                if let model = managedLocalAIModel(for: .postProcessing) {
+                    LocalAIModelRowView(
+                        feature: .postProcessing,
+                        model: model,
+                        isSelected: settingsAIProcessingChoice(for: .postProcessing)
+                            == .localAI(modelID: model.id)
+                    )
+                }
 
-            if postProcessingUsesCloud && !hasConfiguredCloudAPIKey {
-                providerConfigurationWarning(
-                    appState.disablePostProcessing
-                        ? "Add an API key in Cloud Provider to enable Post-processing."
-                        : "Post-processing is on, but cloud processing is unavailable until an API key is configured."
-                )
-            }
+                if postProcessingEnabledDraft && postProcessingUsesCloud
+                    && !hasConfiguredCloudAPIKey {
+                    providerConfigurationWarning(
+                        "Post-processing is on, but cloud processing is unavailable until an API key is configured."
+                    )
+                }
 
-            if appState.disablePostProcessing {
-                Text("Normal dictation uses the raw transcript while Post-processing is off. Edit Mode still uses this model configuration.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+                if !postProcessingEnabledDraft {
+                    Text("Normal dictation uses the raw transcript while Post-processing is off. Edit Mode still uses this model configuration.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
 
-            if !appState.transcriptionEnabled {
-                Text("Applies to recordings when Transcription is enabled.")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-            }
+                if !transcriptionEnabledDraft {
+                    Text("Applies to recordings when Transcription is enabled.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
 
-            DisclosureGroup("Details") {
-                postProcessingDetails
-                    .padding(.top, 8)
+                DisclosureGroup("Details") {
+                    postProcessingDetails
+                        .padding(.top, 8)
+                }
             }
+            .disabled(!postProcessingEnabledDraft)
+            .opacity(postProcessingEnabledDraft ? 1 : 0.45)
         }
     }
 
     private var contextEnabled: Binding<Bool> {
         Binding(
-            get: { !appState.disableContextCapture },
-            set: { appState.disableContextCapture = !$0 }
+            get: { contextEnabledDraft },
+            set: { newValue in
+                contextEnabledDraft = newValue
+                guard newValue else {
+                    appState.disableContextCapture = true
+                    return
+                }
+                guard appState.isAIProcessingChoiceReady(
+                    settingsAIProcessingChoice(for: .context)
+                ) else {
+                    return
+                }
+                appState.selectAIProcessingBackendChoice(
+                    settingsAIProcessingChoice(for: .context),
+                    for: .context
+                )
+                appState.disableContextCapture = false
+            }
         )
     }
 
     private var contextUsesCloud: Bool {
-        if case .cloud = appState.contextBackendChoice { return true }
+        if case .cloud = settingsAIProcessingChoice(for: .context) {
+            return true
+        }
         return false
     }
 
@@ -2279,47 +2400,50 @@ struct ModelsSettingsView: View {
                     .accessibilityLabel("Context")
             }
 
-            aiProcessingChoicePicker(for: .context)
+            VStack(alignment: .leading, spacing: 12) {
+                aiProcessingChoicePicker(for: .context)
 
-            if let model = managedLocalAIModel(for: .context) {
-                LocalAIModelRowView(
-                    feature: .context,
-                    model: model,
-                    isSelected: appState.contextBackendChoice
-                        == .localAI(modelID: model.id)
-                )
-            }
+                if let model = managedLocalAIModel(for: .context) {
+                    LocalAIModelRowView(
+                        feature: .context,
+                        model: model,
+                        isSelected: settingsAIProcessingChoice(for: .context)
+                            == .localAI(modelID: model.id)
+                    )
+                }
 
-            if contextUsesLocal {
-                Text("Local Context uses app and window text only. Screenshots stay on this Mac.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+                if contextUsesLocal {
+                    Text("Local Context uses app and window text only. Screenshots stay on this Mac.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
 
-            if contextUsesCloud && !hasConfiguredCloudAPIKey {
-                providerConfigurationWarning(
-                    appState.disableContextCapture
-                        ? "Add an API key in Cloud Provider to enable Context."
-                        : "Context is on, but AI context analysis is unavailable until an API key is configured."
-                )
-            }
+                if contextEnabledDraft && contextUsesCloud
+                    && !hasConfiguredCloudAPIKey {
+                    providerConfigurationWarning(
+                        "Context is on, but AI context analysis is unavailable until an API key is configured."
+                    )
+                }
 
-            if appState.disableContextCapture {
-                Text("Context capture is off. Quill skips app context and screenshots for normal dictation.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+                if !contextEnabledDraft {
+                    Text("Context capture is off. Quill skips app context and screenshots for normal dictation.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
 
-            if !appState.transcriptionEnabled {
-                Text("Applies to recordings when Transcription is enabled.")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-            }
+                if !transcriptionEnabledDraft {
+                    Text("Applies to recordings when Transcription is enabled.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
 
-            DisclosureGroup("Details") {
-                contextDetails
-                    .padding(.top, 8)
+                DisclosureGroup("Details") {
+                    contextDetails
+                        .padding(.top, 8)
+                }
             }
+            .disabled(!contextEnabledDraft)
+            .opacity(contextEnabledDraft ? 1 : 0.45)
         }
     }
 
@@ -2463,9 +2587,9 @@ struct ModelsSettingsView: View {
 
     private var realtimeTranscriptionSetting: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Toggle("Show Realtime transcription option", isOn: $showRealtimeTranscriptionOption)
+            Toggle("Show Realtime transcription option", isOn: $appState.showRealtimeTranscriptionOption)
 
-            if showRealtimeTranscriptionOption || appState.realtimeStreamingEnabled {
+            if appState.showRealtimeTranscriptionOption || appState.realtimeStreamingEnabled {
                 Text("Realtime Transcription Model")
                     .font(.caption.weight(.semibold))
                 HStack(spacing: 8) {
@@ -2593,14 +2717,14 @@ struct ModelsSettingsView: View {
     }
 
     private var isOutputLanguageAvailable: Bool {
-        !appState.disablePostProcessing || appState.isCommandModeEnabled
+        postProcessingEnabledDraft || appState.isCommandModeEnabled
     }
 
     private var outputLanguageHelpText: String {
         let key: String
         if !isOutputLanguageAvailable {
             key = "Output Language is unavailable while Post-processing and Edit Mode are off."
-        } else if appState.disablePostProcessing {
+        } else if !postProcessingEnabledDraft {
             key = "Output Language remains available for Edit Mode transforms."
         } else {
             key = "Final transcript language for post-processing and Edit Mode transforms."

--- a/Tests/AppContextBackendTests.swift
+++ b/Tests/AppContextBackendTests.swift
@@ -17,6 +17,7 @@ struct AppContextBackendTests {
         try testAppStateContextCaptureGuardsCancelledPublication()
         try testAppStatePersistsPostProcessingIssueBeforeContextIssue()
         try testStopTimeFallbackDistinguishesDisabledFromIncompleteCapture()
+        try testResolveStoppedRecordingContextSanitizesUnusableCapture()
         try await testLocalFailureReturnsNilAndRecordsPrivateIssue()
         try await testLocalProcessExitRecordsDedicatedIssue()
         print("AppContextBackendTests passed")
@@ -452,6 +453,86 @@ struct AppContextBackendTests {
         try expect(
             body.contains("Could not refresh app context at stop time; using text-only post-processing."),
             "fallback keeps the incomplete-capture wording for the still-enabled case"
+        )
+    }
+
+    // Context is only injected into post-processing when it was successfully
+    // captured. A fallback/placeholder or error-severity capture must not be
+    // injected as if it were real activity; instead the note should show a
+    // warning (not an error) so post-processing still counts as completed.
+    private static func testResolveStoppedRecordingContextSanitizesUnusableCapture() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+
+        guard let resolveStart = source.range(of: "private func resolveStoppedRecordingContext("),
+              let resolveEnd = source.range(
+                of: "\n    @MainActor\n    private func bootstrapLastTranscriptForPasteAgain",
+                range: resolveStart.upperBound..<source.endIndex
+              ) else {
+            throw AppContextBackendTestFailure("AppState resolveStoppedRecordingContext source")
+        }
+        let resolveBody = String(source[resolveStart.lowerBound..<resolveEnd.lowerBound])
+
+        try expect(
+            resolveBody.contains("Self.sanitizedCapturedContext("),
+            "resolveStoppedRecordingContext sanitizes whatever context it resolves"
+        )
+        try expect(
+            resolveBody.contains("contextCaptureDisabled: disableContextCapture"),
+            "sanitization is gated by the current context capture setting"
+        )
+
+        guard let placeholderStart = source.range(of: "private static func isPlaceholderContextSummary("),
+              let placeholderEnd = source.range(
+                of: "\n    private static func isUsableCapturedContext",
+                range: placeholderStart.upperBound..<source.endIndex
+              ) else {
+            throw AppContextBackendTestFailure("AppState isPlaceholderContextSummary source")
+        }
+        let placeholderBody = String(source[placeholderStart.lowerBound..<placeholderEnd.lowerBound])
+        try expect(placeholderBody.contains("trimmed.isEmpty"), "empty activity counts as placeholder")
+        try expect(
+            placeholderBody.contains(
+                "Could not refresh app context at stop time; using text-only post-processing."
+            ),
+            "the stop-time fallback wording is a known placeholder"
+        )
+
+        guard let usableStart = source.range(of: "private static func isUsableCapturedContext("),
+              let usableEnd = source.range(
+                of: "\n    private static func sanitizedCapturedContext",
+                range: usableStart.upperBound..<source.endIndex
+              ) else {
+            throw AppContextBackendTestFailure("AppState isUsableCapturedContext source")
+        }
+        let usableBody = String(source[usableStart.lowerBound..<usableEnd.lowerBound])
+        try expect(
+            usableBody.contains("isPlaceholderContextSummary(context.currentActivity)"),
+            "usability requires non-placeholder activity"
+        )
+        try expect(
+            usableBody.contains(".severity != .error") || usableBody.contains(".severity == .error"),
+            "usability excludes error-severity capture issues"
+        )
+
+        guard let sanitizeStart = source.range(of: "private static func sanitizedCapturedContext("),
+              let sanitizeEnd = source.range(
+                of: "\n    private func fallbackContextAtStop",
+                range: sanitizeStart.upperBound..<source.endIndex
+              ) else {
+            throw AppContextBackendTestFailure("AppState sanitizedCapturedContext source")
+        }
+        let sanitizeBody = String(source[sanitizeStart.lowerBound..<sanitizeEnd.lowerBound])
+
+        let disabledGuardRange = try requiredRange("guard !contextCaptureDisabled else { return context }", in: sanitizeBody)
+        let usableGuardRange = try requiredRange("guard !isUsableCapturedContext(context) else { return context }", in: sanitizeBody)
+        try expect(
+            disabledGuardRange.lowerBound < usableGuardRange.lowerBound,
+            "disabled setting bypasses sanitization before checking usability"
+        )
+        try expect(sanitizeBody.contains("currentActivity: \"\""), "unusable capture is not injected")
+        try expect(
+            sanitizeBody.contains("QuillUserIssueRecord(code: .contextUnavailable)"),
+            "unusable capture attaches the context-unavailable warning"
         )
     }
 

--- a/Tests/AppContextBackendTests.swift
+++ b/Tests/AppContextBackendTests.swift
@@ -16,6 +16,7 @@ struct AppContextBackendTests {
         try await testLocalRequestUsesEndpointRequestAndSelectedModelIDs()
         try testAppStateContextCaptureGuardsCancelledPublication()
         try testAppStatePersistsPostProcessingIssueBeforeContextIssue()
+        try testStopTimeFallbackDistinguishesDisabledFromIncompleteCapture()
         try await testLocalFailureReturnsNilAndRecordsPrivateIssue()
         try await testLocalProcessExitRecordsDedicatedIssue()
         print("AppContextBackendTests passed")
@@ -425,6 +426,32 @@ struct AppContextBackendTests {
         try expect(
             contextIssue.lowerBound < normalStatus.lowerBound,
             "Context issue takes priority over normal success status"
+        )
+    }
+
+    private static func testStopTimeFallbackDistinguishesDisabledFromIncompleteCapture() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        guard let start = source.range(of: "private func fallbackContextAtStop() -> AppContext {"),
+              let end = source.range(
+                of: "private func resolvedContextSystemPrompt()",
+                range: start.upperBound..<source.endIndex
+              ) else {
+            throw AppContextBackendTestFailure("AppState fallbackContextAtStop source")
+        }
+        let body = String(source[start.lowerBound..<end.lowerBound])
+
+        // Context capture being turned off is an intentional setting: the
+        // stop-time fallback must leave the activity empty (genuine text-only
+        // post-processing, no placeholder injected into the prompt) rather than
+        // read as a failed refresh attempt.
+        try expect(
+            body.contains("disableContextCapture")
+                && body.contains("? \"\""),
+            "fallback leaves currentActivity empty when context capture is disabled"
+        )
+        try expect(
+            body.contains("Could not refresh app context at stop time; using text-only post-processing."),
+            "fallback keeps the incomplete-capture wording for the still-enabled case"
         )
     }
 

--- a/Tests/AppStateAIProcessingBackendTests.swift
+++ b/Tests/AppStateAIProcessingBackendTests.swift
@@ -80,6 +80,7 @@ struct AppStateAIProcessingBackendTests {
         try testAppDelegateStartsIdleMonitoring()
         try testTerminationRoutesThroughUnifiedModelCleanup()
         await testWarningBannerDismissalIsScopedToNoteAndResetsOnRetryGeneration()
+        try testDeletingNotesForgetsWarningBannerState()
         print("AppStateAIProcessingBackendTests passed")
     }
 
@@ -2225,6 +2226,37 @@ struct AppStateAIProcessingBackendTests {
             appState.dismissWarningBanner(noteID: noteID, code: code)
             assert(appState.isWarningBannerDismissed(noteID: noteID, code: code))
         }
+    }
+
+    // The dismissal side-store dictionaries would otherwise grow unbounded as
+    // notes are deleted, so the delete/clear paths must forget that state.
+    private static func testDeletingNotesForgetsWarningBannerState() throws {
+        let source = try appStateSource()
+
+        let deleteBody = sourceBlock(
+            in: source,
+            from: "func deleteHistoryEntry(id: UUID) {",
+            to: "func updateHistoryItemTitle("
+        )
+        assert(deleteBody.contains("forgetWarningBannerState(for: id)"))
+
+        let clearBody = sourceBlock(
+            in: source,
+            from: "func clearPipelineHistory() {",
+            to: "func deleteHistoryEntry("
+        )
+        assert(clearBody.contains("forgetAllWarningBannerState()"))
+
+        let forgetOne = sourceBlock(
+            in: source,
+            from: "private func forgetWarningBannerState(for noteID: UUID) {",
+            to: "private func forgetAllWarningBannerState() {"
+        )
+        assert(forgetOne.contains("noteRetryGenerationByID.removeValue(forKey: noteID.uuidString)"))
+        assert(forgetOne.contains("dismissedWarningBannerGeneration = dismissedWarningBannerGeneration.filter"))
+        assert(forgetOne.contains("Self.saveIntDictionary(noteRetryGenerationByID"))
+        assert(forgetOne.contains("Self.noteRetryGenerationDefaultsKey"))
+        assert(forgetOne.contains("Self.dismissedWarningBannerGenerationDefaultsKey"))
     }
 
     private static func appStateSource() throws -> String {

--- a/Tests/AppStateAIProcessingBackendTests.swift
+++ b/Tests/AppStateAIProcessingBackendTests.swift
@@ -40,6 +40,10 @@ struct AppStateAIProcessingBackendTests {
         await testChangingCloudModelWhileLocalPreservesLocalChoice()
         await testDirectCloudChoiceSynchronizesRememberedModel()
         await testPostProcessingAndContextChoicesStayIndependent()
+        await testDiscardUndownloadedSelectionsRestoresActiveChoices()
+        await testDiscardUndownloadedSelectionsPreservesStartedDownloads()
+        await testSettingsDismissalDisablesAIWithoutReadyModels()
+        await testSettingsDismissalFallsBackToReadyLocalAIModel()
         await testSameModelDownloadCoalescesAndSelectsBothFeatures()
         await testDifferentModelsStartIndependentDownloads()
         await testNativeWhisperProgressCoalescesAndCancellationWins()
@@ -273,6 +277,134 @@ struct AppStateAIProcessingBackendTests {
             appState.contextBackendChoice = .cloud(modelID: "context/cloud")
             assert(appState.postProcessingBackendChoice.isLocal)
             assert(appState.contextBackendChoice == .cloud(modelID: "context/cloud"))
+        }
+    }
+
+    private static func testDiscardUndownloadedSelectionsRestoresActiveChoices() async {
+        resetAIProcessingDefaults()
+        let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
+        let seams = LocalAISeamSnapshot()
+        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
+        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
+        defer { seams.restore() }
+
+        let model = LocalAIModelCatalog.fast
+        let appState = await makeRefreshedAppState()
+        await MainActor.run {
+            appState.apiKey = "configured-key"
+            appState.disablePostProcessing = false
+            appState.disableContextCapture = false
+            let originalPostChoice = appState.postProcessingBackendChoice
+            let originalContextChoice = appState.contextBackendChoice
+            appState.selectAIProcessingBackendChoice(
+                .localAI(modelID: model.id),
+                for: .postProcessing
+            )
+            appState.selectAIProcessingBackendChoice(
+                .localAI(modelID: model.id),
+                for: .context
+            )
+            precondition(appState.pendingLocalAIModelID(for: .postProcessing) == model.id)
+            precondition(appState.pendingLocalAIModelID(for: .context) == model.id)
+
+            appState.commitModelSettingsDrafts(
+                transcriptionEnabled: appState.transcriptionEnabled,
+                transcriptionChoice: appState.currentNoteBrowserTranscriptionChoice,
+                postProcessingEnabled: true,
+                postProcessingChoice: .localAI(modelID: model.id),
+                contextEnabled: true,
+                contextChoice: .localAI(modelID: model.id)
+            )
+
+            precondition(appState.pendingLocalAIModelID(for: .postProcessing) == nil)
+            precondition(appState.pendingLocalAIModelID(for: .context) == nil)
+            precondition(appState.postProcessingBackendChoice == originalPostChoice)
+            precondition(appState.contextBackendChoice == originalContextChoice)
+            precondition(!appState.disablePostProcessing)
+            precondition(!appState.disableContextCapture)
+        }
+    }
+
+    private static func testDiscardUndownloadedSelectionsPreservesStartedDownloads() async {
+        resetAIProcessingDefaults()
+        let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
+        let installHarness = LocalAIInstallHarness()
+        let seams = LocalAISeamSnapshot()
+        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
+        AppState.localAIInstallStarter = installHarness.start
+        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
+        defer { seams.restore() }
+
+        let model = LocalAIModelCatalog.fast
+        let appState = await makeRefreshedAppState()
+        await MainActor.run {
+            appState.selectAIProcessingBackendChoice(
+                .localAI(modelID: model.id),
+                for: .postProcessing
+            )
+            appState.installLocalAIModel(model, autoSelectFor: .postProcessing)
+            precondition(appState.localAIInstallState(for: model).isInstalling)
+
+            appState.discardUndownloadedLocalAISelections()
+
+            precondition(appState.pendingLocalAIModelID(for: .postProcessing) == model.id)
+            precondition(appState.localAIInstallState(for: model).isInstalling)
+            appState.cancelLocalAIInstall(model)
+        }
+        installHarness.complete(model: model, with: .failure(.cancelled))
+        await waitUntil { !appState.localAIInstallState(for: model).isInstalling }
+    }
+
+    private static func testSettingsDismissalDisablesAIWithoutReadyModels() async {
+        resetAIProcessingDefaults()
+        let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
+        let seams = LocalAISeamSnapshot()
+        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
+        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
+        defer { seams.restore() }
+
+        let appState = await makeRefreshedAppState()
+        await MainActor.run {
+            appState.apiKey = ""
+            appState.disablePostProcessing = false
+            appState.disableContextCapture = false
+
+            appState.reconcileModelSelectionsAfterSettingsDismissal()
+
+            precondition(appState.disablePostProcessing)
+            precondition(appState.disableContextCapture)
+        }
+    }
+
+    private static func testSettingsDismissalFallsBackToReadyLocalAIModel() async {
+        resetAIProcessingDefaults()
+        let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
+        let seams = LocalAISeamSnapshot()
+        let model = LocalAIModelCatalog.fast
+        statusHarness.set(.ready, for: model)
+        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
+        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
+        defer { seams.restore() }
+
+        let appState = await makeRefreshedAppState()
+        await MainActor.run {
+            appState.apiKey = ""
+            appState.postProcessingBackendChoice = .cloud(
+                modelID: AppState.defaultPostProcessingModel
+            )
+            appState.contextBackendChoice = .cloud(
+                modelID: AppState.defaultContextModel
+            )
+            appState.disablePostProcessing = false
+            appState.disableContextCapture = false
+
+            appState.reconcileModelSelectionsAfterSettingsDismissal()
+
+            let expected = AIProcessingBackendChoice.localAI(modelID: model.id)
+            precondition(appState.postProcessingBackendChoice == expected)
+            precondition(appState.contextBackendChoice == expected)
+            precondition(!appState.disablePostProcessing)
+            precondition(!appState.disableContextCapture)
         }
     }
 

--- a/Tests/AppStateAIProcessingBackendTests.swift
+++ b/Tests/AppStateAIProcessingBackendTests.swift
@@ -79,6 +79,7 @@ struct AppStateAIProcessingBackendTests {
         try testContextModelObserverRebuildsOnlyThroughChoiceChanges()
         try testAppDelegateStartsIdleMonitoring()
         try testTerminationRoutesThroughUnifiedModelCleanup()
+        await testWarningBannerDismissalIsScopedToNoteAndResetsOnRetryGeneration()
         print("AppStateAIProcessingBackendTests passed")
     }
 
@@ -2196,6 +2197,34 @@ struct AppStateAIProcessingBackendTests {
         )
         assert(!nativeCancellation.contains("deletePartialModel"))
         assert(!nativeCancellation.contains("refreshNativeWhisperInstallStatus()"))
+    }
+
+    // Dismissing a warning banner hides it for the note's current retry
+    // generation only; a later retry bumps the generation and invalidates
+    // the dismissal so the banner can reappear if the condition still holds.
+    private static func testWarningBannerDismissalIsScopedToNoteAndResetsOnRetryGeneration() async {
+        let appState = await makeRefreshedAppState()
+        let noteID = UUID()
+        let otherNoteID = UUID()
+        let code = QuillUserIssueCode.contextUnavailable
+
+        await MainActor.run {
+            assert(!appState.isWarningBannerDismissed(noteID: noteID, code: code))
+
+            appState.dismissWarningBanner(noteID: noteID, code: code)
+            assert(appState.isWarningBannerDismissed(noteID: noteID, code: code))
+
+            // Dismissal is scoped to this exact note + issue code.
+            assert(!appState.isWarningBannerDismissed(noteID: otherNoteID, code: code))
+            assert(!appState.isWarningBannerDismissed(noteID: noteID, code: .postProcessingFailed))
+
+            appState.incrementNoteRetryGeneration(for: noteID)
+            assert(!appState.isWarningBannerDismissed(noteID: noteID, code: code))
+
+            // Dismissing again at the new generation hides it again.
+            appState.dismissWarningBanner(noteID: noteID, code: code)
+            assert(appState.isWarningBannerDismissed(noteID: noteID, code: code))
+        }
     }
 
     private static func appStateSource() throws -> String {

--- a/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
+++ b/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
@@ -182,11 +182,38 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         precondition(switchBody.contains("activeInputSwitchToken = switchToken"))
         precondition(switchBody.contains("isActiveInputSwitchPhysicalStopInProgress = true"))
         precondition(switchBody.contains("isActiveInputSwitchPhysicalStopInProgress = false"))
+        let readinessGuardRange = try requiredRange(of: "guard isAudioInputSelectable(newInputID) else", in: switchBody)
+        let switchTokenRange = try requiredRange(of: "let switchToken = UUID()", in: switchBody)
+        precondition(readinessGuardRange.lowerBound < switchTokenRange.lowerBound)
         let stopRange = try requiredRange(of: "stopPhysicalAudioRecorder(", in: switchBody)
         let switchRange = try requiredRange(of: "controller.switchSegment(", in: switchBody)
         let startRange = try requiredRange(of: "startPhysicalAudioRecorder(inputID: newInputID)", in: switchBody)
         precondition(stopRange.lowerBound < switchRange.lowerBound)
         precondition(switchRange.lowerBound < startRange.lowerBound)
+
+        precondition(source.contains("func isAudioInputSelectable(_ inputID: String) -> Bool"))
+        let selectableBody = try functionBody(named: "isAudioInputSelectable", in: source)
+        precondition(selectableBody.contains("AudioInputDevice.isSystemDefaultAndSystemAudio(inputID)"))
+        precondition(selectableBody.contains("isActiveRecordingUsingLiveOnlyTranscription"))
+        precondition(selectableBody.contains("transcriptionEnabled && currentNoteBrowserTranscriptionChoiceIsLiveOnly"))
+        let liveOnlyBody = try body(
+            startingWith: "private var isActiveRecordingUsingLiveOnlyTranscription: Bool",
+            in: source
+        )
+        precondition(liveOnlyBody.contains("currentNoteBrowserTranscriptionChoiceIsLiveOnly"))
+        let choiceLiveOnlyBody = try body(
+            startingWith: "private var currentNoteBrowserTranscriptionChoiceIsLiveOnly: Bool",
+            in: source
+        )
+        precondition(choiceLiveOnlyBody.contains("case .appleLive, .apiRealtime:"))
+        precondition(choiceLiveOnlyBody.contains("return true"))
+
+        let overlayOptionsBody = try functionBody(named: "recordingOverlayInputOptions", in: source)
+        precondition(
+            overlayOptionsBody.contains(
+                "isEnabled: isAudioInputSelectable(AudioInputDevice.systemDefaultAndSystemAudioID)"
+            )
+        )
         precondition(switchBody.contains("controller.terminalPersistenceFailure"))
         precondition(switchBody.contains("activeRecordingStorageFailureID == controller.recordingID"))
         precondition(switchBody.contains("finishRecordingAfterJournalPersistenceFailure("))

--- a/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
+++ b/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
@@ -191,6 +191,16 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         precondition(stopRange.lowerBound < switchRange.lowerBound)
         precondition(switchRange.lowerBound < startRange.lowerBound)
 
+        // The live transcriber must be torn down off the main thread so the
+        // audio-source menu action returns immediately instead of stalling the
+        // UI while an Apple Speech session is cancelled/deallocated.
+        precondition(switchBody.contains("tearDownLiveTranscriberOffMainThread()"))
+        precondition(!switchBody.contains("liveTranscriber = nil"))
+        let offMainTeardownBody = try functionBody(named: "tearDownLiveTranscriberOffMainThread", in: source)
+        precondition(offMainTeardownBody.contains("liveTranscriber = nil"))
+        precondition(offMainTeardownBody.contains("DispatchQueue.global"))
+        precondition(offMainTeardownBody.contains("transcriber.cancel()"))
+
         precondition(source.contains("func isAudioInputSelectable(_ inputID: String) -> Bool"))
         let selectableBody = try functionBody(named: "isAudioInputSelectable", in: source)
         precondition(selectableBody.contains("AudioInputDevice.isSystemDefaultAndSystemAudio(inputID)"))

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -75,6 +75,7 @@ struct AppStateTranscriptionConfigurationTests {
         testStoppedTranscriptionCompletionSummaryHidesFallbackIndicatorForEmptyRawFallback()
         testStoppedTranscriptionSettingsSnapshotCapturesHistoryMetadata()
         try testAppStateCreatedTranscriptionServicesPassLegacyMlxWhisperToggle()
+        try testRetrySnapshotGatesStoredContextByCurrentToggleAndUsability()
         try testNativeWhisperPreparesAudioBeforeRuntime()
         try testNoteBrowserTranscriptionMenuUsesFlatNativeCheckedItems()
         await testAudioImportConfigurationUsesChoiceDerivedBackend()
@@ -1055,6 +1056,67 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(retryBody.contains("cloudExecutionContext: snapshot.cloudExecutionContext"))
         precondition(stoppedRecordingBody.contains("let capturedUseLegacyMlxWhisper = useLegacyMlxWhisper"))
         precondition(stoppedRecordingBody.contains("useLegacyMlxWhisper: capturedUseLegacyMlxWhisper,"))
+    }
+
+    // Retry never re-captures context; it reuses the note's stored
+    // contextSummary, gated by the CURRENT context-capture toggle and by
+    // whether the stored summary is actually usable (old notes may still
+    // carry the stop-time placeholder sentence).
+    private static func testRetrySnapshotGatesStoredContextByCurrentToggleAndUsability() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let snapshotBody = sourceBlock(
+            in: source,
+            from: "private func makeRetrySnapshot(for item: PipelineHistoryItem) throws -> RetrySnapshot {",
+            to: "\n    private func makeRetryHistoryItem("
+        )
+
+        precondition(
+            snapshotBody.contains("disableContextCapture"),
+            "retry gates stored context injection by the current context toggle"
+        )
+        precondition(
+            snapshotBody.contains("Self.isPlaceholderContextSummary(item.contextSummary)"),
+            "retry treats a placeholder/empty stored summary as unusable"
+        )
+        precondition(
+            snapshotBody.contains("QuillUserIssueRecord(code: .contextUnavailable)"),
+            "retry attaches the context-unavailable warning when stored context is enabled but unusable"
+        )
+        guard let restoredContextRange = snapshotBody.range(of: "restoredContext: AppContext(") else {
+            preconditionFailure("Expected restoredContext construction in makeRetrySnapshot")
+        }
+        guard let restoredContextEnd = snapshotBody.range(
+            of: "restoredIntent:",
+            range: restoredContextRange.upperBound..<snapshotBody.endIndex
+        ) else {
+            preconditionFailure("Expected restoredContext to precede restoredIntent")
+        }
+        let restoredContextBody = String(
+            snapshotBody[restoredContextRange.lowerBound..<restoredContextEnd.lowerBound]
+        )
+        precondition(
+            restoredContextBody.contains("userIssueRecord:"),
+            "restoredContext threads a userIssueRecord for the warning banner"
+        )
+
+        let retryBody = sourceBlock(
+            in: source,
+            from: "func retryTranscription(item: PipelineHistoryItem)",
+            to: "\n    @MainActor\n    private func copyRetryTranscriptToPasteboardIfNeeded"
+        )
+        guard let postProcessingIssueRange = retryBody.range(of: "result.userIssueRecord?.persistedStatus"),
+              let contextIssueRange = retryBody.range(
+                of: "snapshot.restoredContext.userIssueRecord?.persistedStatus",
+                range: postProcessingIssueRange.upperBound..<retryBody.endIndex
+              ),
+              let normalStatusRange = retryBody.range(
+                of: "Self.statusMessage(",
+                range: contextIssueRange.upperBound..<retryBody.endIndex
+              ) else {
+            preconditionFailure("Expected retry status fallback chain: post-processing issue, then context issue, then normal status")
+        }
+        precondition(postProcessingIssueRange.lowerBound < contextIssueRange.lowerBound)
+        precondition(contextIssueRange.lowerBound < normalStatusRange.lowerBound)
     }
 
     private static func testNativeWhisperPreparesAudioBeforeRuntime() throws {
@@ -2485,7 +2547,12 @@ struct AppStateTranscriptionConfigurationTests {
         assert(!retrySnapshot.contains("item.usedPostProcessing"))
         assert(retrySnapshot.contains("isAudioOnly ? customVocabulary : item.customVocabulary"))
         assert(retrySnapshot.contains("isAudioOnly ? customSystemPrompt : item.customSystemPrompt"))
-        assert(retrySnapshot.contains("currentActivity: isAudioOnly ? \"\" : item.contextSummary"))
+        // Retry no longer injects the stored contextSummary unconditionally:
+        // it is gated by the current context toggle and by whether the
+        // stored summary is actually usable (see
+        // testRetrySnapshotGatesStoredContextByCurrentToggleAndUsability).
+        assert(retrySnapshot.contains("let usesStoredContext = !isAudioOnly && !disableContextCapture"))
+        assert(retrySnapshot.contains("currentActivity: restoredCurrentActivity"))
     }
 
     private static func testAudioOnlyRetryCreatesTranscriptFileAndPreservesMetadata() throws {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -40,6 +40,12 @@ struct AppStateTranscriptionConfigurationTests {
         await testRecordOnlyDoesNotRequireAccessibility()
         await testTranscriptionOffPreservesRememberedBackend()
         await testTranscriptionOnPreservesRememberedBackendReadiness()
+        await testNoteBrowserSelectionControlsTranscriptionWithoutForgettingModel()
+        await testNoteBrowserSelectionRejectsUnreadyChoice()
+        await testSettingsTranscriptionToggleRequiresReadyRememberedChoice()
+        await testSettingsDraftPreservesPreviousReadyTranscriptionChoice()
+        await testSettingsDismissalTurnsOffTranscriptionWithoutReadyModel()
+        await testSettingsDismissalFallsBackToReadyTranscriptionModel()
         await testFreshInstallSeedsNewHiddenDefaultsOnce()
         await testCompletedInstallKeepsLegacyFallbacksWhenKeysAreMissing()
         await testStoredUserDefaultsBeatFirstInstallSeed()
@@ -95,11 +101,12 @@ struct AppStateTranscriptionConfigurationTests {
         await testRemovingAPIKeyPreservesSelectedAPIMode()
         await testRemovingAPIKeyPreservesSelectedAPIModeWhileRecording()
         await testSystemDefaultAndSystemAudioConvertsAPIRealtimeToStandard()
-        await testSystemDefaultAndSystemAudioFallsBackToSelectableAPIStandard()
+        await testSystemDefaultAndSystemAudioTurnsOffWithoutReadyFallback()
         await testSystemDefaultAndSystemAudioRejectsLiveModeSelections()
+        await testCombinedSourceDisabledWhenQueuedLiveOnlyChoiceNotRecording()
         await testSystemDefaultAndSystemAudioNormalizesStoredAPIRealtimeOnStartup()
-        await testSystemDefaultAndSystemAudioFallsBackFromStoredRealtimeToAPIStandardWithoutKey()
-        await testSystemDefaultAndSystemAudioFallsBackFromStoredAppleLiveToAPIStandardWithoutWhisper()
+        await testSystemDefaultAndSystemAudioStartupTurnsOffStoredRealtimeWithoutKey()
+        await testSystemDefaultAndSystemAudioStartupTurnsOffStoredAppleLiveWithoutWhisper()
         await testSystemDefaultAndSystemAudioFallsBackFromStoredAppleLiveToInstalledNativeWhisperWithoutReentry()
         await testRepeatedNativeWhisperSelectionRemainsStable()
         await testLegacyAndNativeWhisperTransitionsRemainStable()
@@ -435,6 +442,148 @@ struct AppStateTranscriptionConfigurationTests {
                 !appState.isNoteBrowserTranscriptionChoiceReady(
                     appState.currentNoteBrowserTranscriptionChoice
                 )
+            )
+        }
+    }
+
+    private static func testNoteBrowserSelectionControlsTranscriptionWithoutForgettingModel() async {
+        resetDefaults()
+        let appState = await MainActor.run { AppState() }
+
+        await MainActor.run {
+            appState.apiKey = "configured-key"
+            let choice = TranscriptionBackendChoice.apiStandard(
+                modelID: "remembered-model"
+            )
+            appState.setNoteBrowserTranscriptionSelection(choice)
+            precondition(appState.transcriptionEnabled)
+            precondition(appState.currentNoteBrowserTranscriptionChoice == choice)
+
+            appState.setNoteBrowserTranscriptionSelection(nil)
+            precondition(!appState.transcriptionEnabled)
+            precondition(appState.currentNoteBrowserTranscriptionChoice == choice)
+        }
+    }
+
+    private static func testNoteBrowserSelectionRejectsUnreadyChoice() async {
+        resetDefaults()
+        let appState = await MainActor.run { AppState() }
+
+        await MainActor.run {
+            appState.transcriptionEnabled = false
+            let originalChoice = appState.currentNoteBrowserTranscriptionChoice
+
+            appState.setNoteBrowserTranscriptionSelection(
+                .apiStandard(modelID: "missing-key-model")
+            )
+
+            precondition(!appState.transcriptionEnabled)
+            precondition(appState.currentNoteBrowserTranscriptionChoice == originalChoice)
+        }
+    }
+
+    private static func testSettingsTranscriptionToggleRequiresReadyRememberedChoice() async {
+        resetDefaults()
+        let appState = await MainActor.run { AppState() }
+
+        await MainActor.run {
+            appState.selectedMicrophoneID =
+                AudioInputDevice.systemDefaultAndSystemAudioID
+            appState.setNoteBrowserTranscriptionChoice(
+                .apiStandard(modelID: "remembered-model")
+            )
+            appState.transcriptionEnabled = false
+
+            appState.setSettingsTranscriptionEnabled(true)
+
+            precondition(!appState.transcriptionEnabled)
+            precondition(
+                appState.currentNoteBrowserTranscriptionChoice
+                    == .apiStandard(modelID: "remembered-model")
+            )
+
+            appState.apiKey = "configured-key"
+            appState.setSettingsTranscriptionEnabled(true)
+            precondition(appState.transcriptionEnabled)
+
+            appState.setSettingsTranscriptionEnabled(false)
+            precondition(!appState.transcriptionEnabled)
+        }
+    }
+
+    private static func testSettingsDraftPreservesPreviousReadyTranscriptionChoice() async {
+        resetDefaults()
+        let originalProvider = AppState.nativeWhisperInstallStatusProvider
+        AppState.nativeWhisperInstallStatusProvider = { _ in .ready }
+        defer { AppState.nativeWhisperInstallStatusProvider = originalProvider }
+        let appState = await MainActor.run { AppState() }
+
+        await MainActor.run {
+            let previousChoice = TranscriptionBackendChoice.nativeWhisper(
+                modelID: NativeWhisperModelCatalog.recommended.id
+            )
+            appState.setNoteBrowserTranscriptionChoice(previousChoice)
+            appState.transcriptionEnabled = true
+
+            appState.commitModelSettingsDrafts(
+                transcriptionEnabled: true,
+                transcriptionChoice: .apiStandard(modelID: "missing-key-model"),
+                postProcessingEnabled: false,
+                postProcessingChoice: appState.postProcessingBackendChoice,
+                contextEnabled: false,
+                contextChoice: appState.contextBackendChoice
+            )
+
+            precondition(appState.transcriptionEnabled)
+            precondition(appState.currentNoteBrowserTranscriptionChoice == previousChoice)
+        }
+    }
+
+    private static func testSettingsDismissalTurnsOffTranscriptionWithoutReadyModel() async {
+        resetDefaults()
+        let appState = await MainActor.run { AppState() }
+
+        await MainActor.run {
+            appState.selectedMicrophoneID =
+                AudioInputDevice.systemDefaultAndSystemAudioID
+            appState.setNoteBrowserTranscriptionChoice(
+                .apiStandard(modelID: "remembered-model")
+            )
+            appState.transcriptionEnabled = true
+
+            appState.reconcileModelSelectionsAfterSettingsDismissal()
+
+            precondition(!appState.transcriptionEnabled)
+            precondition(
+                appState.currentNoteBrowserTranscriptionChoice
+                    == .apiStandard(modelID: "remembered-model")
+            )
+        }
+    }
+
+    private static func testSettingsDismissalFallsBackToReadyTranscriptionModel() async {
+        resetDefaults()
+        let originalProvider = AppState.nativeWhisperInstallStatusProvider
+        AppState.nativeWhisperInstallStatusProvider = { _ in .ready }
+        defer { AppState.nativeWhisperInstallStatusProvider = originalProvider }
+        let appState = await MainActor.run { AppState() }
+
+        await MainActor.run {
+            appState.selectedMicrophoneID =
+                AudioInputDevice.systemDefaultAndSystemAudioID
+            appState.setNoteBrowserTranscriptionChoice(
+                .apiStandard(modelID: "remembered-model")
+            )
+            appState.transcriptionEnabled = true
+
+            appState.reconcileModelSelectionsAfterSettingsDismissal()
+
+            precondition(appState.transcriptionEnabled)
+            precondition(
+                appState.currentNoteBrowserTranscriptionChoice
+                    == .nativeWhisper(
+                        modelID: NativeWhisperModelCatalog.recommended.id
+                    )
             )
         }
     }
@@ -941,9 +1090,17 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(source.contains("ForEach(transcriptionChoiceDisplays(in: \"On This Mac\"))"))
         precondition(!source.contains("transcriptionChoiceDisplays(in: \"Legacy mlx-whisper\")"))
         precondition(menuItemSource.contains("Toggle(isOn: Binding<Bool>("))
-        precondition(menuItemSource.contains("get: { appState.currentNoteBrowserTranscriptionChoice == display.choice }"))
-        precondition(menuItemSource.contains("if isSelected { appState.setNoteBrowserTranscriptionChoice(display.choice) }"))
-        precondition(menuItemSource.contains(".disabled(!display.isAvailable)"))
+        precondition(menuItemSource.contains("appState.transcriptionEnabled"))
+        precondition(menuItemSource.contains("appState.currentNoteBrowserTranscriptionChoice == display.choice"))
+        precondition(menuItemSource.contains("appState.setNoteBrowserTranscriptionSelection(display.choice)"))
+        precondition(
+            menuItemSource.contains(
+                ".disabled(!appState.isNoteBrowserTranscriptionChoiceReady(display.choice))"
+            )
+        )
+        precondition(!menuItemSource.contains(".disabled(!display.isAvailable)"))
+        precondition(source.contains("appState.setNoteBrowserTranscriptionSelection(nil)"))
+        precondition(source.contains("localizedCatalogString(\"Off\")"))
         precondition(!menuItemSource.contains("Picker(\"Transcription\", selection:"))
         precondition(!menuItemSource.contains("Image(systemName: \"checkmark\")"))
     }
@@ -1039,12 +1196,12 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(importBody.contains("openProviderSettings()"))
 
         guard let retryGuard = retryBody.range(
-            of: "noteBrowserRetryAvailability(for: item) == .needsProviderConfiguration"
+            of: "guard noteBrowserRetryAvailability(for: item) == .ready else"
         ), let retrySnapshot = retryBody.range(of: "snapshot = try makeRetrySnapshot(for: item)") else {
-            preconditionFailure("Expected retry provider readiness guard")
+            preconditionFailure("Expected retry readiness guard")
         }
         precondition(retryGuard.lowerBound < retrySnapshot.lowerBound)
-        precondition(retryBody.contains("openProviderSettings()"))
+        precondition(!retryBody.contains("openProviderSettings()"))
     }
 
     private static func testRecordingStartRequiresProviderConfigurationBeforePermissions() throws {
@@ -1478,16 +1635,15 @@ struct AppStateTranscriptionConfigurationTests {
 
         precondition(!models.contains("showingLocalTranscriptionSettings"))
         precondition(!models.contains("Picker(\"Transcription Mode\""))
-        precondition(models.contains("@State private var showRealtimeTranscriptionOption = false"))
         precondition(models.contains("private var transcriptionChoiceDisplays: [TranscriptionChoiceDisplay]"))
-        precondition(models.contains("private var standardAPIModelIDs: [String]"))
-        precondition(models.contains("showRealtimeTranscriptionOption || appState.realtimeStreamingEnabled"))
+        precondition(models.contains("appState.standardAPIModelIDs.map"))
+        precondition(models.contains("appState.showRealtimeTranscriptionOption || appState.realtimeStreamingEnabled"))
         precondition(models.contains("appState.showLegacyMlxWhisperOptions"))
-        precondition(models.contains("ModelConfiguration.transcriptionModels"))
         precondition(models.contains("appState.noteBrowserTranscriptionDisplay(for: .apiStandard(modelID: modelID))"))
-        precondition(models.contains("appState.transcriptionModel.trimmingCharacters(in: .whitespacesAndNewlines)"))
         precondition(models.contains("private var transcriptionChoice: Binding<TranscriptionBackendChoice>"))
-        precondition(models.contains("get: { appState.currentNoteBrowserTranscriptionChoice }"))
+        precondition(models.contains("get: { transcriptionEnabledDraft }"))
+        precondition(models.contains("transcriptionEnabledDraft = newValue"))
+        precondition(models.contains("get: { settingsTranscriptionChoice }"))
         precondition(models.contains("set: { handleTranscriptionChoiceSelection($0) }"))
         precondition(models.contains("Picker(\"Model\", selection: transcriptionChoice)"))
         precondition(models.contains("@State private var pendingNativeModelID: String?"))
@@ -1653,22 +1809,19 @@ struct AppStateTranscriptionConfigurationTests {
         }
     }
 
-    private static func testSystemDefaultAndSystemAudioFallsBackToSelectableAPIStandard() async {
+    private static func testSystemDefaultAndSystemAudioTurnsOffWithoutReadyFallback() async {
         resetDefaults()
         await MainActor.run {
             let appState = AppState()
             appState.setNoteBrowserTranscriptionMode(.localAppleLive)
+            appState.transcriptionEnabled = true
             precondition(appState.currentNoteBrowserTranscriptionMode == .localAppleLive)
 
             appState.selectedMicrophoneID = AudioInputDevice.systemDefaultAndSystemAudioID
 
-            precondition(appState.currentNoteBrowserTranscriptionMode == .apiStandard)
-            precondition(!appState.useLocalTranscription)
-            precondition(
-                !appState.isNoteBrowserTranscriptionChoiceReady(
-                    appState.currentNoteBrowserTranscriptionChoice
-                )
-            )
+            precondition(!appState.transcriptionEnabled)
+            precondition(appState.currentNoteBrowserTranscriptionMode == .localAppleLive)
+            precondition(appState.useLocalTranscription)
         }
     }
 
@@ -1682,12 +1835,56 @@ struct AppStateTranscriptionConfigurationTests {
             precondition(!appState.isNoteBrowserTranscriptionModeAvailable(.localAppleLive))
             precondition(appState.isNoteBrowserTranscriptionModeAvailable(.apiStandard))
             precondition(!appState.isNoteBrowserTranscriptionModeAvailable(.localWhisper))
+            precondition(
+                !appState.noteBrowserTranscriptionDisplay(
+                    for: .apiRealtime(modelID: nil)
+                ).isAvailable
+            )
+            precondition(
+                !appState.noteBrowserTranscriptionDisplay(for: .appleLive).isAvailable
+            )
+            precondition(
+                appState.noteBrowserTranscriptionDisplay(
+                    for: .apiStandard(modelID: AppState.defaultTranscriptionModel)
+                ).isAvailable
+            )
 
             appState.setNoteBrowserTranscriptionMode(.apiRealtime)
             precondition(appState.currentNoteBrowserTranscriptionMode == .apiStandard)
 
             appState.setNoteBrowserTranscriptionMode(.localAppleLive)
             precondition(appState.currentNoteBrowserTranscriptionMode == .apiStandard)
+        }
+    }
+
+    private static func testCombinedSourceDisabledWhenQueuedLiveOnlyChoiceNotRecording() async {
+        resetDefaults()
+        await MainActor.run {
+            let appState = AppState()
+            appState.apiKey = "global-key"
+            appState.setNoteBrowserTranscriptionMode(.apiRealtime)
+            appState.transcriptionEnabled = true
+            precondition(!appState.isRecording)
+
+            precondition(
+                !appState.isAudioInputSelectable(AudioInputDevice.systemDefaultAndSystemAudioID),
+                "combined source must be disabled while queued for a live-only model, even before recording starts"
+            )
+            precondition(appState.isAudioInputSelectable(AudioInputDevice.defaultMicrophoneID))
+            precondition(appState.isAudioInputSelectable(AudioInputDevice.systemAudioID))
+
+            appState.setNoteBrowserTranscriptionMode(.apiStandard)
+            precondition(
+                appState.isAudioInputSelectable(AudioInputDevice.systemDefaultAndSystemAudioID),
+                "combined source is selectable again once the queued model doesn't need live streaming"
+            )
+
+            appState.setNoteBrowserTranscriptionMode(.apiRealtime)
+            appState.transcriptionEnabled = false
+            precondition(
+                appState.isAudioInputSelectable(AudioInputDevice.systemDefaultAndSystemAudioID),
+                "combined source is selectable when transcription is off, regardless of the remembered model"
+            )
         }
     }
 
@@ -1708,7 +1905,7 @@ struct AppStateTranscriptionConfigurationTests {
         }
     }
 
-    private static func testSystemDefaultAndSystemAudioFallsBackFromStoredRealtimeToAPIStandardWithoutKey() async {
+    private static func testSystemDefaultAndSystemAudioStartupTurnsOffStoredRealtimeWithoutKey() async {
         resetDefaults()
         let defaults = UserDefaults.standard
         defaults.set(AudioInputDevice.systemDefaultAndSystemAudioID, forKey: "selected_microphone_id")
@@ -1718,18 +1915,14 @@ struct AppStateTranscriptionConfigurationTests {
         await MainActor.run {
             let appState = AppState()
 
-            precondition(appState.currentNoteBrowserTranscriptionMode == .apiStandard)
+            precondition(!appState.transcriptionEnabled)
+            precondition(appState.currentNoteBrowserTranscriptionMode == .apiRealtime)
             precondition(!appState.useLocalTranscription)
-            precondition(!appState.realtimeStreamingEnabled)
-            precondition(
-                !appState.isNoteBrowserTranscriptionChoiceReady(
-                    appState.currentNoteBrowserTranscriptionChoice
-                )
-            )
+            precondition(appState.realtimeStreamingEnabled)
         }
     }
 
-    private static func testSystemDefaultAndSystemAudioFallsBackFromStoredAppleLiveToAPIStandardWithoutWhisper() async {
+    private static func testSystemDefaultAndSystemAudioStartupTurnsOffStoredAppleLiveWithoutWhisper() async {
         resetDefaults()
         let defaults = UserDefaults.standard
         defaults.set(AudioInputDevice.systemDefaultAndSystemAudioID, forKey: "selected_microphone_id")
@@ -1739,14 +1932,9 @@ struct AppStateTranscriptionConfigurationTests {
         await MainActor.run {
             let appState = AppState()
 
-            precondition(appState.currentNoteBrowserTranscriptionMode == .apiStandard)
-            precondition(!appState.useLocalTranscription)
-            precondition(!appState.realtimeStreamingEnabled)
-            precondition(
-                !appState.isNoteBrowserTranscriptionChoiceReady(
-                    appState.currentNoteBrowserTranscriptionChoice
-                )
-            )
+            precondition(!appState.transcriptionEnabled)
+            precondition(appState.currentNoteBrowserTranscriptionMode == .localAppleLive)
+            precondition(appState.useLocalTranscription)
         }
     }
 

--- a/Tests/ModelsSettingsUIContractTests.swift
+++ b/Tests/ModelsSettingsUIContractTests.swift
@@ -22,6 +22,7 @@ struct ModelsSettingsUIContractTests {
         try testTranscriptionUsesNativePickerAndExistingChoiceAPI(settings)
         testNativeDropdownUsesPendingContextualManagement(settings)
         testNativeManagementRegressionGuards(settings: settings, appDelegate: appDelegate, appState: appState)
+        testPendingLocalAISelectionsResetWithModelsView(settings: settings, appState: appState)
         testReviewRegressionGuards(settings)
         testPostProcessingUsesExplicitSwitchAndExistingState(settings)
         testContextUsesExplicitSwitchAndExistingState(settings)
@@ -36,6 +37,9 @@ struct ModelsSettingsUIContractTests {
         try testTranscriptionCardHasIndependentToggle()
         try testMenuBarUsesRecordingCopyWhenTranscriptionIsOff()
         testCurrentSpecDocumentsCorrectedLayout(currentSpec)
+        try testSettingsDraftsApplyImmediatelyWhenReadyOrOff(settings)
+        try testSettingsDraftsSyncFromExternalAppStateChanges(settings)
+        try testNoteBrowserSharesStandardModelsAndGatesRealtime(appState)
         print("ModelsSettingsUIContractTests passed")
     }
 
@@ -46,7 +50,6 @@ struct ModelsSettingsUIContractTests {
             "contextBackendStorageKey",
             "localAIBaseURLStorageKey",
             "localAIAPIKeyStorageKey",
-            "showRealtimeTranscriptionOptionStorageKey",
             "showLegacyTranscriptionOptionStorageKey"
         ] {
             precondition(!appState.contains(forbidden), "UI-only work added functional state: \(forbidden)")
@@ -57,8 +60,11 @@ struct ModelsSettingsUIContractTests {
             "@Published var disableContextCapture: Bool",
             "@Published var disableAutoPaste: Bool",
             "@Published var realtimeStreamingEnabled: Bool",
+            "@Published var showRealtimeTranscriptionOption: Bool",
             "@Published var showLegacyMlxWhisperOptions: Bool",
-            "func setNoteBrowserTranscriptionChoice(_ choice: TranscriptionBackendChoice)"
+            "func setNoteBrowserTranscriptionChoice(_ choice: TranscriptionBackendChoice)",
+            "var standardAPIModelIDs: [String]",
+            "ModelConfiguration.transcriptionModels"
         ] {
             precondition(appState.contains(existing), "Missing existing state/action: \(existing)")
         }
@@ -200,8 +206,8 @@ struct ModelsSettingsUIContractTests {
         precondition(models.contains("appState.hasTranscriptionAPIKey"))
         precondition(models.contains("Cloud transcription requires an API key. Add one in Cloud Provider or use the transcription override in Details."))
         precondition(models.contains("private func providerConfigurationWarning("))
-        precondition(models.contains("Button(\"Open Provider Settings\")"))
-        precondition(models.contains("appState.openProviderSettings()"))
+        precondition(!models.contains("Button(\"Open Provider Settings\")"))
+        precondition(!models.contains("appState.openProviderSettings()"))
         precondition(transcription.contains("providerConfigurationWarning("))
         precondition(postProcessing.contains("providerConfigurationWarning("))
         precondition(context.contains("providerConfigurationWarning("))
@@ -212,12 +218,12 @@ struct ModelsSettingsUIContractTests {
         precondition(!postProcessing.contains(".opacity(hasConfiguredCloudAPIKey ? 1 : 0.45)"))
         precondition(!context.contains(".disabled(!hasConfiguredCloudAPIKey)"))
         precondition(!context.contains(".opacity(hasConfiguredCloudAPIKey ? 1 : 0.45)"))
-        precondition(postProcessing.contains("if postProcessingUsesCloud && !hasConfiguredCloudAPIKey"))
-        precondition(context.contains("if contextUsesCloud && !hasConfiguredCloudAPIKey"))
+        precondition(postProcessing.contains("if postProcessingEnabledDraft && postProcessingUsesCloud"))
+        precondition(context.contains("if contextEnabledDraft && contextUsesCloud"))
         precondition(models.contains("localizedCatalogString(message)"))
-        precondition(postProcessing.contains("Add an API key in Cloud Provider to enable Post-processing."))
+        precondition(!postProcessing.contains("Add an API key in Cloud Provider to enable Post-processing."))
         precondition(postProcessing.contains("Post-processing is on, but cloud processing is unavailable until an API key is configured."))
-        precondition(context.contains("Add an API key in Cloud Provider to enable Context."))
+        precondition(!context.contains("Add an API key in Cloud Provider to enable Context."))
         precondition(context.contains("Context is on, but AI context analysis is unavailable until an API key is configured."))
         precondition(!postProcessingDetails.contains(".disabled(!hasConfiguredCloudAPIKey)"))
         precondition(!context.contains("contextPromptSection\n                    .disabled(!hasConfiguredCloudAPIKey)"))
@@ -236,18 +242,14 @@ struct ModelsSettingsUIContractTests {
         )
 
         precondition(models.contains("private var transcriptionChoice: Binding<TranscriptionBackendChoice>"))
-        precondition(models.contains("get: { appState.currentNoteBrowserTranscriptionChoice }"))
+        precondition(models.contains("get: { settingsTranscriptionChoice }"))
         precondition(models.contains("set: { handleTranscriptionChoiceSelection($0) }"))
-        precondition(models.contains("@State private var showRealtimeTranscriptionOption = false"))
         precondition(models.contains("private var transcriptionChoiceDisplays: [TranscriptionChoiceDisplay]"))
-        precondition(models.contains("private var standardAPIModelIDs: [String]"))
-        precondition(models.contains("ModelConfiguration.transcriptionModels"))
+        precondition(models.contains("appState.standardAPIModelIDs.map"))
         precondition(models.contains("appState.noteBrowserTranscriptionChoiceDisplays"))
-        precondition(models.contains("showRealtimeTranscriptionOption || appState.realtimeStreamingEnabled"))
+        precondition(models.contains("appState.showRealtimeTranscriptionOption || appState.realtimeStreamingEnabled"))
         precondition(models.contains("appState.showLegacyMlxWhisperOptions"))
         precondition(models.contains("appState.noteBrowserTranscriptionDisplay(for: .apiStandard(modelID: modelID))"))
-        precondition(models.contains("appState.transcriptionModel.trimmingCharacters(in: .whitespacesAndNewlines)"))
-        precondition(models.contains("!modelIDs.contains(currentModelID)"))
         precondition(picker.contains("transcriptionChoiceDisplays.filter { $0.section == section }"))
         precondition(picker.contains("if #available(macOS 14.0, *)"))
         precondition(picker.contains("Picker(\"Model\", selection: transcriptionChoice)"))
@@ -257,11 +259,21 @@ struct ModelsSettingsUIContractTests {
         precondition(picker.contains(".selectionDisabled(!canSelectTranscriptionDisplay(display))"))
         precondition(picker.contains("transcriptionChoiceMenuItem(display)"))
         precondition(picker.contains(".disabled(!canSelectTranscriptionDisplay(display))"))
+        // Settings lets any model be selected (temporary selection); it must not
+        // gate selectability on the shared display availability the way the
+        // Note Browser does.
+        let canSelect = block(
+            in: models,
+            from: "private func canSelectTranscriptionDisplay(_ display: TranscriptionChoiceDisplay) -> Bool",
+            to: "\n    private func transcriptionChoiceMenuLabel"
+        )
+        precondition(!canSelect.contains("return display.isAvailable"))
+        precondition(canSelect.contains("true"))
         precondition(picker.contains(".pickerStyle(.menu)"))
         precondition(picker.contains(".frame(minWidth: 280, maxWidth: 320, alignment: .leading)"))
         precondition(picker.contains("Menu {"))
         precondition(!models.contains("Required · Always On"))
-        precondition(models.contains("Toggle(\"Show Realtime transcription option\", isOn: $showRealtimeTranscriptionOption)"))
+        precondition(models.contains("Toggle(\"Show Realtime transcription option\", isOn: $appState.showRealtimeTranscriptionOption)"))
         precondition(!models.contains("Toggle(\"Show Realtime transcription option\", isOn: $appState.realtimeStreamingEnabled)"))
     }
 
@@ -292,7 +304,7 @@ struct ModelsSettingsUIContractTests {
         precondition(models.contains("NativeWhisperModelCatalog.all.map"))
         precondition(models.contains("handleTranscriptionChoiceSelection($0)"))
         precondition(models.contains("pendingNativeModelID = modelID"))
-        precondition(models.contains("appState.isNoteBrowserTranscriptionChoiceAvailable(choice)"))
+        precondition(models.contains("appState.isNoteBrowserTranscriptionChoiceReady(choice)"))
         precondition(models.contains("appState.cancelNativeWhisperAutoSelection()"))
         precondition(models.contains("private var managedNativeModel: NativeWhisperModel?"))
         precondition(models.contains("private func transcriptionChoiceMenuLabel(_ display: TranscriptionChoiceDisplay) -> String"))
@@ -366,6 +378,30 @@ struct ModelsSettingsUIContractTests {
         precondition(models.contains("appState.cancelNativeWhisperAutoSelection()"))
     }
 
+    private static func testPendingLocalAISelectionsResetWithModelsView(
+        settings: String,
+        appState: String
+    ) {
+        let models = block(
+            in: settings,
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Shortcuts Settings"
+        )
+        for draftState in [
+            "@State private var transcriptionEnabledDraft = false",
+            "@State private var transcriptionChoiceDraft: TranscriptionBackendChoice?",
+            "@State private var postProcessingEnabledDraft = false",
+            "@State private var postProcessingChoiceDraft: AIProcessingBackendChoice?",
+            "@State private var contextEnabledDraft = false",
+            "@State private var contextChoiceDraft: AIProcessingBackendChoice?"
+        ] {
+            precondition(models.contains(draftState))
+        }
+        precondition(models.contains(".onDisappear {"))
+        precondition(models.contains("appState.commitModelSettingsDrafts("))
+        precondition(appState.contains("func commitModelSettingsDrafts("))
+    }
+
     private static func testReviewRegressionGuards(_ source: String) {
         let models = block(
             in: source,
@@ -399,7 +435,7 @@ struct ModelsSettingsUIContractTests {
         precondition(menuItem.contains("handleTranscriptionChoiceSelection(display.choice)"))
         precondition(!menuItem.contains("appState.setNoteBrowserTranscriptionChoice(display.choice)"))
         precondition(outputLanguage.contains("private var isOutputLanguageAvailable: Bool"))
-        precondition(outputLanguage.contains("!appState.disablePostProcessing || appState.isCommandModeEnabled"))
+        precondition(outputLanguage.contains("postProcessingEnabledDraft || appState.isCommandModeEnabled"))
         precondition(outputLanguage.contains(".disabled(!isOutputLanguageAvailable)"))
         precondition(outputLanguage.contains(".opacity(isOutputLanguageAvailable ? 1 : 0.55)"))
         precondition(outputLanguage.contains("Output Language is unavailable while Post-processing and Edit Mode are off."))
@@ -420,8 +456,8 @@ struct ModelsSettingsUIContractTests {
         )
 
         for expected in [
-            "get: { !appState.disableContextCapture }",
-            "set: { appState.disableContextCapture = !$0 }",
+            "get: { contextEnabledDraft }",
+            "contextEnabledDraft = newValue",
             "customAIProcessingModelSetting(",
             "contextPromptSection",
             "selection: $appState.contextScreenshotMaxDimension"
@@ -435,6 +471,11 @@ struct ModelsSettingsUIContractTests {
         ] {
             precondition(context.contains(expected), "Missing Context switch presentation: \(expected)")
         }
+        precondition(context.contains(".disabled(!contextEnabledDraft)"))
+        precondition(context.contains(".opacity(contextEnabledDraft ? 1 : 0.45)"))
+        precondition(
+            context.contains("if contextEnabledDraft && contextUsesCloud")
+        )
         precondition(!context.contains("Text(contextEnabled.wrappedValue ? \"On\" : \"Off\")"))
     }
 
@@ -451,8 +492,8 @@ struct ModelsSettingsUIContractTests {
         )
 
         for expected in [
-            "get: { !appState.disablePostProcessing }",
-            "set: { appState.disablePostProcessing = !$0 }",
+            "get: { postProcessingEnabledDraft }",
+            "postProcessingEnabledDraft = newValue",
             "Toggle(\"\", isOn: postProcessingEnabled)",
             ".toggleStyle(.switch)",
             ".accessibilityLabel(\"Post-processing\")",
@@ -472,6 +513,15 @@ struct ModelsSettingsUIContractTests {
         ] {
             precondition(postProcessing.contains(expected), "Missing Post-processing switch presentation: \(expected)")
         }
+        precondition(postProcessing.contains(".disabled(!postProcessingEnabledDraft)"))
+        precondition(
+            postProcessing.contains(".opacity(postProcessingEnabledDraft ? 1 : 0.45)")
+        )
+        precondition(
+            postProcessing.contains(
+                "if postProcessingEnabledDraft && postProcessingUsesCloud"
+            )
+        )
         precondition(!postProcessing.contains("Text(postProcessingEnabled.wrappedValue ? \"On\" : \"Off\")"))
         precondition(!models.contains(".disabled(appState.disablePostProcessing || appState.useLocalTranscription)"))
     }
@@ -604,7 +654,7 @@ struct ModelsSettingsUIContractTests {
         precondition(models.contains("aiProcessingChoiceMenuLabel"))
         precondition(models.contains("Text(aiProcessingChoiceMenuLabel(currentDisplay))"))
 
-        precondition(choiceBinding.contains("get: { appState.currentAIProcessingChoice(for: feature) }"))
+        precondition(choiceBinding.contains("get: { settingsAIProcessingChoice(for: feature) }"))
         precondition(choiceBinding.contains("handleAIProcessingChoiceSelection($0, for: feature)"))
         precondition(cloudChoiceSelection.contains("appState.selectAIProcessingBackendChoice(choice, for: feature)"))
         precondition(cloudChoiceSelection.contains("syncCloudModelDraft(modelID, for: feature)"))
@@ -636,7 +686,7 @@ struct ModelsSettingsUIContractTests {
         precondition(retainedResolver.contains("LocalAIManagedModelResolver.Input("))
         precondition(retainedResolver.contains("pendingModelID: appState.pendingLocalAIModelID(for: feature)"))
         precondition(retainedResolver.contains("retainedModelID: retainedModelID"))
-        precondition(retainedResolver.contains("currentChoice: appState.currentAIProcessingChoice(for: feature)"))
+        precondition(retainedResolver.contains("currentChoice: settingsAIProcessingChoice(for: feature)"))
         precondition(retainedResolver.contains("retainedIsInstalling: retainedState?.isInstalling ?? false"))
         precondition(retainedResolver.contains("retainedProgressIsCancelled: retainedState?.progress.isCancelled ?? false"))
         precondition(retainedResolver.contains("retainedHasIssue: retainedState?.issue != nil"))
@@ -664,10 +714,10 @@ struct ModelsSettingsUIContractTests {
 
         precondition(postProcessing.contains("managedLocalAIModel(for: .postProcessing)"))
         precondition(postProcessing.contains("feature: .postProcessing"))
-        precondition(postProcessing.contains("appState.postProcessingBackendChoice"))
+        precondition(postProcessing.contains("settingsAIProcessingChoice(for: .postProcessing)"))
         precondition(context.contains("managedLocalAIModel(for: .context)"))
         precondition(context.contains("feature: .context"))
-        precondition(context.contains("appState.contextBackendChoice"))
+        precondition(context.contains("settingsAIProcessingChoice(for: .context)"))
         precondition(context.contains("Local Context uses app and window text only. Screenshots stay on this Mac."))
 
         precondition(postProcessingDetails.contains("customAIProcessingModelSetting("))
@@ -828,8 +878,10 @@ struct ModelsSettingsUIContractTests {
         )
 
         precondition(source.contains("Record audio without creating a transcript."))
-        precondition(source.contains(".disabled(!appState.transcriptionEnabled)"))
-        precondition(section.contains("} else if appState.transcriptionEnabled,"))
+        precondition(source.contains(".disabled(!transcriptionEnabledDraft)"))
+        precondition(source.contains(".opacity(transcriptionEnabledDraft ? 1 : 0.45)"))
+        precondition(section.contains("if transcriptionEnabledDraft,"))
+        precondition(section.contains("} else if transcriptionEnabledDraft,"))
         precondition(section.contains("let reason = currentTranscriptionDisplay.localizedUnavailableReason()"))
         precondition(!section.contains("} else if let reason = currentTranscriptionDisplay.localizedUnavailableReason()"))
     }
@@ -852,6 +904,86 @@ struct ModelsSettingsUIContractTests {
         precondition(source.contains("Cloud Provider, Transcription, Post-processing, Context의 네 peer card"))
         precondition(source.contains("persisted On/Off 모양은 유지"))
         precondition(source.contains("Settings 진입 시 key를 재검증하는 network request도 추가하지 않는다"))
+    }
+
+    private static func testSettingsDraftsApplyImmediatelyWhenReadyOrOff(
+        _ source: String
+    ) throws {
+        let transcriptionEnabledBinding = block(
+            in: source,
+            from: "private var transcriptionEnabled: Binding<Bool> {",
+            to: "\n    private var managedNativeModel"
+        )
+        precondition(transcriptionEnabledBinding.contains("appState.transcriptionEnabled = false"))
+        precondition(
+            transcriptionEnabledBinding.contains(
+                "appState.isNoteBrowserTranscriptionChoiceReady(settingsTranscriptionChoice)"
+            )
+        )
+        precondition(transcriptionEnabledBinding.contains("appState.transcriptionEnabled = true"))
+
+        let choiceSelection = block(
+            in: source,
+            from: "private func handleTranscriptionChoiceSelection(",
+            to: "\n    private func canSelectTranscriptionDisplay"
+        )
+        precondition(choiceSelection.contains("appState.setNoteBrowserTranscriptionChoice(choice)"))
+        precondition(choiceSelection.contains("appState.transcriptionEnabled = true"))
+
+        let postProcessingEnabledBinding = block(
+            in: source,
+            from: "private var postProcessingEnabled: Binding<Bool> {",
+            to: "\n    private var postProcessingUsesCloud"
+        )
+        precondition(postProcessingEnabledBinding.contains("appState.disablePostProcessing = true"))
+        precondition(postProcessingEnabledBinding.contains("appState.disablePostProcessing = false"))
+
+        let contextEnabledBinding = block(
+            in: source,
+            from: "private var contextEnabled: Binding<Bool> {",
+            to: "\n    private var contextFeatureSection"
+        )
+        precondition(contextEnabledBinding.contains("appState.disableContextCapture = true"))
+        precondition(contextEnabledBinding.contains("appState.disableContextCapture = false"))
+
+        let aiChoiceSelection = block(
+            in: source,
+            from: "private func handleAIProcessingChoiceSelection(",
+            to: "\n    private func setRetainedLocalAIModelID"
+        )
+        precondition(aiChoiceSelection.contains("setAIProcessingFeatureEnabled(true, for: feature)"))
+    }
+
+    private static func testSettingsDraftsSyncFromExternalAppStateChanges(
+        _ source: String
+    ) throws {
+        for expected in [
+            "onChange(of: appState.currentNoteBrowserTranscriptionChoice)",
+            "onChange(of: appState.transcriptionEnabled)",
+            "onChange(of: appState.postProcessingBackendChoice)",
+            "onChange(of: appState.disablePostProcessing)",
+            "onChange(of: appState.contextBackendChoice)",
+            "onChange(of: appState.disableContextCapture)"
+        ] {
+            precondition(source.contains(expected), "Missing external draft sync: \(expected)")
+        }
+    }
+
+    private static func testNoteBrowserSharesStandardModelsAndGatesRealtime(
+        _ appState: String
+    ) throws {
+        let displaysBody = block(
+            in: appState,
+            from: "var noteBrowserTranscriptionChoiceDisplays: [TranscriptionChoiceDisplay] {",
+            to: "\n    @MainActor\n    func label(for mode:"
+        )
+        precondition(displaysBody.contains("standardAPIModelIDs.map"))
+        precondition(
+            displaysBody.contains(
+                "(showRealtimeTranscriptionOption || realtimeStreamingEnabled)"
+            )
+        )
+        precondition(displaysBody.contains("noteBrowserTranscriptionDisplay(for: apiRealtimeChoice)"))
     }
 
     private static func source(_ path: String) throws -> String {

--- a/Tests/NoteBrowserRecoveryTests.swift
+++ b/Tests/NoteBrowserRecoveryTests.swift
@@ -9,6 +9,7 @@ struct NoteBrowserRecoveryTests {
         testProviderConfigurationPresentationOpensProviderSettings()
         testReadyMissingModelSwitchesToRetry()
         testMissingAudioKeepsGenericIssuePresentation()
+        testLocalTranscriptionFailedHidesDebugDetails()
         print("NoteBrowserRecoveryTests passed")
     }
 
@@ -139,5 +140,35 @@ struct NoteBrowserRecoveryTests {
 
         precondition(presentation.title == record.presentation(language: "en").title)
         precondition(presentation.recoveryAction == .openModelsSettings)
+    }
+
+    private static func testLocalTranscriptionFailedHidesDebugDetails() {
+        let record = QuillUserIssueRecord(
+            code: .localTranscriptionFailed,
+            context: QuillUserIssueContext(
+                modelID: "whisper-large-v3-turbo",
+                localBackend: "Apple Speech"
+            )
+        )
+        let original = record.presentation(language: "en")
+        precondition(!original.detailsRows.isEmpty, "precondition: original issue has debug details")
+
+        let state = NoteBrowserActionState(
+            hasStoredAudio: true,
+            transcript: "",
+            retryAvailability: .ready
+        )
+        let presentation = NoteBrowserRecoveryPresentation.presentation(
+            for: record,
+            actionState: state,
+            language: "en",
+            bundle: .main
+        )
+
+        precondition(presentation.title == original.title)
+        precondition(presentation.body == original.body)
+        precondition(presentation.suggestion == original.suggestion)
+        precondition(presentation.detailsRows.isEmpty)
+        precondition(presentation.recoveryAction == original.recoveryAction)
     }
 }

--- a/Tests/PostProcessingBackendTests.swift
+++ b/Tests/PostProcessingBackendTests.swift
@@ -11,6 +11,7 @@ struct PostProcessingBackendTests {
         try testLocalManagerErrorsMapToDedicatedIssues()
         try testInvalidCloudBaseURLIsNotRelabeledAsLocal()
         try await testLeakedRawTranscriptionTemplateIsTreatedAsFailure()
+        try await testStandaloneRawTranscriptionWordIsNotTreatedAsLeak()
         print("PostProcessingBackendTests passed")
     }
 
@@ -80,6 +81,22 @@ struct PostProcessingBackendTests {
                 customVocabulary: ""
             )
         }
+    }
+
+    private static func testStandaloneRawTranscriptionWordIsNotTreatedAsLeak() async throws {
+        // Legit dictation that merely mentions the word "RAW_TRANSCRIPTION"
+        // (without the template's `<<<` wrapper delimiter) must pass through.
+        let cleaned = "The variable RAW_TRANSCRIPTION holds the raw text."
+        let service = makeLocalService { request in
+            try successResponse(request: request, content: cleaned)
+        }
+
+        let result = try await service.postProcess(
+            transcript: "clean this",
+            context: testContext,
+            customVocabulary: ""
+        )
+        try expect(result.transcript == cleaned, "standalone RAW_TRANSCRIPTION word passes through")
     }
 
     private static func testLocalManagerErrorsMapToDedicatedIssues() throws {

--- a/Tests/PostProcessingBackendTests.swift
+++ b/Tests/PostProcessingBackendTests.swift
@@ -10,6 +10,7 @@ struct PostProcessingBackendTests {
         try await testLocalCommandTransformUsesEndpointWithoutCloudFallback()
         try testLocalManagerErrorsMapToDedicatedIssues()
         try testInvalidCloudBaseURLIsNotRelabeledAsLocal()
+        try await testLeakedRawTranscriptionTemplateIsTreatedAsFailure()
         print("PostProcessingBackendTests passed")
     }
 
@@ -60,6 +61,25 @@ struct PostProcessingBackendTests {
         }
 
         try await assertRateLimitedLocalScenario(scenario, label: "command")
+    }
+
+    private static func testLeakedRawTranscriptionTemplateIsTreatedAsFailure() async throws {
+        // instructionExecutionGuardEnabled is false here (see makeLocalService),
+        // so this must be caught independently of that user-facing toggle.
+        let service = makeLocalService { request in
+            try successResponse(
+                request: request,
+                content: "<<<RAW_TRANSCRIPTION\nsome garbled echo\nRAW_TRANSCRIPTION"
+            )
+        }
+
+        try await expectFailure("leaked RAW_TRANSCRIPTION template") {
+            _ = try await service.postProcess(
+                transcript: "clean this",
+                context: testContext,
+                customVocabulary: ""
+            )
+        }
     }
 
     private static func testLocalManagerErrorsMapToDedicatedIssues() throws {

--- a/Tests/QuillUserIssueTests.swift
+++ b/Tests/QuillUserIssueTests.swift
@@ -44,7 +44,8 @@ struct QuillUserIssueTests {
             .postProcessingGuardFallback,
             .localAIModelUnavailable,
             .localAIStartFailed,
-            .localAIProcessExited
+            .localAIProcessExited,
+            .contextUnavailable
         ]
 
         for code in QuillUserIssueCode.allCases {
@@ -97,6 +98,10 @@ struct QuillUserIssueTests {
         try expect(
             QuillUserIssueRecord(code: .postProcessingGuardFallback).recoveryAction == .none,
             "guard fallback does not trigger automatic recovery"
+        )
+        try expect(
+            QuillUserIssueRecord(code: .contextUnavailable).recoveryAction == .none,
+            "context unavailable is informational only, no recovery action"
         )
     }
 

--- a/Tests/QuillUserIssueUIContractTests.swift
+++ b/Tests/QuillUserIssueUIContractTests.swift
@@ -16,6 +16,7 @@ struct QuillUserIssueUIContractTests {
         try testSettingsTestsUseStructuredIssues(settings)
         try testRunLogSanitizesMachineStatuses(settings)
         try testRecoveryActionsUseExistingRoutes(noteBrowser, appState)
+        try testDismissibleBannerScopedToWarningStyle(issueView, noteBrowser, appState)
         print("QuillUserIssueUIContractTests passed")
     }
 
@@ -154,6 +155,66 @@ struct QuillUserIssueUIContractTests {
         try expect(noteBrowser.contains("appState.openScreenCaptureSettings()"), "screen action uses existing route")
         try expect(appState.contains("func openSpeechRecognitionSettings()"), "AppState exposes speech privacy route")
         try expect(!noteBrowser.contains("downloadModel()"), "error recovery never starts an implicit model download")
+    }
+
+    // Dismiss (X) is only meaningful for the compact .warningBanner style;
+    // the centered .full error card must never grow a dismiss control.
+    private static func testDismissibleBannerScopedToWarningStyle(
+        _ issueView: String,
+        _ noteBrowser: String,
+        _ appState: String
+    ) throws {
+        try expect(
+            issueView.contains("var onDismiss: (() -> Void)?"),
+            "shared issue renderer accepts an optional dismiss handler"
+        )
+        let bannerView = block(
+            issueView,
+            from: "private var bannerView: some View {",
+            to: "private var inlineView: some View {"
+        )
+        try expect(bannerView.contains("dismissButton"), "banner style renders the dismiss control")
+        let fullView = block(
+            issueView,
+            from: "private var fullView: some View {",
+            to: "private var bannerView: some View {"
+        )
+        try expect(!fullView.contains("dismissButton"), "centered error card never renders a dismiss control")
+        try expect(!fullView.contains("onDismiss"), "centered error card ignores onDismiss entirely")
+
+        let warningBannerUsage = block(
+            noteBrowser,
+            from: "if let warningPresentation, !isWarningBannerDismissed {",
+            to: "NoteTextView(text: displayContent"
+        )
+        try expect(warningBannerUsage.contains("style: .warningBanner"), "sanity: this is the warning banner usage")
+        try expect(warningBannerUsage.contains("onDismiss:"), "warning banner usage wires a dismiss handler")
+
+        let errorCardUsage = block(
+            noteBrowser,
+            from: "if let issuePresentation {",
+            to: ".fill(Color.primary.opacity(0.04))"
+        )
+        try expect(errorCardUsage.contains("QuillUserIssueView("), "sanity: this is the centered error card usage")
+        try expect(!errorCardUsage.contains("onDismiss"), "centered error card usage never passes onDismiss")
+
+        try expect(
+            appState.contains("func isWarningBannerDismissed(noteID: UUID, code: QuillUserIssueCode) -> Bool"),
+            "AppState exposes per-note, per-code dismissal lookup"
+        )
+        try expect(
+            appState.contains("func dismissWarningBanner(noteID: UUID, code: QuillUserIssueCode)"),
+            "AppState exposes a dismissal setter"
+        )
+        let retryBody = block(
+            appState,
+            from: "func retryTranscription(item: PipelineHistoryItem)",
+            to: "private func copyRetryTranscriptToPasteboardIfNeeded"
+        )
+        try expect(
+            retryBody.contains("incrementNoteRetryGeneration(for: item.id)"),
+            "retry bumps the note's retry generation, invalidating stale dismissals"
+        )
     }
 
     private static func source(_ path: String) throws -> String {

--- a/Tests/QuillUserIssueUIContractTests.swift
+++ b/Tests/QuillUserIssueUIContractTests.swift
@@ -122,9 +122,9 @@ struct QuillUserIssueUIContractTests {
             "Context prompt test uses shared recovery routing"
         )
         try expect(
-            source.contains("case .openProviderSettings:")
-                && source.contains("appState.openProviderSettings()"),
-            "Settings prompt issues can open Provider settings"
+            source.contains("case .openProviderSettings, .openModelsSettings")
+                && !source.contains("appState.openProviderSettings()"),
+            "Settings prompt issues omit no-op Provider navigation"
         )
         try expect(
             source.contains("contextTestIssue = context.userIssueRecord"),

--- a/Tests/RecoveredRecordingNoteBrowserSourceTests.swift
+++ b/Tests/RecoveredRecordingNoteBrowserSourceTests.swift
@@ -41,9 +41,70 @@ struct RecoveredRecordingNoteBrowserSourceTests {
         precondition(source.contains("NoteFileExportView("))
         precondition(source.contains("Image(systemName: \"square.and.arrow.down\")"))
         precondition(source.contains("Image(systemName: \"ellipsis\")"))
+        try testRetryWithoutReadyModelUsesToast(source)
         try testAudioOnlyNoteUsesDedicatedNormalState()
+        try testInputPickerSwitchesActiveRecordingInput(source)
+        try testInputMenuCatcherDisablesAndLocalizesSources(source)
 
         print("RecoveredRecordingNoteBrowserSourceTests passed")
+    }
+
+    private static func testRetryWithoutReadyModelUsesToast(
+        _ source: String
+    ) throws {
+        let retryAction = block(
+            source,
+            from: "private func retryTranscription()",
+            to: "private func showToast("
+        )
+        let providerBranch = block(
+            retryAction,
+            from: "case .needsProviderConfiguration:",
+            to: "case .noAudio:"
+        )
+        precondition(providerBranch.contains("showToast("))
+        precondition(
+            providerBranch.contains(
+                "No transcription method is available. Configure an API key or install a Local Whisper model, then try again."
+            )
+        )
+        precondition(!providerBranch.contains("appState.openProviderSettings()"))
+    }
+
+    private static func testInputPickerSwitchesActiveRecordingInput(
+        _ source: String
+    ) throws {
+        let inputPickerMenu = block(
+            source,
+            from: "private var inputPickerMenu: some View {",
+            to: "private var sidebarPanel: some View {"
+        )
+        precondition(inputPickerMenu.contains("appState.switchActiveRecordingInput(to: newInputID)"))
+        precondition(inputPickerMenu.contains("appState.selectedMicrophoneID = newInputID"))
+        precondition(
+            inputPickerMenu.contains(
+                "disabledSourceIDs: appState.isAudioInputSelectable("
+            )
+        )
+        precondition(!inputPickerMenu.contains("if !appState.isRecording {"))
+    }
+
+    private static func testInputMenuCatcherDisablesAndLocalizesSources(
+        _ source: String
+    ) throws {
+        let catcher = block(
+            source,
+            from: "final class CatcherView: NSView {",
+            to: "@objc private func pick("
+        )
+        // NSMenu defaults to auto-enabling every item with a valid target/action,
+        // which would mask our disabled source; turn that off so isEnabled sticks.
+        precondition(catcher.contains("menu.autoenablesItems = false"))
+        precondition(catcher.contains("item.isEnabled = !disabledSourceIDs.contains(option.id)"))
+        // Quill-authored source labels must be localized; real device names verbatim.
+        precondition(
+            catcher.contains("isStaticQuillName ? String(localized: String.LocalizationValue(option.name)) : option.name")
+        )
     }
 
     private static func testAudioOnlyNoteUsesDedicatedNormalState() throws {
@@ -59,5 +120,40 @@ struct RecoveredRecordingNoteBrowserSourceTests {
         precondition(source.contains("Transcribe audio"))
         precondition(source.contains(".fill(Color.blue.opacity(0.08))"))
         precondition(source.contains(".foregroundStyle(.blue.opacity(0.75))"))
+
+        let row = block(
+            source,
+            from: "private struct NoteListRow: View",
+            to: "// MARK: - Note Detail View"
+        )
+        let header = block(
+            row,
+            from: "HStack(spacing: 4) {",
+            to: "Text(displayData.displayTitle)"
+        )
+        precondition(header.contains("if displayData.status == .audioOnly"))
+        precondition(header.contains("localizedCatalogString(\"Audio only\")"))
+        let audioOnlyStatus = block(
+            row,
+            from: "case .audioOnly:",
+            to: "case .recovered:"
+        )
+        precondition(audioOnlyStatus.contains(".fill(Color.green)"))
+        precondition(!audioOnlyStatus.contains(".fill(Color.blue)"))
+    }
+
+    private static func block(
+        _ source: String,
+        from startMarker: String,
+        to endMarker: String
+    ) -> String {
+        guard let start = source.range(of: startMarker),
+              let end = source.range(
+                of: endMarker,
+                range: start.upperBound..<source.endIndex
+              ) else {
+            preconditionFailure("Expected source block from \(startMarker) to \(endMarker)")
+        }
+        return String(source[start.lowerBound..<end.lowerBound])
     }
 }

--- a/Tests/SettingsLocalizationTests.swift
+++ b/Tests/SettingsLocalizationTests.swift
@@ -13,6 +13,7 @@ struct SettingsLocalizationTests {
         try testRecordingOverlaySettingsCopyLocalizes()
         try testModelFirstSettingsCopyLocalizes()
         try testModelDownloadTerminationCopyLocalizes()
+        try testCombinedAudioSourceUnavailableReasonsLocalize()
         print("SettingsLocalizationTests passed")
     }
 
@@ -230,6 +231,21 @@ struct SettingsLocalizationTests {
             "Quill will cancel unfinished model downloads and delete partial files before quitting.":
                 "종료하면 완료되지 않은 모델 다운로드가 취소되고 부분 다운로드 파일이 삭제됩니다.",
             "Quit and Cancel Downloads": "종료하고 다운로드 취소"
+        ]
+
+        for (key, korean) in expected {
+            assert(localizedCatalogString(key, language: "en", bundle: bundle) == key)
+            assert(localizedCatalogString(key, language: "ko", bundle: bundle) == korean)
+        }
+    }
+
+    private static func testCombinedAudioSourceUnavailableReasonsLocalize() throws {
+        let bundle = try compiledLocalizationBundle()
+        let expected: [String: String] = [
+            "Realtime is unavailable with System Default + System Audio":
+                "실시간은 시스템 기본값 + 시스템 오디오에서 사용할 수 없습니다",
+            "Apple Live is unavailable with System Default + System Audio":
+                "Apple 라이브는 시스템 기본값 + 시스템 오디오에서 사용할 수 없습니다"
         ]
 
         for (key, korean) in expected {

--- a/docs/superpowers/specs/2026-07-23-note-browser-model-consistency-design.md
+++ b/docs/superpowers/specs/2026-07-23-note-browser-model-consistency-design.md
@@ -1,0 +1,173 @@
+# Note Browser 모델 상태 일관성 후속 설계
+
+## 목표
+
+Note Browser와 Models Settings가 전사 켜짐 여부, 오디오 소스 호환성, Provider 준비 상태, 미설치 모델의 임시 선택을 일관되게 표현하도록 정리한다. 기존 상태 구조를 재사용하고 새로운 영구 저장 스키마는 추가하지 않는다.
+
+## 1. 오디오만 노트의 목록 표시
+
+기존 목록 행의 `시간 → 제목 → 내용` 3줄 구조와 고정 높이는 유지한다.
+
+- `오디오만` 배지를 제목 아래 별도 줄에서 제거하고 시간 바로 오른쪽에 같은 기준선으로 배치한다.
+- 배지는 시간 텍스트에 어울리는 작은 캡슐 크기를 사용한다.
+- 오디오만 노트의 파란 상태 점은 정상 완료 노트와 같은 녹색으로 변경한다.
+- `Not transcribed` 내용은 유지하여 색상이나 배지에만 의미를 의존하지 않는다.
+
+예상 배치:
+
+```text
+시간  [오디오만]                              ●
+제목
+내용
+```
+
+## 2. Note Browser 전사 모델 드롭다운
+
+전사 켜짐 여부와 기억된 모델을 하나의 드롭다운에서 제어한다.
+
+- 첫 항목으로 `끔`을 제공한다.
+- `끔`을 선택하면 `transcriptionEnabled`를 `false`로 바꾸고 마지막 모델 선택은 보존한다.
+- 다른 모델을 선택하면 해당 backend를 적용하고 `transcriptionEnabled`를 `true`로 바꾼다.
+- Settings에서 전사를 끄면 Note Browser도 `끔`으로 표시한다.
+- Settings에서 전사를 다시 켤 때 마지막으로 기억한 모델이 ready면 복원하고, ready가 아니면 `끔`을 유지한다.
+- 녹음이나 전사가 진행 중일 때는 현재처럼 드롭다운을 비활성화한다.
+- Settings에서는 설정과 다운로드를 위해 Cloud/API 및 미설치 Local 모델의 selectability를 유지한다.
+- Note Browser에서는 실행 readiness를 기준으로 API key가 설정된 Cloud 모델과 설치된 호환 Local 모델만 선택할 수 있다. `TranscriptionChoiceDisplay.isAvailable`(오디오 소스 capability)이 아니라 `isNoteBrowserTranscriptionChoiceReady`(capability + Provider/설치 readiness)로 항목을 비활성화하며, `setNoteBrowserTranscriptionSelection`도 unready choice 요청을 무시한다.
+
+## 7. Settings 임시 draft와 외부 active 상태 분리
+
+Settings 안에서 On/Off를 켜거나 아직 준비되지 않은 모델(미설치 Local, key 없는 Cloud)을 임시로 선택하는 것은 `ModelsSettingsView`의 로컬 draft 상태(`transcriptionEnabledDraft`, `transcriptionChoiceDraft`, `postProcessingEnabledDraft`, `postProcessingChoiceDraft`, `contextEnabledDraft`, `contextChoiceDraft`)에만 반영한다.
+
+- Settings 화면 안에서는 ready 모델이 하나도 없어도 토글을 임시로 켜고 임의의 모델을 선택할 수 있다.
+- 이 임시 상태는 그 자체로 Note Browser나 실제 녹음/처리 설정에 반영되지 않는다.
+- `ModelsSettingsView`가 사라질 때(`onDisappear`, 곧 다른 탭 이동과 Settings 종료 모두 포함) `AppState.commitModelSettingsDrafts(...)`를 호출해 draft를 한 번에 커밋한다.
+  - draft가 켜져 있고 draft 모델(또는 이전 active 모델)이 ready면 그 모델로 켠다.
+  - ready 모델이 하나도 없으면 실제 설정은 꺼짐을 유지한다(Transcription은 `끔`, Post-processing/Context는 disable).
+  - Note Browser에 표시되는 전사 선택은 커밋 이전에는 항상 이전 ready active 모델(또는 `끔`)을 그대로 유지한다.
+- 진행 중인 Local AI 다운로드와 remembered choice는 커밋 시에도 그대로 보존한다.
+
+## 8. 꺼진 섹션의 균일한 표시
+
+세 섹션(Transcription, Post-processing, Context) 모두 같은 규칙으로 꺼진 상태를 표시한다.
+
+- 섹션이 꺼져 있으면 모델 picker, 관리 행, `Details` 세부 설정을 모두 `.disabled` + 흐림 처리한다.
+- 섹션이 꺼져 있는 동안에는 Provider(API key) 경고를 표시하지 않는다. 예: "후처리를 활성화하려면 클라우드 공급자에서 API Key를 추가하세요." 문구는 섹션이 켜져 있고 Cloud를 사용 중이며 key가 없을 때만 보여준다.
+- 섹션이 켜져 있고 Cloud를 사용 중인데 key가 없을 때만 "기능은 켜져 있지만 key가 없어 사용할 수 없다"는 경고를 표시한다.
+
+## 9. Settings draft와 실제 상태의 즉시 동기화
+
+Draft는 "선택 표시"만 담당하고, 다음 두 경우는 Models 탭 이탈을 기다리지 않고 즉시 실제 상태에 반영한다.
+
+- 토글을 끄면 즉시 `transcriptionEnabled = false` / `disablePostProcessing = true` / `disableContextCapture = true`를 적용한다.
+- 토글을 켜거나 모델을 선택할 때 결과 choice가 ready면 즉시 실제 active choice와 활성화 플래그를 적용한다. ready가 아니면 draft만 갱신하고 실제 상태는 바꾸지 않는다.
+
+또한 Settings가 열려 있는 동안 외부에서(Note Browser 선택, 다른 경로의 readiness 변화 등) 실제 상태가 바뀌면 `onChange`로 draft를 즉시 재동기화해 Settings 화면이 항상 최신 실제 상태를 보여주도록 한다.
+
+## 10. 오디오 입력 변경 시 readiness 기반 자동 전사 정규화
+
+`Apple Live`처럼 혼합 오디오 소스에서 사용할 수 없게 된 선택을 자동으로 다른 모델로 넘기는 기존 정규화는 capability(선택 가능 여부)만 확인했다. 그 결과 API key가 없는 API Standard로 자동 전환되어 실제로는 쓸 수 없는 모델이 활성 선택처럼 보이는 문제가 있었다.
+
+- 오디오 입력 변경, Provider 설정 변경 등으로 트리거되는 자동 정규화는 이제 fallback 후보 중 readiness(capability + Provider/설치 준비 상태)를 만족하는 모델만 적용한다.
+- ready한 fallback이 없으면 모델을 바꾸지 않고 `transcriptionEnabled`를 꺼서 Note Browser가 `끔`으로 보이게 한다.
+- remembered backend(예: Apple Live)는 그대로 보존되어 나중에 다시 사용 가능한 소스로 돌아오면 복원할 수 있다.
+
+## 3. 오디오 소스별 모델 호환성
+
+Settings와 Note Browser는 동일한 오디오 소스 capability 판단을 사용한다.
+
+### `System Default + System Audio`
+
+녹음 종료 후 파일 전사가 가능한 모델은 선택할 수 있다.
+
+- API Standard
+- 설치된 Native Whisper
+- 설치된 Legacy mlx-whisper
+
+실시간 혼합을 지원하지 않는 모델은 목록에 표시하되 비활성화한다.
+
+- API Realtime
+- Apple Live
+
+두 화면에서 동일하게 `현재 오디오 소스에서는 사용할 수 없음` 이유를 표시한다. Settings의 `Show Realtime transcription option`이 꺼져 있으면 API Realtime은 기존처럼 숨기고, 켜져 있을 때만 비활성화 상태로 표시한다. Apple Live는 항상 표시하되 혼합 소스에서 비활성화한다.
+
+미설치 Local Whisper는 Settings에서 다운로드 준비를 위해 선택할 수 있지만 Note Browser에서는 설치 전까지 선택할 수 없다. 이는 오디오 호환성이 아니라 설치 readiness 차이로 취급한다.
+
+순수 `System Audio` 단일 소스에는 이 혼합 소스 제한을 적용하지 않는다.
+
+### 소스 변경 시 선택 정규화
+
+Realtime 또는 Apple Live가 선택된 상태에서 `System Default + System Audio`로 변경하면:
+
+1. 설치된 호환 Local Whisper가 있으면 해당 모델로 자동 전환한다.
+2. 없으면 API Standard로 전환한다.
+3. Settings와 Note Browser가 즉시 같은 선택을 표시한다.
+
+## 4. Provider 설정 액션
+
+Models Settings 내부의 `제공자 설정 열기` 버튼은 제거한다. 현재 구현은 이미 열린 Models 탭을 다시 활성화할 뿐이어서 화면 내에서는 실질적인 동작이 없다.
+
+- Transcription, Post-processing, Context의 Provider 경고 문구는 유지한다.
+- System Prompt와 Context Prompt 테스트의 Provider 오류도 안내 내용은 유지하되 Models Settings 내부 이동 버튼은 표시하지 않는다.
+- Note Browser의 명시적인 recovery action, 오디오 가져오기, 녹음 시작 전 경고 등 Settings 외부에서는 기존 `Open Provider Settings` 액션을 유지한다.
+- 오디오 노트의 재전사 버튼은 ready 모델이 없을 때 Settings를 자동으로 열지 않고 기존 Note Browser 토스트로 설정 필요성을 안내한다.
+
+## 5. 다운로드 전 임시 모델 선택 초기화
+
+미설치 모델을 선택했지만 다운로드를 시작하지 않은 상태는 Settings 화면 세션에만 유효한 임시 선택으로 취급한다.
+
+- Transcription의 현재 동작을 정본으로 삼아 세 기능에 같은 lifecycle을 적용한다.
+- Models 탭에 머무는 동안에는 다운로드 전 임시 선택과 다운로드 행을 유지한다.
+- 다른 Settings 탭으로 이동하면 Models view가 사라질 때 다운로드 전 임시 선택을 폐기한다.
+- Settings 창을 닫아도 다운로드 전 임시 선택을 폐기한다.
+- Models 탭으로 돌아오거나 Settings를 다시 열면 다운로드 행을 복원하지 않고 변경 전 실제 활성 모델을 표시한다.
+- `기본값`은 공장 초기 모델이 아니라 임시 선택 전 실제 활성 모델을 뜻한다.
+- 다운로드를 이미 시작한 경우에는 이 규칙을 적용하지 않는다. 다운로드 task와 진행 상태는 현재처럼 계속 유지한다.
+- 완료, 취소, 실패 후 상태 정리는 기존 lifecycle을 유지한다.
+
+## 6. Models 탭 이탈 시 readiness 정합화
+
+Models 탭을 벗어나거나 Settings 창을 닫을 때 세 기능을 같은 규칙으로 정리한다.
+
+- 현재 active 모델이 ready면 그대로 유지한다.
+- 현재 모델이 ready가 아니고 다른 ready 모델이 있으면 해당 모델로 fallback한다.
+- ready 모델이 하나도 없으면 Transcription, Post-processing 또는 Context의 해당 기능을 끈다.
+- remembered backend와 진행 중인 다운로드는 유지한다.
+- Post-processing과 Context가 꺼져 있으면 Transcription과 동일하게 모델 선택, 관리 행, 세부 설정을 비활성화하고 흐리게 표시한다.
+
+## 상태 경계
+
+- `transcriptionEnabled`: 전사 켜짐 또는 꺼짐
+- remembered backend: 전사가 꺼져 있을 때도 유지되는 마지막 모델
+- capability: 현재 오디오 소스에서 모델을 사용할 수 있는지 여부
+- readiness: Local 모델 설치와 Cloud API key가 실행 준비됐는지 여부
+- pending selection: 다운로드를 시작하기 전 Settings 화면의 일시적인 선택
+- download state: 실제로 시작된 다운로드 task와 진행률
+
+각 상태를 서로 대신 사용하지 않고 UI가 필요한 상태를 조합해 표시한다.
+
+## 검증 범위
+
+빠른 반영을 위해 변경 지점 중심의 코드 검증만 수행한다.
+
+1. 오디오만 목록 행의 배지 위치 계약과 녹색 상태 테스트
+2. `끔` 선택 및 모델 선택에 따른 `transcriptionEnabled` 변경 테스트
+3. 전사를 껐다 켰을 때 remembered backend 유지 테스트
+4. 혼합 오디오 소스에서 공통 모델 capability와 자동 fallback 테스트
+5. Models Settings 내부 Provider 액션 제거 계약 테스트
+6. Post-processing과 Context의 다운로드 전 임시 선택이 Models 탭 이탈과 Settings 종료 시 초기화되는 테스트
+7. 다운로드를 시작한 상태는 탭 이동과 Settings 종료 후에도 유지되는 회귀 테스트
+8. Models 탭 이탈 시 ready fallback 또는 feature off 정합화 테스트
+9. 꺼진 Post-processing과 Context 설정 영역의 비활성화 계약 테스트
+10. ready 전사 모델이 없는 재전사 버튼의 toast 계약 테스트
+11. 관련 테스트 실행, 앱 컴파일, `git diff --check`
+
+`Quill Dev` 실행, 수동 UI 확인, GUI 자동화와 반복적인 전체 테스트는 수행하지 않는다.
+
+## 비범위
+
+- 새로운 모델 선택 persistence schema
+- 오디오 소스별 별도 remembered model 저장
+- 독립 Cloud Provider Settings 탭 또는 스크롤 anchor
+- 다운로드 lifecycle 재설계
+- 순수 `System Audio`의 기존 Live transcription 정책 변경
+- Post-processing의 `Same as spoken language` prompt 처리 변경


### PR DESCRIPTION
## Summary

Makes the Note Browser and Models settings agree on which transcription models and audio sources are usable, and reworks how recording-time context is handled so post-processing only ever sees genuinely captured context.

### Transcription model & audio source consistency
- Settings lets any transcription model be temporarily selected regardless of audio input source or install state; unusable picks show the existing warning instead of being disabled.
- Note Browser lists both Cloud Standard models and gates Realtime on a persisted option shared with Settings.
- Note Browser selection is gated on readiness; unready choices are rejected.
- Combined "System Default + System Audio" is shown but disabled in the Note Browser and recording-overlay pickers whenever the active/queued transcription is live-only (Apple Live / Realtime); `NSMenu.autoenablesItems` is turned off so the disabled state is actually visible. Input-picker labels are localized.

### Context handling
- **Immediate (post-recording):** context is injected into post-processing only when it was successfully captured. If context is enabled but capture didn't succeed (stop-time fallback or a collection error), nothing is injected, the stored summary is left empty, and a non-fatal warning banner is shown — the note stays completed.
- **Re-transcription:** never re-captures; reuses stored context gated by the *current* context toggle, treats old placeholder summaries as "no context", preserves the note's stored context record, and warns when enabled but nothing usable exists.
- Post-processing rejects output that echoes the internal RAW_TRANSCRIPTION prompt template.

### Warning banners
- Warning banners get a top-right close (X), scoped to the warning-banner style only (the centered error card is unaffected).
- Dismissal is persisted per note + issue code and is invalidated by a re-transcription, so a banner reappears if its condition still holds after a retry.

### Recovery presentation
- Local transcription failures hide debug detail rows in the Note Browser.

## Testing
- `make check-test-wiring && make test-core && make test-transcription && make test-recording` — all green
- App compiles (`make all`), `git diff --check` clean
- New user-facing strings have en + ko translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 녹음 중 오디오 입력을 전환하고, 사용 가능한 입력만 선택할 수 있습니다.
  * 전사·후처리·컨텍스트 설정을 초안으로 편집한 뒤 한 번에 적용할 수 있습니다.
  * 경고 배너를 닫을 수 있으며, 재시도 시 관련 안내가 다시 표시됩니다.
  * 컨텍스트를 사용할 수 없는 상황에 대한 안내가 추가되었습니다.

* **개선 사항**
  * 전사 모델과 실시간 전사 옵션이 준비 상태에 따라 자동 조정됩니다.
  * 오디오 전용 노트 표시와 상태 색상이 개선되었습니다.
  * 로컬 전사 실패 시 불필요한 상세 정보가 숨겨집니다.
  * 후처리 결과에서 비정상적인 원문 템플릿 노출을 오류로 처리합니다.

* **현지화**
  * 오디오 입력 전환, 지원되지 않는 전사 조합, 컨텍스트 관련 안내 문구가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->