### PR TITLE
Show current system default microphone

### DIFF
--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -3057,6 +3057,22 @@
         }
       }
     },
+    "System Default (%@)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Default (%@)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 기본값 (%@)"
+          }
+        }
+      }
+    },
     "Tap %@": {
       "localizations": {
         "en": {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2,6 +2,7 @@ import Foundation
 import Combine
 import AppKit
 import AVFoundation
+import CoreAudio
 import ServiceManagement
 import ApplicationServices
 import ScreenCaptureKit
@@ -2101,6 +2102,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
     @Published var availableMicrophones: [AudioDevice] = []
+    @Published private(set) var systemDefaultMicrophoneName: String?
 
     let audioRecorder = AudioRecorder()
     let systemAudioRecorder = SystemAudioRecorder()
@@ -2229,11 +2231,20 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @MainActor
     func selectedMicrophoneDisplayName() -> String {
         if selectedMicrophoneDeviceID == AudioInputDevice.defaultMicrophoneID {
-            return localizedCatalogString("System Default")
+            return systemDefaultMicrophoneDisplayName()
         }
         return availableMicrophones.first(where: {
             $0.uid == selectedMicrophoneDeviceID
         })?.name ?? localizedCatalogString("Selected Microphone")
+    }
+
+    @MainActor
+    func systemDefaultMicrophoneDisplayName() -> String {
+        AudioInputDevice.systemDefaultDisplayName(
+            deviceName: systemDefaultMicrophoneName,
+            defaultTitle: localizedCatalogString("System Default"),
+            format: localizedCatalogString("System Default (%@)")
+        )
     }
 
     @MainActor
@@ -2372,6 +2383,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var shouldTerminateAfterTranscription = false
     private var pendingAudioOnlyStopIDs: Set<UUID> = []
     private var audioDeviceObservers: [NSObjectProtocol] = []
+    private var defaultInputDeviceListener: AudioObjectPropertyListenerBlock?
+    private var defaultInputDeviceListenerAddress: AudioObjectPropertyAddress?
     private var needsMicrophoneRefreshAfterRecording = false
     private let pipelineHistoryStore = PipelineHistoryStore()
     private let recordingJournalStore: RecordingJournalStore
@@ -3893,6 +3906,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
             notificationCenter.removeObserver(observer)
         }
         audioDeviceObservers.removeAll()
+
+        if let defaultInputDeviceListener, var defaultInputDeviceListenerAddress {
+            AudioObjectRemovePropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject),
+                &defaultInputDeviceListenerAddress,
+                DispatchQueue.main,
+                defaultInputDeviceListener
+            )
+        }
+        defaultInputDeviceListener = nil
+        defaultInputDeviceListenerAddress = nil
     }
 
     private static func loadStoredAPIKey(account: String) -> String {
@@ -6768,7 +6792,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         needsMicrophoneRefreshAfterRecording = false
-        availableMicrophones = AudioDevice.availableInputDevices()
+        let microphoneSnapshot = AudioDevice.inputDeviceSnapshot()
+        availableMicrophones = microphoneSnapshot.devices
+        systemDefaultMicrophoneName = microphoneSnapshot.defaultInputDeviceName
     }
 
     private func refreshAvailableMicrophonesIfNeeded() {
@@ -6804,6 +6830,27 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 using: refreshOnAudioDeviceChange
             )
         )
