### PR TITLE
Separate prompt controls from model settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -475,6 +475,8 @@ _test-core: $(SPARKLE_STAMP) $(LOCALIZATION_STAMP) $(TEST_BUILD_DIR)/Localizatio
 	@$(TEST_BUILD_DIR)/SettingsLocalizationTests
 	@swiftc -parse-as-library Tests/ModelsSettingsUIContractTests.swift -o $(TEST_BUILD_DIR)/ModelsSettingsUIContractTests
 	@$(TEST_BUILD_DIR)/ModelsSettingsUIContractTests
+	@swiftc -parse-as-library Tests/PromptsSettingsUIContractTests.swift -o $(TEST_BUILD_DIR)/PromptsSettingsUIContractTests
+	@$(TEST_BUILD_DIR)/PromptsSettingsUIContractTests
 	@swiftc -parse-as-library Tests/QuillUserIssueUIContractTests.swift -o $(TEST_BUILD_DIR)/QuillUserIssueUIContractTests
 	@$(TEST_BUILD_DIR)/QuillUserIssueUIContractTests
 	@swiftc -parse-as-library Sources/CanonicalPCM16WAV.swift Tests/CanonicalPCM16WAVTests.swift -o $(TEST_BUILD_DIR)/CanonicalPCM16WAVTests

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -6687,6 +6687,22 @@
         }
       }
     },
