### PR TITLE
Persist update availability and harden release publishing

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -19,8 +19,11 @@ on:
 permissions:
   contents: write
 
+# Manual prereleases share the stable-release lock because their bundle build
+# numbers become the lower bound for the next Sparkle stable release.
+# Dispatch Quill releases one at a time; GitHub keeps only one pending run.
 concurrency:
-  group: manual-release-${{ github.event.inputs.tag }}
+  group: quill-official-stable-release
   cancel-in-progress: false
 
 jobs:
@@ -38,7 +41,7 @@ jobs:
           INPUT_RELEASE_NAME: ${{ inputs.release_name }}
         run: |
           TAG="$INPUT_TAG"
-          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$ ]]; then
+          if ! [[ "$TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)\.(0|[1-9][0-9]*))?$ ]]; then
             echo "Release tags must look like v0.1.0 or v0.1.0-beta.1." >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,13 @@ on:
 permissions:
   contents: write
 
+# GitHub keeps at most one running and one pending job per concurrency group.
+# Dispatch official stable releases one at a time; the shared group prevents
+# two workflows from racing to update the GitHub latest pointer.
+concurrency:
+  group: quill-official-stable-release
+  cancel-in-progress: false
+
 jobs:
   build-and-release:
     runs-on: macos-latest
@@ -34,7 +41,7 @@ jobs:
           BUILD_TAG="$(make -s print-build-tag)"
           VERSION="${TAG#v}"
 
-          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if ! [[ "$TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
             echo "Release tags must use semantic versioning, for example v0.1.0." >&2
             exit 1
           fi
@@ -62,6 +69,15 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Validate stable release ordering
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/validate_stable_release.py preflight \
+            --repository "${{ github.repository }}" \
+            --candidate-version "${{ steps.version.outputs.version }}" \
+            --candidate-build "${{ steps.version.outputs.build_number }}"
 
       - name: Stamp app version
         run: |
@@ -191,6 +207,18 @@ jobs:
           files: |
             Quill.dmg
             appcast.xml
+
+      - name: Verify published latest release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/validate_stable_release.py verify-latest \
+            --repository "${{ github.repository }}" \
+            --expected-tag "${{ steps.version.outputs.tag }}" \
+            --expected-version "${{ steps.version.outputs.version }}" \
+            --expected-build "${{ steps.version.outputs.build_number }}" \
+            --attempts 12 \
+            --retry-delay 10
 
       - name: Cleanup signing artifacts
         if: always()

--- a/.github/workflows/self-signed-release.yml
+++ b/.github/workflows/self-signed-release.yml
@@ -19,6 +19,13 @@ on:
 permissions:
   contents: write
 
+# GitHub keeps at most one running and one pending job per concurrency group.
+# Dispatch official stable releases one at a time; the shared group prevents
+# two workflows from racing to update the GitHub latest pointer.
+concurrency:
+  group: quill-official-stable-release
+  cancel-in-progress: false
+
 jobs:
   build-and-release:
     runs-on: macos-latest
@@ -38,7 +45,7 @@ jobs:
           BUILD_TAG="$(make -s print-build-tag)"
           VERSION="${TAG#v}"
 
-          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if ! [[ "$TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
             echo "Release tags must use semantic versioning, for example v0.1.0." >&2
             exit 1
           fi
@@ -66,6 +73,15 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Validate stable release ordering
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/validate_stable_release.py preflight \
+            --repository "${{ github.repository }}" \
+            --candidate-version "${{ steps.version.outputs.version }}" \
+            --candidate-build "${{ steps.version.outputs.build_number }}"
 
       - name: Stamp app version
         run: |
@@ -179,6 +195,18 @@ jobs:
           files: |
             Quill.dmg
             appcast.xml
+
+      - name: Verify published latest release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/validate_stable_release.py verify-latest \
+            --repository "${{ github.repository }}" \
+            --expected-tag "${{ steps.version.outputs.tag }}" \
+            --expected-version "${{ steps.version.outputs.version }}" \
+            --expected-build "${{ steps.version.outputs.build_number }}" \
+            --attempts 12 \
+            --retry-delay 10
 
       - name: Cleanup signing artifacts
         if: always()

--- a/Info.plist
+++ b/Info.plist
@@ -37,7 +37,7 @@
     <true/>
     <key>SUAutomaticallyUpdate</key>
     <false/>
-    <key>SUUpdateCheckInterval</key>
+    <key>SUScheduledCheckInterval</key>
     <integer>86400</integer>
     <key>GoogleCalendarOAuthClientID</key>
     <string></string>

--- a/Makefile
+++ b/Makefile
@@ -384,6 +384,9 @@ check-test-wiring:
 $(TEST_BUILD_DIR):
 	@mkdir -p "$@"
 
+$(TEST_BUILD_DIR)/UpdateSnapshotStoreTests: Sources/UpdateSnapshotStore.swift Tests/UpdateSnapshotStoreTests.swift | $(TEST_BUILD_DIR)
+	@swiftc -parse-as-library Sources/UpdateSnapshotStore.swift Tests/UpdateSnapshotStoreTests.swift -o "$@"
+
 $(TEST_BUILD_DIR)/MeetingSummaryModelsTests: Sources/CalendarIntegrationModels.swift Sources/MeetingSummaryModels.swift Tests/MeetingSummaryModelsTests.swift | $(TEST_BUILD_DIR)
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/MeetingSummaryModels.swift Tests/MeetingSummaryModelsTests.swift -o "$@"
 
@@ -422,7 +425,10 @@ test: check-test-wiring
 	@$(call RUN_TIMED_TARGET,_test-recording,recording)
 	@$(call RUN_TIMED_TARGET,_test-transcription,transcription)
 
-_test-core: $(SPARKLE_STAMP) $(LOCALIZATION_STAMP) $(TEST_BUILD_DIR)/LocalizationResourceTests $(TEST_BUILD_DIR)/MeetingSummaryModelsTests $(TEST_BUILD_DIR)/MeetingSummaryTextChunkerTests $(TEST_BUILD_DIR)/MeetingSummaryUIContractTests | $(TEST_BUILD_DIR)
+_test-core: $(SPARKLE_STAMP) $(LOCALIZATION_STAMP) $(TEST_BUILD_DIR)/LocalizationResourceTests $(TEST_BUILD_DIR)/UpdateSnapshotStoreTests $(TEST_BUILD_DIR)/MeetingSummaryModelsTests $(TEST_BUILD_DIR)/MeetingSummaryTextChunkerTests $(TEST_BUILD_DIR)/MeetingSummaryUIContractTests | $(TEST_BUILD_DIR)
+	@$(TEST_BUILD_DIR)/UpdateSnapshotStoreTests
+	@python3 Tests/StableReleaseValidationTests.py
+	@bash Tests/SparkleKeyValidationTests.sh
 	@$(TEST_BUILD_DIR)/MeetingSummaryModelsTests
 	@$(TEST_BUILD_DIR)/MeetingSummaryTextChunkerTests
 	@$(TEST_BUILD_DIR)/MeetingSummaryUIContractTests
@@ -452,7 +458,7 @@ _test-core: $(SPARKLE_STAMP) $(LOCALIZATION_STAMP) $(TEST_BUILD_DIR)/Localizatio
 	@$(TEST_BUILD_DIR)/NativeWhisperBuildContractTests
 	@swiftc -parse-as-library Tests/LocalAIBuildContractTests.swift -o $(TEST_BUILD_DIR)/LocalAIBuildContractTests
 	@$(TEST_BUILD_DIR)/LocalAIBuildContractTests
-	@framework="$$(cat "$(SPARKLE_STAMP)")"; framework_parent="$$(dirname "$$framework")"; swiftc -parse-as-library -F "$$framework_parent" -framework Sparkle -Xlinker -rpath -Xlinker "$$framework_parent" Sources/LocalizedStringLookup.swift Sources/LocalizedUserMessage.swift Sources/UpdateManager.swift Tests/UpdateManagerSafetyTests.swift -o $(TEST_BUILD_DIR)/UpdateManagerSafetyTests
+	@framework="$$(cat "$(SPARKLE_STAMP)")"; framework_parent="$$(dirname "$$framework")"; swiftc -parse-as-library -F "$$framework_parent" -framework Sparkle -Xlinker -rpath -Xlinker "$$framework_parent" Sources/LocalizedStringLookup.swift Sources/LocalizedUserMessage.swift Sources/UpdateSnapshotStore.swift Sources/UpdateManager.swift Tests/UpdateManagerSafetyTests.swift -o $(TEST_BUILD_DIR)/UpdateManagerSafetyTests
 	@$(TEST_BUILD_DIR)/UpdateManagerSafetyTests
 	@swiftc -parse-as-library Sources/LocalizedStringLookup.swift Tests/LocalizedStringLookupTests.swift -o $(TEST_BUILD_DIR)/LocalizedStringLookupTests
 	@$(TEST_BUILD_DIR)/LocalizedStringLookupTests

--- a/Sources/UpdateManager.swift
+++ b/Sources/UpdateManager.swift
@@ -52,6 +52,10 @@ final class UpdateManager: NSObject, ObservableObject {
 
     private let legacyAutoCheckPreferenceKey = "updateAutoCheckEnabled"
     private let legacyAutoCheckMigrationKey = "sparkleAutoCheckPreferenceMigrated"
+    private let sparkleSkippedVersionKey = "SUSkippedVersion"
+    private let sparkleSkippedMajorVersionKey = "SUSkippedMajorVersion"
+    private let sparkleSkippedMajorSubreleaseVersionKey = "SUSkippedMajorSubreleaseVersion"
+    private let updateSnapshotStore = UpdateSnapshotStore(userDefaults: .standard)
     private let postTranscriptionReminderInterval: TimeInterval = 24 * 60 * 60 // 1 day
     private var lastPostTranscriptionReminderVersion: String? {
         get { UserDefaults.standard.string(forKey: "updateLastPostTranscriptionReminderVersion") }
@@ -68,6 +72,7 @@ final class UpdateManager: NSObject, ObservableObject {
     private override init() {
         lastCheckDate = UserDefaults.standard.object(forKey: "updateLastCheckDate") as? Date
         super.init()
+        restorePersistedUpdateIfAvailable()
         migrateLegacyAutoCheckPreferenceIfNeeded()
         bridgeUpdaterChangesToSwiftUI()
     }
@@ -122,6 +127,16 @@ final class UpdateManager: NSObject, ObservableObject {
         }
 
         return true
+    }
+
+    nonisolated static func isCandidateBuildNewerForRestoration(
+        _ candidate: String,
+        than current: String
+    ) -> Bool {
+        SUStandardVersionComparator.default.compareVersion(
+            candidate,
+            toVersion: current
+        ) == .orderedDescending
     }
 
     // MARK: - Sparkle Lifecycle
@@ -207,6 +222,10 @@ final class UpdateManager: NSObject, ObservableObject {
         Bundle.main.object(forInfoDictionaryKey: "QuillBuildTag") as? String
     }
 
+    private var currentBuildVersion: String? {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+    }
+
     private func startUpdaterIfNeeded() {
         guard !hasStartedUpdater else { return }
         updaterController.startUpdater()
@@ -239,12 +258,42 @@ final class UpdateManager: NSObject, ObservableObject {
             .store(in: &updaterObservationCancellables)
     }
 
-    private func applyAvailableUpdate(_ item: SUAppcastItem) {
+    private func restorePersistedUpdateIfAvailable() {
+        guard Self.isReleaseBuildTagForAutomaticChecks(currentBuildTag) else { return }
+        let snapshot = updateSnapshotStore.restorableSnapshot(
+            currentBuildVersion: currentBuildVersion,
+            skippedUpdate: PersistedSkippedUpdate(
+                minorVersion: UserDefaults.standard.string(forKey: sparkleSkippedVersionKey),
+                majorVersion: UserDefaults.standard.string(forKey: sparkleSkippedMajorVersionKey),
+                majorSubreleaseVersion: UserDefaults.standard.string(
+                    forKey: sparkleSkippedMajorSubreleaseVersionKey
+                )
+            ),
+            isNewer: Self.isCandidateBuildNewerForRestoration
+        )
+        guard let snapshot else { return }
+        applyAvailableUpdate(snapshot)
+    }
+
+    private func applyAvailableUpdate(_ snapshot: PersistedUpdateSnapshot) {
         updateAvailable = true
-        latestReleaseVersion = item.displayVersionString
-        latestReleaseDate = item.date?.formatted(date: .abbreviated, time: .omitted) ?? ""
-        releaseNotesURL = item.releaseNotesURL ?? item.infoURL
+        latestReleaseVersion = snapshot.displayVersion
+        latestReleaseDate = snapshot.releaseDate?.formatted(date: .abbreviated, time: .omitted) ?? ""
+        releaseNotesURL = snapshot.releaseNotesURL
         updateStatus = .idle
+    }
+
+    private func applyAvailableUpdate(_ item: SUAppcastItem) {
+        let snapshot = PersistedUpdateSnapshot(
+            buildVersion: item.versionString,
+            displayVersion: item.displayVersionString,
+            releaseDate: item.date,
+            releaseNotesURL: item.releaseNotesURL ?? item.infoURL,
+            minimumAutoupdateVersion: item.minimumAutoupdateVersion,
+            ignoreSkippedUpgradesBelowVersion: item.ignoreSkippedUpgradesBelowVersion
+        )
+        applyAvailableUpdate(snapshot)
+        updateSnapshotStore.save(snapshot)
     }
 
     private func clearAvailableUpdate() {
@@ -254,6 +303,7 @@ final class UpdateManager: NSObject, ObservableObject {
         releaseNotesURL = nil
         downloadProgress = nil
         updateStatus = .idle
+        updateSnapshotStore.clear()
     }
 
     private func suppressPostTranscriptionReminder(for item: SUAppcastItem) {
@@ -288,8 +338,11 @@ extension UpdateManager: SPUUpdaterDelegate {
 
     func updater(_ updater: SPUUpdater, userDidMake choice: SPUUserUpdateChoice, forUpdate updateItem: SUAppcastItem, state: SPUUserUpdateState) {
         switch choice {
-        case .dismiss, .skip:
+        case .dismiss:
             suppressPostTranscriptionReminder(for: updateItem)
+        case .skip:
+            suppressPostTranscriptionReminder(for: updateItem)
+            clearAvailableUpdate()
         case .install:
             break
         @unknown default:

--- a/Sources/UpdateSnapshotStore.swift
+++ b/Sources/UpdateSnapshotStore.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+struct PersistedUpdateSnapshot: Codable, Equatable {
+    let buildVersion: String
+    let displayVersion: String
+    let releaseDate: Date?
+    let releaseNotesURL: URL?
+    let minimumAutoupdateVersion: String?
+    let ignoreSkippedUpgradesBelowVersion: String?
+}
+
+struct PersistedSkippedUpdate {
+    static let none = PersistedSkippedUpdate()
+
+    let minorVersion: String?
+    let majorVersion: String?
+    let majorSubreleaseVersion: String?
+
+    init(
+        minorVersion: String? = nil,
+        majorVersion: String? = nil,
+        majorSubreleaseVersion: String? = nil
+    ) {
+        self.minorVersion = minorVersion
+        self.majorVersion = majorVersion
+        self.majorSubreleaseVersion = majorSubreleaseVersion
+    }
+}
+
+struct UpdateSnapshotStore {
+    static let defaultStorageKey = "updateAvailableSnapshot"
+
+    private let userDefaults: UserDefaults
+    private let storageKey: String
+
+    init(
+        userDefaults: UserDefaults,
+        storageKey: String = Self.defaultStorageKey
+    ) {
+        self.userDefaults = userDefaults
+        self.storageKey = storageKey
+    }
+
+    func save(_ snapshot: PersistedUpdateSnapshot) {
+        guard let data = try? JSONEncoder().encode(snapshot) else { return }
+        userDefaults.set(data, forKey: storageKey)
+    }
+
+    func clear() {
+        userDefaults.removeObject(forKey: storageKey)
+    }
+
+    func restorableSnapshot(
+        currentBuildVersion: String?,
+        skippedUpdate: PersistedSkippedUpdate,
+        isNewer: (String, String) -> Bool
+    ) -> PersistedUpdateSnapshot? {
+        guard userDefaults.object(forKey: storageKey) != nil else { return nil }
+        guard let data = userDefaults.data(forKey: storageKey) else {
+            clear()
+            return nil
+        }
+        guard let snapshot = try? JSONDecoder().decode(PersistedUpdateSnapshot.self, from: data) else {
+            clear()
+            return nil
+        }
+        guard let currentBuildVersion else { return nil }
+        guard isNewer(snapshot.buildVersion, currentBuildVersion),
+              !isSkipped(
+                  snapshot,
+                  currentBuildVersion: currentBuildVersion,
+                  skippedUpdate: skippedUpdate,
+                  isNewer: isNewer
+              ) else {
+            clear()
+            return nil
+        }
+        return snapshot
+    }
+
+    private func isSkipped(
+        _ snapshot: PersistedUpdateSnapshot,
+        currentBuildVersion: String,
+        skippedUpdate: PersistedSkippedUpdate,
+        isNewer: (String, String) -> Bool
+    ) -> Bool {
+        if let skippedMinorVersion = skippedUpdate.minorVersion,
+           !isNewer(snapshot.buildVersion, skippedMinorVersion) {
+            return true
+        }
+
+        guard let skippedMajorVersion = skippedUpdate.majorVersion,
+              let minimumAutoupdateVersion = snapshot.minimumAutoupdateVersion,
+              isNewer(skippedMajorVersion, currentBuildVersion),
+              !isNewer(minimumAutoupdateVersion, skippedMajorVersion) else {
+            return false
+        }
+
+        guard let ignoreThreshold = snapshot.ignoreSkippedUpgradesBelowVersion else {
+            return true
+        }
+        guard let skippedSubreleaseVersion = skippedUpdate.majorSubreleaseVersion else {
+            return false
+        }
+        return !isNewer(ignoreThreshold, skippedSubreleaseVersion)
+    }
+}

--- a/Tests/BuildMetadataTests.swift
+++ b/Tests/BuildMetadataTests.swift
@@ -19,7 +19,9 @@ struct BuildMetadataTests {
         try testMakefileCreatesDmgWithoutFinderMetadata()
         try testSparkleEntitlementsAllowFrameworkLoading()
         try testSparkleMetadataAndBuildIntegration()
+        try testSparkleAppcastGeneratorValidatesSigningKey()
         try testReleaseWorkflowsPassBuildMetadataToMake()
+        try testStableReleaseWorkflowsEnforceMonotonicUpdates()
         try testNotarizedReleaseWorkflowIsManualByDefault()
         try testSettingsSeparatesVersionBuildAndReleaseTag()
         print("BuildMetadataTests passed")
@@ -213,8 +215,9 @@ struct BuildMetadataTests {
         assertContains(infoPlist, "CnlcVsnQ8m/2VyZD7xL4ovP/ukAJtDJY19aVlfOSoOg=")
         assertContains(infoPlist, "<key>SUEnableAutomaticChecks</key>")
         assertContains(infoPlist, "<key>SUAutomaticallyUpdate</key>")
-        assertContains(infoPlist, "<key>SUUpdateCheckInterval</key>")
+        assertContains(infoPlist, "<key>SUScheduledCheckInterval</key>")
         assertContains(infoPlist, "<integer>86400</integer>")
+        assertDoesNotContain(infoPlist, "<key>SUUpdateCheckInterval</key>")
 
         assertContains(makefile, "SPARKLE_VERSION ?= 2.9.2")
         assertContains(makefile, "swift build --product SparkleResolver")
@@ -225,6 +228,15 @@ struct BuildMetadataTests {
         assertContains(makefile, "Versions/Current/XPCServices")
         assertContains(makefile, "Versions/Current/Updater.app")
         assertContains(makefile, "Versions/Current/Autoupdate")
+    }
+
+    private static func testSparkleAppcastGeneratorValidatesSigningKey() throws {
+        let generator = try String(contentsOfFile: "scripts/generate-sparkle-appcast.sh", encoding: .utf8)
+
+        assertContains(generator, "validate-sparkle-key.swift")
+        assertContains(generator, "SUPublicEDKey")
+        assertContains(generator, "--verify --ed-key-file -")
+        assertContains(generator, #"printf '%s\n' "$private_key" |"#)
     }
 
     private static func testReleaseWorkflowsPassBuildMetadataToMake() throws {
@@ -263,6 +275,41 @@ struct BuildMetadataTests {
         assertContains(releaseWorkflow, "appcast.xml")
         assertContains(releaseWorkflow, "Quill.dmg")
         assertDoesNotContain(devReleaseWorkflow, "plutil -replace FreeFlowBuildTag")
+    }
+
+    private static func testStableReleaseWorkflowsEnforceMonotonicUpdates() throws {
+        let stableWorkflows = [
+            try String(contentsOfFile: ".github/workflows/self-signed-release.yml", encoding: .utf8),
+            try String(contentsOfFile: ".github/workflows/release.yml", encoding: .utf8),
+        ]
+        let manualWorkflow = try String(contentsOfFile: ".github/workflows/manual-release.yml", encoding: .utf8)
+        let devWorkflow = try String(contentsOfFile: ".github/workflows/dev-release.yml", encoding: .utf8)
+
+        for workflow in stableWorkflows {
+            assertContains(workflow, "group: quill-official-stable-release")
+            assertContains(workflow, "cancel-in-progress: false")
+            assertContains(workflow, "Validate stable release ordering")
+            assertContains(workflow, "scripts/validate_stable_release.py preflight")
+            assertContains(workflow, "Verify published latest release")
+            assertContains(workflow, "scripts/validate_stable_release.py verify-latest")
+            assertContains(workflow, "--attempts 12")
+            assertContains(workflow, "--retry-delay 10")
+            assertContains(workflow, #"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"#)
+            assertContains(workflow, "GITHUB_TOKEN: ${{ github.token }}")
+            assertAppearsInOrder(
+                workflow,
+                [
+                    "Validate stable release ordering",
+                    "Stamp app version",
+                    "Create tag",
+                    "Create Release",
+                    "Verify published latest release",
+                ]
+            )
+        }
+
+        assertDoesNotContain(manualWorkflow, "validate_stable_release.py")
+        assertDoesNotContain(devWorkflow, "validate_stable_release.py")
     }
 
     private static func testNotarizedReleaseWorkflowIsManualByDefault() throws {
@@ -306,6 +353,16 @@ struct BuildMetadataTests {
         }
 
         return metadata
+    }
+
+    private static func assertAppearsInOrder(_ text: String, _ markers: [String]) {
+        var searchStart = text.startIndex
+        for marker in markers {
+            guard let range = text[searchStart...].range(of: marker) else {
+                preconditionFailure("Expected content to contain \(marker) after previous markers")
+            }
+            searchStart = range.upperBound
+        }
     }
 
     private static func assertContains(_ text: String, _ expected: String) {

--- a/Tests/ManualReleaseWorkflowTests.swift
+++ b/Tests/ManualReleaseWorkflowTests.swift
@@ -13,6 +13,9 @@ struct ManualReleaseWorkflowTests {
         assertContains(workflow, "name: Manual Release")
         assertContains(workflow, "workflow_dispatch:")
         assertContains(workflow, "tag:")
+        assertContains(workflow, "group: quill-official-stable-release")
+        assertContains(workflow, "cancel-in-progress: false")
+        assertDoesNotContain(workflow, "group: manual-release-${{ github.event.inputs.tag }}")
         assertDoesNotContain(workflow, "build_number:")
         assertContains(workflow, "APP_VERSION=\"$(make -s print-app-version)\"")
         assertContains(workflow, "BUILD_NUMBER=\"$(make -s print-build-number)\"")
@@ -31,6 +34,10 @@ struct ManualReleaseWorkflowTests {
         assertDoesNotContain(workflow, "IS_PRERELEASE=false")
         assertDoesNotContain(workflow, "MAKE_LATEST=true")
         assertContains(workflow, "VERSION=\"${TAG#v}\"")
+        assertContains(
+            workflow,
+            #"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)\.(0|[1-9][0-9]*))?$"#
+        )
         assertContains(workflow, "if ! [[ \"$BUILD_NUMBER\" =~ ^[1-9][0-9]*$ ]]")
         assertContains(workflow, "echo \"build_number=$BUILD_NUMBER\" >> \"$GITHUB_OUTPUT\"")
         assertContains(workflow, "RELEASE_NAME_DELIM=\"RELEASE_NAME_$(uuidgen)\"")

--- a/Tests/SparkleKeyValidationTests.sh
+++ b/Tests/SparkleKeyValidationTests.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PRIVATE_SEED="nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A="
+PUBLIC_KEY="11qYAYKxCrfVS/7TyWQHOg7hcvPapiMlrwIaaPcHURo="
+WRONG_PUBLIC_KEY="CnlcVsnQ8m/2VyZD7xL4ovP/ukAJtDJY19aVlfOSoOg="
+
+printf '%s\n' "$PRIVATE_SEED" |
+  xcrun swift scripts/validate-sparkle-key.swift "$PUBLIC_KEY"
+
+if printf '%s\n' "$PRIVATE_SEED" |
+  xcrun swift scripts/validate-sparkle-key.swift "$WRONG_PUBLIC_KEY" >/dev/null 2>&1; then
+  echo "Expected mismatched Sparkle key validation to fail" >&2
+  exit 1
+fi
+
+if printf '%s\n' "not-base64" |
+  xcrun swift scripts/validate-sparkle-key.swift "$PUBLIC_KEY" >/dev/null 2>&1; then
+  echo "Expected malformed Sparkle private key validation to fail" >&2
+  exit 1
+fi
+
+temporary_dir="$(mktemp -d -t quill-sparkle-key-test)"
+trap 'rm -rf "$temporary_dir"' EXIT
+printf 'signed update fixture\n' > "$temporary_dir/Quill.dmg"
+sign_update="$(find .build/artifacts -type f -name sign_update -perm +111 -print -quit)"
+test -n "$sign_update"
+
+RELEASE_TAG=v0.0.1 \
+VERSION=0.0.1 \
+BUILD_NUMBER=1 \
+DMG_PATH="$temporary_dir/Quill.dmg" \
+APPCAST_PATH="$temporary_dir/appcast.xml" \
+SPARKLE_PRIVATE_KEY="$PRIVATE_SEED" \
+SPARKLE_PUBLIC_KEY="$PUBLIC_KEY" \
+SPARKLE_SIGN_UPDATE="$sign_update" \
+  scripts/generate-sparkle-appcast.sh
+
+grep -q 'sparkle:edSignature=' "$temporary_dir/appcast.xml"
+
+printf 'SparkleKeyValidationTests passed\n'

--- a/Tests/StableReleaseValidationTests.py
+++ b/Tests/StableReleaseValidationTests.py
@@ -1,0 +1,346 @@
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.dont_write_bytecode = True
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import validate_stable_release as module
+
+
+APPCAST_XML = """<?xml version="1.0"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel><item>
+    <sparkle:version>31</sparkle:version>
+    <sparkle:shortVersionString>0.1.28</sparkle:shortVersionString>
+    <enclosure url="https://github.com/woosublee/quill/releases/download/v0.1.28/Quill.dmg"
+      sparkle:version="31" sparkle:shortVersionString="0.1.28" />
+  </item></channel>
+</rss>"""
+
+
+class StableReleaseValidationTests(unittest.TestCase):
+    def records(self):
+        return [
+            module.StableReleaseRecord("v0.1.27", (0, 1, 27), 30),
+            module.StableReleaseRecord("v0.1.28", (0, 1, 28), 31),
+        ]
+
+    def test_accepts_strictly_newer_version_and_build(self):
+        module.validate_preflight("0.1.29", 32, self.records())
+
+    def test_rejects_equal_or_lower_version(self):
+        with self.assertRaises(module.ValidationError):
+            module.validate_preflight("0.1.28", 32, self.records())
+
+    def test_rejects_equal_or_lower_build(self):
+        with self.assertRaises(module.ValidationError):
+            module.validate_preflight("0.1.29", 31, self.records())
+
+    def test_rejects_build_not_newer_than_published_prerelease(self):
+        prerelease_builds = [
+            module.PublishedBuildRecord("v0.2.0-beta.1", 40),
+        ]
+
+        with self.assertRaises(module.ValidationError):
+            module.validate_preflight(
+                "0.2.0",
+                32,
+                self.records(),
+                prerelease_builds,
+            )
+
+    def test_uses_maximum_build_across_all_stable_records(self):
+        records = [
+            module.StableReleaseRecord("v0.1.28", (0, 1, 28), 31),
+            module.StableReleaseRecord("v0.1.27", (0, 1, 27), 32),
+        ]
+
+        with self.assertRaises(module.ValidationError):
+            module.validate_preflight("0.1.29", 32, records)
+
+    def test_allows_first_stable_release(self):
+        module.validate_preflight("0.1.0", 1, [])
+
+    def test_collects_only_published_stable_releases(self):
+        releases = [
+            release("v0.1.28", APPCAST_XML),
+            release("v0.1.29-beta.1", APPCAST_XML, prerelease=True),
+            release("v0.1.30", APPCAST_XML, draft=True),
+            release("not-a-version", APPCAST_XML),
+            release("v0.1.5", None),
+        ]
+
+        records = module.collect_stable_release_records(
+            releases,
+            lambda url: APPCAST_XML.encode() if url else b"",
+        )
+
+        self.assertEqual(
+            records,
+            [
+                module.StableReleaseRecord("v0.1.28", (0, 1, 28), 31),
+                module.StableReleaseRecord("v0.1.5", (0, 1, 5), None),
+            ],
+        )
+
+    def test_rejects_appcast_display_version_that_does_not_match_tag(self):
+        mismatched_appcast = APPCAST_XML.replace("0.1.28", "0.1.30")
+
+        with self.assertRaises(module.ValidationError):
+            module.collect_stable_release_records(
+                [release("v0.1.28", mismatched_appcast)],
+                lambda url: mismatched_appcast.encode(),
+            )
+
+    def test_collects_prerelease_build_from_version_metadata(self):
+        releases = [release("v0.2.0-beta.1", None, prerelease=True)]
+        metadata = b"APP_VERSION := 0.2.0-beta.1\nBUILD_NUMBER := 40\n"
+
+        records = module.collect_prerelease_build_records(
+            releases,
+            lambda tag: metadata,
+            first_appcast_version=(0, 1, 6),
+        )
+
+        self.assertEqual(
+            records,
+            [module.PublishedBuildRecord("v0.2.0-beta.1", 40)],
+        )
+
+    def test_collects_manual_prerelease_with_stable_shaped_tag(self):
+        releases = [release("v0.2.0", None, prerelease=True)]
+        metadata = b"APP_VERSION := 0.2.0\nBUILD_NUMBER := 40\n"
+
+        records = module.collect_prerelease_build_records(
+            releases,
+            lambda tag: metadata,
+            first_appcast_version=(0, 1, 6),
+        )
+
+        self.assertEqual(
+            records,
+            [module.PublishedBuildRecord("v0.2.0", 40)],
+        )
+
+    def test_prerelease_build_parser_uses_last_make_assignment(self):
+        releases = [release("v0.2.0-beta.1", None, prerelease=True)]
+        metadata = b"BUILD_NUMBER := 40\nBUILD_NUMBER := 50\n"
+
+        records = module.collect_prerelease_build_records(
+            releases,
+            lambda tag: metadata,
+            first_appcast_version=(0, 1, 6),
+        )
+
+        self.assertEqual(
+            records,
+            [module.PublishedBuildRecord("v0.2.0-beta.1", 50)],
+        )
+
+    def test_prerelease_build_parser_supports_conditional_assignment(self):
+        releases = [release("v0.2.0-beta.1", None, prerelease=True)]
+        metadata = b"BUILD_NUMBER ?= 40\n"
+
+        records = module.collect_prerelease_build_records(
+            releases,
+            lambda tag: metadata,
+            first_appcast_version=(0, 1, 6),
+        )
+
+        self.assertEqual(
+            records,
+            [module.PublishedBuildRecord("v0.2.0-beta.1", 40)],
+        )
+
+    def test_allows_legacy_prerelease_without_version_metadata(self):
+        records = module.collect_prerelease_build_records(
+            [release("v0.1.0-beta.2", None, prerelease=True)],
+            lambda tag: None,
+            first_appcast_version=(0, 1, 6),
+        )
+
+        self.assertEqual(records, [])
+
+    def test_rejects_new_prerelease_without_version_metadata(self):
+        with self.assertRaises(module.ValidationError):
+            module.collect_prerelease_build_records(
+                [release("v0.2.0-beta.1", None, prerelease=True)],
+                lambda tag: None,
+                first_appcast_version=(0, 1, 6),
+            )
+
+    def test_rejects_missing_appcast_after_sparkle_adoption(self):
+        releases = [
+            release("v0.1.5", None),
+            release("v0.1.6", APPCAST_XML),
+            release("v0.1.7", None),
+        ]
+
+        with self.assertRaises(module.ValidationError):
+            module.collect_stable_release_records(
+                releases,
+                lambda url: APPCAST_XML.encode() if url else b"",
+            )
+
+    def test_rejects_missing_first_sparkle_appcast(self):
+        appcast_017 = APPCAST_XML.replace("0.1.28", "0.1.7")
+        releases = [
+            release("v0.1.6", None),
+            release("v0.1.7", appcast_017),
+        ]
+
+        with self.assertRaises(module.ValidationError):
+            module.collect_stable_release_records(
+                releases,
+                lambda url: appcast_017.encode(),
+            )
+
+    def test_rejects_leading_zero_version_components(self):
+        with self.assertRaises(module.ValidationError):
+            module.parse_version("0.01.29")
+
+    def test_retries_transient_latest_verification_failure(self):
+        attempts = []
+
+        def operation():
+            attempts.append(1)
+            if len(attempts) < 3:
+                raise module.ValidationError("not propagated yet")
+            return "verified"
+
+        result = module.run_with_retries(
+            operation,
+            attempts=3,
+            retry_delay=0,
+            sleep=lambda _: None,
+        )
+
+        self.assertEqual(result, "verified")
+        self.assertEqual(len(attempts), 3)
+
+    def test_stops_after_latest_verification_retries_are_exhausted(self):
+        with self.assertRaises(module.ValidationError):
+            module.run_with_retries(
+                lambda: (_ for _ in ()).throw(module.ValidationError("still stale")),
+                attempts=2,
+                retry_delay=0,
+                sleep=lambda _: None,
+            )
+
+    def test_public_asset_request_does_not_include_token(self):
+        public_request = module.build_request(
+            "https://github.com/woosublee/quill/releases/latest/download/appcast.xml",
+            accept="application/octet-stream",
+            token=None,
+        )
+        api_request = module.build_request(
+            "https://api.github.com/repos/woosublee/quill/releases/latest",
+            accept="application/vnd.github+json",
+            token="secret-token",
+        )
+
+        self.assertIsNone(public_request.get_header("Authorization"))
+        self.assertEqual(api_request.get_header("Authorization"), "Bearer secret-token")
+
+    def test_latest_appcast_url_matches_application_feed(self):
+        self.assertEqual(
+            module.latest_appcast_url("woosublee/quill"),
+            "https://github.com/woosublee/quill/releases/latest/download/appcast.xml",
+        )
+
+    def test_parses_appcast_version_and_enclosure(self):
+        metadata = module.parse_appcast(APPCAST_XML.encode())
+
+        self.assertEqual(metadata.build_number, 31)
+        self.assertEqual(metadata.display_version, "0.1.28")
+        self.assertEqual(
+            metadata.enclosure_url,
+            "https://github.com/woosublee/quill/releases/download/v0.1.28/Quill.dmg",
+        )
+
+    def test_rejects_malformed_existing_appcast(self):
+        with self.assertRaises(module.ValidationError):
+            module.parse_appcast(b"<rss><channel></channel></rss>")
+
+    def test_accepts_expected_latest_release(self):
+        module.validate_latest(
+            repository="woosublee/quill",
+            expected_tag="v0.1.28",
+            expected_version="0.1.28",
+            expected_build=31,
+            actual_tag="v0.1.28",
+            appcast=module.parse_appcast(APPCAST_XML.encode()),
+        )
+
+    def test_rejects_latest_release_with_wrong_tag(self):
+        with self.assertRaises(module.ValidationError):
+            module.validate_latest(
+                repository="woosublee/quill",
+                expected_tag="v0.1.29",
+                expected_version="0.1.28",
+                expected_build=31,
+                actual_tag="v0.1.28",
+                appcast=module.parse_appcast(APPCAST_XML.encode()),
+            )
+
+    def test_rejects_latest_appcast_with_wrong_display_version(self):
+        with self.assertRaises(module.ValidationError):
+            module.validate_latest(
+                repository="woosublee/quill",
+                expected_tag="v0.1.28",
+                expected_version="0.1.29",
+                expected_build=31,
+                actual_tag="v0.1.28",
+                appcast=module.parse_appcast(APPCAST_XML.encode()),
+            )
+
+    def test_rejects_latest_appcast_with_wrong_build(self):
+        with self.assertRaises(module.ValidationError):
+            module.validate_latest(
+                repository="woosublee/quill",
+                expected_tag="v0.1.28",
+                expected_version="0.1.28",
+                expected_build=32,
+                actual_tag="v0.1.28",
+                appcast=module.parse_appcast(APPCAST_XML.encode()),
+            )
+
+    def test_rejects_latest_appcast_with_wrong_enclosure(self):
+        appcast = module.AppcastMetadata(
+            build_number=31,
+            display_version="0.1.28",
+            enclosure_url="https://example.test/Quill.dmg",
+        )
+
+        with self.assertRaises(module.ValidationError):
+            module.validate_latest(
+                repository="woosublee/quill",
+                expected_tag="v0.1.28",
+                expected_version="0.1.28",
+                expected_build=31,
+                actual_tag="v0.1.28",
+                appcast=appcast,
+            )
+
+
+def release(tag, appcast, draft=False, prerelease=False):
+    assets = []
+    if appcast is not None:
+        assets.append(
+            {
+                "name": "appcast.xml",
+                "browser_download_url": f"https://example.test/{tag}/appcast.xml",
+            }
+        )
+    return {
+        "tag_name": tag,
+        "draft": draft,
+        "prerelease": prerelease,
+        "assets": assets,
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/UpdateManagerSafetyTests.swift
+++ b/Tests/UpdateManagerSafetyTests.swift
@@ -4,7 +4,9 @@ import Foundation
 struct UpdateManagerSafetyTests {
     static func main() throws {
         testReleaseBuildTagEligibility()
+        testUpdateBuildComparison()
         try testUpdateManagerUsesSparkleFacade()
+        try testUpdateManagerPersistsAvailableUpdate()
         try testUpdateManagerRemovedSelfInstallPipeline()
         try testAppDelegateStartsPeriodicUpdateChecks()
         try testSettingsShowsUpdatesCard()
@@ -26,6 +28,13 @@ struct UpdateManagerSafetyTests {
         precondition(!UpdateManager.isReleaseBuildTagForAutomaticChecks("v1.2.3-"))
     }
 
+    private static func testUpdateBuildComparison() {
+        precondition(UpdateManager.isCandidateBuildNewerForRestoration("32", than: "31"))
+        precondition(UpdateManager.isCandidateBuildNewerForRestoration("1.10", than: "1.9"))
+        precondition(!UpdateManager.isCandidateBuildNewerForRestoration("31", than: "31"))
+        precondition(!UpdateManager.isCandidateBuildNewerForRestoration("30", than: "31"))
+    }
+
     private static func testUpdateManagerUsesSparkleFacade() throws {
         let source = try String(contentsOfFile: "Sources/UpdateManager.swift", encoding: .utf8)
 
@@ -41,6 +50,39 @@ struct UpdateManagerSafetyTests {
         assertContains(source, "extension UpdateManager: SPUUpdaterDelegate")
         assertContains(source, "updateLastPostTranscriptionReminderVersion")
         assertContains(source, "updateLastPostTranscriptionReminderDate")
+    }
+
+    private static func testUpdateManagerPersistsAvailableUpdate() throws {
+        let source = try String(contentsOfFile: "Sources/UpdateManager.swift", encoding: .utf8)
+
+        assertContains(source, "UpdateSnapshotStore(userDefaults: .standard)")
+        assertContains(source, "restorePersistedUpdateIfAvailable()")
+        assertContains(source, "item.versionString")
+        assertContains(source, "SUSkippedVersion")
+        assertContains(source, "SUSkippedMajorVersion")
+        assertContains(source, "SUSkippedMajorSubreleaseVersion")
+        assertContains(source, "guard Self.isReleaseBuildTagForAutomaticChecks(currentBuildTag) else { return }")
+        assertContains(source, "SUStandardVersionComparator.default")
+        assertContains(source, "updateSnapshotStore.save(snapshot)")
+        assertContains(source, "updateSnapshotStore.clear()")
+        assertContains(source, "case .skip:")
+
+        let noUpdateCallback = extract(
+            source,
+            from: "func updaterDidNotFindUpdate",
+            to: "func updater(_ updater: SPUUpdater, userDidMake"
+        )
+        let abortCallback = extract(
+            source,
+            from: "func updater(_ updater: SPUUpdater, didAbortWithError",
+            to: "func updater(_ updater: SPUUpdater, didFinishUpdateCycleFor"
+        )
+        assertContains(noUpdateCallback, "clearAvailableUpdate()")
+        assertDoesNotContain(abortCallback, "clearAvailableUpdate()")
+        assertContains(
+            source,
+            "if nsError.domain == SUSparkleErrorDomain, nsError.code == SUError.noUpdateError.rawValue {\n                clearAvailableUpdate()\n            } else if updateStatus == .idle {"
+        )
     }
 
     private static func testUpdateManagerRemovedSelfInstallPipeline() throws {

--- a/Tests/UpdateSnapshotStoreTests.swift
+++ b/Tests/UpdateSnapshotStoreTests.swift
@@ -1,0 +1,226 @@
+import Foundation
+
+@main
+struct UpdateSnapshotStoreTests {
+    static func main() {
+        testSavesAndLoadsNewerSnapshot()
+        testClearsInstalledSnapshot()
+        testClearsSkippedSnapshot()
+        testClearsSnapshotBelowSkippedMinorCeiling()
+        testClearsSkippedMajorUpgradeSnapshot()
+        testRestoresMajorUpgradeWhenCurrentBuildPassesSkippedMajorVersion()
+        testRestoresMajorUpgradeWhenIgnoreThresholdExceedsSkippedSubrelease()
+        testPreservesSnapshotWhenCurrentBuildIsUnavailable()
+        testRemovesCorruptSnapshot()
+        testRemovesSnapshotWithUnexpectedDefaultsType()
+        print("UpdateSnapshotStoreTests passed")
+    }
+
+    private static func testSavesAndLoadsNewerSnapshot() {
+        withStore { _, store in
+            let snapshot = PersistedUpdateSnapshot(
+                buildVersion: "32",
+                displayVersion: "0.1.29",
+                releaseDate: Date(timeIntervalSince1970: 1_700_000_000),
+                releaseNotesURL: URL(string: "https://github.com/woosublee/quill/releases/tag/v0.1.29"),
+                minimumAutoupdateVersion: nil,
+                ignoreSkippedUpgradesBelowVersion: nil
+            )
+
+            store.save(snapshot)
+            let restored = store.restorableSnapshot(
+                currentBuildVersion: "31",
+                skippedUpdate: .none,
+                isNewer: numericIsNewer
+            )
+
+            precondition(restored == snapshot)
+        }
+    }
+
+    private static func testClearsInstalledSnapshot() {
+        withStore { defaults, store in
+            store.save(snapshot(build: "31"))
+
+            let restored = store.restorableSnapshot(
+                currentBuildVersion: "31",
+                skippedUpdate: .none,
+                isNewer: numericIsNewer
+            )
+
+            precondition(restored == nil)
+            precondition(defaults.data(forKey: UpdateSnapshotStore.defaultStorageKey) == nil)
+        }
+    }
+
+    private static func testClearsSkippedSnapshot() {
+        withStore { defaults, store in
+            store.save(snapshot(build: "32"))
+
+            let restored = store.restorableSnapshot(
+                currentBuildVersion: "31",
+                skippedUpdate: PersistedSkippedUpdate(minorVersion: "32"),
+                isNewer: numericIsNewer
+            )
+
+            precondition(restored == nil)
+            precondition(defaults.data(forKey: UpdateSnapshotStore.defaultStorageKey) == nil)
+        }
+    }
+
+    private static func testClearsSnapshotBelowSkippedMinorCeiling() {
+        withStore { defaults, store in
+            store.save(snapshot(build: "31"))
+
+            let restored = store.restorableSnapshot(
+                currentBuildVersion: "30",
+                skippedUpdate: PersistedSkippedUpdate(minorVersion: "32"),
+                isNewer: numericIsNewer
+            )
+
+            precondition(restored == nil)
+            precondition(defaults.data(forKey: UpdateSnapshotStore.defaultStorageKey) == nil)
+        }
+    }
+
+    private static func testClearsSkippedMajorUpgradeSnapshot() {
+        withStore { defaults, store in
+            store.save(
+                snapshot(
+                    build: "40",
+                    minimumAutoupdateVersion: "35"
+                )
+            )
+
+            let restored = store.restorableSnapshot(
+                currentBuildVersion: "30",
+                skippedUpdate: PersistedSkippedUpdate(
+                    majorVersion: "35",
+                    majorSubreleaseVersion: "40"
+                ),
+                isNewer: numericIsNewer
+            )
+
+            precondition(restored == nil)
+            precondition(defaults.data(forKey: UpdateSnapshotStore.defaultStorageKey) == nil)
+        }
+    }
+
+    private static func testRestoresMajorUpgradeWhenCurrentBuildPassesSkippedMajorVersion() {
+        withStore { _, store in
+            let expected = snapshot(
+                build: "40",
+                minimumAutoupdateVersion: "35"
+            )
+            store.save(expected)
+
+            let restored = store.restorableSnapshot(
+                currentBuildVersion: "36",
+                skippedUpdate: PersistedSkippedUpdate(
+                    majorVersion: "35",
+                    majorSubreleaseVersion: "40"
+                ),
+                isNewer: numericIsNewer
+            )
+
+            precondition(restored == expected)
+        }
+    }
+
+    private static func testRestoresMajorUpgradeWhenIgnoreThresholdExceedsSkippedSubrelease() {
+        withStore { _, store in
+            let expected = snapshot(
+                build: "42",
+                minimumAutoupdateVersion: "35",
+                ignoreSkippedUpgradesBelowVersion: "41"
+            )
+            store.save(expected)
+
+            let restored = store.restorableSnapshot(
+                currentBuildVersion: "30",
+                skippedUpdate: PersistedSkippedUpdate(
+                    majorVersion: "35",
+                    majorSubreleaseVersion: "40"
+                ),
+                isNewer: numericIsNewer
+            )
+
+            precondition(restored == expected)
+        }
+    }
+
+    private static func testPreservesSnapshotWhenCurrentBuildIsUnavailable() {
+        withStore { defaults, store in
+            store.save(snapshot(build: "32"))
+
+            let restored = store.restorableSnapshot(
+                currentBuildVersion: nil,
+                skippedUpdate: .none,
+                isNewer: numericIsNewer
+            )
+
+            precondition(restored == nil)
+            precondition(defaults.data(forKey: UpdateSnapshotStore.defaultStorageKey) != nil)
+        }
+    }
+
+    private static func testRemovesCorruptSnapshot() {
+        withStore { defaults, store in
+            defaults.set(Data("not-json".utf8), forKey: UpdateSnapshotStore.defaultStorageKey)
+
+            let restored = store.restorableSnapshot(
+                currentBuildVersion: "31",
+                skippedUpdate: .none,
+                isNewer: numericIsNewer
+            )
+
+            precondition(restored == nil)
+            precondition(defaults.data(forKey: UpdateSnapshotStore.defaultStorageKey) == nil)
+        }
+    }
+
+    private static func testRemovesSnapshotWithUnexpectedDefaultsType() {
+        withStore { defaults, store in
+            defaults.set("not-data", forKey: UpdateSnapshotStore.defaultStorageKey)
+
+            let restored = store.restorableSnapshot(
+                currentBuildVersion: "31",
+                skippedUpdate: .none,
+                isNewer: numericIsNewer
+            )
+
+            precondition(restored == nil)
+            precondition(defaults.object(forKey: UpdateSnapshotStore.defaultStorageKey) == nil)
+        }
+    }
+
+    private static let numericIsNewer: (String, String) -> Bool = {
+        guard let candidate = Int($0), let current = Int($1) else { return false }
+        return candidate > current
+    }
+
+    private static func snapshot(
+        build: String,
+        minimumAutoupdateVersion: String? = nil,
+        ignoreSkippedUpgradesBelowVersion: String? = nil
+    ) -> PersistedUpdateSnapshot {
+        PersistedUpdateSnapshot(
+            buildVersion: build,
+            displayVersion: "0.1.29",
+            releaseDate: nil,
+            releaseNotesURL: nil,
+            minimumAutoupdateVersion: minimumAutoupdateVersion,
+            ignoreSkippedUpgradesBelowVersion: ignoreSkippedUpgradesBelowVersion
+        )
+    }
+
+    private static func withStore(
+        _ body: (UserDefaults, UpdateSnapshotStore) -> Void
+    ) {
+        let suiteName = "UpdateSnapshotStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(defaults, UpdateSnapshotStore(userDefaults: defaults))
+    }
+}

--- a/docs/superpowers/specs/2026-07-27-update-state-and-release-safety-design.md
+++ b/docs/superpowers/specs/2026-07-27-update-state-and-release-safety-design.md
@@ -1,0 +1,280 @@
+# 업데이트 상태 복원 및 릴리스 안전성 설계
+
+## 목적
+
+Quill의 Sparkle 업데이트 흐름에서 확인된 다음 세 문제를 최소 변경으로 해결한다.
+
+1. 자동 확인에서 업데이트를 발견해도 앱 재시작 후 설정창과 메뉴바의 업데이트 카드가 사라질 수 있다.
+2. 표시 버전과 빌드 번호가 서로 다른 방향으로 움직이거나 공식 릴리스가 동시에 실행되면, 최신 표시 버전보다 낮은 릴리스가 업데이트 대상으로 선택될 수 있다.
+3. `Info.plist`가 Sparkle 2.9.2에서 읽지 않는 `SUUpdateCheckInterval` 키를 사용한다.
+
+현재 `UpdateManager`와 Sparkle의 공통 확인 경로를 유지하고, 별도 업데이터나 설정창 진입 시 강제 네트워크 확인은 추가하지 않는다.
+
+## 배경과 확인된 원인
+
+### 업데이트 카드 상태
+
+Sparkle은 마지막 확인 시각인 `SULastCheckTime`을 저장하지만, Quill의 `updateAvailable`, 표시 버전, 릴리스 날짜, 릴리스 노트 URL은 프로세스 메모리에만 존재한다. 자동 확인에서 업데이트를 찾은 뒤 앱을 재시작하면 카드 상태는 초기화된다. 마지막 확인 후 하루가 지나지 않았다면 Sparkle은 즉시 다시 확인하지 않으므로, 수동 확인이나 다음 예약 확인 전까지 카드가 보이지 않을 수 있다.
+
+### 업데이트 버전 선택
+
+Sparkle은 사용자에게 보이는 `CFBundleShortVersionString`이 아니라 `CFBundleVersion`과 appcast의 `sparkle:version`을 비교한다. 현재 릴리스 workflow는 후보 표시 버전과 빌드 번호가 기존 공개 릴리스보다 모두 증가하는지 검사하지 않는다. 두 공식 workflow를 함께 직렬화하는 `concurrency` 그룹도 없다.
+
+### 확인 주기 설정
+
+Quill은 `SUUpdateCheckInterval=86400`을 설정하지만 Sparkle 2.9.2는 `SUScheduledCheckInterval`을 읽는다. 현재 Sparkle 기본값도 86,400초라 실효 동작은 같지만, Quill이 의도한 설정은 적용되지 않는다.
+
+## 목표
+
+- 자동 또는 수동 확인에서 찾은 업데이트 카드를 앱 재시작 후에도 복원한다.
+- 이미 설치했거나 정상 확인에서 더 이상 존재하지 않는 업데이트 정보는 제거한다.
+- 확인 실패나 일시적인 오프라인 상태 때문에 기존에 확인한 업데이트 정보를 잃지 않는다.
+- 사용자가 Sparkle에서 건너뛴 버전을 자동으로 다시 노출하지 않는다.
+- 공식 stable 릴리스의 표시 버전과 빌드 번호가 기존 최대값보다 모두 큰 경우에만 배포를 허용한다.
+- 두 공식 stable 릴리스 workflow를 저장소 전체에서 직렬화한다.
+- 실제 Sparkle 확인 주기 키를 명시적으로 사용한다.
+- production appcast나 기존 GitHub Release를 수정하지 않고 변경을 검증한다.
+
+## 제외 범위
+
+- Sparkle을 다른 업데이트 프레임워크로 교체하지 않는다.
+- 누적 appcast로 전환하거나 기존 Release의 appcast 자산을 다시 생성하지 않는다.
+- 설정창을 열거나 앱이 활성화될 때마다 강제 확인하지 않는다.
+- prerelease용 `manual-release.yml`과 `dev-release.yml`에 stable 표시 버전 단조 증가 규칙을 적용하지 않는다. 다만 이미 공개된 prerelease의 빌드 번호는 다음 stable 빌드 번호의 하한에 포함한다.
+- 업데이트 설정 UI의 배치나 시각 디자인을 변경하지 않는다.
+- 기존 Git tag, GitHub Release, DMG 자산을 삭제하거나 수정하지 않는다.
+
+## 설계 1: 업데이트 상태 영속화
+
+### 저장 모델
+
+업데이트 카드 복원에 필요한 값만 담는 작은 저장 모델을 둔다.
+
+- `buildVersion`: Sparkle `SPUAppcastItem.versionString`
+- `displayVersion`: Sparkle `SPUAppcastItem.displayVersionString`
+- `releaseDate`: 선택 값
+- `releaseNotesURL`: 선택 값
+
+모델은 하나의 Codable 값으로 직렬화하여 Quill의 `UserDefaults`에 저장한다. 확인 진행 여부인 `isChecking`과 오류 메시지 같은 일시 상태는 저장하지 않는다.
+
+저장과 복원 책임은 `UpdateManager`에 직접 흩어 놓지 않고, 테스트 가능한 작은 내부 저장소 타입으로 분리한다. 저장소는 주입된 `UserDefaults`를 사용하여 테스트에서 별도 suite를 사용할 수 있게 한다.
+
+### 빌드 비교
+
+복원 판단은 표시 버전이 아니라 Sparkle과 동일한 버전 비교 규칙을 사용한다.
+
+- 저장된 `buildVersion`이 현재 앱의 `CFBundleVersion`보다 크면 복원한다.
+- 같거나 작으면 이미 설치했거나 오래된 정보이므로 저장 상태를 제거한다.
+- 저장 데이터가 손상되었거나 필수 값이 없으면 조용히 제거하고 앱 실행을 계속한다.
+
+앱 자체의 비교와 Sparkle의 비교가 달라지지 않도록 단순 문자열 비교나 별도 semantic version 비교를 도입하지 않는다.
+
+### 상태 흐름
+
+#### 업데이트 발견
+
+Sparkle의 유효 업데이트 delegate가 호출되면 다음 순서로 처리한다.
+
+1. 기존 `@Published` 화면 상태를 갱신한다.
+2. 같은 값으로 저장 모델을 기록한다.
+3. 자동 확인과 수동 확인 모두 동일한 경로를 사용한다.
+
+#### 앱 시작
+
+`UpdateManager` 초기화 시 저장 모델을 읽는다.
+
+1. 공식 release build tag인 경우에만 저장 상태 복원을 시도한다.
+2. 저장된 빌드가 현재 빌드보다 높고 Sparkle의 minor·major skip 범위에 포함되지 않으면 카드 상태를 복원한다.
+3. 저장된 빌드가 현재 빌드 이하이거나 `SUSkippedVersion` 이하라면 저장 모델과 카드 상태를 제거한다.
+4. major update 정보가 있는 경우 `SUSkippedMajorVersion`, `SUSkippedMajorSubreleaseVersion`, `minimumAutoupdateVersion`, `ignoreSkippedUpgradesBelowVersion`을 Sparkle과 같은 방향으로 비교한다.
+5. 저장 데이터 복원과 별개로 기존 Sparkle 자동 확인 스케줄은 그대로 시작한다.
+
+#### 업데이트 없음
+
+Sparkle이 정상적으로 업데이트 없음 결과를 반환하면 화면 상태와 저장 모델을 함께 제거한다.
+
+#### 확인 실패
+
+네트워크 오류, feed 오류, 서명 검증 오류처럼 업데이트 존재 여부를 정상적으로 판단하지 못한 경우에는 기존 저장 모델을 제거하지 않는다. 마지막으로 성공한 확인 결과를 유지하고 오류는 기존 오류 처리 경로로 전달한다.
+
+#### 업데이트 설치 후 재실행
+
+설치된 앱의 `CFBundleVersion`이 저장된 빌드 이상이 되므로 초기 복원 단계에서 오래된 저장 모델이 자동으로 제거된다. 별도의 설치 완료 플래그는 추가하지 않는다.
+
+### 기존 상태와의 관계
+
+- `updateLastCheckDate`는 현재처럼 마지막 확인 표시 용도로 유지한다.
+- `SULastCheckTime`과 실제 확인 예약은 Sparkle이 계속 관리한다.
+- `updateAvailable`, 표시 버전, 릴리스 날짜, 릴리스 노트 URL의 기존 공개 인터페이스를 유지하여 `SettingsView`와 `MenuBarView`를 변경하지 않거나 최소화한다.
+- 로컬·개발 빌드의 release tag guard와 GitHub Release 웹 fallback은 유지한다.
+
+## 설계 2: 공식 릴리스 단조 증가 검증
+
+### 공용 검증 스크립트
+
+공식 stable 릴리스 전에 실행할 읽기 전용 검증 스크립트를 `scripts/` 아래에 추가한다. workflow 안에 비교 로직을 중복 작성하지 않는다.
+
+입력:
+
+- 후보 `APP_VERSION`
+- 후보 `BUILD_NUMBER`
+- 대상 저장소 `woosublee/quill`
+- GitHub API 인증 토큰
+
+검증 데이터:
+
+1. GitHub Releases API에서 공개된 non-draft Release를 페이지네이션하여 조회한다.
+2. `vX.Y.Z` 형식의 stable tag만 표시 버전 비교 대상으로 사용한다.
+3. 각 stable Release의 `appcast.xml`에서 `sparkle:version`과 `sparkle:shortVersionString`을 읽고, 표시 버전이 tag와 다르면 안전하게 실패한다.
+4. Sparkle 도입 이후 stable Release의 appcast가 없거나 손상된 경우에는 안전하게 실패한다.
+5. Sparkle 도입 전이라 appcast가 없는 과거 stable Release는 표시 버전 비교에는 포함하고 빌드 최대값 계산에서는 제외한다.
+6. 공개 prerelease는 해당 tag의 `version.mk`에서 `BUILD_NUMBER`를 읽어 빌드 최대값 계산에만 포함한다. Sparkle 도입 이후 prerelease의 빌드 메타데이터를 읽지 못하면 안전하게 실패한다.
+
+통과 조건:
+
+- 후보 `APP_VERSION`이 기존 stable 표시 버전 최대값보다 엄격히 크다.
+- 후보 `BUILD_NUMBER`가 기존 appcast 빌드 번호 최대값보다 엄격히 크다.
+- 비교할 기존 stable Release나 appcast가 없으면 해당 검사를 통과시킨다.
+
+실패 출력:
+
+- 후보 표시 버전과 빌드 번호
+- 기존 최대 표시 버전과 빌드 번호
+- 실패한 비교 조건
+- 비교에 사용한 Release tag
+
+검증 스크립트는 GitHub 데이터를 변경하지 않는다. 테스트에서는 네트워크 대신 fixture 입력을 사용할 수 있게 데이터 조회와 비교를 분리한다.
+
+### workflow 적용
+
+다음 공식 workflow가 같은 검증 스크립트를 사용한다.
+
+- `.github/workflows/self-signed-release.yml`
+- `.github/workflows/release.yml`
+
+검증은 앱 빌드, tag push, GitHub Release 생성보다 먼저 실행한다. 실패하면 외부 상태를 만들기 전에 workflow를 종료한다.
+
+두 공식 stable workflow와 `manual-release.yml`에는 저장소 전체에서 공유되는 동일한 `concurrency` 그룹을 설정한다. manual prerelease의 빌드 번호도 다음 stable의 하한이므로 preflight와 prerelease publication이 겹치지 않아야 한다.
+
+- 그룹: 공식 Quill stable release 전용 고정 이름
+- `cancel-in-progress: false`
+
+먼저 시작한 릴리스를 취소하지 않고 완료시킨다. GitHub concurrency는 실행 1개와 대기 1개만 유지하므로 공식 stable 릴리스는 한 번에 하나씩 dispatch한다. 이 제약 아래 대기 중인 다음 릴리스는 앞선 릴리스가 공개된 뒤 단조 증가 검사를 실행하여, 낮은 버전이 나중에 `latest`가 되는 경합을 막는다.
+
+### 게시 후 읽기 전용 확인
+
+Release 생성 후 다음을 확인한다.
+
+- GitHub latest tag가 방금 배포한 tag와 같다.
+- `/releases/latest/download/appcast.xml`이 방금 배포한 Release로 연결된다.
+- appcast의 `sparkle:version`과 `sparkle:shortVersionString`이 후보 빌드·표시 버전과 같다.
+- enclosure URL이 방금 배포한 `Quill.dmg`를 가리킨다.
+- appcast 생성 전에 CI private key에서 파생한 public key가 앱의 `SUPublicEDKey`와 일치한다.
+- 생성한 DMG의 EdDSA signature를 같은 public key로 다시 검증한다.
+
+GitHub latest와 asset 전파 지연은 제한된 횟수로 재시도한다. 최종 실패 시 자동 삭제나 롤백을 수행하지 않고 workflow를 실패 처리하여 잘못된 latest 상태를 즉시 드러낸다.
+
+## 설계 3: Sparkle 확인 주기 키 수정
+
+`Info.plist`에서 다음 키를 교체한다.
+
+```diff
+- SUUpdateCheckInterval
++ SUScheduledCheckInterval
+```
+
+값은 `86400`으로 유지한다. `SUEnableAutomaticChecks=true`와 `SUAutomaticallyUpdate=false`의 현재 기본 정책은 변경하지 않는다.
+
+기존 사용자의 UserDefaults에 `SUScheduledCheckInterval` override가 있으면 Sparkle의 기존 우선순위를 따른다. 잘못된 `SUUpdateCheckInterval` UserDefaults 값을 마이그레이션하는 코드는 추가하지 않는다. Quill이 해당 값을 사용자 설정으로 기록한 적이 없고, 현재 기본값과도 동일하기 때문이다.
+
+## 오류 처리
+
+- 저장 모델 decode 실패: 상태를 제거하고 실행을 계속한다.
+- 현재 앱 빌드 정보를 읽지 못함: 잘못된 업데이트 카드를 복원하지 않고 저장 상태를 보존하여 다음 정상 실행에서 다시 판단한다.
+- Sparkle 확인 실패: 기존에 확인한 업데이트 카드를 보존한다.
+- GitHub API 실패 또는 rate limit: 공식 릴리스 검증을 실패시킨다. 검증을 건너뛰고 릴리스를 계속하지 않는다.
+- appcast 다운로드·파싱 실패: 공식 릴리스 검증을 실패시킨다.
+- 게시 후 latest 확인 실패: 기존 Release를 자동 변경하지 않고 workflow를 실패 처리한다.
+
+## 테스트 설계
+
+### 업데이트 상태 단위 테스트
+
+- 유효한 업데이트 발견 시 저장 모델이 기록된다.
+- 새 `UpdateManager` 또는 상태 복원 단위가 저장 모델을 읽어 카드를 복원한다.
+- 저장 빌드가 현재 빌드보다 높을 때만 복원한다.
+- 저장 빌드가 현재 빌드와 같거나 낮으면 제거한다.
+- 저장 빌드가 `SUSkippedVersion`과 같으면 자동 복원하지 않는다.
+- 정상적인 업데이트 없음 결과는 화면 상태와 저장 모델을 제거한다.
+- 확인 실패는 기존 저장 모델을 보존한다.
+- 손상된 저장 데이터는 앱을 중단하지 않고 제거한다.
+- 릴리스 날짜와 릴리스 노트 URL이 없는 appcast item도 복원할 수 있다.
+
+### 릴리스 검증 스크립트 테스트
+
+fixture 기반으로 다음을 검증한다.
+
+- 표시 버전과 빌드 번호가 모두 증가하면 통과한다.
+- 표시 버전이 낮거나 같으면 실패한다.
+- 빌드 번호가 낮거나 같으면 실패한다.
+- 표시 버전만 증가하고 빌드가 감소하면 실패한다.
+- 빌드만 증가하고 표시 버전이 감소하면 실패한다.
+- GitHub latest 지정이 잘못되어도 전체 stable Release의 최대값을 사용한다.
+- draft는 모든 비교에서 제외하고, prerelease는 stable 표시 버전 최대값에서는 제외하되 빌드 번호 최대값에는 포함한다.
+- Sparkle 이전 Release의 appcast 누락은 허용한다.
+- 존재하는 appcast가 손상되면 실패한다.
+- 비교 대상이 없는 첫 stable 릴리스는 통과한다.
+
+### 소스 계약 테스트
+
+- `Info.plist`에 `SUScheduledCheckInterval=86400`이 존재한다.
+- `SUUpdateCheckInterval`이 존재하지 않는다.
+- 두 공식 stable workflow가 같은 검증 스크립트를 호출한다.
+- 두 공식 stable workflow가 같은 `concurrency` 그룹과 `cancel-in-progress: false`를 사용한다.
+- prerelease workflow에는 stable 단조 증가 검사가 추가되지 않는다.
+
+## 수동 검증
+
+1. 기존 테스트 전체를 실행한다.
+2. 서명된 Quill 앱을 빌드한다.
+3. 격리된 UserDefaults suite 또는 테스트 환경에 현재 앱보다 높은 저장 snapshot을 준비한다.
+4. 앱을 실행하고 설정창과 메뉴바에 업데이트 카드가 즉시 복원되는지 확인한다.
+5. 현재 앱과 같거나 낮은 snapshot에서는 카드가 나타나지 않고 저장 상태가 정리되는지 확인한다.
+6. 오프라인 또는 확인 실패 조건에서 기존 카드가 사라지지 않는지 확인한다.
+7. 검증 스크립트를 현재 공개 Release 데이터에 대해 dry-run으로 실행한다.
+8. 낮은 표시 버전, 낮은 빌드 번호 fixture가 외부 상태 변경 없이 실패하는지 확인한다.
+9. production GitHub Release와 appcast는 생성하거나 수정하지 않는다.
+
+## 예상 변경 파일
+
+- `Sources/UpdateManager.swift`
+- 업데이트 snapshot 저장소를 위한 작은 새 Swift 파일 또는 기존 파일의 private 보조 타입
+- `Info.plist`
+- `scripts/` 아래 공식 릴리스 단조 증가 검증 스크립트
+- `.github/workflows/self-signed-release.yml`
+- `.github/workflows/release.yml`
+- `Tests/UpdateManagerSafetyTests.swift` 또는 새 상태 복원 테스트
+- `Tests/BuildMetadataTests.swift` 또는 새 릴리스 검증 테스트
+
+정확한 파일 분리는 구현 계획 단계에서 기존 테스트 구조와 재사용 가능한 경계를 다시 확인하여 확정한다.
+
+## 구현 순서
+
+1. `main`을 기준으로 별도 브랜치를 만든다.
+2. 상태 저장·복원과 릴리스 검증의 실패 테스트를 먼저 작성한다.
+3. 업데이트 snapshot 저장소와 `UpdateManager` 연결을 구현한다.
+4. 공식 릴리스 검증 스크립트와 fixture 테스트를 구현한다.
+5. 두 공식 workflow에 검증과 공용 concurrency 그룹을 적용한다.
+6. Sparkle interval 키를 수정하고 소스 계약 테스트를 갱신한다.
+7. 전체 테스트, 서명 빌드, GUI 상태 복원, 실제 공개 데이터 dry-run을 수행한다.
+8. 결과를 보고한 뒤 커밋·푸시·PR은 사용자 요청에 따라 별도로 진행한다.
+
+## 성공 기준
+
+- 업데이트 발견 후 앱을 재시작해도 유효한 업데이트 카드가 설정창과 메뉴바에 유지된다.
+- 설치 완료, 정상적인 업데이트 없음, 또는 사용자의 버전 건너뛰기 이후에는 오래된 카드가 자동 노출되지 않는다.
+- 오프라인이나 일시적 확인 실패는 마지막으로 성공한 업데이트 정보를 제거하지 않는다.
+- 낮거나 같은 표시 버전 또는 빌드 번호를 가진 공식 stable 릴리스는 tag 생성 전에 차단된다.
+- 두 공식 stable workflow가 동시에 latest 상태를 변경할 수 없다.
+- Sparkle의 실제 확인 주기 키가 `86400`초로 명시된다.
+- 기존 테스트와 새 테스트가 모두 통과하고 서명된 앱에서 상태 복원이 확인된다.

--- a/scripts/generate-sparkle-appcast.sh
+++ b/scripts/generate-sparkle-appcast.sh
@@ -84,9 +84,16 @@ xml_escape() {
 }
 
 SIGN_UPDATE="$(find_sign_update)"
-signature_output="$(sparkle_private_key | "$SIGN_UPDATE" "$DMG_PATH" --ed-key-file -)"
+expected_public_key="${SPARKLE_PUBLIC_KEY:-$(plutil -extract SUPublicEDKey raw -o - "$REPO_ROOT/Info.plist")}"
+private_key="$(sparkle_private_key)"
+printf '%s\n' "$private_key" |
+  xcrun swift "$SCRIPT_DIR/validate-sparkle-key.swift" "$expected_public_key"
+
+signature_output="$(printf '%s\n' "$private_key" | "$SIGN_UPDATE" "$DMG_PATH" --ed-key-file -)"
 ed_signature="$(printf '%s\n' "$signature_output" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p' | sed -n '1p')"
 [[ -n "$ed_signature" ]] || fail "Unable to parse sparkle:edSignature from sign_update output"
+printf '%s\n' "$private_key" |
+  "$SIGN_UPDATE" --verify --ed-key-file - "$DMG_PATH" "$ed_signature" >/dev/null
 
 length="$(wc -c < "$DMG_PATH" | tr -d '[:space:]')"
 pub_date="$(date -u '+%a, %d %b %Y %H:%M:%S +0000')"

--- a/scripts/validate-sparkle-key.swift
+++ b/scripts/validate-sparkle-key.swift
@@ -1,0 +1,44 @@
+#!/usr/bin/env swift
+
+import CryptoKit
+import Foundation
+
+func fail(_ message: String) -> Never {
+    FileHandle.standardError.write(Data("ERROR: \(message)\n".utf8))
+    exit(1)
+}
+
+guard CommandLine.arguments.count == 2 else {
+    fail("Usage: validate-sparkle-key.swift <expected-public-key-base64>")
+}
+
+guard let expectedPublicKey = Data(base64Encoded: CommandLine.arguments[1]),
+      expectedPublicKey.count == 32 else {
+    fail("Expected Sparkle public key must decode to 32 bytes")
+}
+
+let secretInput = FileHandle.standardInput.readDataToEndOfFile()
+guard let secretString = String(data: secretInput, encoding: .utf8)?
+    .trimmingCharacters(in: .whitespacesAndNewlines),
+      let secret = Data(base64Encoded: secretString) else {
+    fail("Sparkle private key is not valid base64")
+}
+
+let derivedPublicKey: Data
+switch secret.count {
+case 32:
+    do {
+        let privateKey = try Curve25519.Signing.PrivateKey(rawRepresentation: secret)
+        derivedPublicKey = privateKey.publicKey.rawRepresentation
+    } catch {
+        fail("Unable to derive the Sparkle public key from the private seed")
+    }
+case 96:
+    derivedPublicKey = secret.suffix(32)
+default:
+    fail("Sparkle private key must decode to 32 or 96 bytes")
+}
+
+guard derivedPublicKey == expectedPublicKey else {
+    fail("Sparkle private key does not match SUPublicEDKey")
+}

--- a/scripts/validate_stable_release.py
+++ b/scripts/validate_stable_release.py
@@ -1,0 +1,544 @@
+#!/usr/bin/env python3
+import argparse
+import dataclasses
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from typing import Callable, Iterable, Optional, Sequence, Tuple
+
+
+SPARKLE_NS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+VERSION_COMPONENT = r"(?:0|[1-9]\d*)"
+STABLE_TAG_PATTERN = re.compile(
+    rf"^v({VERSION_COMPONENT})\.({VERSION_COMPONENT})\.({VERSION_COMPONENT})$"
+)
+STABLE_VERSION_PATTERN = re.compile(
+    rf"^({VERSION_COMPONENT})\.({VERSION_COMPONENT})\.({VERSION_COMPONENT})$"
+)
+PRERELEASE_TAG_PATTERN = re.compile(
+    rf"^v({VERSION_COMPONENT})\.({VERSION_COMPONENT})\.({VERSION_COMPONENT})"
+    rf"-(?:alpha|beta|rc)\.({VERSION_COMPONENT})$"
+)
+BUILD_NUMBER_ASSIGNMENT_PATTERN = re.compile(
+    r"^BUILD_NUMBER\s*(\?=|:=|=)\s*(.*?)\s*$"
+)
+SPARKLE_ADOPTION_VERSION = (0, 1, 6)
+
+
+class ValidationError(RuntimeError):
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class StableReleaseRecord:
+    tag: str
+    version: Tuple[int, int, int]
+    build_number: Optional[int]
+
+
+@dataclasses.dataclass(frozen=True)
+class PublishedBuildRecord:
+    tag: str
+    build_number: int
+
+
+@dataclasses.dataclass(frozen=True)
+class AppcastMetadata:
+    build_number: int
+    display_version: str
+    enclosure_url: str
+
+
+def parse_version(value: str) -> Tuple[int, int, int]:
+    match = STABLE_VERSION_PATTERN.fullmatch(value)
+    if match is None:
+        raise ValidationError(f"Stable version must use X.Y.Z: {value}")
+    return tuple(int(part) for part in match.groups())
+
+
+def parse_stable_tag(value: str) -> Optional[Tuple[int, int, int]]:
+    match = STABLE_TAG_PATTERN.fullmatch(value)
+    if match is None:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def parse_prerelease_tag(value: str) -> Optional[Tuple[int, int, int]]:
+    match = PRERELEASE_TAG_PATTERN.fullmatch(value)
+    if match is None:
+        return None
+    return tuple(int(part) for part in match.groups()[:3])
+
+
+def parse_positive_build(value: object, context: str) -> int:
+    try:
+        build_number = int(str(value))
+    except (TypeError, ValueError) as error:
+        raise ValidationError(f"{context} must be a positive integer: {value}") from error
+    if build_number <= 0:
+        raise ValidationError(f"{context} must be a positive integer: {value}")
+    return build_number
+
+
+def validate_preflight(
+    candidate_version: str,
+    candidate_build: int,
+    records: Iterable[StableReleaseRecord],
+    additional_build_records: Iterable[PublishedBuildRecord] = (),
+) -> None:
+    parsed_candidate = parse_version(candidate_version)
+    candidate_build = parse_positive_build(candidate_build, "Candidate build")
+    records = list(records)
+    if records:
+        highest_version_record = max(records, key=lambda record: record.version)
+        if parsed_candidate <= highest_version_record.version:
+            raise ValidationError(
+                f"Candidate version {candidate_version} must be greater than "
+                f"{highest_version_record.tag}"
+            )
+
+    build_records = [
+        PublishedBuildRecord(record.tag, record.build_number)
+        for record in records
+        if record.build_number is not None
+    ]
+    build_records.extend(additional_build_records)
+    if not build_records:
+        return
+
+    highest_build_record = max(
+        build_records,
+        key=lambda record: record.build_number,
+    )
+    if candidate_build <= highest_build_record.build_number:
+        raise ValidationError(
+            f"Candidate build {candidate_build} must be greater than build "
+            f"{highest_build_record.build_number} from {highest_build_record.tag}"
+        )
+
+
+def collect_stable_release_records(
+    releases: Sequence[dict],
+    appcast_loader: Callable[[str], bytes],
+) -> list[StableReleaseRecord]:
+    stable_releases = []
+    for release in releases:
+        if release.get("draft") or release.get("prerelease"):
+            continue
+
+        tag = release.get("tag_name")
+        version = parse_stable_tag(tag) if isinstance(tag, str) else None
+        if version is None:
+            continue
+
+        appcast_assets = [
+            asset
+            for asset in release.get("assets", [])
+            if asset.get("name") == "appcast.xml"
+        ]
+        if len(appcast_assets) > 1:
+            raise ValidationError(f"Release {tag} has multiple appcast.xml assets")
+        stable_releases.append((tag, version, appcast_assets))
+
+    records = []
+    for tag, version, appcast_assets in stable_releases:
+        if not appcast_assets:
+            if version >= SPARKLE_ADOPTION_VERSION:
+                raise ValidationError(
+                    f"Release {tag} is missing appcast.xml after Sparkle adoption"
+                )
+            records.append(StableReleaseRecord(tag, version, None))
+            continue
+
+        appcast_url = appcast_assets[0].get("browser_download_url")
+        if not appcast_url:
+            raise ValidationError(f"Release {tag} appcast.xml has no download URL")
+        try:
+            appcast = parse_appcast(appcast_loader(appcast_url))
+        except ValidationError:
+            raise
+        except Exception as error:
+            raise ValidationError(f"Unable to load appcast.xml for {tag}: {error}") from error
+        expected_display_version = tag.removeprefix("v")
+        if appcast.display_version != expected_display_version:
+            raise ValidationError(
+                f"Release {tag} appcast display version {appcast.display_version} "
+                f"does not match {expected_display_version}"
+            )
+        records.append(StableReleaseRecord(tag, version, appcast.build_number))
+
+    return records
+
+
+def parse_make_build_number(metadata_text: str, context: str) -> int:
+    build_number = None
+    for raw_line in metadata_text.splitlines():
+        line = raw_line.split("#", maxsplit=1)[0].strip()
+        if not line or not line.startswith("BUILD_NUMBER"):
+            continue
+        match = BUILD_NUMBER_ASSIGNMENT_PATTERN.fullmatch(line)
+        if match is None:
+            raise ValidationError(f"{context} uses an unsupported BUILD_NUMBER assignment")
+        operator, value = match.groups()
+        parsed_value = parse_positive_build(value, f"{context} build")
+        if operator != "?=" or build_number is None:
+            build_number = parsed_value
+    if build_number is None:
+        raise ValidationError(f"{context} has no BUILD_NUMBER")
+    return build_number
+
+
+def collect_prerelease_build_records(
+    releases: Sequence[dict],
+    version_metadata_loader: Callable[[str], Optional[bytes]],
+    first_appcast_version: Optional[Tuple[int, int, int]],
+) -> list[PublishedBuildRecord]:
+    records = []
+    for release in releases:
+        if release.get("draft") or not release.get("prerelease"):
+            continue
+
+        tag = release.get("tag_name")
+        version = None
+        if isinstance(tag, str):
+            version = parse_prerelease_tag(tag) or parse_stable_tag(tag)
+        if version is None:
+            continue
+
+        metadata = version_metadata_loader(tag)
+        if metadata is None:
+            if first_appcast_version is not None and version >= first_appcast_version:
+                raise ValidationError(
+                    f"Prerelease {tag} is missing version.mk after Sparkle adoption"
+                )
+            continue
+
+        try:
+            metadata_text = metadata.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise ValidationError(f"Prerelease {tag} version.mk is not UTF-8") from error
+        records.append(
+            PublishedBuildRecord(
+                tag,
+                parse_make_build_number(metadata_text, f"Prerelease {tag} version.mk"),
+            )
+        )
+    return records
+
+
+def parse_appcast(data: bytes) -> AppcastMetadata:
+    try:
+        root = ET.fromstring(data)
+    except ET.ParseError as error:
+        raise ValidationError(f"Invalid appcast XML: {error}") from error
+
+    item = root.find("./channel/item")
+    if item is None:
+        raise ValidationError("Appcast is missing channel/item")
+
+    enclosure = item.find("enclosure")
+    if enclosure is None:
+        raise ValidationError("Appcast item is missing enclosure")
+
+    namespace = f"{{{SPARKLE_NS}}}"
+    element_build = item.findtext(f"{namespace}version")
+    attribute_build = enclosure.get(f"{namespace}version")
+    build_value = element_build or attribute_build
+    if build_value is None:
+        raise ValidationError("Appcast item is missing sparkle:version")
+    if element_build and attribute_build and element_build != attribute_build:
+        raise ValidationError("Appcast item and enclosure use different build numbers")
+
+    element_version = item.findtext(f"{namespace}shortVersionString")
+    attribute_version = enclosure.get(f"{namespace}shortVersionString")
+    display_version = element_version or attribute_version
+    if not display_version:
+        raise ValidationError("Appcast item is missing sparkle:shortVersionString")
+    if element_version and attribute_version and element_version != attribute_version:
+        raise ValidationError("Appcast item and enclosure use different display versions")
+    parse_version(display_version)
+
+    enclosure_url = enclosure.get("url")
+    if not enclosure_url:
+        raise ValidationError("Appcast enclosure is missing url")
+
+    return AppcastMetadata(
+        build_number=parse_positive_build(build_value, "Appcast build"),
+        display_version=display_version,
+        enclosure_url=enclosure_url,
+    )
+
+
+def validate_latest(
+    repository: str,
+    expected_tag: str,
+    expected_version: str,
+    expected_build: int,
+    actual_tag: str,
+    appcast: AppcastMetadata,
+) -> None:
+    expected_build = parse_positive_build(expected_build, "Expected build")
+    parse_version(expected_version)
+
+    if actual_tag != expected_tag:
+        raise ValidationError(
+            f"GitHub latest tag {actual_tag} does not match expected {expected_tag}"
+        )
+    if appcast.display_version != expected_version:
+        raise ValidationError(
+            f"Latest appcast display version {appcast.display_version} does not match "
+            f"expected {expected_version}"
+        )
+    if appcast.build_number != expected_build:
+        raise ValidationError(
+            f"Latest appcast build {appcast.build_number} does not match "
+            f"expected {expected_build}"
+        )
+
+    expected_url = (
+        f"https://github.com/{repository}/releases/download/"
+        f"{expected_tag}/Quill.dmg"
+    )
+    if appcast.enclosure_url != expected_url:
+        raise ValidationError(
+            f"Latest appcast enclosure {appcast.enclosure_url} does not match "
+            f"expected {expected_url}"
+        )
+
+
+def build_request(
+    url: str,
+    accept: str,
+    token: Optional[str],
+) -> urllib.request.Request:
+    headers = {
+        "Accept": accept,
+        "User-Agent": "quill-release-validator",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    return urllib.request.Request(url, headers=headers)
+
+
+def github_request(
+    url: str,
+    accept: str,
+    token: Optional[str] = None,
+) -> bytes:
+    request = build_request(url, accept, token)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.read()
+    except urllib.error.HTTPError as error:
+        raise ValidationError(f"GitHub request failed with HTTP {error.code}: {url}") from error
+    except urllib.error.URLError as error:
+        raise ValidationError(f"GitHub request failed: {url}: {error.reason}") from error
+
+
+def github_json(url: str, token: str):
+    try:
+        return json.loads(
+            github_request(
+                url,
+                "application/vnd.github+json",
+                token,
+            ).decode("utf-8")
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValidationError(f"GitHub returned invalid JSON: {url}") from error
+
+
+def download_public_bytes(url: str) -> bytes:
+    return github_request(url, "application/octet-stream")
+
+
+def download_optional_public_bytes(url: str) -> Optional[bytes]:
+    try:
+        return download_public_bytes(url)
+    except ValidationError as error:
+        if "HTTP 404" in str(error):
+            return None
+        raise
+
+
+def version_metadata_url(repository: str, tag: str) -> str:
+    encoded_tag = urllib.parse.quote(tag, safe="")
+    return f"https://raw.githubusercontent.com/{repository}/{encoded_tag}/version.mk"
+
+
+def run_with_retries(
+    operation: Callable[[], object],
+    attempts: int,
+    retry_delay: float,
+    sleep: Callable[[float], None] = time.sleep,
+):
+    if attempts < 1:
+        raise ValidationError("Retry attempts must be at least 1")
+    last_error = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return operation()
+        except ValidationError as error:
+            last_error = error
+            if attempt == attempts:
+                raise
+            print(
+                f"Verification attempt {attempt}/{attempts} failed: {error}; retrying",
+                file=sys.stderr,
+            )
+            sleep(retry_delay)
+    raise last_error
+
+
+def fetch_all_releases(repository: str, token: str) -> list[dict]:
+    releases = []
+    page = 1
+    while True:
+        batch = github_json(
+            f"https://api.github.com/repos/{repository}/releases?per_page=100&page={page}",
+            token,
+        )
+        if not isinstance(batch, list):
+            raise ValidationError("GitHub releases response must be an array")
+        releases.extend(batch)
+        if len(batch) < 100:
+            return releases
+        page += 1
+
+
+def fetch_latest_release(repository: str, token: str) -> dict:
+    release = github_json(
+        f"https://api.github.com/repos/{repository}/releases/latest",
+        token,
+    )
+    if not isinstance(release, dict):
+        raise ValidationError("GitHub latest release response must be an object")
+    return release
+
+
+def latest_appcast_url(repository: str) -> str:
+    return f"https://github.com/{repository}/releases/latest/download/appcast.xml"
+
+
+def require_token() -> str:
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise ValidationError("GITHUB_TOKEN is required")
+    return token
+
+
+def run_preflight(args) -> None:
+    token = require_token()
+    releases = fetch_all_releases(args.repository, token)
+    records = collect_stable_release_records(
+        releases,
+        download_public_bytes,
+    )
+    prerelease_builds = collect_prerelease_build_records(
+        releases,
+        lambda tag: download_optional_public_bytes(
+            version_metadata_url(args.repository, tag)
+        ),
+        first_appcast_version=SPARKLE_ADOPTION_VERSION,
+    )
+    validate_preflight(
+        args.candidate_version,
+        args.candidate_build,
+        records,
+        prerelease_builds,
+    )
+
+    highest_version = max(records, key=lambda record: record.version, default=None)
+    build_records = [
+        PublishedBuildRecord(record.tag, record.build_number)
+        for record in records
+        if record.build_number is not None
+    ]
+    build_records.extend(prerelease_builds)
+    highest_build = max(
+        build_records,
+        key=lambda record: record.build_number,
+        default=None,
+    )
+    print(
+        "Stable release preflight passed: "
+        f"candidate={args.candidate_version}/{args.candidate_build}, "
+        f"highest_version={highest_version.tag if highest_version else 'none'}, "
+        f"highest_build={highest_build.build_number if highest_build else 'none'}"
+    )
+
+
+def run_verify_latest(args) -> None:
+    token = require_token()
+
+    def verify_once() -> None:
+        release = fetch_latest_release(args.repository, token)
+        appcast = parse_appcast(
+            download_public_bytes(latest_appcast_url(args.repository))
+        )
+        validate_latest(
+            repository=args.repository,
+            expected_tag=args.expected_tag,
+            expected_version=args.expected_version,
+            expected_build=args.expected_build,
+            actual_tag=release.get("tag_name", ""),
+            appcast=appcast,
+        )
+
+    run_with_retries(
+        verify_once,
+        attempts=args.attempts,
+        retry_delay=args.retry_delay,
+    )
+    print(
+        "Latest release verification passed: "
+        f"tag={args.expected_tag}, "
+        f"version={args.expected_version}, "
+        f"build={args.expected_build}"
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate Quill stable release ordering and latest appcast metadata."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    preflight = subparsers.add_parser("preflight")
+    preflight.add_argument("--repository", required=True)
+    preflight.add_argument("--candidate-version", required=True)
+    preflight.add_argument("--candidate-build", required=True, type=int)
+    preflight.set_defaults(handler=run_preflight)
+
+    verify_latest = subparsers.add_parser("verify-latest")
+    verify_latest.add_argument("--repository", required=True)
+    verify_latest.add_argument("--expected-tag", required=True)
+    verify_latest.add_argument("--expected-version", required=True)
+    verify_latest.add_argument("--expected-build", required=True, type=int)
+    verify_latest.add_argument("--attempts", type=int, default=1)
+    verify_latest.add_argument("--retry-delay", type=float, default=10)
+    verify_latest.set_defaults(handler=run_verify_latest)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        args.handler(args)
+    except ValidationError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Persist Sparkle update metadata so Settings and the menu bar can restore a valid available update after relaunch, while respecting installed builds and Sparkle minor/major skip state.
- Harden stable release publication with canonical version checks, stable and prerelease build floors, serialized release workflows, retrying latest-feed verification, and appcast/tag consistency checks.
- Validate Sparkle signing-key compatibility before publication, verify generated DMG signatures, and use the correct scheduled-check interval key.

## Verification

- `make test`
- `python3 Tests/StableReleaseValidationTests.py` (28 tests)
- `bash Tests/SparkleKeyValidationTests.sh`
- Live read-only verification of the current `v0.1.28` latest appcast and a hypothetical `v0.1.29` / build `32` preflight
- Parsed all modified release workflow YAML files
- Built and code-signature-verified an isolated app, then verified update snapshot restoration, stale snapshot cleanup, and local-build suppression in the GUI
- `/code-review medium` findings reproduced and addressed

## Operational note

Official stable and manual prerelease workflows now share one release concurrency group because published prerelease build numbers establish the lower bound for the next stable build. Dispatch release workflows one at a time; GitHub retains only one pending run per concurrency group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)