+
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            DispatchQueue.main.async {
+                self?.refreshAvailableMicrophones()
+            }
+        }
+        guard AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            DispatchQueue.main,
+            listener
+        ) == noErr else {
+            return
+        }
+        defaultInputDeviceListener = listener
+        defaultInputDeviceListenerAddress = address
     }
 
     var usesFnShortcut: Bool {

--- a/Sources/AudioInputDevice.swift
+++ b/Sources/AudioInputDevice.swift
@@ -53,6 +53,18 @@ enum AudioInputDevice {
     static let systemDefaultAndSystemAudioID = "__system_default_and_system_audio__"
     static let defaultMicrophoneID = "default"
 
+    static func systemDefaultDisplayName(
+        deviceName: String?,
+        defaultTitle: String,
+        format: String
+    ) -> String {
+        guard let deviceName = deviceName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !deviceName.isEmpty else {
+            return defaultTitle
+        }
+        return String(format: format, deviceName)
+    }
+
     static func isSystemAudio(_ id: String) -> Bool {
         id == systemAudioID
     }

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -25,9 +25,29 @@ struct AudioDevice: Identifiable {
         ).devices
     }
 
+    static func defaultInputDevice() -> AVCaptureDevice? {
+        AVCaptureDevice.default(for: .audio) ?? captureDevices().first
+    }
+
+    static func inputDeviceSnapshot() -> (
+        devices: [AudioDevice],
+        defaultInputDeviceName: String?
+    ) {
+        let resolvedCaptureDevices = captureDevices()
+        let defaultDevice = AVCaptureDevice.default(for: .audio) ?? resolvedCaptureDevices.first
+        return (
+            devices: makeAudioDevices(from: resolvedCaptureDevices),
+            defaultInputDeviceName: displayName(for: defaultDevice)
+        )
+    }
+
     static func availableInputDevices() -> [AudioDevice] {
+        makeAudioDevices(from: captureDevices())
+    }
+
+    private static func makeAudioDevices(from captureDevices: [AVCaptureDevice]) -> [AudioDevice] {
         var seenUIDs = Set<String>()
-        return captureDevices()
+        return captureDevices
             .compactMap { device in
                 let uid = device.uniqueID.trimmingCharacters(in: .whitespacesAndNewlines)
                 let name = device.localizedName.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -39,6 +59,11 @@ struct AudioDevice: Identifiable {
             .sorted { lhs, rhs in
                 lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
             }
+    }
+
+    private static func displayName(for device: AVCaptureDevice?) -> String? {
+        let name = device?.localizedName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return name?.isEmpty == false ? name : nil
     }
 }
 
@@ -162,7 +187,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     }
 
     private static func defaultCaptureDevice() -> AVCaptureDevice? {
-        AVCaptureDevice.default(for: .audio) ?? AudioDevice.captureDevices().first
+        AudioDevice.defaultInputDevice()
     }
 
     private func preferredCaptureDevice(

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -349,14 +349,14 @@ struct MenuBarView: View {
                 }
 
                 Menu("Microphone") {
+                    let systemDefaultName = appState.systemDefaultMicrophoneDisplayName()
                     Button {
                         appState.selectMicrophoneDevice(AudioInputDevice.defaultMicrophoneID)
                     } label: {
-                        if appState.selectedMicrophoneDeviceID == AudioInputDevice.defaultMicrophoneID {
-                            Text("✓ System Default")
-                        } else {
-                            Text("  System Default")
-                        }
+                        let prefix = appState.selectedMicrophoneDeviceID == AudioInputDevice.defaultMicrophoneID
+                            ? "✓ "
+                            : "  "
+                        Text(verbatim: prefix + systemDefaultName)
                     }
                     ForEach(appState.availableMicrophones) { device in
                         Button {

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -568,8 +568,8 @@ struct NoteBrowserView: View {
                     microphones: [
                         AudioInputMenuOption(
                             id: AudioInputDevice.defaultMicrophoneID,
-                            name: "System Default",
-                            isStaticQuillName: true
+                            name: appState.systemDefaultMicrophoneDisplayName(),
+                            isStaticQuillName: false
                         )
                     ] + appState.availableMicrophones.map {
                         AudioInputMenuOption(

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -3863,7 +3863,7 @@ struct InputSettingsView: View {
 
             VStack(spacing: 6) {
                 MicrophoneOptionRow(
-                    title: "System Default",
+                    verbatimName: appState.systemDefaultMicrophoneDisplayName(),
                     isSelected: appState.selectedMicrophoneDeviceID == AudioInputDevice.defaultMicrophoneID,
                     action: { appState.selectMicrophoneDevice(AudioInputDevice.defaultMicrophoneID) }
                 )

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -177,7 +177,7 @@ struct LocalizationResourceTests {
         try assertInfoPlistTranslations(root: root)
 
         let settingsSource = try String(contentsOf: root.appendingPathComponent("Sources/SettingsView.swift"), encoding: .utf8)
-        assert(settingsSource.contains("MicrophoneOptionRow(\n                    title: \"System Default\""))
+        assert(settingsSource.contains("verbatimName: appState.systemDefaultMicrophoneDisplayName(),"))
         assert(settingsSource.contains("verbatimName: device.name,"))
         assert(settingsSource.contains("init(title: LocalizedStringKey"))
         assert(settingsSource.contains("init(verbatimName: String"))
@@ -193,7 +193,7 @@ struct LocalizationResourceTests {
         }
         for key in [
             "Auto Detect", "Audio Input", "Audio Source", "Microphone",
-            "System Default", "System Audio", "Microphone + System Audio",
+            "System Default", "System Default (%@)", "System Audio", "Microphone + System Audio",
             "%@ + System Audio", "Choose what Quill records.",
             "Used for Microphone and Microphone + System Audio."
         ] {

--- a/Tests/SettingsLocalizationTests.swift
+++ b/Tests/SettingsLocalizationTests.swift
@@ -7,6 +7,7 @@ struct SettingsLocalizationTests {
         try testTranscriptionModelKeepsIdentityAndLocalizesDescription()
         try testNativeWhisperModelKeepsIdentityAndLocalizesDescription()
         try testAudioImportDisplayKeepsModelIDAndLocalizesStaticLabels()
+        try testSystemDefaultMicrophoneLabelLocalization()
         try testSettingsSectionTitlePolicy()
         try testGoogleCalendarHealthMessagesLocalizeWithoutChangingDetail()
         try testCalendarReminderLeadTimeUsesLocalizedCopy()
@@ -77,6 +78,27 @@ struct SettingsLocalizationTests {
         assert(legacyDisplay.title == "Legacy mlx-whisper")
         assert(legacyDisplay.localizedCurrentLabel(language: "en", bundle: localizationBundle) == "On This Mac · Legacy · Whisper Medium")
         assert(legacyDisplay.localizedCurrentLabel(language: "ko", bundle: localizationBundle) == "이 Mac에서 · 레거시 · Whisper Medium")
+    }
+
+    private static func testSystemDefaultMicrophoneLabelLocalization() throws {
+        let bundle = try compiledLocalizationBundle()
+
+        assert(
+            localizedCatalogFormat(
+                "System Default (%@)",
+                "MacBook Air Microphone",
+                language: "en",
+                bundle: bundle
+            ) == "System Default (MacBook Air Microphone)"
+        )
+        assert(
+            localizedCatalogFormat(
+                "System Default (%@)",
+                "MacBook Air Microphone",
+                language: "ko",
+                bundle: bundle
+            ) == "시스템 기본값 (MacBook Air Microphone)"
+        )
     }
 
     private static func testSettingsSectionTitlePolicy() throws {

--- a/Tests/SystemAudioInputSelectionTests.swift
+++ b/Tests/SystemAudioInputSelectionTests.swift
@@ -11,10 +11,13 @@ struct SystemAudioInputSelectionTests {
         testAudioSourceMapping()
         testAudioSourceCatalog()
         testMicrophoneDeviceNormalization()
+        testSystemDefaultMicrophoneDisplayName()
+        try testSystemDefaultInputChangeRefreshesCachedName()
         try testSettingsSeparatesSourceAndMicrophone()
         try testMenuBarSeparatesSourceAndMicrophone()
         try testSettingsPickerIncludesMicrophoneAndSystemAudio()
         try testMenuBarPickerIncludesMicrophoneAndSystemAudio()
+        try testMicrophoneSelectorsUseCommonSystemDefaultDisplayName()
         try testSetupOmitsAudioInputPicker()
         print("SystemAudioInputSelectionTests passed")
     }
@@ -97,6 +100,43 @@ struct SystemAudioInputSelectionTests {
         assert(AudioInputDevice.normalizedMicrophoneDeviceID("device-uid") == "device-uid")
     }
 
+    private static func testSystemDefaultMicrophoneDisplayName() {
+        let fallback = "System Default"
+        let format = "System Default (%@)"
+
+        precondition(
+            AudioInputDevice.systemDefaultDisplayName(
+                deviceName: "MacBook Air Microphone",
+                defaultTitle: fallback,
+                format: format
+            ) == "System Default (MacBook Air Microphone)"
+        )
+        precondition(
+            AudioInputDevice.systemDefaultDisplayName(
+                deviceName: " \n ",
+                defaultTitle: fallback,
+                format: format
+            ) == fallback
+        )
+        precondition(
+            AudioInputDevice.systemDefaultDisplayName(
+                deviceName: nil,
+                defaultTitle: fallback,
+                format: format
+            ) == fallback
+        )
+    }
+
+    private static func testSystemDefaultInputChangeRefreshesCachedName() throws {
+        let appStateSource = try sourceFile("Sources/AppState.swift")
+
+        assertContains(appStateSource, "import CoreAudio")
+        assertContains(appStateSource, "kAudioHardwarePropertyDefaultInputDevice")
+        assertContains(appStateSource, "AudioObjectAddPropertyListenerBlock")
+        assertContains(appStateSource, "AudioObjectRemovePropertyListenerBlock")
+        assertContains(appStateSource, "refreshAvailableMicrophones()")
+    }
+
     private static func testSettingsSeparatesSourceAndMicrophone() throws {
         let source = try sourceFile("Sources/SettingsView.swift")
         assertOrder(
@@ -134,6 +174,17 @@ struct SystemAudioInputSelectionTests {
         assertContains(source, "ForEach(AudioRecordingSource.allCases)")
         assertContains(source, "localizedCatalogString(source.titleKey)")
         assertContains(source, "appState.isAudioSourceSelectable(source)")
+    }
+
+    private static func testMicrophoneSelectorsUseCommonSystemDefaultDisplayName() throws {
+        for path in [
+            "Sources/SettingsView.swift",
+            "Sources/NoteBrowserView.swift",
+            "Sources/MenuBarView.swift"
+        ] {
+            let source = try sourceFile(path)
+            assertContains(source, "systemDefaultMicrophoneDisplayName()")
+        }
     }
 
     private static func testSetupOmitsAudioInputPicker() throws {


### PR DESCRIPTION
## Summary
- Show the macOS default input device alongside System Default in microphone selectors.
- Refresh the cached name when macOS changes the default input, without querying while menus open.
- Keep recorder fallback and the displayed device resolution aligned.

## Testing
- `make test CODESIGN_IDENTITY=Quill`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 시스템 기본 마이크가 실제 장치 이름과 함께 표시됩니다.
  * 시스템 기본 입력 장치 변경 시 표시 정보가 자동으로 갱신됩니다.
  * 영어와 한국어로 시스템 기본 마이크 이름이 현지화됩니다.

* **개선 사항**
  * 설정, 메뉴 막대, 오디오 입력 선택 화면에서 일관된 마이크 표시명을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->