+    "Prompts": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompts"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프롬프트"
+          }
+        }
+      }
+    },
     "Shortcuts": {
       "localizations": {
         "en": {

--- a/Sources/CalendarIntegrationModels.swift
+++ b/Sources/CalendarIntegrationModels.swift
@@ -4,6 +4,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     case general
     case appearance
     case models
+    case prompts
     case shortcuts
     case input
     case calendar
@@ -14,7 +15,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 
     static var orderedCases: [SettingsTab] {
-        [.general, .appearance, .models, .shortcuts, .input, .calendar, .about, .runLog, .debug]
+        [.general, .appearance, .models, .prompts, .shortcuts, .input, .calendar, .about, .runLog, .debug]
     }
 
     var title: String {
@@ -22,6 +23,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: return "General"
         case .appearance: return "Appearance"
         case .models: return "Models"
+        case .prompts: return "Prompts"
         case .shortcuts: return "Shortcuts"
         case .input: return "Input"
         case .calendar: return "Calendar"
@@ -36,6 +38,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: return "gearshape"
         case .appearance: return "paintbrush"
         case .models: return "waveform.badge.magnifyingglass"
+        case .prompts: return "text.bubble"
         case .shortcuts: return "keyboard.fill"
         case .input: return "mic.fill"
         case .calendar: return "calendar"

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -391,6 +391,8 @@ struct SettingsView: View {
                     AppearanceSettingsView()
                 case .models:
                     ModelsSettingsView()
+                case .prompts:
+                    PromptsSettingsView()
                 case .shortcuts:
                     ShortcutsSettingsView()
                 case .input:
@@ -3405,6 +3407,509 @@ struct ModelsSettingsView: View {
                         }
                         .font(.caption)
                     }
+                }
+            }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Test Context Prompt")
+                    .font(.caption.weight(.semibold))
+                Text("Captures a screenshot and metadata from the frontmost app, then runs the context prompt to infer activity.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Button {
+                    runContextPromptTest()
+                } label: {
+                    HStack(spacing: 6) {
+                        if contextTestRunning {
+                            ProgressView().controlSize(.small)
+                            Text("Running...")
+                        } else {
+                            Image(systemName: "play.fill")
+                            Text("Test Context Prompt")
+                        }
+                    }
+                }
+                .disabled(
+                    contextTestRunning
+                        || !appState.isAIProcessingBackendReady(for: .context)
+                )
+
+                if contextUsesCloud && !hasConfiguredCloudAPIKey {
+                    providerConfigurationWarning("API key required to test")
+                }
+
+                if let issue = contextTestIssue {
+                    QuillUserIssueView(
+                        presentation: issue.presentation(),
+                        style: .inline,
+                        action: settingsTestRecoveryAction(
+                            for: issue,
+                            retry: runContextPromptTest
+                        )
+                    )
+                }
+
+                if let error = contextTestError {
+                    Label(error, systemImage: "xmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+
+                if let output = contextTestOutput {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Result:")
+                            .font(.caption.weight(.semibold))
+                        Text(output.isEmpty ? "(empty — no output)" : output)
+                            .font(.system(.caption, design: .monospaced))
+                            .padding(8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color.green.opacity(0.08))
+                            .cornerRadius(6)
+                    }
+                }
+
+                if let prompt = contextTestPrompt {
+                    DisclosureGroup("Full prompt sent") {
+                        Text(prompt)
+                            .font(.system(.caption2, design: .monospaced))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func runContextPromptTest() {
+        contextTestRunning = true
+        contextTestOutput = nil
+        contextTestIssue = nil
+        contextTestError = nil
+        contextTestPrompt = nil
+
+        let service = appState.makeAppContextService()
+
+        Task {
+            let context = await service.collectContext()
+            await MainActor.run {
+                contextTestIssue = context.userIssueRecord
+                if context.userIssueRecord != nil {
+                    contextTestOutput = context.contextSummary
+                    contextTestPrompt = context.contextPrompt
+                } else if let prompt = context.contextPrompt {
+                    contextTestOutput = context.contextSummary
+                    contextTestPrompt = prompt
+                } else {
+                    contextTestError = "Context inference returned no result. This may be a permissions issue or the API could not be reached."
+                    contextTestOutput = context.contextSummary
+                }
+                contextTestRunning = false
+            }
+        }
+    }
+}
+
+// MARK: - Prompts Settings
+
+struct PromptsSettingsView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var customSystemPromptInput: String = ""
+    @State private var customContextPromptInput: String = ""
+    @State private var showDefaultSystemPrompt = false
+    @State private var showDefaultContextPrompt = false
+    @State private var systemTestInput = "Um, so I was like, thinking we should uh, refactor the authentication module, you know?"
+    @State private var systemTestRunning = false
+    @State private var systemTestOutput: String?
+    @State private var systemTestIssue: QuillUserIssueRecord?
+    @State private var systemTestPrompt: String?
+    @State private var contextTestRunning = false
+    @State private var contextTestOutput: String?
+    @State private var contextTestIssue: QuillUserIssueRecord?
+    @State private var contextTestError: String?
+    @State private var contextTestPrompt: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                SettingsCard("System Prompt", icon: "text.bubble.fill") {
+                    systemPromptSection
+                }
+                SettingsCard("Instruction Guard", icon: "shield.lefthalf.filled") {
+                    instructionGuardSection
+                }
+                SettingsCard("Context Prompt", icon: "eye.fill") {
+                    contextPromptSection
+                }
+            }
+            .padding(24)
+        }
+        .onAppear {
+            customSystemPromptInput = appState.customSystemPrompt.isEmpty
+                ? PostProcessingService.defaultSystemPrompt
+                : appState.customSystemPrompt
+            customContextPromptInput = appState.customContextPrompt.isEmpty
+                ? AppContextService.defaultContextPrompt
+                : appState.customContextPrompt
+        }
+    }
+
+    private var hasConfiguredCloudAPIKey: Bool {
+        !appState.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var postProcessingUsesCloud: Bool {
+        if case .cloud = appState.postProcessingBackendChoice { return true }
+        return false
+    }
+
+    private var contextUsesCloud: Bool {
+        if case .cloud = appState.contextBackendChoice { return true }
+        return false
+    }
+
+    private func settingsTestRecoveryAction(
+        for issue: QuillUserIssueRecord,
+        retry: @escaping () -> Void
+    ) -> (() -> Void)? {
+        switch issue.recoveryAction {
+        case .retryTranscription:
+            return retry
+        case .openProviderSettings, .openModelsSettings,
+             .openMicrophoneSettings, .openSpeechRecognitionSettings,
+             .openScreenRecordingSettings, .none:
+            return nil
+        }
+    }
+
+    private func providerConfigurationWarning(_ message: String) -> some View {
+        Label(localizedCatalogString(message), systemImage: "exclamationmark.triangle")
+            .font(.caption)
+            .foregroundStyle(.orange)
+    }
+
+    // MARK: System Prompt
+
+    private var instructionGuardSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle(
+                "Prevent dictated prompts from being executed",
+                isOn: $appState.instructionExecutionGuardEnabled
+            )
+            .toggleStyle(.switch)
+
+            Text("When enabled, \(AppName.displayName) retries or falls back to the literal transcript if post-processing looks like it answered the dictated text instead of cleaning it.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var systemPromptSection: some View {
+        let isCustom = !appState.customSystemPrompt.isEmpty
+        let hasNewerDefault = isCustom
+            && !appState.customSystemPromptLastModified.isEmpty
+            && appState.customSystemPromptLastModified < PostProcessingService.defaultSystemPromptDate
+
+        return VStack(alignment: .leading, spacing: 10) {
+            Text("Controls how raw transcriptions are cleaned up.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if hasNewerDefault {
+                HStack(spacing: 8) {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .foregroundStyle(.blue)
+                    Text("A newer default prompt is available.")
+                        .font(.caption.weight(.semibold))
+                    Spacer()
+                    Button("View Default") { showDefaultSystemPrompt.toggle() }
+                        .font(.caption)
+                    Button("Switch to Default") {
+                        customSystemPromptInput = PostProcessingService.defaultSystemPrompt
+                        appState.customSystemPrompt = ""
+                        appState.customSystemPromptLastModified = ""
+                    }
+                    .font(.caption)
+                }
+                .padding(10)
+                .background(Color.blue.opacity(0.1))
+                .cornerRadius(6)
+            }
+
+            if showDefaultSystemPrompt {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Default System Prompt")
+                            .font(.caption.weight(.semibold))
+                        Spacer()
+                        Button("Hide") { showDefaultSystemPrompt = false }
+                            .font(.caption)
+                    }
+                    Text(verbatim: PostProcessingService.defaultSystemPrompt)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(10)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .cornerRadius(6)
+            }
+
+            TextEditor(text: $customSystemPromptInput)
+                .font(.system(.body, design: .monospaced))
+                .frame(minHeight: 120, maxHeight: 200)
+                .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.3), lineWidth: 1))
+                .onChange(of: customSystemPromptInput) { newValue in
+                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let defaultTrimmed = PostProcessingService.defaultSystemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if trimmed == defaultTrimmed || trimmed.isEmpty {
+                        if !appState.customSystemPrompt.isEmpty {
+                            appState.customSystemPrompt = ""
+                            appState.customSystemPromptLastModified = ""
+                        }
+                    } else {
+                        appState.customSystemPrompt = trimmed
+                        let today = iso8601DayFormatter.string(from: Date())
+                        if appState.customSystemPromptLastModified != today {
+                            appState.customSystemPromptLastModified = today
+                        }
+                    }
+                }
+
+            HStack {
+                if isCustom {
+                    Label("Using custom prompt", systemImage: "pencil")
+                        .font(.caption)
+                        .foregroundStyle(.blue)
+                } else {
+                    Label("Using default", systemImage: "checkmark.circle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if isCustom {
+                    Button("Reset to Default") {
+                        customSystemPromptInput = PostProcessingService.defaultSystemPrompt
+                        appState.customSystemPrompt = ""
+                        appState.customSystemPromptLastModified = ""
+                    }
+                    .font(.caption)
+                }
+            }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Test System Prompt")
+                    .font(.caption.weight(.semibold))
+                Text("Enter sample text to see how the current prompt cleans it up.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                TextEditor(text: $systemTestInput)
+                    .font(.system(.body, design: .monospaced))
+                    .frame(minHeight: 60, maxHeight: 100)
+                    .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.3), lineWidth: 1))
+
+                Button {
+                    runSystemPromptTest()
+                } label: {
+                    HStack(spacing: 6) {
+                        if systemTestRunning {
+                            ProgressView().controlSize(.small)
+                            Text("Running...")
+                        } else {
+                            Image(systemName: "play.fill")
+                            Text("Test System Prompt")
+                        }
+                    }
+                }
+                .disabled(
+                    systemTestRunning
+                        || !appState.isAIProcessingBackendReady(for: .postProcessing)
+                        || systemTestInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                )
+
+                if postProcessingUsesCloud && !hasConfiguredCloudAPIKey {
+                    providerConfigurationWarning("API key required to test")
+                }
+
+                if let issue = systemTestIssue {
+                    QuillUserIssueView(
+                        presentation: issue.presentation(),
+                        style: .inline,
+                        action: settingsTestRecoveryAction(
+                            for: issue,
+                            retry: runSystemPromptTest
+                        )
+                    )
+                }
+
+                if let output = systemTestOutput {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Result:")
+                            .font(.caption.weight(.semibold))
+                        Text(output.isEmpty ? "(empty — no output)" : output)
+                            .font(.system(.caption, design: .monospaced))
+                            .padding(8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color.green.opacity(0.08))
+                            .cornerRadius(6)
+                    }
+                }
+
+                if let prompt = systemTestPrompt {
+                    DisclosureGroup("Full prompt sent") {
+                        Text(prompt)
+                            .font(.system(.caption2, design: .monospaced))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func runSystemPromptTest() {
+        systemTestRunning = true
+        systemTestOutput = nil
+        systemTestIssue = nil
+        systemTestPrompt = nil
+
+        let service = appState.makePostProcessingService()
+        let input = systemTestInput
+        let customPrompt = appState.customSystemPrompt
+        let vocabulary = appState.customVocabulary
+
+        let context = AppContext(
+            appName: "Quill Settings",
+            bundleIdentifier: "com.woosublee.quill",
+            windowTitle: "System Prompt Test",
+            selectedText: nil,
+            currentActivity: "User is testing the system prompt in Quill settings.",
+            contextSystemPrompt: nil,
+            contextPrompt: nil,
+            screenshotDataURL: nil,
+            screenshotMimeType: nil,
+            screenshotError: nil
+        )
+
+        Task {
+            do {
+                let result = try await service.postProcess(
+                    transcript: input,
+                    context: context,
+                    customVocabulary: vocabulary,
+                    customSystemPrompt: customPrompt
+                )
+                await MainActor.run {
+                    systemTestOutput = result.transcript
+                    systemTestPrompt = result.prompt
+                    systemTestRunning = false
+                }
+            } catch {
+                await MainActor.run {
+                    systemTestIssue = service.userIssue(for: error).record
+                    systemTestRunning = false
+                }
+            }
+        }
+    }
+
+    // MARK: Context Prompt
+
+    private var contextPromptSection: some View {
+        let isCustom = !appState.customContextPrompt.isEmpty
+        let hasNewerDefault = isCustom
+            && !appState.customContextPromptLastModified.isEmpty
+            && appState.customContextPromptLastModified < AppContextService.defaultContextPromptDate
+
+        return VStack(alignment: .leading, spacing: 10) {
+            Text("Controls how Quill infers your current activity from app metadata and screenshots.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if hasNewerDefault {
+                HStack(spacing: 8) {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .foregroundStyle(.blue)
+                    Text("A newer default prompt is available.")
+                        .font(.caption.weight(.semibold))
+                    Spacer()
+                    Button("View Default") { showDefaultContextPrompt.toggle() }
+                        .font(.caption)
+                    Button("Switch to Default") {
+                        customContextPromptInput = AppContextService.defaultContextPrompt
+                        appState.customContextPrompt = ""
+                        appState.customContextPromptLastModified = ""
+                    }
+                    .font(.caption)
+                }
+                .padding(10)
+                .background(Color.blue.opacity(0.1))
+                .cornerRadius(6)
+            }
+
+            if showDefaultContextPrompt {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Default Context Prompt")
+                            .font(.caption.weight(.semibold))
+                        Spacer()
+                        Button("Hide") { showDefaultContextPrompt = false }
+                            .font(.caption)
+                    }
+                    Text(verbatim: AppContextService.defaultContextPrompt)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(10)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .cornerRadius(6)
+            }
+
+            TextEditor(text: $customContextPromptInput)
+                .font(.system(.body, design: .monospaced))
+                .frame(minHeight: 120, maxHeight: 200)
+                .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.3), lineWidth: 1))
+                .onChange(of: customContextPromptInput) { newValue in
+                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let defaultTrimmed = AppContextService.defaultContextPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if trimmed == defaultTrimmed || trimmed.isEmpty {
+                        if !appState.customContextPrompt.isEmpty {
+                            appState.customContextPrompt = ""
+                            appState.customContextPromptLastModified = ""
+                        }
+                    } else {
+                        appState.customContextPrompt = trimmed
+                        let today = iso8601DayFormatter.string(from: Date())
+                        if appState.customContextPromptLastModified != today {
+                            appState.customContextPromptLastModified = today
+                        }
+                    }
+                }
+
+            HStack {
+                if isCustom {
+                    Label("Using custom prompt", systemImage: "pencil")
+                        .font(.caption)
+                        .foregroundStyle(.blue)
+                } else {
+                    Label("Using default", systemImage: "checkmark.circle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if isCustom {
+                    Button("Reset to Default") {
+                        customContextPromptInput = AppContextService.defaultContextPrompt
+                        appState.customContextPrompt = ""
+                        appState.customContextPromptLastModified = ""
+                    }
+                    .font(.caption)
                 }
             }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1543,21 +1543,6 @@ struct ModelsSettingsView: View {
     @State private var customVocabularyInput: String = ""
     @State private var advancedProviderSettingsExpanded = false
 
-    @State private var customSystemPromptInput: String = ""
-    @State private var customContextPromptInput: String = ""
-    @State private var showDefaultSystemPrompt = false
-    @State private var showDefaultContextPrompt = false
-    @State private var systemTestInput: String = "Um, so I was like, thinking we should uh, refactor the authentication module, you know?"
-    @State private var systemTestRunning = false
-    @State private var systemTestOutput: String? = nil
-    @State private var systemTestIssue: QuillUserIssueRecord? = nil
-    @State private var systemTestPrompt: String? = nil
-    @State private var contextTestRunning = false
-    @State private var contextTestOutput: String? = nil
-    @State private var contextTestIssue: QuillUserIssueRecord? = nil
-    @State private var contextTestError: String? = nil
-    @State private var contextTestPrompt: String? = nil
-
     private struct OutputLanguageOption {
         let label: LocalizedStringKey
         let value: String // Persisted prompt/API value; never localize.
@@ -1619,12 +1604,6 @@ struct ModelsSettingsView: View {
             )
             meetingSummaryFallbackModelDraft = appState.meetingSummaryFallbackModel
             customVocabularyInput = appState.customVocabulary
-            customSystemPromptInput = appState.customSystemPrompt.isEmpty
-                ? PostProcessingService.defaultSystemPrompt
-                : appState.customSystemPrompt
-            customContextPromptInput = appState.customContextPrompt.isEmpty
-                ? AppContextService.defaultContextPrompt
-                : appState.customContextPrompt
             initializeManagedNativeModel()
             reconcileRetainedLocalAIModels()
         }
@@ -2615,10 +2594,6 @@ struct ModelsSettingsView: View {
             Divider()
             vocabularySection
             Divider()
-            systemPromptSection
-            Divider()
-            instructionGuardSection
-            Divider()
             Text("Edit Mode uses this model, fallback model, Output Language, and Custom Vocabulary. Invocation Style and Extra Modifier remain in Shortcuts.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -2632,7 +2607,7 @@ struct ModelsSettingsView: View {
                 feature: .context
             )
             Divider()
-            contextPromptSection
+            contextScreenshotResolutionSection
         }
     }
 
@@ -2665,6 +2640,44 @@ struct ModelsSettingsView: View {
                 Text("Cloud fallback is only used when Meeting Summary uses a cloud model.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var contextScreenshotResolutionSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Screenshot Resolution")
+                .font(.caption.weight(.semibold))
+            Text("Controls the maximum image dimension sent for context inference.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Picker("", selection: $appState.contextScreenshotMaxDimension) {
+                ForEach(AppState.contextScreenshotDimensionOptions, id: \.self) { dimension in
+                    Text("\(dimension) px").tag(dimension)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .accessibilityLabel("Screenshot Resolution")
+
+            HStack {
+                if appState.contextScreenshotMaxDimension == AppState.defaultContextScreenshotMaxDimension {
+                    Label("Using default", systemImage: "checkmark.circle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Label("Using custom value", systemImage: "pencil")
+                        .font(.caption)
+                        .foregroundStyle(.blue)
+                }
+                Spacer()
+                if appState.contextScreenshotMaxDimension != AppState.defaultContextScreenshotMaxDimension {
+                    Button("Reset to Default") {
+                        appState.contextScreenshotMaxDimension = AppState.defaultContextScreenshotMaxDimension
+                    }
+                    .font(.caption)
+                }
             }
         }
     }
@@ -3050,467 +3063,6 @@ struct ModelsSettingsView: View {
         }
     }
 
-    // MARK: System Prompt
-
-    private var instructionGuardSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Toggle(
-                "Prevent dictated prompts from being executed",
-                isOn: $appState.instructionExecutionGuardEnabled
-            )
-            .toggleStyle(.switch)
-
-            Text("When enabled, \(AppName.displayName) retries or falls back to the literal transcript if post-processing looks like it answered the dictated text instead of cleaning it.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-    }
-
-    private var systemPromptSection: some View {
-        let isCustom = !appState.customSystemPrompt.isEmpty
-        let hasNewerDefault = isCustom
-            && !appState.customSystemPromptLastModified.isEmpty
-            && appState.customSystemPromptLastModified < PostProcessingService.defaultSystemPromptDate
-
-        return VStack(alignment: .leading, spacing: 10) {
-            Text("Controls how raw transcriptions are cleaned up.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            if hasNewerDefault {
-                HStack(spacing: 8) {
-                    Image(systemName: "arrow.triangle.2.circlepath")
-                        .foregroundStyle(.blue)
-                    Text("A newer default prompt is available.")
-                        .font(.caption.weight(.semibold))
-                    Spacer()
-                    Button("View Default") { showDefaultSystemPrompt.toggle() }
-                        .font(.caption)
-                    Button("Switch to Default") {
-                        customSystemPromptInput = PostProcessingService.defaultSystemPrompt
-                        appState.customSystemPrompt = ""
-                        appState.customSystemPromptLastModified = ""
-                    }
-                    .font(.caption)
-                }
-                .padding(10)
-                .background(Color.blue.opacity(0.1))
-                .cornerRadius(6)
-            }
-
-            if showDefaultSystemPrompt {
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack {
-                        Text("Default System Prompt")
-                            .font(.caption.weight(.semibold))
-                        Spacer()
-                        Button("Hide") { showDefaultSystemPrompt = false }
-                            .font(.caption)
-                    }
-                    Text(verbatim: PostProcessingService.defaultSystemPrompt)
-                        .font(.system(.caption, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                }
-                .padding(10)
-                .background(Color(nsColor: .controlBackgroundColor))
-                .cornerRadius(6)
-            }
-
-            TextEditor(text: $customSystemPromptInput)
-                .font(.system(.body, design: .monospaced))
-                .frame(minHeight: 120, maxHeight: 200)
-                .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.3), lineWidth: 1))
-                .onChange(of: customSystemPromptInput) { newValue in
-                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let defaultTrimmed = PostProcessingService.defaultSystemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if trimmed == defaultTrimmed || trimmed.isEmpty {
-                        if !appState.customSystemPrompt.isEmpty {
-                            appState.customSystemPrompt = ""
-                            appState.customSystemPromptLastModified = ""
-                        }
-                    } else {
-                        appState.customSystemPrompt = trimmed
-                        let today = iso8601DayFormatter.string(from: Date())
-                        if appState.customSystemPromptLastModified != today {
-                            appState.customSystemPromptLastModified = today
-                        }
-                    }
-                }
-
-            HStack {
-                if isCustom {
-                    Label("Using custom prompt", systemImage: "pencil")
-                        .font(.caption)
-                        .foregroundStyle(.blue)
-                } else {
-                    Label("Using default", systemImage: "checkmark.circle")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                if isCustom {
-                    Button("Reset to Default") {
-                        customSystemPromptInput = PostProcessingService.defaultSystemPrompt
-                        appState.customSystemPrompt = ""
-                        appState.customSystemPromptLastModified = ""
-                    }
-                    .font(.caption)
-                }
-            }
-
-            Divider()
-
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Test System Prompt")
-                    .font(.caption.weight(.semibold))
-                Text("Enter sample text to see how the current prompt cleans it up.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                TextEditor(text: $systemTestInput)
-                    .font(.system(.body, design: .monospaced))
-                    .frame(minHeight: 60, maxHeight: 100)
-                    .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.3), lineWidth: 1))
-
-                Button {
-                    runSystemPromptTest()
-                } label: {
-                    HStack(spacing: 6) {
-                        if systemTestRunning {
-                            ProgressView().controlSize(.small)
-                            Text("Running...")
-                        } else {
-                            Image(systemName: "play.fill")
-                            Text("Test System Prompt")
-                        }
-                    }
-                }
-                .disabled(
-                    systemTestRunning
-                        || !appState.isAIProcessingBackendReady(for: .postProcessing)
-                        || systemTestInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                )
-
-                if postProcessingUsesCloud && !hasConfiguredCloudAPIKey {
-                    providerConfigurationWarning("API key required to test")
-                }
-
-                if let issue = systemTestIssue {
-                    QuillUserIssueView(
-                        presentation: issue.presentation(),
-                        style: .inline,
-                        action: settingsTestRecoveryAction(
-                            for: issue,
-                            retry: runSystemPromptTest
-                        )
-                    )
-                }
-
-                if let output = systemTestOutput {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Result:")
-                            .font(.caption.weight(.semibold))
-                        Text(output.isEmpty ? "(empty — no output)" : output)
-                            .font(.system(.caption, design: .monospaced))
-                            .padding(8)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(Color.green.opacity(0.08))
-                            .cornerRadius(6)
-                    }
-                }
-
-                if let prompt = systemTestPrompt {
-                    DisclosureGroup("Full prompt sent") {
-                        Text(prompt)
-                            .font(.system(.caption2, design: .monospaced))
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                }
-            }
-        }
-    }
-
-    private func runSystemPromptTest() {
-        systemTestRunning = true
-        systemTestOutput = nil
-        systemTestIssue = nil
-        systemTestPrompt = nil
-
-        let service = appState.makePostProcessingService()
-        let input = systemTestInput
-        let customPrompt = appState.customSystemPrompt
-        let vocabulary = appState.customVocabulary
-
-        let context = AppContext(
-            appName: "Quill Settings",
-            bundleIdentifier: "com.woosublee.quill",
-            windowTitle: "System Prompt Test",
-            selectedText: nil,
-            currentActivity: "User is testing the system prompt in Quill settings.",
-            contextSystemPrompt: nil,
-            contextPrompt: nil,
-            screenshotDataURL: nil,
-            screenshotMimeType: nil,
-            screenshotError: nil
-        )
-
-        Task {
-            do {
-                let result = try await service.postProcess(
-                    transcript: input,
-                    context: context,
-                    customVocabulary: vocabulary,
-                    customSystemPrompt: customPrompt
-                )
-                await MainActor.run {
-                    systemTestOutput = result.transcript
-                    systemTestPrompt = result.prompt
-                    systemTestRunning = false
-                }
-            } catch {
-                await MainActor.run {
-                    systemTestIssue = service.userIssue(for: error).record
-                    systemTestRunning = false
-                }
-            }
-        }
-    }
-
-    // MARK: Context Prompt
-
-    private var contextPromptSection: some View {
-        let isCustom = !appState.customContextPrompt.isEmpty
-        let hasNewerDefault = isCustom
-            && !appState.customContextPromptLastModified.isEmpty
-            && appState.customContextPromptLastModified < AppContextService.defaultContextPromptDate
-
-        return VStack(alignment: .leading, spacing: 10) {
-            Text("Controls how Quill infers your current activity from app metadata and screenshots.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            if hasNewerDefault {
-                HStack(spacing: 8) {
-                    Image(systemName: "arrow.triangle.2.circlepath")
-                        .foregroundStyle(.blue)
-                    Text("A newer default prompt is available.")
-                        .font(.caption.weight(.semibold))
-                    Spacer()
-                    Button("View Default") { showDefaultContextPrompt.toggle() }
-                        .font(.caption)
-                    Button("Switch to Default") {
-                        customContextPromptInput = AppContextService.defaultContextPrompt
-                        appState.customContextPrompt = ""
-                        appState.customContextPromptLastModified = ""
-                    }
-                    .font(.caption)
-                }
-                .padding(10)
-                .background(Color.blue.opacity(0.1))
-                .cornerRadius(6)
-            }
-
-            if showDefaultContextPrompt {
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack {
-                        Text("Default Context Prompt")
-                            .font(.caption.weight(.semibold))
-                        Spacer()
-                        Button("Hide") { showDefaultContextPrompt = false }
-                            .font(.caption)
-                    }
-                    Text(verbatim: AppContextService.defaultContextPrompt)
-                        .font(.system(.caption, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                }
-                .padding(10)
-                .background(Color(nsColor: .controlBackgroundColor))
-                .cornerRadius(6)
-            }
-
-            TextEditor(text: $customContextPromptInput)
-                .font(.system(.body, design: .monospaced))
-                .frame(minHeight: 120, maxHeight: 200)
-                .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.3), lineWidth: 1))
-                .onChange(of: customContextPromptInput) { newValue in
-                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let defaultTrimmed = AppContextService.defaultContextPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if trimmed == defaultTrimmed || trimmed.isEmpty {
-                        if !appState.customContextPrompt.isEmpty {
-                            appState.customContextPrompt = ""
-                            appState.customContextPromptLastModified = ""
-                        }
-                    } else {
-                        appState.customContextPrompt = trimmed
-                        let today = iso8601DayFormatter.string(from: Date())
-                        if appState.customContextPromptLastModified != today {
-                            appState.customContextPromptLastModified = today
-                        }
-                    }
-                }
-
-            HStack {
-                if isCustom {
-                    Label("Using custom prompt", systemImage: "pencil")
-                        .font(.caption)
-                        .foregroundStyle(.blue)
-                } else {
-                    Label("Using default", systemImage: "checkmark.circle")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                if isCustom {
-                    Button("Reset to Default") {
-                        customContextPromptInput = AppContextService.defaultContextPrompt
-                        appState.customContextPrompt = ""
-                        appState.customContextPromptLastModified = ""
-                    }
-                    .font(.caption)
-                }
-            }
-
-            Divider()
-
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Screenshot Resolution")
-                    .font(.caption.weight(.semibold))
-                Text("Controls the maximum image dimension sent for context inference.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                Picker("", selection: $appState.contextScreenshotMaxDimension) {
-                    ForEach(AppState.contextScreenshotDimensionOptions, id: \.self) { dimension in
-                        Text("\(dimension) px").tag(dimension)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .accessibilityLabel("Screenshot Resolution")
-
-                HStack {
-                    if appState.contextScreenshotMaxDimension == AppState.defaultContextScreenshotMaxDimension {
-                        Label("Using default", systemImage: "checkmark.circle")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    } else {
-                        Label("Using custom value", systemImage: "pencil")
-                            .font(.caption)
-                            .foregroundStyle(.blue)
-                    }
-                    Spacer()
-                    if appState.contextScreenshotMaxDimension != AppState.defaultContextScreenshotMaxDimension {
-                        Button("Reset to Default") {
-                            appState.contextScreenshotMaxDimension = AppState.defaultContextScreenshotMaxDimension
-                        }
-                        .font(.caption)
-                    }
-                }
-            }
-
-            Divider()
-
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Test Context Prompt")
-                    .font(.caption.weight(.semibold))
-                Text("Captures a screenshot and metadata from the frontmost app, then runs the context prompt to infer activity.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                Button {
-                    runContextPromptTest()
-                } label: {
-                    HStack(spacing: 6) {
-                        if contextTestRunning {
-                            ProgressView().controlSize(.small)
-                            Text("Running...")
-                        } else {
-                            Image(systemName: "play.fill")
-                            Text("Test Context Prompt")
-                        }
-                    }
-                }
-                .disabled(
-                    contextTestRunning
-                        || !appState.isAIProcessingBackendReady(for: .context)
-                )
-
-                if contextUsesCloud && !hasConfiguredCloudAPIKey {
-                    providerConfigurationWarning("API key required to test")
-                }
-
-                if let issue = contextTestIssue {
-                    QuillUserIssueView(
-                        presentation: issue.presentation(),
-                        style: .inline,
-                        action: settingsTestRecoveryAction(
-                            for: issue,
-                            retry: runContextPromptTest
-                        )
-                    )
-                }
-
-                if let error = contextTestError {
-                    Label(error, systemImage: "xmark.circle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                }
-
-                if let output = contextTestOutput {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Result:")
-                            .font(.caption.weight(.semibold))
-                        Text(output.isEmpty ? "(empty — no output)" : output)
-                            .font(.system(.caption, design: .monospaced))
-                            .padding(8)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(Color.green.opacity(0.08))
-                            .cornerRadius(6)
-                    }
-                }
-
-                if let prompt = contextTestPrompt {
-                    DisclosureGroup("Full prompt sent") {
-                        Text(prompt)
-                            .font(.system(.caption2, design: .monospaced))
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                }
-            }
-        }
-    }
-
-    private func runContextPromptTest() {
-        contextTestRunning = true
-        contextTestOutput = nil
-        contextTestIssue = nil
-        contextTestError = nil
-        contextTestPrompt = nil
-
-        let service = appState.makeAppContextService()
-
-        Task {
-            let context = await service.collectContext()
-            await MainActor.run {
-                contextTestIssue = context.userIssueRecord
-                if context.userIssueRecord != nil {
-                    contextTestOutput = context.contextSummary
-                    contextTestPrompt = context.contextPrompt
-                } else if let prompt = context.contextPrompt {
-                    contextTestOutput = context.contextSummary
-                    contextTestPrompt = prompt
-                } else {
-                    contextTestError = "Context inference returned no result. This may be a permissions issue or the API could not be reached."
-                    contextTestOutput = context.contextSummary
-                }
-                contextTestRunning = false
-            }
-        }
-    }
 }
 
 // MARK: - Prompts Settings

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -187,7 +187,13 @@ struct LocalizationResourceTests {
                 assert(!(((localizations?[language] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String ?? "").isEmpty, "Missing \(language) input localization for \(key)")
             }
         }
-        for key in ["General", "Appearance", "Models", "Shortcuts", "Input", "About", "My calendars", "Shared calendars", "Primary", "My calendar", "Shared", "Use API Provider transcription to choose a final output language.", "Enable post-processing to choose a final output language.", "Final transcript language for post-processing."] {
+        for key in [
+            "General", "Appearance", "Models", "Prompts", "Shortcuts", "Input", "About",
+            "My calendars", "Shared calendars", "Primary", "My calendar", "Shared",
+            "Use API Provider transcription to choose a final output language.",
+            "Enable post-processing to choose a final output language.",
+            "Final transcript language for post-processing."
+        ] {
             let localizations = (strings[key] as? [String: Any])?["localizations"] as? [String: Any]
             assert(!(((localizations?["en"] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String ?? "").isEmpty)
             assert(!(((localizations?["ko"] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String ?? "").isEmpty)

--- a/Tests/ModelsSettingsUIContractTests.swift
+++ b/Tests/ModelsSettingsUIContractTests.swift
@@ -18,6 +18,7 @@ struct ModelsSettingsUIContractTests {
         testExistingModelCatalogRemains(modelConfiguration)
         testExistingModelLifecycleRemains(settings)
         try testModelFirstTopLevelStructure(settings)
+        testPromptControlsMovedOutOfModels(settings)
         testCloudAPIReadinessPresentation(settings)
         try testTranscriptionUsesNativePickerAndExistingChoiceAPI(settings)
         testNativeDropdownUsesPendingContextualManagement(settings)
@@ -138,7 +139,7 @@ struct ModelsSettingsUIContractTests {
         let models = block(
             in: source,
             from: "struct ModelsSettingsView",
-            to: "// MARK: - Shortcuts Settings"
+            to: "// MARK: - Prompts Settings"
         )
         guard let cloudProvider = models.range(of: "SettingsCard(\"Cloud Provider\""),
               let transcription = models.range(of: "SettingsCard(\"Transcription\""),
@@ -157,11 +158,49 @@ struct ModelsSettingsUIContractTests {
         precondition(!models.contains("@State private var showingLocalTranscriptionSettings"))
     }
 
+    private static func testPromptControlsMovedOutOfModels(_ source: String) {
+        let models = block(
+            in: source,
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Prompts Settings"
+        )
+        let contextDetails = block(
+            in: models,
+            from: "private var contextDetails: some View",
+            to: "\n    private var meetingSummaryDetails"
+        )
+        let screenshot = block(
+            in: models,
+            from: "private var contextScreenshotResolutionSection: some View",
+            to: "\n    private var transcriptionLanguageSetting"
+        )
+
+        for removed in [
+            "@State private var customSystemPromptInput",
+            "@State private var customContextPromptInput",
+            "systemPromptSection",
+            "contextPromptSection",
+            "instructionGuardSection",
+            "runSystemPromptTest()",
+            "runContextPromptTest()",
+            "Test System Prompt",
+            "Test Context Prompt"
+        ] {
+            precondition(!models.contains(removed), "Prompt behavior remains in Models: \(removed)")
+        }
+
+        precondition(contextDetails.contains("contextScreenshotResolutionSection"))
+        precondition(screenshot.contains("Text(\"Screenshot Resolution\")"))
+        precondition(screenshot.contains("selection: $appState.contextScreenshotMaxDimension"))
+        precondition(screenshot.contains("AppState.contextScreenshotDimensionOptions"))
+        precondition(screenshot.contains("appState.contextScreenshotMaxDimension = AppState.defaultContextScreenshotMaxDimension"))
+    }
+
     private static func testCloudAPIReadinessPresentation(_ source: String) {
         let models = block(
             in: source,
             from: "struct ModelsSettingsView",
-            to: "// MARK: - Shortcuts Settings"
+            to: "// MARK: - Prompts Settings"
         )
         let provider = block(
             in: models,
@@ -188,16 +227,6 @@ struct ModelsSettingsUIContractTests {
             from: "private var postProcessingDetails: some View",
             to: "\n    private var transcriptionLanguageSetting"
         )
-        let systemPrompt = block(
-            in: models,
-            from: "private var systemPromptSection: some View",
-            to: "\n    private func runSystemPromptTest()"
-        )
-        let contextPrompt = block(
-            in: models,
-            from: "private var contextPromptSection: some View",
-            to: "\n    private func runContextPromptTest()"
-        )
 
         precondition(models.contains("private var hasConfiguredCloudAPIKey: Bool"))
         precondition(models.contains("!appState.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty"))
@@ -212,8 +241,6 @@ struct ModelsSettingsUIContractTests {
         precondition(transcription.contains("providerConfigurationWarning("))
         precondition(postProcessing.contains("providerConfigurationWarning("))
         precondition(context.contains("providerConfigurationWarning("))
-        precondition(systemPrompt.contains("providerConfigurationWarning("))
-        precondition(contextPrompt.contains("providerConfigurationWarning("))
 
         precondition(!postProcessing.contains(".disabled(!hasConfiguredCloudAPIKey)"))
         precondition(!postProcessing.contains(".opacity(hasConfiguredCloudAPIKey ? 1 : 0.45)"))
@@ -234,7 +261,7 @@ struct ModelsSettingsUIContractTests {
         let models = block(
             in: source,
             from: "struct ModelsSettingsView",
-            to: "// MARK: - Shortcuts Settings"
+            to: "// MARK: - Prompts Settings"
         )
         let picker = block(
             in: models,
@@ -282,7 +309,7 @@ struct ModelsSettingsUIContractTests {
         let models = block(
             in: source,
             from: "struct ModelsSettingsView",
-            to: "// MARK: - Shortcuts Settings"
+            to: "// MARK: - Prompts Settings"
         )
         let transcription = block(
             in: models,
@@ -332,7 +359,7 @@ struct ModelsSettingsUIContractTests {
         let models = block(
             in: settings,
             from: "struct ModelsSettingsView",
-            to: "// MARK: - Shortcuts Settings"
+            to: "// MARK: - Prompts Settings"
         )
         let nativeRow = block(
             in: settings,
@@ -386,7 +413,7 @@ struct ModelsSettingsUIContractTests {
         let models = block(
             in: settings,
             from: "struct ModelsSettingsView",
-            to: "// MARK: - Shortcuts Settings"
+            to: "// MARK: - Prompts Settings"
         )
         for draftState in [
             "@State private var transcriptionEnabledDraft = false",
@@ -407,7 +434,7 @@ struct ModelsSettingsUIContractTests {
         let models = block(
             in: source,
             from: "struct ModelsSettingsView",
-            to: "// MARK: - Shortcuts Settings"
+            to: "// MARK: - Prompts Settings"
         )
         let displays = block(
             in: models,
@@ -427,7 +454,7 @@ struct ModelsSettingsUIContractTests {
         let validation = block(
             in: models,
             from: "private func validateAndSaveKey()",
-            to: "\n    // MARK: System Prompt"
+            to: "\n}"
         )
 
         precondition(displays.contains("case .legacyMlxWhisper:"))
@@ -448,7 +475,7 @@ struct ModelsSettingsUIContractTests {
         let models = block(
             in: source,
             from: "struct ModelsSettingsView",
-            to: "// MARK: - Shortcuts Settings"
+            to: "// MARK: - Prompts Settings"
         )
         let context = block(
             in: models,
@@ -460,7 +487,7 @@ struct ModelsSettingsUIContractTests {
             "get: { contextEnabledDraft }",
             "contextEnabledDraft = newValue",
             "customAIProcessingModelSetting(",
-            "contextPromptSection",
+            "contextScreenshotResolutionSection",
             "selection: $appState.contextScreenshotMaxDimension"
         ] {
             precondition(models.contains(expected), "Missing Context binding/configuration: \(expected)")
@@ -486,7 +513,7 @@ struct ModelsSettingsUIContractTests {
         let models = block(
             in: source,
             from: "struct ModelsSettingsView",
-            to: "// MARK: - Shortcuts Settings"
+            to: "// MARK: - Prompts Settings"
         )
 
         precondition(
@@ -520,7 +547,7 @@ struct ModelsSettingsUIContractTests {
         let models = block(
             in: source,
             from: "struct ModelsSettingsView",
-            to: "// MARK: - Shortcuts Settings"
+            to: "// MARK: - Prompts Settings"
         )
         let postProcessing = block(
             in: models,
@@ -537,9 +564,7 @@ struct ModelsSettingsUIContractTests {
             "customAIProcessingModelSetting(",
             "defaultModel: AppState.defaultPostProcessingFallbackModel",
             "selection: $appState.outputLanguage",
-            "vocabularySection",
-            "systemPromptSection",
-            "instructionGuardSection"
+            "vocabularySection"
         ] {
             precondition(models.contains(expected), "Missing Post-processing UI binding: \(expected)")
         }
@@ -571,7 +596,7 @@ struct ModelsSettingsUIContractTests {
         let models = block(
             in: settings,
             from: "struct ModelsSettingsView",
-            to: "// MARK: - Shortcuts Settings"
+            to: "// MARK: - Prompts Settings"
         )
         let postProcessing = block(
             in: models,
@@ -607,16 +632,6 @@ struct ModelsSettingsUIContractTests {
             in: models,
             from: "private func customAIProcessingModelDraft(",
             to: "\n    private func customStandardAPIModelDraft"
-        )
-        let systemPrompt = block(
-            in: models,
-            from: "private var systemPromptSection: some View",
-            to: "\n    private func runSystemPromptTest()"
-        )
-        let contextPrompt = block(
-            in: models,
-            from: "private var contextPromptSection: some View",
-            to: "\n    private func runContextPromptTest()"
         )
         let choiceBinding = block(
             in: models,
@@ -802,11 +817,6 @@ struct ModelsSettingsUIContractTests {
         precondition(modelDropdown.contains("self._isEditing = isEditing"))
         precondition(modelDropdown.contains("isEditing = focused"))
 
-        precondition(systemPrompt.contains("appState.isAIProcessingBackendReady(for: .postProcessing)"))
-        precondition(contextPrompt.contains("appState.isAIProcessingBackendReady(for: .context)"))
-        precondition(models.contains("let service = appState.makePostProcessingService()"))
-        precondition(!models.contains("let service = PostProcessingService("))
-
         precondition(!localAIModelRow.isEmpty, "Missing LocalAIModelRowView source")
         precondition(localAIModelRow.contains("appState.localAIInstallState(for: model)"))
         precondition(localAIModelRow.contains("appState.pendingLocalAIModelID(for: feature)"))
@@ -826,7 +836,7 @@ struct ModelsSettingsUIContractTests {
         let models = block(
             in: source,
             from: "struct ModelsSettingsView",
-            to: "// MARK: - Shortcuts Settings"
+            to: "// MARK: - Prompts Settings"
         )
         let shortcuts = block(
             in: source,
@@ -855,7 +865,7 @@ struct ModelsSettingsUIContractTests {
         let models = block(
             in: source,
             from: "struct ModelsSettingsView",
-            to: "// MARK: - Shortcuts Settings"
+            to: "// MARK: - Prompts Settings"
         )
         let local = block(
             in: models,

--- a/Tests/PromptsSettingsUIContractTests.swift
+++ b/Tests/PromptsSettingsUIContractTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+@main
+struct PromptsSettingsUIContractTests {
+    static func main() throws {
+        let tabs = try source("Sources/CalendarIntegrationModels.swift")
+        let settings = try source("Sources/SettingsView.swift")
+
+        testNavigation(tabs: tabs, settings: settings)
+        testCardOrder(settings)
+        testPromptPersistence(settings)
+        testBackendAwareTests(settings)
+        testInstructionGuard(settings)
+        testScreenshotResolutionStaysOut(settings)
+
+        print("PromptsSettingsUIContractTests passed")
+    }
+
+    private static func testNavigation(tabs: String, settings: String) {
+        precondition(tabs.contains("case prompts"), "Missing Prompts settings tab")
+        precondition(
+            tabs.contains("[.general, .appearance, .models, .prompts, .shortcuts, .input, .calendar, .about, .runLog, .debug]"),
+            "Prompts must appear between Models and Shortcuts"
+        )
+        precondition(tabs.contains("case .prompts: return \"Prompts\""))
+        precondition(tabs.contains("case .prompts: return \"text.bubble\""))
+        precondition(settings.contains("case .prompts:\n                    PromptsSettingsView()"))
+    }
+
+    private static func testCardOrder(_ source: String) {
+        let prompts = promptsBlock(source)
+        guard let system = prompts.range(of: "SettingsCard(\"System Prompt\""),
+              let guardCard = prompts.range(of: "SettingsCard(\"Instruction Guard\""),
+              let context = prompts.range(of: "SettingsCard(\"Context Prompt\"") else {
+            preconditionFailure("Missing Prompt settings cards")
+        }
+        precondition(system.lowerBound < guardCard.lowerBound)
+        precondition(guardCard.lowerBound < context.lowerBound)
+    }
+
+    private static func testPromptPersistence(_ source: String) {
+        let prompts = promptsBlock(source)
+        for expected in [
+            "@State private var customSystemPromptInput: String = \"\"",
+            "@State private var customContextPromptInput: String = \"\"",
+            "PostProcessingService.defaultSystemPrompt",
+            "AppContextService.defaultContextPrompt",
+            "appState.customSystemPrompt = trimmed",
+            "appState.customSystemPromptLastModified = today",
+            "appState.customContextPrompt = trimmed",
+            "appState.customContextPromptLastModified = today",
+            "Button(\"Switch to Default\")",
+            "Button(\"Reset to Default\")"
+        ] {
+            precondition(prompts.contains(expected), "Missing Prompt persistence behavior: \(expected)")
+        }
+    }
+
+    private static func testBackendAwareTests(_ source: String) {
+        let prompts = promptsBlock(source)
+        precondition(prompts.contains("appState.isAIProcessingBackendReady(for: .postProcessing)"))
+        precondition(prompts.contains("appState.isAIProcessingBackendReady(for: .context)"))
+        precondition(prompts.contains("let service = appState.makePostProcessingService()"))
+        precondition(prompts.contains("let service = appState.makeAppContextService()"))
+        precondition(!prompts.contains("let service = PostProcessingService("))
+        precondition(prompts.contains("QuillUserIssueView("))
+        precondition(prompts.contains("settingsTestRecoveryAction("))
+        precondition(prompts.contains("providerConfigurationWarning("))
+        precondition(prompts.contains("if postProcessingUsesCloud && !hasConfiguredCloudAPIKey"))
+        precondition(prompts.contains("if contextUsesCloud && !hasConfiguredCloudAPIKey"))
+    }
+
+    private static func testInstructionGuard(_ source: String) {
+        let prompts = promptsBlock(source)
+        precondition(prompts.contains("isOn: $appState.instructionExecutionGuardEnabled"))
+        precondition(prompts.contains("Prevent dictated prompts from being executed"))
+    }
+
+    private static func testScreenshotResolutionStaysOut(_ source: String) {
+        let prompts = promptsBlock(source)
+        precondition(!prompts.contains("Screenshot Resolution"))
+        precondition(!prompts.contains("contextScreenshotMaxDimension"))
+    }
+
+    private static func promptsBlock(_ source: String) -> String {
+        block(
+            in: source,
+            from: "struct PromptsSettingsView",
+            to: "// MARK: - Shortcuts Settings"
+        )
+    }
+
+    private static func source(_ path: String) throws -> String {
+        try String(contentsOfFile: path, encoding: .utf8)
+    }
+
+    private static func block(in source: String, from start: String, to end: String) -> String {
+        guard let startRange = source.range(of: start),
+              let endRange = source.range(of: end, range: startRange.upperBound..<source.endIndex) else {
+            preconditionFailure("Unable to locate source block from \(start) to \(end)")
+        }
+        return String(source[startRange.lowerBound..<endRange.lowerBound])
+    }
+}

--- a/docs/superpowers/specs/2026-07-24-prompt-settings-separation-design.md
+++ b/docs/superpowers/specs/2026-07-24-prompt-settings-separation-design.md
@@ -1,0 +1,308 @@
+# Prompt Settings Separation Design
+
+- **Date:** 2026-07-24
+- **Status:** Approved
+- **Scope:** Settings 정보 구조와 UI 경계 분리
+- **Related design:** [`2026-07-17-model-first-settings-redesign.md`](./2026-07-17-model-first-settings-redesign.md)
+
+## Goal
+
+`Models` Settings 안에 함께 배치된 Prompt 편집·테스트 기능을 독립된 `Prompts` 메뉴로 이동한다.
+
+변경 후 사용자는 다음 두 목적을 서로 다른 화면에서 처리한다.
+
+- `Models`: 기능별 backend, model, provider, language와 입력 설정 관리
+- `Prompts`: System Prompt와 Context Prompt 편집·초기화·테스트 및 Instruction Guard 관리
+
+기존 model-first 설정 구조와 모든 저장값·runtime 동작은 유지하면서, `Models` 화면의 길이와 복잡도만 줄이는 것이 목표다.
+
+## Current problem
+
+현재 `ModelsSettingsView`는 Cloud Provider, Transcription, Post-processing, Context, Meeting Summary의 backend와 model 설정을 제공한다. 여기에 다음 Prompt 관련 기능도 각 기능의 `Details` 안에 포함되어 있다.
+
+- Post-processing Details
+  - System Prompt 편집과 기본값 관리
+  - System Prompt 테스트와 결과
+  - Instruction Guard
+- Context Details
+  - Context Prompt 편집과 기본값 관리
+  - Context Prompt 테스트와 결과
+  - Screenshot Resolution
+
+Prompt 편집기는 기본값 비교, 긴 `TextEditor`, 테스트 입력, 실행 결과, 실제 전송 Prompt를 모두 포함한다. 이 때문에 model을 선택하려는 사용자에게 `Models` 화면이 지나치게 길고, model 설정과 Prompt 작성이라는 서로 다른 작업이 한 메뉴에서 경쟁한다.
+
+업스트림은 별도의 `PromptsSettingsView`를 제공하지만, Quill은 이후 다음 동작을 추가했으므로 업스트림 구현을 그대로 복사하지 않는다.
+
+- Cloud와 Local AI backend 선택
+- backend-aware readiness
+- `AppState` service factory를 통한 테스트
+- `QuillUserIssueView` 기반 구조화된 오류와 복구
+- 영어·한국어 localization
+
+업스트림에서는 정보 구조만 참고하고 Quill의 현재 동작을 보존한다.
+
+## Design decisions
+
+### Add a peer Prompts menu
+
+Settings sidebar 순서는 다음과 같다.
+
+```text
+General
+Appearance
+Models
+Prompts
+Shortcuts
+Input
+Calendar
+About
+```
+
+`Prompts`는 `Models` 바로 뒤에 배치한다. Prompt가 model을 사용하는 관계는 유지하되, model 선택 후 Prompt를 세부 조정하는 자연스러운 순서를 제공한다.
+
+`SettingsTab`에는 `.prompts`를 추가하고 `SettingsView`는 해당 탭에서 `PromptsSettingsView`를 표시한다.
+
+- Title: `Prompts`
+- Korean localization: `프롬프트`
+- SF Symbol: `text.bubble`
+
+### Keep model-adjacent settings in Models
+
+`Models`는 다음 구조를 유지한다.
+
+```text
+Models
+├─ Cloud Provider
+├─ Transcription
+├─ Post-processing
+│  └─ Details
+│     ├─ Model
+│     ├─ Output Language
+│     ├─ Fallback Model
+│     └─ Custom Vocabulary
+├─ Context
+│  └─ Details
+│     ├─ Model
+│     └─ Screenshot Resolution
+└─ Meeting Summary
+```
+
+다음 항목은 `Models`에 남긴다.
+
+- Cloud Provider와 API credential
+- 모든 Transcription 설정과 model lifecycle
+- Post-processing과 Context의 enabled state, backend, primary/fallback model
+- Output Language
+- Custom Vocabulary
+- Screenshot Resolution
+- Meeting Summary 설정
+
+`Screenshot Resolution`은 Prompt 본문이 아니라 Context 입력의 품질·비용을 조절하는 설정이다. 따라서 현재 `contextPromptSection`에서 별도 section으로 분리한 뒤 `Models > Context > Details`에 유지한다.
+
+### Put prompt-specific behavior in Prompts
+
+`PromptsSettingsView`는 세 개의 peer `SettingsCard`를 순서대로 표시한다.
+
+```text
+Prompts
+├─ System Prompt
+├─ Instruction Guard
+└─ Context Prompt
+```
+
+#### System Prompt
+
+현재 기능을 그대로 제공한다.
+
+- Prompt 역할 설명
+- 기본 Prompt와 사용자 지정 Prompt 상태
+- 새 기본 Prompt가 있을 때 안내
+- 기본 Prompt 표시, 전환, 초기화
+- 사용자 지정 Prompt 편집기
+- 샘플 transcript 입력
+- 현재 Post-processing backend로 테스트
+- 결과, 구조화된 오류, 재시도, 실제 전송 Prompt 표시
+
+#### Instruction Guard
+
+현재 toggle과 설명을 그대로 제공한다.
+
+- `instructionExecutionGuardEnabled` binding
+- 받아쓰기 내용을 명령으로 실행한 것으로 판단될 때 retry 또는 literal transcript fallback을 수행한다는 설명
+
+Instruction Guard는 Prompt 텍스트 자체는 아니지만 Prompt 실행 안전성과 직접 관련되므로 `Prompts`에 포함한다.
+
+#### Context Prompt
+
+현재 Prompt 관련 기능만 제공한다.
+
+- Prompt 역할 설명
+- 기본 Prompt와 사용자 지정 Prompt 상태
+- 새 기본 Prompt가 있을 때 안내
+- 기본 Prompt 표시, 전환, 초기화
+- 사용자 지정 Prompt 편집기
+- 현재 앱의 metadata와 가능한 screenshot을 캡처해 테스트
+- 결과, 구조화된 오류, 재시도, 실제 전송 Prompt 표시
+
+`Screenshot Resolution`은 이 카드에 포함하지 않는다.
+
+## Code boundaries
+
+### SettingsTab and navigation
+
+`Sources/CalendarIntegrationModels.swift`의 `SettingsTab`에 `.prompts`를 추가한다.
+
+- `orderedCases`: `.models`와 `.shortcuts` 사이
+- `title`: `Prompts`
+- `icon`: `text.bubble`
+
+`Sources/SettingsView.swift`의 tab switch에 다음 연결을 추가한다.
+
+```swift
+case .prompts:
+    PromptsSettingsView()
+```
+
+### PromptsSettingsView
+
+기존 Settings View들이 같은 파일에 모여 있는 관례와 최소 변경 원칙을 따라, 이번 변경에서는 `PromptsSettingsView`를 `Sources/SettingsView.swift` 안의 독립된 SwiftUI View로 둔다.
+
+View-local state:
+
+- `customSystemPromptInput`
+- `customContextPromptInput`
+- 기본 Prompt 표시 여부
+- 각 테스트의 running, output, issue/error, sent prompt
+- System Prompt 테스트용 sample input
+
+Persistent state는 기존 `AppState` property를 그대로 사용한다.
+
+- `customSystemPrompt`
+- `customSystemPromptLastModified`
+- `customContextPrompt`
+- `customContextPromptLastModified`
+- `instructionExecutionGuardEnabled`
+
+새 persistence key나 migration은 추가하지 않는다.
+
+### ModelsSettingsView cleanup
+
+`ModelsSettingsView`에서 다음 상태와 UI를 제거한다.
+
+- Prompt editor draft
+- 기본 Prompt 표시 여부
+- Prompt 테스트 state
+- `systemPromptSection`
+- `instructionGuardSection`
+- `contextPromptSection`의 Prompt 편집·테스트 부분
+- System/Context Prompt 테스트 함수
+
+현재 `contextPromptSection` 안의 Screenshot Resolution UI는 `contextScreenshotResolutionSection`처럼 독립된 section으로 분리해 `contextDetails`에서 사용한다.
+
+Models와 Prompts 사이에 view-local state나 callback을 공유하지 않는다. 두 화면은 `AppState`를 유일한 영구 설정 경계로 사용한다.
+
+## Data and behavior preservation
+
+Prompt를 저장하는 방식은 변경하지 않는다.
+
+- 입력값이 기본 Prompt와 같거나 비어 있으면 custom value와 last-modified date를 비운다.
+- 기본 Prompt와 다르면 trim한 값을 저장하고 현재 날짜를 last-modified date로 기록한다.
+- 새 기본 Prompt 안내는 기존 날짜 비교 규칙을 유지한다.
+- Reset과 Switch to Default는 기존 custom value와 last-modified date를 비운다.
+
+Prompt 테스트는 현재 Quill 경로를 유지한다.
+
+- System Prompt: `appState.makePostProcessingService()`
+- Context Prompt: `appState.makeAppContextService()`
+- Readiness: `appState.isAIProcessingBackendReady(for:)`
+- 오류: `QuillUserIssueRecord`와 `QuillUserIssueView`
+- 선택 backend와 model은 `AppState`의 현재 값을 사용하며 테스트 중 변경하지 않는다.
+
+메뉴 이동은 runtime pipeline, model 선택, fallback, 기본값 또는 기존 사용자 설정을 바꾸지 않는다.
+
+## Error handling
+
+현재 오류 표현을 보존한다.
+
+- 선택한 backend가 준비되지 않으면 해당 테스트 버튼을 비활성화한다.
+- Cloud backend인데 API Key가 없으면 기존 provider configuration warning을 표시한다.
+- Local AI model이 준비되지 않았으면 backend readiness 결과를 반영한다.
+- System Prompt 테스트 실패는 Post-processing service가 생성한 `QuillUserIssueRecord`를 표시한다.
+- Context capture 또는 inference 실패는 기존 issue 또는 context error를 표시한다.
+- retry 가능한 issue만 기존 recovery mapping을 통해 retry action을 제공한다.
+
+오류가 발생해도 Prompt, backend, model 또는 enabled state를 자동 변경하지 않는다.
+
+## Localization and accessibility
+
+- `Prompts`의 영어·한국어 catalog entry를 제공한다.
+- 기존 Prompt card의 문자열과 번역을 재사용한다.
+- sidebar row는 기존 `localizedCatalogString(tab.title)` 경로를 사용한다.
+- `text.bubble` 아이콘과 title을 함께 표시해 아이콘에만 의미를 의존하지 않는다.
+- Prompt test button의 disabled state와 inline warning을 유지한다.
+- 기존 toggle label과 accessibility semantics를 유지한다.
+
+## Testing
+
+### Navigation contract
+
+- `SettingsTab.orderedCases`에서 `.prompts`가 `.models` 다음, `.shortcuts` 이전인지 확인한다.
+- `.prompts` title과 icon을 확인한다.
+- `SettingsView`가 `.prompts`를 `PromptsSettingsView`로 연결하는지 확인한다.
+
+### Models UI contract
+
+기존 `ModelsSettingsUIContractTests`를 새 경계에 맞게 조정한다.
+
+- Cloud Provider, Transcription, Post-processing, Context, Meeting Summary card가 유지된다.
+- Models block에 System Prompt editor, Context Prompt editor, Instruction Guard가 남아 있지 않다.
+- Post-processing Details에 Output Language, fallback model, Custom Vocabulary가 유지된다.
+- Context Details에 Screenshot Resolution이 유지된다.
+- 기존 backend, model lifecycle, readiness 계약은 변경하지 않는다.
+
+### Prompts UI contract
+
+`Tests/PromptsSettingsUIContractTests.swift`를 추가하고 Makefile test wiring에 정확히 한 번 포함한다. 기존 `ModelsSettingsUIContractTests`는 Models에 남는 계약만 검사하도록 좁힌다.
+
+- `PromptsSettingsView`가 존재한다.
+- card 순서가 System Prompt, Instruction Guard, Context Prompt다.
+- 두 editor가 기존 default/custom 저장 규칙을 사용한다.
+- 기본값 보기, 전환, reset과 newer-default 안내가 유지된다.
+- System test가 `makePostProcessingService()`를 사용한다.
+- Context test가 `makeAppContextService()`를 사용한다.
+- 두 테스트가 backend readiness, provider warning, 구조화된 issue를 유지한다.
+- Prompts block에 Screenshot Resolution이 포함되지 않는다.
+
+### Localization and regression
+
+- `Prompts`에 영어·한국어 번역이 있는지 확인한다.
+- 전체 `make test`를 실행한다.
+- 앱을 빌드하고 Settings navigation과 두 화면을 직접 확인한다.
+- 기존 custom System/Context Prompt가 메뉴 이동 후 그대로 표시되는지 확인한다.
+- Cloud와 Local AI 선택 각각에서 test readiness와 결과 표시를 확인한다.
+
+## Non-goals
+
+이번 변경에는 다음을 포함하지 않는다.
+
+- 새로운 Prompt 종류 추가
+- Meeting Summary Prompt를 사용자 편집 설정으로 노출
+- Prompt preset, version history, import/export 추가
+- Prompt persistence key 또는 기본 Prompt 변경
+- model, backend, fallback 또는 provider 동작 변경
+- Settings 전체 파일 분해
+- Models 이외 다른 메뉴의 정보 구조 변경
+- 업스트림 `PromptsSettingsView`의 직접 cherry-pick
+
+## Acceptance criteria
+
+1. Settings sidebar에 `Models` 다음 `Prompts` 메뉴가 표시된다.
+2. `Prompts` 화면은 System Prompt, Instruction Guard, Context Prompt 세 카드를 제공한다.
+3. Prompt 편집, default/custom 상태, newer-default 안내, reset과 테스트 동작이 기존과 동일하다.
+4. Prompt 테스트는 현재 선택된 Quill Cloud/Local AI backend와 구조화된 오류 처리를 유지한다.
+5. `Models` 화면에는 Prompt 편집기와 Instruction Guard가 남아 있지 않다.
+6. Screenshot Resolution은 `Models > Context > Details`에 남아 있다.
+7. 기존 사용자 설정과 persistence key는 변경되지 않는다.
+8. 영어·한국어에서 새 메뉴가 올바르게 표시된다.
+9. 관련 contract test와 전체 테스트가 통과한다.
+10. 앱에서 Models 화면이 짧아지고 Prompts 화면이 독립적으로 스크롤된다.


### PR DESCRIPTION
## Summary

- add a dedicated Prompts settings menu between Models and Shortcuts
- move System Prompt, Instruction Guard, and Context Prompt editing and testing out of Models
- keep Screenshot Resolution under Models > Context while preserving existing prompt persistence, backend readiness, structured errors, and English/Korean localization

## Verification

- `make test`
- signed Quill Dev build
- `PromptsSettingsUIContractTests`
- `ModelsSettingsUIContractTests`
- `LocalizationResourceTests`
- `git diff --check HEAD~2..HEAD`

## Manual verification

- GUI verification will be completed separately by the maintainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 설정에 독립적인 **프롬프트** 메뉴가 추가되었습니다.
  * 시스템 프롬프트, Instruction Guard, 컨텍스트 프롬프트를 별도 화면에서 관리할 수 있습니다.
  * 프롬프트 기본값 복원, 테스트 및 관련 설정을 새 화면에서 이용할 수 있습니다.
  * 프롬프트 메뉴가 영어와 한국어로 제공됩니다.

* **개선 사항**
  * 모델 설정 화면에서 프롬프트 관련 항목을 분리해 설정 구성을 더 명확하게 개선했습니다.
  * 컨텍스트 스크린샷 해상도 설정을 별도 영역으로 정리했습니다.

* **문서**
  * 프롬프트 설정 분리와 동작 기준을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->