### PR TITLE
Protect recording history when persistence fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,9 @@ FULL_SOURCE_TRANSCRIPTION_TESTS = \
 FULL_SOURCE_APP_STATE_TESTS = \
 	Tests/AudioImportFileCopyTests.swift \
 	Tests/LatestValueProgressCoalescerTests.swift \
+	Tests/AppStateTestStorage.swift \
+	Tests/AppStateStorageSafetyTests.swift \
+	Tests/AppStateHistoryProtectionSourceTests.swift \
 	Tests/AppStateTranscriptionConfigurationTests.swift \
 	Tests/AppStateAIProcessingBackendTests.swift \
 	Tests/MeetingSummaryAppStateTests.swift

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -13733,6 +13733,38 @@
         }
       }
     },
+    "Audio file unavailable": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio file unavailable"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오 파일을 찾을 수 없음"
+          }
+        }
+      }
+    },
+    "This recording's audio file is unavailable, so it can't be transcribed.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This recording's audio file is unavailable, so it can't be transcribed."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 녹음의 오디오 파일을 찾을 수 없어 재전사할 수 없습니다."
+          }
+        }
+      }
+    },
     "Audio recording": {
       "localizations": {
         "en": {
@@ -14705,6 +14737,86 @@
           "stringUnit": {
             "state": "translated",
             "value": "Context를 활성화하려면 이미지를 지원하는 모델을 선택하세요."
+          }
+        }
+      }
+    },
+    "Open Data Folder": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Data Folder"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "데이터 폴더 열기"
+          }
+        }
+      }
+    },
+    "Open the data folder to keep the original history available for support and recovery.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open the data folder to keep the original history available for support and recovery."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지원 및 복구에 사용할 수 있도록 원본 기록이 보존된 데이터 폴더를 여세요."
+          }
+        }
+      }
+    },
+    "Quit Quill": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit Quill"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill 종료"
+          }
+        }
+      }
+    },
+    "Recording history couldn’t be opened": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording history couldn’t be opened"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 기록을 열 수 없음"
+          }
+        }
+      }
+    },
+    "Your notes and audio files were not deleted. Restart Quill to try again, or open the data folder for support and recovery.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your notes and audio files were not deleted. Restart Quill to try again, or open the data folder for support and recovery."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노트와 오디오 파일은 삭제되지 않았습니다. Quill을 다시 시작해 재시도하거나 데이터 폴더를 열어 지원 및 복구에 사용할 수 있습니다."
           }
         }
       }

--- a/Sources/AppName.swift
+++ b/Sources/AppName.swift
@@ -5,9 +5,11 @@ enum AppName {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "Quill"
 
     static var applicationSupportDirectory: URL {
-        FileManager.default.urls(
+        let baseURL = FileManager.default.urls(
             for: .applicationSupportDirectory,
             in: .userDomainMask
-        ).first!.appendingPathComponent(displayName, isDirectory: true)
+        ).first ?? URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+        return baseURL.appendingPathComponent(displayName, isDirectory: true)
     }
 }

--- a/Sources/AppName.swift
+++ b/Sources/AppName.swift
@@ -3,4 +3,11 @@ import Foundation
 enum AppName {
     static let displayName: String =
         Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "Quill"
+
+    static var applicationSupportDirectory: URL {
+        FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first!.appendingPathComponent(displayName, isDirectory: true)
+    }
 }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2092,14 +2092,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         [UUID: CloudTranscriptionDisplayProgress] = [:]
     @Published var lastTranscript: String = ""
     @Published var errorMessage: String?
-    var isHistoryUnavailable: Bool {
-        pipelineHistoryStore.availability == .unavailable
-    }
-    var historyPersistenceWarning: QuillUserIssueRecord? {
-        isHistoryUnavailable
-            ? QuillUserIssueRecord(code: .historyPersistenceUnavailable)
-            : nil
-    }
+    @Published private(set) var isHistoryUnavailable = false
+    @Published private(set) var historyPersistenceWarning: QuillUserIssueRecord?
     var historyUnavailableMessage: String {
         QuillUserIssueRecord(code: .historyPersistenceUnavailable)
             .presentation().compactMessage
@@ -3007,7 +3001,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.localTranscriptionModel = localTranscriptionModel
         self.soundVolume = soundVolume
         self.voiceMacros = initialMacros
+        let initialHistoryUnavailable = pipelineHistoryStore.availability == .unavailable
         self.pipelineHistory = savedHistory
+        self.isHistoryUnavailable = initialHistoryUnavailable
+        self.historyPersistenceWarning = initialHistoryUnavailable
+            ? QuillUserIssueRecord(code: .historyPersistenceUnavailable)
+            : nil
         self.hasAccessibility = initialAccessibility
         self.hasScreenRecordingPermission = initialScreenCapturePermission
         self.launchAtLogin = SMAppService.mainApp.status == .enabled
@@ -5539,7 +5538,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 for assets in removedAssets {
                     cleanupDeletedPipelineHistoryAssets(assets)
                 }
-                if let item = pipelineHistoryStore.loadAllHistory().first(where: {
+                if let item = loadPipelineHistory().first(where: {
                     $0.id == recovered.recordingID
                 }), item.isIncompleteTranscription {
                     try pipelineHistoryStore.update(
@@ -5547,7 +5546,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     )
                 }
                 pipelineHistory = Self.markInterruptedRecoveryPlaceholders(
-                    in: pipelineHistoryStore.loadAllHistory(),
+                    in: loadPipelineHistory(),
                     store: pipelineHistoryStore
                 )
                 let context = RecoveredRecordingContext(
@@ -6137,8 +6136,24 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
     }
 
+    private func synchronizeHistoryPersistenceState() {
+        let unavailable = pipelineHistoryStore.availability == .unavailable
+        guard isHistoryUnavailable != unavailable else { return }
+        isHistoryUnavailable = unavailable
+        historyPersistenceWarning = isHistoryUnavailable
+            ? QuillUserIssueRecord(code: .historyPersistenceUnavailable)
+            : nil
+    }
+
+    private func loadPipelineHistory() -> [PipelineHistoryItem] {
+        let history = pipelineHistoryStore.loadAllHistory()
+        synchronizeHistoryPersistenceState()
+        return history
+    }
+
     @discardableResult
     private func requireAvailableHistoryForMutation() -> Bool {
+        synchronizeHistoryPersistenceState()
         guard !isHistoryUnavailable else {
             errorMessage = historyUnavailableMessage
             return false
@@ -6824,7 +6839,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 }
                 do {
                     try self.pipelineHistoryStore.update(updatedItem)
-                    self.pipelineHistory = self.pipelineHistoryStore.loadAllHistory()
+                    self.pipelineHistory = self.loadPipelineHistory()
                     if retrySucceeded {
                         if snapshot.useLocalTranscription,
                            let cloudContext = snapshot.cloudExecutionContext {
@@ -10108,7 +10123,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     transcriptFileName: item.transcriptFileName
                 )
                 try pipelineHistoryStore.update(updated)
-                pipelineHistory = pipelineHistoryStore.loadAllHistory()
+                pipelineHistory = loadPipelineHistory()
                 completeCloudTranscriptionHistory(
                     historyID: record.historyID,
                     context: context,
@@ -10431,7 +10446,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             for removedAssets in removed {
                 cleanupDeletedPipelineHistoryAssets(removedAssets)
             }
-            pipelineHistory = pipelineHistoryStore.loadAllHistory()
+            pipelineHistory = loadPipelineHistory()
         } catch {
             updateTranscriptionJob(jobID) { $0.liveNoteID = nil }
         }
@@ -10546,7 +10561,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
         } catch {
             if journalRecordingID == nil,
-               !pipelineHistoryStore.loadAllHistory().contains(where: { $0.id == recordingID }) {
+               !loadPipelineHistory().contains(where: { $0.id == recordingID }) {
                 Self.deleteStoredFiles(
                     audioFileName: audioFileName,
                     transcriptFileName: nil
@@ -10591,7 +10606,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             for assets in removedAssets {
                 cleanupDeletedPipelineHistoryAssets(assets)
             }
-            if let item = pipelineHistoryStore.loadAllHistory().first(where: {
+            if let item = loadPipelineHistory().first(where: {
                 $0.id == recovered.recordingID
             }) {
                 let normalized = item.isIncompleteTranscription
@@ -10602,7 +10617,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 }
             }
             pipelineHistory = Self.markInterruptedRecoveryPlaceholders(
-                in: pipelineHistoryStore.loadAllHistory(),
+                in: loadPipelineHistory(),
                 store: pipelineHistoryStore
             )
             presentation = (

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -365,8 +365,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
         (AppState) -> any MeetingSummaryGenerating = { appState in
             appState.makeMeetingSummaryService()
         }
+    static var storageRootProvider: () -> URL = {
+        AppName.applicationSupportDirectory
+    }
     static var pipelineHistoryStoreFactory: () -> PipelineHistoryStore = {
-        PipelineHistoryStore()
+        makeDefaultPipelineHistoryStore()
+    }
+
+    static func makeDefaultPipelineHistoryStore() -> PipelineHistoryStore {
+        PipelineHistoryStore(
+            storeURL: appStorageRootDirectory()
+                .appendingPathComponent("PipelineHistory.sqlite")
+        )
     }
 
     static var googleCalendarTokenLoader: (Bool) -> GoogleCalendarOAuthToken? = { allowsAuthenticationUI in
@@ -2082,7 +2092,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
         [UUID: CloudTranscriptionDisplayProgress] = [:]
     @Published var lastTranscript: String = ""
     @Published var errorMessage: String?
-    @Published private(set) var historyPersistenceWarning: QuillUserIssueRecord?
+    var isHistoryUnavailable: Bool {
+        pipelineHistoryStore.availability == .unavailable
+    }
+    var historyPersistenceWarning: QuillUserIssueRecord? {
+        isHistoryUnavailable
+            ? QuillUserIssueRecord(code: .historyPersistenceUnavailable)
+            : nil
+    }
+    var historyUnavailableMessage: String {
+        QuillUserIssueRecord(code: .historyPersistenceUnavailable)
+            .presentation().compactMessage
+    }
     @Published var statusText: String = localizedCatalogString("Ready")
 
     // MCP interface
@@ -2763,56 +2784,137 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         let initialAccessibility = AXIsProcessTrusted()
         let initialScreenCapturePermission = CGPreflightScreenCaptureAccess()
-        Self.recoverRecordingJournalsBeforeHistoryLoad(
-            recordingJournalStore: recordingJournalStore,
-            historyStore: pipelineHistoryStore
-        )
-        var removedStoredFiles: [DeletedPipelineHistoryAssets] = []
-        do {
-            removedStoredFiles = try pipelineHistoryStore.trim(to: maxPipelineHistoryCount)
-        } catch {
-            print("Failed to trim pipeline history during init: \(error)")
-        }
-        for removedAssets in removedStoredFiles {
-            cloudTranscriptionJobStore.invalidateSession(
-                historyID: removedAssets.historyID
-            )
-            Self.deleteStoredFiles(removedAssets)
-            try? cloudTranscriptionJobStore.delete(
-                historyID: removedAssets.historyID,
-                session: nil
-            )
-        }
-        var savedHistory = Self.markInterruptedRecoveryPlaceholders(
-            in: pipelineHistoryStore.loadAllHistory(),
-            store: pipelineHistoryStore
-        )
-        try? cloudTranscriptionJobStore.removeStaleTemporaryArtifacts()
-        let cloudReconciliation = cloudTranscriptionJobStore.reconcile(
-            history: savedHistory,
-            audioRoot: audioDirectory
-        )
-        let historyStore = pipelineHistoryStore
-        do {
-            savedHistory = try LegacyNoteTitleMigration.migrate(history: savedHistory) { item in
-                try historyStore.update(item)
-            }
-        } catch {
-            print("Failed to migrate legacy note titles: \(error)")
-        }
-        let referencedAudioFileNames = Set(savedHistory.compactMap(\.audioFileName))
-        let referencedTranscriptFileNames = Set(savedHistory.compactMap(\.transcriptFileName))
-        let protectedInflightAudioFileNames = Self.protectedInflightAudioFileNames(
-            store: recordingJournalStore
-        )
-        Task.detached(priority: .background) {
-            Self.sweepOrphanStoredFiles(
-                referencedAudioFileNames: referencedAudioFileNames,
-                referencedTranscriptFileNames: referencedTranscriptFileNames,
-                protectedInflightAudioFileNames: protectedInflightAudioFileNames
-            )
-        }
+        var savedHistory: [PipelineHistoryItem] = []
+        var cloudReconciliation: CloudTranscriptionReconciliation?
 
+        if pipelineHistoryStore.availability == .ready {
+            pipelineHistoryStore.verifyHistoryReadable()
+        }
+        if pipelineHistoryStore.availability == .ready {
+            Self.recoverRecordingJournalsBeforeHistoryLoad(
+                recordingJournalStore: recordingJournalStore,
+                historyStore: pipelineHistoryStore
+            )
+            let transcriptDirectory = Self.transcriptStorageDirectory()
+            savedHistory = pipelineHistoryStore.loadAllHistory()
+            if pipelineHistoryStore.availability == .ready {
+                var referenceTrust = pipelineHistoryStore.referenceTrust
+                var shouldBootstrapAssetReferenceSnapshot = false
+                let loadedAudioFileNames = Set(savedHistory.compactMap(\.audioFileName))
+                let loadedTranscriptFileNames = Set(savedHistory.compactMap(\.transcriptFileName))
+                if !pipelineHistoryStore.hadPersistentStoreAtLoad,
+                   Self.hasStoredAssets(
+                       audioDirectory: audioDirectory,
+                       transcriptDirectory: transcriptDirectory
+                   ) {
+                    Self.markAssetReferencesIncomplete(
+                        storageRoot: audioDirectory.deletingLastPathComponent()
+                    )
+                    referenceTrust = .recovered
+                } else {
+                    switch pipelineHistoryStore.assetReferenceSnapshotState(
+                        audioFileNames: loadedAudioFileNames,
+                        transcriptFileNames: loadedTranscriptFileNames
+                    ) {
+                    case .matches:
+                        break
+                    case .missing:
+                        if Self.hasUnreferencedStoredAssets(
+                            audioDirectory: audioDirectory,
+                            transcriptDirectory: transcriptDirectory,
+                            referencedAudioFileNames: loadedAudioFileNames,
+                            referencedTranscriptFileNames: loadedTranscriptFileNames
+                        ) {
+                            Self.markAssetReferencesIncomplete(
+                                storageRoot: audioDirectory.deletingLastPathComponent()
+                            )
+                            referenceTrust = .recovered
+                        } else {
+                            shouldBootstrapAssetReferenceSnapshot = true
+                            referenceTrust = .unavailable
+                        }
+                    case .mismatch, .unavailable:
+                        Self.markAssetReferencesIncomplete(
+                            storageRoot: audioDirectory.deletingLastPathComponent()
+                        )
+                        referenceTrust = .recovered
+                    }
+                }
+                if referenceTrust.permitsStartupReferenceCleanup {
+                    var removedStoredFiles: [DeletedPipelineHistoryAssets] = []
+                    do {
+                        removedStoredFiles = try pipelineHistoryStore.trim(
+                            to: maxPipelineHistoryCount
+                        )
+                    } catch {
+                        print("Failed to trim pipeline history during init: \(error)")
+                    }
+                    for removedAssets in removedStoredFiles {
+                        cloudTranscriptionJobStore.invalidateSession(
+                            historyID: removedAssets.historyID
+                        )
+                        Self.deleteStoredFiles(removedAssets)
+                        try? cloudTranscriptionJobStore.delete(
+                            historyID: removedAssets.historyID,
+                            session: nil
+                        )
+                    }
+                    if !removedStoredFiles.isEmpty {
+                        savedHistory = pipelineHistoryStore.loadAllHistory()
+                        referenceTrust = pipelineHistoryStore.referenceTrust
+                    }
+                } else {
+                    print("Skipping startup history cleanup because asset references are unavailable.")
+                }
+                savedHistory = Self.markInterruptedRecoveryPlaceholders(
+                    in: savedHistory,
+                    store: pipelineHistoryStore
+                )
+                try? cloudTranscriptionJobStore.removeStaleTemporaryArtifacts()
+                cloudReconciliation = cloudTranscriptionJobStore.reconcile(
+                    history: savedHistory,
+                    audioRoot: audioDirectory
+                )
+                let historyStore = pipelineHistoryStore
+                do {
+                    savedHistory = try LegacyNoteTitleMigration.migrate(history: savedHistory) { item in
+                        try historyStore.update(item)
+                    }
+                } catch {
+                    print("Failed to migrate legacy note titles: \(error)")
+                }
+                let referencedAudioFileNames = Set(savedHistory.compactMap(\.audioFileName))
+                let referencedTranscriptFileNames = Set(savedHistory.compactMap(\.transcriptFileName))
+                if shouldBootstrapAssetReferenceSnapshot {
+                    _ = pipelineHistoryStore.bootstrapAssetReferenceSnapshot(
+                        audioFileNames: referencedAudioFileNames,
+                        transcriptFileNames: referencedTranscriptFileNames
+                    )
+                }
+                let protectedInflightAudioFileNames = Self.protectedInflightAudioFileNames(
+                    store: recordingJournalStore
+                )
+                if referenceTrust.permitsStartupReferenceCleanup {
+                    let sweepReferenceTrust = referenceTrust
+                    let sweepNow = Date()
+                    Task.detached(priority: .background) {
+                        Self.sweepOrphanStoredFiles(
+                            audioDirectory: audioDirectory,
+                            transcriptDirectory: transcriptDirectory,
+                            referencedAudioFileNames: referencedAudioFileNames,
+                            referencedTranscriptFileNames: referencedTranscriptFileNames,
+                            protectedInflightAudioFileNames: protectedInflightAudioFileNames,
+                            referenceTrust: sweepReferenceTrust,
+                            now: sweepNow
+                        )
+                    }
+                }
+            } else {
+                print("Skipping history startup work because persistent history is unavailable.")
+            }
+        } else {
+            print("Skipping history startup work because persistent history is unavailable.")
+        }
         let storedInputID = AudioInputDevice.normalized(
             UserDefaults.standard.string(forKey: selectedMicrophoneStorageKey) ?? ""
         )
@@ -2906,18 +3008,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.soundVolume = soundVolume
         self.voiceMacros = initialMacros
         self.pipelineHistory = savedHistory
-        switch pipelineHistoryStore.durability {
-        case .durable:
-            self.historyPersistenceWarning = nil
-        case .inMemory, .inMemoryFallback:
-            self.historyPersistenceWarning = QuillUserIssueRecord(
-                code: .historyPersistenceUnavailable
-            )
-        case .recovered:
-            self.historyPersistenceWarning = QuillUserIssueRecord(
-                code: .historyRecovered
-            )
-        }
         self.hasAccessibility = initialAccessibility
         self.hasScreenRecordingPermission = initialScreenCapturePermission
         self.launchAtLogin = SMAppService.mainApp.status == .enabled
@@ -2929,8 +3019,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
         scheduleNoteBrowserTranscriptionModeNormalizationForSelectedInput()
         self.precomputeMacros()
-        Task { @MainActor [weak self] in
-            self?.scheduleCloudTranscriptionAutoResume(cloudReconciliation)
+        if let cloudReconciliation {
+            Task { @MainActor [weak self] in
+                self?.scheduleCloudTranscriptionAutoResume(cloudReconciliation)
+            }
         }
 
         speechRecognitionAuthorizationStatus = Self.currentSpeechRecognitionAuthorizationStatus()
@@ -4689,24 +4781,43 @@ final class AppState: ObservableObject, @unchecked Sendable {
         case savingAudioOnly
     }
 
-    static func audioStorageDirectory() -> URL {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "Quill"
-        let audioDir = appSupport.appendingPathComponent("\(appName)/audio", isDirectory: true)
-        if !FileManager.default.fileExists(atPath: audioDir.path) {
-            try? FileManager.default.createDirectory(at: audioDir, withIntermediateDirectories: true)
+    func openHistoryDataFolder() {
+        NSWorkspace.shared.open(Self.appStorageRootDirectory())
+    }
+
+    static func appStorageRootDirectory() -> URL {
+        let rootDirectory = storageRootProvider()
+        if !FileManager.default.fileExists(atPath: rootDirectory.path) {
+            try? FileManager.default.createDirectory(
+                at: rootDirectory,
+                withIntermediateDirectories: true
+            )
         }
-        return audioDir
+        return rootDirectory
+    }
+
+    static func audioStorageDirectory() -> URL {
+        let audioDirectory = appStorageRootDirectory()
+            .appendingPathComponent("audio", isDirectory: true)
+        if !FileManager.default.fileExists(atPath: audioDirectory.path) {
+            try? FileManager.default.createDirectory(
+                at: audioDirectory,
+                withIntermediateDirectories: true
+            )
+        }
+        return audioDirectory
     }
 
     static func transcriptStorageDirectory() -> URL {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "Quill"
-        let dir = appSupport.appendingPathComponent("\(appName)/transcripts", isDirectory: true)
-        if !FileManager.default.fileExists(atPath: dir.path) {
-            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let directory = appStorageRootDirectory()
+            .appendingPathComponent("transcripts", isDirectory: true)
+        if !FileManager.default.fileExists(atPath: directory.path) {
+            try? FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
         }
-        return dir
+        return directory
     }
 
     private static func recoverRecordingJournalsBeforeHistoryLoad(
@@ -4728,8 +4839,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         artifact,
                         maxCount: Int.max
                     )
-                    for assets in removedAssets {
-                        Self.deleteStoredFiles(assets)
+                    if historyStore.referenceTrust.permitsStartupReferenceCleanup {
+                        for assets in removedAssets {
+                            Self.deleteStoredFiles(assets)
+                        }
                     }
                 } catch {
                     print("Failed to persist recovered recording \(artifact.recordingID): \(error)")
@@ -4755,15 +4868,82 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
     }
 
-    private static func sweepOrphanStoredFiles(
+    private static func hasStoredAssets(
+        audioDirectory: URL,
+        transcriptDirectory: URL
+    ) -> Bool {
+        let fileManager = FileManager.default
+        for directory in [audioDirectory, transcriptDirectory] {
+            guard fileManager.fileExists(atPath: directory.path) else { continue }
+            guard let fileNames = try? fileManager.contentsOfDirectory(
+                atPath: directory.path
+            ) else {
+                return true
+            }
+            if fileNames.contains(where: { $0 != "inflight" }) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func hasUnreferencedStoredAssets(
+        audioDirectory: URL,
+        transcriptDirectory: URL,
+        referencedAudioFileNames: Set<String>,
+        referencedTranscriptFileNames: Set<String>
+    ) -> Bool {
+        let fileManager = FileManager.default
+        let directories = [
+            (audioDirectory, referencedAudioFileNames),
+            (transcriptDirectory, referencedTranscriptFileNames)
+        ]
+        for (directory, referencedFileNames) in directories {
+            guard fileManager.fileExists(atPath: directory.path) else { continue }
+            guard let fileNames = try? fileManager.contentsOfDirectory(
+                atPath: directory.path
+            ) else {
+                return true
+            }
+            if fileNames.contains(where: {
+                $0 != "inflight" && !referencedFileNames.contains($0)
+            }) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func markAssetReferencesIncomplete(storageRoot: URL) {
+        let markerURL = storageRoot
+            .appendingPathComponent("History Recovery", isDirectory: true)
+            .appendingPathComponent(
+                "asset-references-incomplete",
+                isDirectory: true
+            )
+        do {
+            try FileManager.default.createDirectory(
+                at: markerURL,
+                withIntermediateDirectories: true
+            )
+        } catch {
+            print("Failed to preserve incomplete history-reference evidence: \(error)")
+        }
+    }
+
+    static func sweepOrphanStoredFiles(
+        audioDirectory: URL,
+        transcriptDirectory: URL,
         referencedAudioFileNames: Set<String>,
         referencedTranscriptFileNames: Set<String>,
-        protectedInflightAudioFileNames: Set<String> = []
+        protectedInflightAudioFileNames: Set<String> = [],
+        referenceTrust: PipelineHistoryReferenceTrust,
+        now: Date = Date()
     ) {
+        guard referenceTrust.permitsStartupReferenceCleanup else { return }
+
         let fileManager = FileManager.default
-        let now = Date()
         let gracePeriod: TimeInterval = 300
-        let audioDirectory = audioStorageDirectory()
         if let audioFiles = try? fileManager.contentsOfDirectory(atPath: audioDirectory.path) {
             for fileName in audioFiles where !referencedAudioFileNames.contains(fileName) {
                 guard fileName != "inflight" else { continue }
@@ -4775,7 +4955,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 try? fileManager.removeItem(at: fileURL)
             }
         }
-        let transcriptDirectory = transcriptStorageDirectory()
         if let transcriptFiles = try? fileManager.contentsOfDirectory(atPath: transcriptDirectory.path) {
             for fileName in transcriptFiles where !referencedTranscriptFileNames.contains(fileName) {
                 let fileURL = transcriptDirectory.appendingPathComponent(fileName)
@@ -5958,8 +6137,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
     }
 
+    @discardableResult
+    private func requireAvailableHistoryForMutation() -> Bool {
+        guard !isHistoryUnavailable else {
+            errorMessage = historyUnavailableMessage
+            return false
+        }
+        return true
+    }
+
     @MainActor
     func clearPipelineHistory() {
+        guard requireAvailableHistoryForMutation() else { return }
         let historyIDs = pipelineHistory.map(\.id)
         for historyID in historyIDs {
             cloudTranscriptionHistoryCoordinator.cancelAndInvalidate(
@@ -5990,7 +6179,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func deleteHistoryEntry(id: UUID) {
-        guard let index = pipelineHistory.firstIndex(where: { $0.id == id }) else { return }
+        guard requireAvailableHistoryForMutation(),
+              let index = pipelineHistory.firstIndex(where: { $0.id == id }) else { return }
         cloudTranscriptionHistoryCoordinator.cancelAndInvalidate(
             historyID: id,
             store: cloudTranscriptionJobStore
@@ -6016,7 +6206,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func updateHistoryItemTitle(id: UUID, title: String) {
-        guard let index = pipelineHistory.firstIndex(where: { $0.id == id }) else { return }
+        guard requireAvailableHistoryForMutation(),
+              let index = pipelineHistory.firstIndex(where: { $0.id == id }) else { return }
         let item = pipelineHistory[index]
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedTitle = trimmed.isEmpty ? nil : trimmed
@@ -6091,16 +6282,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func generateMeetingSummary(id: UUID) async throws {
+        guard requireAvailableHistoryForMutation() else {
+            throw QuillUserIssueError.historyPersistenceUnavailable()
+        }
         guard let startItem = pipelineHistory.first(where: { $0.id == id }) else {
             throw MeetingSummaryError.invalidInput
         }
         guard meetingSummaryAvailability(for: startItem) == .available else {
             throw MeetingSummaryError.invalidInput
         }
-        switch pipelineHistoryStore.durability {
-        case .durable, .recovered:
-            break
-        case .inMemory, .inMemoryFallback:
+        guard pipelineHistoryStore.durability == .durable else {
             throw QuillUserIssueError.historyPersistenceUnavailable()
         }
 
@@ -6148,7 +6339,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         actionID: UUID,
         isCompleted: Bool
     ) throws {
-        guard let noteIndex = pipelineHistory.firstIndex(
+        guard requireAvailableHistoryForMutation(),
+              let noteIndex = pipelineHistory.firstIndex(
             where: { $0.id == noteID }
         ), var envelope = pipelineHistory[noteIndex].meetingSummary,
         let actionIndex = envelope.content.actionItems.firstIndex(
@@ -6165,7 +6357,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func deleteMeetingSummary(noteID: UUID) throws {
-        guard let noteIndex = pipelineHistory.firstIndex(
+        guard requireAvailableHistoryForMutation(),
+              let noteIndex = pipelineHistory.firstIndex(
             where: { $0.id == noteID }
         ), pipelineHistory[noteIndex].meetingSummary != nil else {
             throw MeetingSummaryError.invalidInput
@@ -6176,7 +6369,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     func updateTranscript(id: UUID, text: String) {
-        guard let item = pipelineHistory.first(where: { $0.id == id }) else { return }
+        guard requireAvailableHistoryForMutation(),
+              let item = pipelineHistory.first(where: { $0.id == id }) else { return }
         // 파일에도 동기화해서 앱 재시작 후 폴백 로딩 시에도 일관성 유지
         if let fileName = item.transcriptFileName {
             let fileURL = Self.transcriptStorageDirectory().appendingPathComponent(fileName)
@@ -6226,11 +6420,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func importAudioFile(_ fileURL: URL, mode: NoteBrowserTranscriptionMode) {
+        guard requireAvailableHistoryForMutation() else { return }
         importAudioFile(fileURL, choice: preferredAudioImportChoice(for: mode))
     }
 
     @MainActor
     func importAudioFile(_ fileURL: URL, choice: TranscriptionBackendChoice) {
+        guard requireAvailableHistoryForMutation() else { return }
         guard !choice.usesCloudAPI || hasTranscriptionAPIKey else {
             openProviderSettings()
             return
@@ -6522,6 +6718,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func retryTranscription(item: PipelineHistoryItem) {
+        guard requireAvailableHistoryForMutation() else { return }
         guard !retryingItemIDs.contains(item.id) else { return }
         guard noteBrowserRetryAvailability(for: item) == .ready else { return }
 
@@ -7475,6 +7672,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func toggleRecording() {
+        guard isRecording || requireAvailableHistoryForMutation() else { return }
         os_log(.info, log: recordingLog, "toggleRecording() called, isRecording=%{public}d", isRecording)
         cancelPendingShortcutStart()
         if isRecording {
@@ -7487,17 +7685,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     // MCP public interface
     @MainActor
-    func startRecordingFromMCP() {
+    @discardableResult
+    func startRecordingFromMCP() -> Bool {
+        guard requireAvailableHistoryForMutation() else { return false }
         if transcriptionEnabled {
             lastTranscript = ""
         }
         mcpLastRecordingFailed = false
         shortcutSessionController.beginManual(mode: .toggle)
         startRecording(triggerMode: .toggle)
+        return true
     }
 
     @MainActor
     func startRecordingFromCalendarReminder(_ action: CalendarRecordingReminderNotificationAction) {
+        guard requireAvailableHistoryForMutation() else { return }
         beginCalendarReminderRecording { [weak self] in
             self?.calendarRecordingReminderScheduler.markReminderHandledExternally(
                 identifier: action.identifier,
@@ -7508,6 +7710,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func startRecordingFromCalendarReminder() {
+        guard requireAvailableHistoryForMutation() else { return }
         beginCalendarReminderRecording()
     }
 
@@ -7885,6 +8088,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func startRecording(triggerMode: RecordingTriggerMode, onStarted: (@MainActor () -> Void)? = nil) {
+        guard requireAvailableHistoryForMutation() else { return }
         let t0 = CFAbsoluteTimeGetCurrent()
         os_log(.info, log: recordingLog, "startRecording() entered")
         guard !isRecording else { return }
@@ -10714,12 +10918,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 )
             }
         } catch {
-            if !isJournalAudioFile {
+            if existingID == nil, !isJournalAudioFile {
                 Self.deleteStoredFiles(
                     audioFileName: audioFileName,
                     transcriptFileName: transcriptFileName
                 )
-            } else if let transcriptFileName {
+            } else if existingID == nil, let transcriptFileName {
                 Self.deleteTranscriptFile(transcriptFileName)
             }
             let issue = self.userIssue(for: error)

--- a/Sources/KeychainStorage.swift
+++ b/Sources/KeychainStorage.swift
@@ -5,8 +5,7 @@ enum AppSettingsStorage {
     static var storageDirectoryOverride: URL?
 
     private static var defaultStorageDirectory: URL {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        return appSupport.appendingPathComponent(AppName.displayName, isDirectory: true)
+        AppName.applicationSupportDirectory
     }
 
     private static var storageDirectory: URL {

--- a/Sources/MCPServer.swift
+++ b/Sources/MCPServer.swift
@@ -270,13 +270,24 @@ final class MCPServer {
 
         switch name {
         case "start_recording":
+            if appState.isHistoryUnavailable {
+                return textContent(
+                    "Error: \(appState.historyUnavailableMessage)",
+                    isError: true
+                )
+            }
             if appState.isRecording {
                 return textContent("Already recording.")
             }
             if let context = args["context"] as? String, !context.isEmpty {
                 appState.mcpAdditionalContext = context
             }
-            appState.startRecordingFromMCP()
+            guard appState.startRecordingFromMCP() else {
+                return textContent(
+                    "Error: \(appState.historyUnavailableMessage)",
+                    isError: true
+                )
+            }
             let ctx = appState.mcpAdditionalContext
             return textContent("Recording started.\(ctx.isEmpty ? "" : " Context: \(ctx)")")
 
@@ -304,6 +315,12 @@ final class MCPServer {
             }
 
         case "get_status":
+            if appState.isHistoryUnavailable {
+                return textContent("""
+                    status: history_unavailable
+                    message: \(appState.historyUnavailableMessage)
+                    """)
+            }
             let status: String
             if appState.isRecording {
                 status = "recording"
@@ -324,6 +341,12 @@ final class MCPServer {
                 """)
 
         case "list_transcripts":
+            if appState.isHistoryUnavailable {
+                return textContent(
+                    "Error: \(appState.historyUnavailableMessage)",
+                    isError: true
+                )
+            }
             let limit = max(0, min(args["limit"] as? Int ?? 10, 50))
             let entries = Array(appState.pipelineHistory.prefix(limit))
             if entries.isEmpty {
@@ -338,6 +361,12 @@ final class MCPServer {
             return textContent(lines.joined(separator: "\n\n"))
 
         case "get_transcript":
+            if appState.isHistoryUnavailable {
+                return textContent(
+                    "Error: \(appState.historyUnavailableMessage)",
+                    isError: true
+                )
+            }
             guard let idString = args["id"] as? String, let uuid = UUID(uuidString: idString) else {
                 return textContent("Error: valid 'id' is required.", isError: true)
             }
@@ -358,6 +387,12 @@ final class MCPServer {
             return textContent(lines.joined(separator: "\n"))
 
         case "get_meeting_source":
+            if appState.isHistoryUnavailable {
+                return textContent(
+                    "Error: \(appState.historyUnavailableMessage)",
+                    isError: true
+                )
+            }
             guard let idString = args["id"] as? String, let uuid = UUID(uuidString: idString) else {
                 return textContent("Error: valid 'id' is required.", isError: true)
             }

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -125,7 +125,7 @@ struct MenuBarView: View {
             Button(recordingButtonTitle) {
                 appState.toggleRecording()
             }
-            .disabled(appState.isTranscribing)
+            .disabled(appState.isTranscribing || appState.isHistoryUnavailable)
 
             if let hotkeyError = appState.hotkeyMonitoringErrorMessage {
                 Divider()
@@ -136,7 +136,34 @@ struct MenuBarView: View {
                     .lineLimit(3)
             }
 
-            if let warning = appState.historyPersistenceWarning {
+            if appState.isHistoryUnavailable,
+               let warning = appState.historyPersistenceWarning {
+                let presentation = warning.presentation()
+                Divider()
+                VStack(alignment: .leading, spacing: 6) {
+                    Label(
+                        presentation.title,
+                        systemImage: "externaldrive.badge.exclamationmark"
+                    )
+                    .font(.caption.weight(.semibold))
+                    Text(presentation.body)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    HStack {
+                        Button("Open Data Folder") {
+                            appState.openHistoryDataFolder()
+                        }
+                        Button("Quit Quill") {
+                            NSApplication.shared.terminate(nil)
+                        }
+                    }
+                    .controlSize(.small)
+                }
+                .foregroundStyle(.orange)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 4)
+            } else if let warning = appState.historyPersistenceWarning {
                 Divider()
                 Label(
                     warning.presentation().compactMessage,

--- a/Sources/NoteBrowserRecovery.swift
+++ b/Sources/NoteBrowserRecovery.swift
@@ -25,7 +25,7 @@ struct NoteBrowserActionState: Equatable {
         self.retryAvailability = retryAvailability
     }
 
-    var showsRetryButton: Bool { hasStoredAudio }
+    var showsRetryButton: Bool { true }
     var canCopy: Bool { hasTranscriptText }
     var canSaveFiles: Bool { hasStoredAudio || hasTranscriptText }
 }

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -479,7 +479,11 @@ struct NoteBrowserView: View {
     }
 
     var body: some View {
-        HStack(spacing: 0) {
+        Group {
+            if appState.isHistoryUnavailable {
+                historyUnavailableView
+            } else {
+                HStack(spacing: 0) {
             sidebarPanel
             detailPanel
         }
@@ -516,6 +520,37 @@ struct NoteBrowserView: View {
             }
             knownHistoryIDs = Set(ids)
         }
+            }
+        }
+    }
+
+    private var historyUnavailableView: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "externaldrive.badge.exclamationmark")
+                .font(.system(size: 42, weight: .light))
+                .foregroundStyle(.orange)
+            Text("Recording history couldn’t be opened")
+                .font(.system(size: 20, weight: .semibold))
+            Text("Your notes and audio files were not deleted. Restart Quill to try again, or open the data folder for support and recovery.")
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 440)
+            HStack(spacing: 10) {
+                Button("Open Data Folder") {
+                    appState.openHistoryDataFolder()
+                }
+                Button("Quit Quill") {
+                    NSApplication.shared.terminate(nil)
+                }
+            }
+            .controlSize(.large)
+            Spacer()
+        }
+        .padding(32)
+        .frame(minWidth: 800, maxWidth: .infinity, minHeight: 520, maxHeight: .infinity)
+        .background(Color(nsColor: .textBackgroundColor))
     }
 
     // MARK: - Sidebar
@@ -1261,7 +1296,10 @@ private struct NoteDetailView: View {
         item.machineStatus == .audioOnly
     }
     private var transcriptionActionHelp: LocalizedStringKey {
-        isAudioOnly ? "Transcribe audio" : "Retry transcription"
+        if retryAvailability == .noAudio {
+            return "Audio file unavailable"
+        }
+        return isAudioOnly ? "Transcribe audio" : "Retry transcription"
     }
     private var isCloudTranscribing: Bool {
         item.machineStatus == .cloudTranscribing
@@ -2112,7 +2150,11 @@ private struct NoteDetailView: View {
                 )
             )
         case .noAudio:
-            break
+            showToast(
+                localizedCatalogString(
+                    "This recording's audio file is unavailable, so it can't be transcribed."
+                )
+            )
         }
     }
 

--- a/Sources/PipelineHistoryStore.swift
+++ b/Sources/PipelineHistoryStore.swift
@@ -462,7 +462,8 @@ final class PipelineHistoryStore {
             do {
                 let request = pipelineHistoryRequest()
                 request.sortDescriptors = [NSSortDescriptor(key: "timestamp", ascending: false)]
-                guard let entities = try? container.viewContext.fetch(request), entities.count > maxCount else { return }
+                let entities = try historyFetcher(container.viewContext, request)
+                guard entities.count > maxCount else { return }
                 let dropped = entities[maxCount...]
                 deletedAssets = dropped.map(Self.deletedAssets(from:))
                 beforeDeleting(deletedAssets)
@@ -550,23 +551,50 @@ final class PipelineHistoryStore {
 
     private func synchronizeAssetReferenceSnapshot() {
         guard canSynchronizeAssetReferenceSnapshot,
-              referenceTrust.permitsStartupReferenceCleanup else {
+              referenceTrust.permitsStartupReferenceCleanup,
+              let fileNames = loadAssetReferenceFileNames() else {
             return
         }
-        let history = loadAllHistory()
         guard referenceTrust.permitsStartupReferenceCleanup else {
             canSynchronizeAssetReferenceSnapshot = false
             return
         }
         do {
             try saveAssetReferenceSnapshot(
-                audioFileNames: Set(history.compactMap(\.audioFileName)),
-                transcriptFileNames: Set(history.compactMap(\.transcriptFileName))
+                audioFileNames: fileNames.audio,
+                transcriptFileNames: fileNames.transcripts
             )
         } catch {
             canSynchronizeAssetReferenceSnapshot = false
             referenceTrust = .unavailable
         }
+    }
+
+    private func loadAssetReferenceFileNames() -> (
+        audio: Set<String>,
+        transcripts: Set<String>
+    )? {
+        guard availability == .ready, isStoreLoaded else { return nil }
+        var audioFileNames = Set<String>()
+        var transcriptFileNames = Set<String>()
+        var fetchError: Error?
+        container.viewContext.performAndWait {
+            do {
+                let request = NSFetchRequest<NSDictionary>(entityName: "PipelineHistoryEntry")
+                request.resultType = .dictionaryResultType
+                request.propertiesToFetch = ["audioFileName", "transcriptFileName"]
+                let rows = try container.viewContext.fetch(request)
+                audioFileNames = Set(rows.compactMap { $0["audioFileName"] as? String })
+                transcriptFileNames = Set(rows.compactMap { $0["transcriptFileName"] as? String })
+            } catch {
+                fetchError = error
+            }
+        }
+        if let fetchError {
+            markHistoryUnavailable(fetchError)
+            return nil
+        }
+        return (audioFileNames, transcriptFileNames)
     }
 
     private func pipelineHistoryRequest() -> NSFetchRequest<PipelineHistoryEntry> {

--- a/Sources/PipelineHistoryStore.swift
+++ b/Sources/PipelineHistoryStore.swift
@@ -12,11 +12,41 @@ enum PipelineHistoryStoreError: Error {
     case durableStoreUnavailable
 }
 
+enum PipelineHistoryStoreAvailability: Equatable, Sendable {
+    case ready
+    case unavailable
+}
+
 enum PipelineHistoryDurability: Equatable, Sendable {
     case durable
-    case recovered(backupName: String)
     case inMemory
-    case inMemoryFallback
+}
+
+enum PipelineHistoryReferenceTrust: Equatable, Sendable {
+    case complete
+    case recovered
+    case unavailable
+
+    var permitsStartupReferenceCleanup: Bool {
+        self == .complete
+    }
+}
+
+enum PipelineHistoryAssetReferenceSnapshotState: Equatable {
+    case matches
+    case missing
+    case mismatch
+    case unavailable
+}
+
+private struct PipelineHistoryAssetReferenceSnapshot: Codable, Equatable {
+    let audioFileNames: [String]
+    let transcriptFileNames: [String]
+
+    init(audioFileNames: Set<String>, transcriptFileNames: Set<String>) {
+        self.audioFileNames = audioFileNames.sorted()
+        self.transcriptFileNames = transcriptFileNames.sorted()
+    }
 }
 
 final class PipelineHistoryStore {
@@ -26,16 +56,18 @@ final class PipelineHistoryStore {
     nonisolated(unsafe) private static let managedObjectModel = makeModel()
 
     private let container: NSPersistentContainer
+    private let historyFetcher: (NSManagedObjectContext, NSFetchRequest<PipelineHistoryEntry>) throws -> [PipelineHistoryEntry]
+    private let assetReferenceSnapshotURL: URL?
     private var isStoreLoaded: Bool
+    private var canSynchronizeAssetReferenceSnapshot = false
+    private(set) var hadPersistentStoreAtLoad: Bool
+    private(set) var availability: PipelineHistoryStoreAvailability
+    private(set) var loadError: Error?
     private(set) var durability: PipelineHistoryDurability
+    private(set) var referenceTrust: PipelineHistoryReferenceTrust
 
     private var isDurableStore: Bool {
-        switch durability {
-        case .durable, .recovered:
-            true
-        case .inMemory, .inMemoryFallback:
-            false
-        }
+        durability == .durable
     }
 
     convenience init() {
@@ -46,8 +78,7 @@ final class PipelineHistoryStore {
         self.init(
             storeURL: inMemory ? nil : Self.defaultStoreURL(),
             usesInMemoryStore: inMemory,
-            persistentStoreLoader: Self.loadPersistentStoresSynchronously,
-            moveItem: Self.moveFile
+            persistentStoreLoader: Self.loadPersistentStoresSynchronously
         )
     }
 
@@ -60,14 +91,27 @@ final class PipelineHistoryStore {
 
     convenience init(
         storeURL: URL,
-        persistentStoreLoader: @escaping (NSPersistentContainer) -> Error?,
-        moveItem: @escaping (URL, URL) throws -> Void = PipelineHistoryStore.moveFile
+        persistentStoreLoader: @escaping (NSPersistentContainer) -> Error?
     ) {
         self.init(
             storeURL: storeURL,
             usesInMemoryStore: false,
-            persistentStoreLoader: persistentStoreLoader,
-            moveItem: moveItem
+            persistentStoreLoader: persistentStoreLoader
+        )
+    }
+
+    convenience init(
+        storeURL: URL,
+        historyFetcher: @escaping (
+            NSManagedObjectContext,
+            NSFetchRequest<PipelineHistoryEntry>
+        ) throws -> [PipelineHistoryEntry]
+    ) {
+        self.init(
+            storeURL: storeURL,
+            usesInMemoryStore: false,
+            persistentStoreLoader: Self.loadPersistentStoresSynchronously,
+            historyFetcher: historyFetcher
         )
     }
 
@@ -75,88 +119,200 @@ final class PipelineHistoryStore {
         storeURL: URL?,
         usesInMemoryStore: Bool,
         persistentStoreLoader: @escaping (NSPersistentContainer) -> Error?,
-        moveItem: @escaping (URL, URL) throws -> Void
+        historyFetcher: @escaping (
+            NSManagedObjectContext,
+            NSFetchRequest<PipelineHistoryEntry>
+        ) throws -> [PipelineHistoryEntry] = { context, request in
+            try context.fetch(request)
+        }
     ) {
         container = NSPersistentContainer(
             name: "PipelineHistory",
             managedObjectModel: Self.managedObjectModel
         )
+        self.historyFetcher = historyFetcher
+        assetReferenceSnapshotURL = Self.assetReferenceSnapshotURL(for: storeURL)
         isStoreLoaded = false
+        hadPersistentStoreAtLoad = Self.hasPersistentStoreFiles(at: storeURL)
+        availability = .ready
+        loadError = nil
         durability = usesInMemoryStore ? .inMemory : .durable
-
-        var loaded = false
-        var recoveredBackupName: String?
+        referenceTrust = .unavailable
 
         if usesInMemoryStore {
             configureInMemoryStore()
-            loaded = persistentStoreLoader(container) == nil
-        } else {
-            configurePersistentStore(at: storeURL)
-            if persistentStoreLoader(container) == nil {
-                loaded = true
-            } else if let storeURL {
-                print("[PipelineHistoryStore] Failed to load persistent store. Attempting recovery.")
-                do {
-                    recoveredBackupName = try Self.moveSQLiteStoreFilesToRecovery(
-                        at: storeURL,
-                        moveItem: moveItem
-                    )
-                    removeLoadedPersistentStores()
-                    configurePersistentStore(at: storeURL)
-                    loaded = persistentStoreLoader(container) == nil
-                } catch {
-                    print("[PipelineHistoryStore] Failed to preserve persistent history. Falling back to in-memory history.")
-                    configureInMemoryStore()
-                    loaded = persistentStoreLoader(container) == nil
-                    durability = .inMemoryFallback
-                    isStoreLoaded = loaded
-                    return
-                }
+            loadError = persistentStoreLoader(container)
+            isStoreLoaded = loadError == nil
+            availability = isStoreLoaded ? .ready : .unavailable
+            referenceTrust = .unavailable
+            return
+        }
 
-                if !loaded {
-                    print("[PipelineHistoryStore] Failed to recover persistent store. Falling back to in-memory history.")
-                    configureInMemoryStore()
-                    loaded = persistentStoreLoader(container) == nil
-                    durability = .inMemoryFallback
-                    isStoreLoaded = loaded
-                    return
-                }
-            } else {
-                loaded = persistentStoreLoader(container) == nil
-                if !loaded {
-                    configureInMemoryStore()
-                    loaded = persistentStoreLoader(container) == nil
-                    durability = .inMemoryFallback
-                    isStoreLoaded = loaded
-                    return
-                }
+        configurePersistentStore(at: storeURL)
+        if let error = persistentStoreLoader(container) {
+            loadError = error
+            availability = .unavailable
+            durability = .inMemory
+            referenceTrust = .unavailable
+            removeLoadedPersistentStores()
+            configureInMemoryStore()
+            isStoreLoaded = Self.loadPersistentStoresSynchronously(container: container) == nil
+            print("[PipelineHistoryStore] Persistent history is unavailable; preserving the original store files.")
+            return
+        }
+
+        isStoreLoaded = true
+        availability = .ready
+        durability = .durable
+        referenceTrust = Self.makeReferenceTrust(
+            isStoreLoaded: true,
+            usesInMemoryStore: false,
+            storeURL: storeURL
+        )
+    }
+
+    @discardableResult
+    func verifyHistoryReadable() -> Bool {
+        guard availability == .ready, isStoreLoaded else {
+            referenceTrust = .unavailable
+            return false
+        }
+        var fetchError: Error?
+        container.viewContext.performAndWait {
+            do {
+                let request = pipelineHistoryRequest()
+                request.fetchLimit = 1
+                request.includesPropertyValues = false
+                _ = try historyFetcher(container.viewContext, request)
+            } catch {
+                fetchError = error
             }
         }
-
-        isStoreLoaded = loaded
-        if usesInMemoryStore {
-            durability = .inMemory
-        } else {
-            durability = recoveredBackupName.map(PipelineHistoryDurability.recovered) ?? .durable
+        if let fetchError {
+            markHistoryUnavailable(fetchError)
+            return false
         }
+        return true
     }
 
     func loadAllHistory() -> [PipelineHistoryItem] {
-        guard isStoreLoaded else { return [] }
+        guard availability == .ready, isStoreLoaded else {
+            referenceTrust = .unavailable
+            return []
+        }
         var result: [PipelineHistoryItem] = []
+        var fetchError: Error?
         container.viewContext.performAndWait {
-            let request = pipelineHistoryRequest()
-            request.sortDescriptors = [NSSortDescriptor(key: "timestamp", ascending: false)]
-            guard let entities = try? container.viewContext.fetch(request) else { return }
-            result = entities.compactMap(Self.makeHistoryItem(from:))
+            do {
+                let request = pipelineHistoryRequest()
+                request.sortDescriptors = [NSSortDescriptor(key: "timestamp", ascending: false)]
+                let entities = try historyFetcher(container.viewContext, request)
+                result = entities.compactMap(Self.makeHistoryItem(from:))
+            } catch {
+                fetchError = error
+            }
+        }
+        if let fetchError {
+            markHistoryUnavailable(fetchError)
         }
         return result
     }
 
+    private func markHistoryUnavailable(_ error: Error) {
+        availability = .unavailable
+        isStoreLoaded = false
+        loadError = error
+        referenceTrust = .unavailable
+        canSynchronizeAssetReferenceSnapshot = false
+    }
+
+    func assetReferenceSnapshotState(
+        audioFileNames: Set<String>,
+        transcriptFileNames: Set<String>
+    ) -> PipelineHistoryAssetReferenceSnapshotState {
+        guard availability == .ready else {
+            canSynchronizeAssetReferenceSnapshot = false
+            return .unavailable
+        }
+        guard let assetReferenceSnapshotURL else {
+            canSynchronizeAssetReferenceSnapshot = false
+            return .unavailable
+        }
+        guard FileManager.default.fileExists(atPath: assetReferenceSnapshotURL.path) else {
+            canSynchronizeAssetReferenceSnapshot = false
+            return .missing
+        }
+        do {
+            let snapshot = try JSONDecoder().decode(
+                PipelineHistoryAssetReferenceSnapshot.self,
+                from: Data(contentsOf: assetReferenceSnapshotURL)
+            )
+            let currentSnapshot = PipelineHistoryAssetReferenceSnapshot(
+                audioFileNames: audioFileNames,
+                transcriptFileNames: transcriptFileNames
+            )
+            let state: PipelineHistoryAssetReferenceSnapshotState = snapshot == currentSnapshot
+                ? .matches
+                : .mismatch
+            canSynchronizeAssetReferenceSnapshot = state == .matches
+            return state
+        } catch {
+            canSynchronizeAssetReferenceSnapshot = false
+            return .unavailable
+        }
+    }
+
+    @discardableResult
+    func bootstrapAssetReferenceSnapshot(
+        audioFileNames: Set<String>,
+        transcriptFileNames: Set<String>
+    ) -> Bool {
+        guard availability == .ready,
+              assetReferenceSnapshotState(
+            audioFileNames: audioFileNames,
+            transcriptFileNames: transcriptFileNames
+        ) == .missing else {
+            return false
+        }
+        do {
+            try saveAssetReferenceSnapshot(
+                audioFileNames: audioFileNames,
+                transcriptFileNames: transcriptFileNames
+            )
+            canSynchronizeAssetReferenceSnapshot = true
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    func saveAssetReferenceSnapshot(
+        audioFileNames: Set<String>,
+        transcriptFileNames: Set<String>
+    ) throws {
+        guard availability == .ready,
+              let assetReferenceSnapshotURL else {
+            throw PipelineHistoryStoreError.storeUnavailable
+        }
+        let snapshot = PipelineHistoryAssetReferenceSnapshot(
+            audioFileNames: audioFileNames,
+            transcriptFileNames: transcriptFileNames
+        )
+        let data = try JSONEncoder().encode(snapshot)
+        try data.write(to: assetReferenceSnapshotURL, options: .atomic)
+    }
+
     func append(_ item: PipelineHistoryItem, maxCount: Int) throws -> [DeletedPipelineHistoryAssets] {
-        guard isStoreLoaded else { return [] }
+        guard availability == .ready, isStoreLoaded else {
+            throw PipelineHistoryStoreError.storeUnavailable
+        }
         try insert(item)
-        return try trim(to: maxCount)
+        let deletedAssets = try trim(
+            to: maxCount,
+            shouldSynchronizeAssetReferenceSnapshot: false
+        )
+        synchronizeAssetReferenceSnapshot()
+        return deletedAssets
     }
 
     func upsert(
@@ -164,7 +320,7 @@ final class PipelineHistoryStore {
         maxCount: Int,
         requiresDurableStore: Bool = false
     ) throws -> [DeletedPipelineHistoryAssets] {
-        guard isStoreLoaded else {
+        guard availability == .ready, isStoreLoaded else {
             throw PipelineHistoryStoreError.storeUnavailable
         }
         if requiresDurableStore, !isDurableStore {
@@ -185,24 +341,34 @@ final class PipelineHistoryStore {
             }
         }
         if let thrownError { throw thrownError }
-        return try trim(to: maxCount)
+        let deletedAssets = try trim(
+            to: maxCount,
+            shouldSynchronizeAssetReferenceSnapshot: false
+        )
+        synchronizeAssetReferenceSnapshot()
+        return deletedAssets
     }
 
     func update(
         _ item: PipelineHistoryItem,
         requiresDurableStore: Bool = false
     ) throws {
-        guard isStoreLoaded else { return }
+        guard availability == .ready, isStoreLoaded else {
+            throw PipelineHistoryStoreError.storeUnavailable
+        }
         if requiresDurableStore, !isDurableStore {
             throw PipelineHistoryStoreError.durableStoreUnavailable
         }
 
         var thrownError: Error?
+        var didChangeAssetReferences = false
         container.viewContext.performAndWait {
             do {
                 let request = pipelineHistoryRequest()
                 request.predicate = NSPredicate(format: "id == %@", item.id as CVarArg)
                 guard let entity = try container.viewContext.fetch(request).first else { return }
+                didChangeAssetReferences = entity.audioFileName != item.audioFileName
+                    || entity.transcriptFileName != item.transcriptFileName
                 Self.apply(item, to: entity)
                 try saveContext()
             } catch {
@@ -210,13 +376,18 @@ final class PipelineHistoryStore {
             }
         }
         if let thrownError { throw thrownError }
+        if didChangeAssetReferences {
+            synchronizeAssetReferenceSnapshot()
+        }
     }
 
     func delete(
         id: UUID,
         beforeDeleting: (DeletedPipelineHistoryAssets) -> Void = { _ in }
     ) throws -> DeletedPipelineHistoryAssets? {
-        guard isStoreLoaded else { return nil }
+        guard availability == .ready, isStoreLoaded else {
+            throw PipelineHistoryStoreError.storeUnavailable
+        }
 
         var deletedAssets: DeletedPipelineHistoryAssets?
         var thrownError: Error?
@@ -235,13 +406,18 @@ final class PipelineHistoryStore {
             }
         }
         if let thrownError { throw thrownError }
+        if deletedAssets != nil {
+            synchronizeAssetReferenceSnapshot()
+        }
         return deletedAssets
     }
 
     func clearAll(
         beforeDeleting: ([DeletedPipelineHistoryAssets]) -> Void = { _ in }
     ) throws -> [DeletedPipelineHistoryAssets] {
-        guard isStoreLoaded else { return [] }
+        guard availability == .ready, isStoreLoaded else {
+            throw PipelineHistoryStoreError.storeUnavailable
+        }
 
         var deletedAssets: [DeletedPipelineHistoryAssets] = []
         var thrownError: Error?
@@ -249,7 +425,7 @@ final class PipelineHistoryStore {
             do {
                 let request = pipelineHistoryRequest()
                 request.sortDescriptors = [NSSortDescriptor(key: "timestamp", ascending: false)]
-                guard let entities = try? container.viewContext.fetch(request) else { return }
+                let entities = try historyFetcher(container.viewContext, request)
                 deletedAssets = entities.map(Self.deletedAssets(from:))
                 beforeDeleting(deletedAssets)
                 for entity in entities {
@@ -261,14 +437,20 @@ final class PipelineHistoryStore {
             }
         }
         if let thrownError { throw thrownError }
+        if !deletedAssets.isEmpty {
+            synchronizeAssetReferenceSnapshot()
+        }
         return deletedAssets
     }
 
     func trim(
         to maxCount: Int,
-        beforeDeleting: ([DeletedPipelineHistoryAssets]) -> Void = { _ in }
+        beforeDeleting: ([DeletedPipelineHistoryAssets]) -> Void = { _ in },
+        shouldSynchronizeAssetReferenceSnapshot: Bool = true
     ) throws -> [DeletedPipelineHistoryAssets] {
-        guard isStoreLoaded else { return [] }
+        guard availability == .ready, isStoreLoaded else {
+            throw PipelineHistoryStoreError.storeUnavailable
+        }
         guard maxCount > 0 else {
             let deletedAssets = try clearAll(beforeDeleting: beforeDeleting)
             return deletedAssets
@@ -293,6 +475,9 @@ final class PipelineHistoryStore {
             }
         }
         if let thrownError { throw thrownError }
+        if shouldSynchronizeAssetReferenceSnapshot, !deletedAssets.isEmpty {
+            synchronizeAssetReferenceSnapshot()
+        }
         return deletedAssets
     }
 
@@ -363,6 +548,27 @@ final class PipelineHistoryStore {
         }
     }
 
+    private func synchronizeAssetReferenceSnapshot() {
+        guard canSynchronizeAssetReferenceSnapshot,
+              referenceTrust.permitsStartupReferenceCleanup else {
+            return
+        }
+        let history = loadAllHistory()
+        guard referenceTrust.permitsStartupReferenceCleanup else {
+            canSynchronizeAssetReferenceSnapshot = false
+            return
+        }
+        do {
+            try saveAssetReferenceSnapshot(
+                audioFileNames: Set(history.compactMap(\.audioFileName)),
+                transcriptFileNames: Set(history.compactMap(\.transcriptFileName))
+            )
+        } catch {
+            canSynchronizeAssetReferenceSnapshot = false
+            referenceTrust = .unavailable
+        }
+    }
+
     private func pipelineHistoryRequest() -> NSFetchRequest<PipelineHistoryEntry> {
         NSFetchRequest<PipelineHistoryEntry>(entityName: "PipelineHistoryEntry")
     }
@@ -400,17 +606,74 @@ final class PipelineHistoryStore {
         }
     }
 
-    private static func defaultStoreURL() -> URL? {
-        guard let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first else {
-            return nil
+    private enum RecoveryBackupInspection {
+        case absent
+        case present
+        case unavailable
+    }
+
+    private static func makeReferenceTrust(
+        isStoreLoaded: Bool,
+        usesInMemoryStore: Bool,
+        storeURL: URL?
+    ) -> PipelineHistoryReferenceTrust {
+        guard isStoreLoaded, !usesInMemoryStore else {
+            return .unavailable
         }
-        let baseURL = appSupport.appendingPathComponent(
-            AppName.displayName,
-            isDirectory: true
+        switch inspectRecoveryBackups(near: storeURL) {
+        case .present:
+            return .recovered
+        case .unavailable:
+            return .unavailable
+        case .absent:
+            return .complete
+        }
+    }
+
+    private static func hasPersistentStoreFiles(at storeURL: URL?) -> Bool {
+        guard let storeURL else { return false }
+        return FileManager.default.fileExists(atPath: storeURL.path)
+    }
+
+    private static func assetReferenceSnapshotURL(for storeURL: URL?) -> URL? {
+        guard let storeURL else { return nil }
+        let storeName = storeURL.deletingPathExtension().lastPathComponent
+        return storeURL.deletingLastPathComponent().appendingPathComponent(
+            "\(storeName)-asset-references.json"
         )
+    }
+
+    private static func inspectRecoveryBackups(
+        near storeURL: URL?
+    ) -> RecoveryBackupInspection {
+        guard let storeURL else { return .absent }
+        let recoveryRootURL = storeURL.deletingLastPathComponent()
+            .appendingPathComponent("History Recovery", isDirectory: true)
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: recoveryRootURL.path) else {
+            return .absent
+        }
+        do {
+            let entries = try fileManager.contentsOfDirectory(
+                at: recoveryRootURL,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+            for entry in entries {
+                guard try entry.resourceValues(forKeys: [.isDirectoryKey])
+                    .isDirectory == true else {
+                    continue
+                }
+                return .present
+            }
+            return .absent
+        } catch {
+            return .unavailable
+        }
+    }
+
+    private static func defaultStoreURL() -> URL? {
+        let baseURL = AppName.applicationSupportDirectory
         try? FileManager.default.createDirectory(
             at: baseURL,
             withIntermediateDirectories: true
@@ -441,63 +704,6 @@ final class PipelineHistoryStore {
 
         semaphore.wait()
         return capturedError
-    }
-
-    private static func moveFile(from sourceURL: URL, to destinationURL: URL) throws {
-        try FileManager.default.moveItem(at: sourceURL, to: destinationURL)
-    }
-
-    private static func moveSQLiteStoreFilesToRecovery(
-        at storeURL: URL,
-        moveItem: (URL, URL) throws -> Void
-    ) throws -> String? {
-        let fileManager = FileManager.default
-        let components = [
-            storeURL,
-            URL(fileURLWithPath: storeURL.path + "-wal"),
-            URL(fileURLWithPath: storeURL.path + "-shm")
-        ].filter { fileManager.fileExists(atPath: $0.path) }
-        guard !components.isEmpty else { return nil }
-
-        let recoveryRootURL = storeURL.deletingLastPathComponent()
-            .appendingPathComponent("History Recovery", isDirectory: true)
-        let backupName = "\(recoveryTimestamp())-\(UUID().uuidString)"
-        let backupURL = recoveryRootURL.appendingPathComponent(
-            backupName,
-            isDirectory: true
-        )
-        try fileManager.createDirectory(
-            at: backupURL,
-            withIntermediateDirectories: true
-        )
-
-        var movedComponents: [URL] = []
-        do {
-            for component in components {
-                try moveItem(
-                    component,
-                    backupURL.appendingPathComponent(component.lastPathComponent)
-                )
-                movedComponents.append(component)
-            }
-        } catch {
-            for component in movedComponents.reversed() {
-                let backupComponent = backupURL.appendingPathComponent(
-                    component.lastPathComponent
-                )
-                try? moveItem(backupComponent, component)
-            }
-            throw error
-        }
-        return backupName
-    }
-
-    private static func recoveryTimestamp() -> String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = "yyyyMMdd-HHmmss"
-        return formatter.string(from: Date())
     }
 
     private static func encodeCalendarMatch(_ match: CalendarEventMatch?) -> String? {

--- a/Sources/QuillUserIssue.swift
+++ b/Sources/QuillUserIssue.swift
@@ -583,9 +583,9 @@ private extension QuillUserIssueCode {
             )
         case .historyPersistenceUnavailable:
             return QuillUserIssueCopy(
-                titleKey: "History isn't being saved",
-                bodyKey: "Quill cannot save history for this session.",
-                suggestionKey: "Keep Quill open while you work, then restart it after checking available disk space and permissions."
+                titleKey: "Recording history couldn’t be opened",
+                bodyKey: "Your notes and audio files were not deleted. Restart Quill to try again, or open the data folder for support and recovery.",
+                suggestionKey: "Open the data folder to keep the original history available for support and recovery."
             )
         case .historyRecovered:
             return QuillUserIssueCopy(

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -4202,7 +4202,7 @@ struct RunLogView: View {
                 Button("Clear History") {
                     appState.clearPipelineHistory()
                 }
-                .disabled(appState.pipelineHistory.isEmpty)
+                .disabled(appState.pipelineHistory.isEmpty || appState.isHistoryUnavailable)
             }
             .padding(.horizontal, 24)
             .padding(.top, 20)
@@ -4210,7 +4210,32 @@ struct RunLogView: View {
 
             Divider()
 
-            if appState.pipelineHistory.isEmpty {
+            if appState.isHistoryUnavailable {
+                VStack(spacing: 12) {
+                    Spacer()
+                    Image(systemName: "externaldrive.badge.exclamationmark")
+                        .font(.system(size: 30, weight: .light))
+                        .foregroundStyle(.orange)
+                    Text("Recording history couldn’t be opened")
+                        .font(.headline)
+                    Text("Your notes and audio files were not deleted. Restart Quill to try again, or open the data folder for support and recovery.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 420)
+                    HStack {
+                        Button("Open Data Folder") {
+                            appState.openHistoryDataFolder()
+                        }
+                        Button("Quit Quill") {
+                            NSApplication.shared.terminate(nil)
+                        }
+                    }
+                    Spacer()
+                }
+                .padding(24)
+                .frame(maxWidth: .infinity)
+            } else if appState.pipelineHistory.isEmpty {
                 VStack {
                     Spacer()
                     Text("No runs yet. Use dictation to populate history.")
@@ -4400,7 +4425,7 @@ struct RunLogEntryView: View {
                             }
                         }
                         .buttonStyle(.plain)
-                        .disabled(isRetrying)
+                        .disabled(isRetrying || appState.isHistoryUnavailable)
                         .help("Retry transcription")
                     } else {
                         Color.clear
@@ -4423,7 +4448,11 @@ struct RunLogEntryView: View {
                         copyTranscriptToPasteboard()
                     }
 
-                    actionIconButton(systemName: "trash", help: "Delete this run") {
+                    actionIconButton(
+                        systemName: "trash",
+                        help: "Delete this run",
+                        disabled: appState.isHistoryUnavailable
+                    ) {
                         withAnimation(.easeInOut(duration: 0.2)) {
                             appState.deleteHistoryEntry(id: item.id)
                         }

--- a/Tests/AppStateAIProcessingBackendTests.swift
+++ b/Tests/AppStateAIProcessingBackendTests.swift
@@ -2,9 +2,8 @@ import AppKit
 import Combine
 import Foundation
 
-#if !QUILL_GROUPED_TEST_RUNNER
-@main
-#endif
+// AppState tests run only through FullSourceAppStateTestRunner so its process
+// isolation always protects production preferences and stored recordings.
 struct AppStateAIProcessingBackendTests {
     static func main() async throws {
         let defaultsSnapshot = UserDefaultsSnapshot()

--- a/Tests/AppStateCloudTranscriptionCleanupSourceTests.swift
+++ b/Tests/AppStateCloudTranscriptionCleanupSourceTests.swift
@@ -11,6 +11,7 @@ struct AppStateCloudTranscriptionCleanupSourceTests {
         try verifiesCommonCleanupOrder(source)
         try verifiesDeleteUsesCommonCleanup(source)
         try verifiesClearUsesCommonCleanup(source)
+        try verifiesStartupCleanupRequiresTrustedReferences(source)
         try verifiesTrimmedAssetsUseCommonCleanup(source)
         try verifiesIncompatibleRetryInvalidatesBeforeReplacement(source)
         try verifiesActiveCloudTasksAreInstalled(source)
@@ -74,7 +75,9 @@ struct AppStateCloudTranscriptionCleanupSourceTests {
         )
     }
 
-    private static func verifiesTrimmedAssetsUseCommonCleanup(_ source: String) throws {
+    private static func verifiesStartupCleanupRequiresTrustedReferences(
+        _ source: String
+    ) throws {
         let initializer = block(
             source,
             from: "init() {",
@@ -82,15 +85,29 @@ struct AppStateCloudTranscriptionCleanupSourceTests {
         )
         try expectOrdered(
             [
-                "pipelineHistoryStore.trim(to: maxPipelineHistoryCount)",
-                "cloudTranscriptionJobStore.invalidateSession(",
+                "savedHistory = pipelineHistoryStore.loadAllHistory()",
+                "referenceTrust = pipelineHistoryStore.referenceTrust",
+                "if referenceTrust.permitsStartupReferenceCleanup {",
+                "pipelineHistoryStore.trim(",
                 "Self.deleteStoredFiles(removedAssets)",
-                "cloudTranscriptionJobStore.delete("
+                "sweepOrphanStoredFiles("
             ],
             in: initializer,
-            label: "startup trim invalidates then deletes permanent assets and sidecar"
+            label: "startup cleanup uses trusted references before deleting files"
         )
 
+        let sweep = block(
+            source,
+            from: "static func sweepOrphanStoredFiles(",
+            to: "static func saveTranscriptFile("
+        )
+        try expect(
+            sweep.contains("guard referenceTrust.permitsStartupReferenceCleanup else { return }"),
+            "orphan cleanup returns before inspecting files when references are untrusted"
+        )
+    }
+
+    private static func verifiesTrimmedAssetsUseCommonCleanup(_ source: String) throws {
         for marker in [
             "pipelineHistoryStore.append(item, maxCount: maxPipelineHistoryCount)",
             "pipelineHistoryStore.upsert("

--- a/Tests/AppStateHistoryProtectionSourceTests.swift
+++ b/Tests/AppStateHistoryProtectionSourceTests.swift
@@ -37,9 +37,17 @@ struct AppStateHistoryProtectionSourceTests {
         )
 
         try expect(
-            !source.contains("@Published private(set) var historyPersistenceWarning")
-                && source.contains("var historyPersistenceWarning: QuillUserIssueRecord? {\n        isHistoryUnavailable"),
-            "history-unavailable warning stays current after a runtime read failure"
+            source.contains("@Published private(set) var isHistoryUnavailable = false")
+                && source.contains("private func synchronizeHistoryPersistenceState()")
+                && source.contains("let unavailable = pipelineHistoryStore.availability == .unavailable")
+                && source.contains("isHistoryUnavailable = unavailable")
+                && source.contains("historyPersistenceWarning = isHistoryUnavailable"),
+            "history-unavailable transitions publish protection UI state"
+        )
+        try expect(
+            source.contains("private func loadPipelineHistory() -> [PipelineHistoryItem]")
+                && source.contains("synchronizeHistoryPersistenceState()"),
+            "runtime history reads synchronize the published protection state"
         )
 
         let persistenceRange = try source.range(

--- a/Tests/AppStateHistoryProtectionSourceTests.swift
+++ b/Tests/AppStateHistoryProtectionSourceTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+struct AppStateHistoryProtectionSourceTests {
+    static func main() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+
+        try expect(
+            source.contains("if pipelineHistoryStore.availability == .ready {"),
+            "startup work is gated by history availability"
+        )
+        let startupRange = try source.range(
+            from: "var savedHistory: [PipelineHistoryItem] = []",
+            to: "let storedInputID = AudioInputDevice.normalized("
+        )
+        let startup = String(source[startupRange])
+        try expectOrdered(
+            [
+                "if pipelineHistoryStore.availability == .ready {",
+                "pipelineHistoryStore.verifyHistoryReadable()",
+                "recoverRecordingJournalsBeforeHistoryLoad(",
+                "cloudTranscriptionJobStore.reconcile(",
+                "sweepOrphanStoredFiles(",
+                "} else {\n            print(\"Skipping history startup work because persistent history is unavailable.\")"
+            ],
+            in: startup,
+            label: "ready startup work remains grouped behind availability gate"
+        )
+        let initialHistoryRead = try startup.range(
+            of: "pipelineHistoryStore.verifyHistoryReadable()"
+        ).unwrap("history readability probe")
+        let journalRecovery = try startup.range(
+            of: "recoverRecordingJournalsBeforeHistoryLoad("
+        ).unwrap("journal recovery")
+        try expect(
+            initialHistoryRead.lowerBound < journalRecovery.lowerBound,
+            "history readability is verified before startup recovery work"
+        )
+
+        try expect(
+            !source.contains("@Published private(set) var historyPersistenceWarning")
+                && source.contains("var historyPersistenceWarning: QuillUserIssueRecord? {\n        isHistoryUnavailable"),
+            "history-unavailable warning stays current after a runtime read failure"
+        )
+
+        let persistenceRange = try source.range(
+            from: "private func recordPipelineHistoryEntry(",
+            to: "private func startRealtimeStreamingIfEnabled()"
+        )
+        let persistence = String(source[persistenceRange])
+        try expect(
+            persistence.contains("if existingID == nil, !isJournalAudioFile {"),
+            "a failed update preserves assets already owned by an existing history entry"
+        )
+
+        let orphanSweepRange = try source.range(
+            from: "if referenceTrust.permitsStartupReferenceCleanup {\n                    let sweepReferenceTrust",
+            to: "            } else {\n                print(\"Skipping history startup work because persistent history is unavailable.\")"
+        )
+        let orphanSweep = String(source[orphanSweepRange])
+        try expect(
+            orphanSweep.contains("let sweepNow = Date()")
+                && orphanSweep.contains("now: sweepNow"),
+            "delayed orphan cleanup uses the startup reference snapshot time"
+        )
+
+        for functionMarker in [
+            "func clearPipelineHistory()",
+            "func deleteHistoryEntry(id: UUID)",
+            "func updateHistoryItemTitle(id: UUID, title: String)",
+            "func retryTranscription(item: PipelineHistoryItem)",
+            "func importAudioFile(_ fileURL: URL, choice: TranscriptionBackendChoice)",
+            "func startRecordingFromMCP() -> Bool",
+            "private func startRecording(triggerMode: RecordingTriggerMode",
+            "func setMeetingSummaryActionCompleted(",
+            "func deleteMeetingSummary(noteID: UUID)",
+            "func updateTranscript(id: UUID, text: String)"
+        ] {
+            let range = try source.range(of: functionMarker).unwrap(functionMarker)
+            let suffix = String(source[range.lowerBound...])
+            try expect(
+                suffix.prefix(360).contains("requireAvailableHistoryForMutation()"),
+                "\(functionMarker) checks protected history before side effects"
+            )
+        }
+
+        print("AppStateHistoryProtectionSourceTests passed")
+    }
+
+    private static func expectOrdered(
+        _ markers: [String],
+        in source: String,
+        label: String
+    ) throws {
+        var lowerBound = source.startIndex
+        for marker in markers {
+            guard let range = source.range(of: marker, range: lowerBound..<source.endIndex) else {
+                throw TestFailure("\(label): missing or misordered \(marker)")
+            }
+            lowerBound = range.upperBound
+        }
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ label: String
+    ) throws {
+        guard condition() else { throw TestFailure(label) }
+    }
+}
+
+private extension String {
+    func range(from startMarker: String, to endMarker: String) throws -> Range<Index> {
+        let start = try range(of: startMarker).unwrap(startMarker)
+        let end = try range(of: endMarker, range: start.upperBound..<endIndex).unwrap(endMarker)
+        return start.lowerBound..<end.lowerBound
+    }
+}
+
+private extension Optional where Wrapped == Range<String.Index> {
+    func unwrap(_ marker: String) throws -> Range<String.Index> {
+        guard let self else { throw TestFailure("Missing \(marker)") }
+        return self
+    }
+}
+
+private struct TestFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
+++ b/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
@@ -51,11 +51,18 @@ struct AppStateRecordingJournalIntegrationSourceTests {
             of: "recoverRecordingJournalsBeforeHistoryLoad(",
             in: initializerBody
         )
-        let historyRange = try requiredRange(
-            of: "pipelineHistoryStore.loadAllHistory()",
+        let preflightHistoryRange = try requiredRange(
+            of: "pipelineHistoryStore.verifyHistoryReadable()",
             in: initializerBody
         )
-        precondition(recoveryRange.lowerBound < historyRange.lowerBound)
+        guard let recoveredHistoryRange = initializerBody.range(
+            of: "pipelineHistoryStore.loadAllHistory()",
+            range: recoveryRange.upperBound..<initializerBody.endIndex
+        ) else {
+            throw TestFailure("missing history reload after journal recovery")
+        }
+        precondition(preflightHistoryRange.lowerBound < recoveryRange.lowerBound)
+        precondition(recoveryRange.lowerBound < recoveredHistoryRange.lowerBound)
 
         let startBody = try functionBody(named: "startSelectedAudioRecorder", in: source)
         precondition(startBody.contains("makeActiveSegmentedJournalController(inputID: inputID)"))

--- a/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
+++ b/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
@@ -170,7 +170,7 @@ struct AppStateRecordingJournalIntegrationSourceTests {
             in: source
         )
         precondition(completeFailureBody.contains("RecordingRecoveryHistory("))
-        precondition(completeFailureBody.contains("pipelineHistoryStore.loadAllHistory()"))
+        precondition(completeFailureBody.contains("loadPipelineHistory()"))
         precondition(completeFailureBody.contains("pipelineHistoryStore.delete(id:"))
 
         let storageBodies = storageFailureBody
@@ -395,7 +395,7 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         let catchBody = String(persist[catchRange.upperBound...])
 
         assert(catchBody.contains("journalRecordingID == nil"))
-        assert(catchBody.contains("!pipelineHistoryStore.loadAllHistory().contains(where: { $0.id == recordingID })"))
+        assert(catchBody.contains("!loadPipelineHistory().contains(where: { $0.id == recordingID })"))
         assert(catchBody.contains("Self.deleteStoredFiles("))
         assert(catchBody.contains("audioFileName: audioFileName"))
         assert(catchBody.contains("transcriptFileName: nil"))

--- a/Tests/AppStateStorageSafetyTests.swift
+++ b/Tests/AppStateStorageSafetyTests.swift
@@ -1,0 +1,319 @@
+import Darwin
+import Foundation
+
+struct AppStateStorageSafetyTests {
+    static func main() async throws {
+        try await verifiesHistoryCreatedAfterAssetsDoesNotSweep()
+        try await verifiesHistoryRowsLostAfterSnapshotDoesNotSweep()
+        try await verifiesUnavailableHistoryBlocksMutatingActions()
+        try await verifiesMissingSnapshotWithUnreferencedAudioDoesNotSweep()
+        try await verifiesMatchingHistorySnapshotSweepsOrphansAtStartup()
+        try await verifiesTrustedHistorySweepsOrphans()
+        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+            let fallbackAudioURL = try await verifiesFallbackHistoryDoesNotSweepStoredAudio()
+            try await verifiesMissingHistoryDoesNotSweepStoredAudio(
+                audioURL: fallbackAudioURL,
+                rootDirectory: rootDirectory
+            )
+
+            let audioDirectory = AppState.audioStorageDirectory()
+                .standardizedFileURL
+            let transcriptDirectory = AppState.transcriptStorageDirectory()
+                .standardizedFileURL
+            let rootPath = rootDirectory.standardizedFileURL.path + "/"
+
+            try expect(
+                audioDirectory.path.hasPrefix(rootPath),
+                "AppState tests write audio below their isolated root"
+            )
+            try expect(
+                transcriptDirectory.path.hasPrefix(rootPath),
+                "AppState tests write transcripts below their isolated root"
+            )
+        }
+        print("AppStateStorageSafetyTests passed")
+    }
+
+    private static func verifiesHistoryCreatedAfterAssetsDoesNotSweep() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+            let audioURL = AppState.audioStorageDirectory()
+                .appendingPathComponent("history-lost.wav")
+            try Data("fixture".utf8).write(to: audioURL)
+            try setOldModificationDate(of: audioURL)
+            try await Task.sleep(nanoseconds: 1_200_000_000)
+            _ = PipelineHistoryStore(
+                storeURL: rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
+            )
+
+            _ = await MainActor.run { AppState() }
+            try await Task.sleep(nanoseconds: 1_200_000_000)
+            try expect(
+                FileManager.default.fileExists(atPath: audioURL.path),
+                "history created after stored audio never treats it as an orphan"
+            )
+        }
+    }
+
+    private static func verifiesHistoryRowsLostAfterSnapshotDoesNotSweep() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+            let historyStore = PipelineHistoryStore(
+                storeURL: rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
+            )
+            let audioURL = AppState.audioStorageDirectory()
+                .appendingPathComponent("history-row-lost.wav")
+            try Data("fixture".utf8).write(to: audioURL)
+            try setOldModificationDate(of: audioURL)
+            try historyStore.saveAssetReferenceSnapshot(
+                audioFileNames: [audioURL.lastPathComponent],
+                transcriptFileNames: []
+            )
+
+            _ = await MainActor.run { AppState() }
+            try await Task.sleep(nanoseconds: 1_200_000_000)
+            try expect(
+                FileManager.default.fileExists(atPath: audioURL.path),
+                "a history snapshot mismatch never sweeps audio after history rows are lost"
+            )
+        }
+    }
+
+    private static func verifiesUnavailableHistoryBlocksMutatingActions() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+            let audioURL = AppState.audioStorageDirectory()
+                .appendingPathComponent("protected-audio.wav")
+            let transcriptURL = AppState.transcriptStorageDirectory()
+                .appendingPathComponent("protected-transcript.txt")
+            try Data("audio".utf8).write(to: audioURL)
+            try Data("original transcript".utf8).write(to: transcriptURL)
+            let unavailableStore = PipelineHistoryStore(
+                storeURL: rootDirectory.appendingPathComponent("PipelineHistory.sqlite"),
+                persistentStoreLoader: { _ in
+                    TestFailure("Injected protected history failure")
+                }
+            )
+            let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
+            AppState.pipelineHistoryStoreFactory = { unavailableStore }
+            defer {
+                AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
+            }
+
+            let item = PipelineHistoryItem(
+                timestamp: Date(),
+                rawTranscript: "original transcript",
+                postProcessedTranscript: "original transcript",
+                postProcessingPrompt: nil,
+                contextSummary: "",
+                contextScreenshotDataURL: nil,
+                contextScreenshotStatus: "No screenshot",
+                postProcessingStatus: "succeeded",
+                debugStatus: "",
+                customVocabulary: "",
+                audioFileName: audioURL.lastPathComponent,
+                transcriptFileName: transcriptURL.lastPathComponent
+            )
+            let appState = await MainActor.run { AppState() }
+            await MainActor.run {
+                appState.pipelineHistory = [item]
+                appState.clearPipelineHistory()
+                appState.updateTranscript(id: item.id, text: "replacement transcript")
+                appState.toggleRecording()
+            }
+
+            try expect(appState.isHistoryUnavailable, "history load failure enters protection mode")
+            try expect(
+                appState.pipelineHistory.map(\.id) == [item.id],
+                "protected history clear does not alter in-memory note ownership"
+            )
+            try expect(
+                FileManager.default.fileExists(atPath: audioURL.path),
+                "protected history clear does not delete audio"
+            )
+            let storedTranscript = try String(contentsOf: transcriptURL, encoding: .utf8)
+            try expect(
+                storedTranscript == "original transcript",
+                "protected history transcript edit does not write a sidecar"
+            )
+            try expect(!appState.isRecording, "protected history cannot start recording")
+        }
+    }
+
+    private static func verifiesMissingSnapshotWithUnreferencedAudioDoesNotSweep() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+            let historyStore = PipelineHistoryStore(
+                storeURL: rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
+            )
+            let referencedAudioURL = AppState.audioStorageDirectory()
+                .appendingPathComponent("still-referenced.wav")
+            let unreferencedAudioURL = AppState.audioStorageDirectory()
+                .appendingPathComponent("history-row-lost-without-snapshot.wav")
+            for fileURL in [referencedAudioURL, unreferencedAudioURL] {
+                try Data("fixture".utf8).write(to: fileURL)
+                try setOldModificationDate(of: fileURL)
+            }
+            _ = try historyStore.upsert(
+                PipelineHistoryItem(
+                    timestamp: Date(),
+                    rawTranscript: "fixture",
+                    postProcessedTranscript: "fixture",
+                    postProcessingPrompt: nil,
+                    contextSummary: "",
+                    contextScreenshotDataURL: nil,
+                    contextScreenshotStatus: "No screenshot",
+                    postProcessingStatus: "succeeded",
+                    debugStatus: "",
+                    customVocabulary: "",
+                    audioFileName: referencedAudioURL.lastPathComponent
+                ),
+                maxCount: 10
+            )
+
+            _ = await MainActor.run { AppState() }
+            try await Task.sleep(nanoseconds: 1_200_000_000)
+            _ = await MainActor.run { AppState() }
+            try await Task.sleep(nanoseconds: 1_200_000_000)
+            try expect(
+                FileManager.default.fileExists(atPath: unreferencedAudioURL.path),
+                "a missing snapshot never sweeps audio absent from the loaded history"
+            )
+        }
+    }
+
+    private static func verifiesMatchingHistorySnapshotSweepsOrphansAtStartup() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+            let historyStore = PipelineHistoryStore(
+                storeURL: rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
+            )
+            try historyStore.saveAssetReferenceSnapshot(
+                audioFileNames: [],
+                transcriptFileNames: []
+            )
+            let audioURL = AppState.audioStorageDirectory()
+                .appendingPathComponent("known-orphan.wav")
+            try Data("fixture".utf8).write(to: audioURL)
+            try setOldModificationDate(of: audioURL)
+
+            _ = await MainActor.run { AppState() }
+            try await Task.sleep(nanoseconds: 1_200_000_000)
+            try expect(
+                !FileManager.default.fileExists(atPath: audioURL.path),
+                "matching history snapshots sweep old unreferenced audio at startup"
+            )
+        }
+    }
+
+    private static func verifiesTrustedHistorySweepsOrphans() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+            let historyStore = PipelineHistoryStore(
+                storeURL: rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
+            )
+            try expect(
+                historyStore.referenceTrust == .complete,
+                "new persistent history is trusted before recording files exist"
+            )
+            let audioDirectory = AppState.audioStorageDirectory()
+            let transcriptDirectory = AppState.transcriptStorageDirectory()
+            let audioURL = audioDirectory.appendingPathComponent("trusted-orphan.wav")
+            let transcriptURL = transcriptDirectory.appendingPathComponent("trusted-orphan.txt")
+            for fileURL in [audioURL, transcriptURL] {
+                try Data("fixture".utf8).write(to: fileURL)
+            }
+
+            AppState.sweepOrphanStoredFiles(
+                audioDirectory: audioDirectory,
+                transcriptDirectory: transcriptDirectory,
+                referencedAudioFileNames: [],
+                referencedTranscriptFileNames: [],
+                protectedInflightAudioFileNames: [],
+                referenceTrust: .complete,
+                now: Date(timeIntervalSinceNow: 301)
+            )
+            try expect(
+                !FileManager.default.fileExists(atPath: audioURL.path),
+                "trusted history removes old unreferenced audio at startup"
+            )
+            try expect(
+                !FileManager.default.fileExists(atPath: transcriptURL.path),
+                "trusted history removes old unreferenced transcripts at startup"
+            )
+        }
+    }
+
+    private static func verifiesFallbackHistoryDoesNotSweepStoredAudio() async throws -> URL {
+        let audioURL = AppState.audioStorageDirectory()
+            .appendingPathComponent("fallback-history.wav")
+        try Data("fixture".utf8).write(to: audioURL)
+        try setOldModificationDate(of: audioURL)
+
+        let fallbackStore = PipelineHistoryStore(
+            storeURL: AppState.appStorageRootDirectory()
+                .appendingPathComponent("FallbackHistory.sqlite"),
+            persistentStoreLoader: { _ in
+                TestFailure("Injected history load failure")
+            }
+        )
+        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
+        AppState.pipelineHistoryStoreFactory = { fallbackStore }
+        defer {
+            AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
+        }
+
+        _ = await MainActor.run { AppState() }
+        try await Task.sleep(nanoseconds: 1_200_000_000)
+        try expect(
+            FileManager.default.fileExists(atPath: audioURL.path),
+            "fallback history never sweeps existing audio"
+        )
+        return audioURL
+    }
+
+    private static func verifiesMissingHistoryDoesNotSweepStoredAudio(
+        audioURL: URL,
+        rootDirectory: URL
+    ) async throws {
+        _ = await MainActor.run { AppState() }
+        try await Task.sleep(nanoseconds: 1_200_000_000)
+        try expect(
+            FileManager.default.fileExists(atPath: audioURL.path),
+            "a missing history database never sweeps existing audio"
+        )
+        try expect(
+            FileManager.default.fileExists(
+                atPath: rootDirectory
+                    .appendingPathComponent(
+                        "History Recovery/asset-references-incomplete",
+                        isDirectory: true
+                    ).path
+            ),
+            "missing history records persistent incomplete-reference evidence"
+        )
+    }
+
+    private static func setOldModificationDate(of fileURL: URL) throws {
+        let seconds = time_t(Date(timeIntervalSinceNow: -301).timeIntervalSince1970)
+        var timestamps = [
+            timeval(tv_sec: seconds, tv_usec: 0),
+            timeval(tv_sec: seconds, tv_usec: 0)
+        ]
+        let result = fileURL.withUnsafeFileSystemRepresentation { path in
+            utimes(path, &timestamps)
+        }
+        guard result == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ label: String
+    ) throws {
+        guard condition() else { throw TestFailure(label) }
+    }
+
+    private struct TestFailure: Error, CustomStringConvertible {
+        let description: String
+
+        init(_ description: String) {
+            self.description = description
+        }
+    }
+}

--- a/Tests/AppStateTestStorage.swift
+++ b/Tests/AppStateTestStorage.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+@MainActor
+enum AppStateTestStorage {
+    static func withIsolatedStorage<T>(
+        _ operation: (URL) async throws -> T
+    ) async throws -> T {
+        let rootDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "quill-app-state-tests-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        let originalStorageRootProvider = AppState.storageRootProvider
+        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
+        let originalSettingsDirectory = AppSettingsStorage.storageDirectoryOverride
+
+        try FileManager.default.createDirectory(
+            at: rootDirectory,
+            withIntermediateDirectories: true
+        )
+        AppState.storageRootProvider = { rootDirectory }
+        AppState.pipelineHistoryStoreFactory = {
+            AppState.makeDefaultPipelineHistoryStore()
+        }
+        AppSettingsStorage.storageDirectoryOverride = rootDirectory
+            .appendingPathComponent("settings", isDirectory: true)
+        defer {
+            AppState.storageRootProvider = originalStorageRootProvider
+            AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
+            AppSettingsStorage.storageDirectoryOverride = originalSettingsDirectory
+            try? FileManager.default.removeItem(at: rootDirectory)
+        }
+
+        return try await operation(rootDirectory)
+    }
+}

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -2,9 +2,8 @@ import Combine
 import Darwin
 import Foundation
 
-#if !QUILL_GROUPED_TEST_RUNNER
-@main
-#endif
+// AppState tests run only through FullSourceAppStateTestRunner so its process
+// isolation always protects production preferences and stored recordings.
 struct AppStateTranscriptionConfigurationTests {
     static func main() async throws {
         let originalNativeWhisperInstallStatusProvider =

--- a/Tests/BuildMetadataTests.swift
+++ b/Tests/BuildMetadataTests.swift
@@ -7,7 +7,7 @@ struct BuildMetadataTests {
         try testMakefilePrintsVersionMetadata()
         try testBuildSettingsTrackCodesignIdentity()
         try testGroupedTestArchitectureRespectsBuildOverride()
-        try testAppStateRunnerRequiresIsolatedHome()
+        try testAppStateRunnerOwnsProcessIsolation()
         try testMakefileSeparatesDevRunFromInstallBuild()
         try testMakefileCopiesSelectedIconToBundleIconName()
         try testMakefileBundlesLocalizationResources()
@@ -88,10 +88,33 @@ struct BuildMetadataTests {
         assertDoesNotContain(makefile, "-target $(shell uname -m)-apple-macosx13.0")
     }
 
-    private static func testAppStateRunnerRequiresIsolatedHome() throws {
+    private static func testAppStateRunnerOwnsProcessIsolation() throws {
         let makefile = try String(contentsOfFile: "Makefile", encoding: .utf8)
+        let runner = try String(
+            contentsOfFile: "Tests/FullSourceAppStateTestRunner.swift",
+            encoding: .utf8
+        )
+        let appStateTestStorage = try String(
+            contentsOfFile: "Tests/AppStateTestStorage.swift",
+            encoding: .utf8
+        )
 
         assertContains(makefile, "test -n \"$$isolated_home\" || exit 1")
+        assertContains(runner, "QUILL_APP_STATE_TEST_ISOLATION_ROOT")
+        assertContains(runner, "isValidIsolatedChildEnvironment()")
+        assertContains(runner, "if !isValidIsolatedChildEnvironment()")
+        assertContains(runner, "runInIsolatedProcess()")
+        assertContains(runner, "CFFIXED_USER_HOME")
+        assertContains(
+            runner,
+            "let expectedTemporaryDirectory = rootDirectory\n            .appendingPathComponent(\"tmp\")"
+        )
+        assertContains(runner, "AppStateTestStorage.withIsolatedStorage")
+        assertContains(
+            appStateTestStorage,
+            "AppState.makeDefaultPipelineHistoryStore()"
+        )
+        assertDoesNotContain(appStateTestStorage, "PipelineHistory.sqlite")
     }
 
     private static func testMakefileSeparatesDevRunFromInstallBuild() throws {

--- a/Tests/FullSourceAppStateTestRunner.swift
+++ b/Tests/FullSourceAppStateTestRunner.swift
@@ -1,10 +1,80 @@
+import Foundation
+
 @main
 struct FullSourceAppStateTestRunner {
+    private static let isolatedChildArgument = "--quill-app-state-isolated-child"
+    private static let isolatedRootEnvironmentKey = "QUILL_APP_STATE_TEST_ISOLATION_ROOT"
+
     static func main() async throws {
-        try await AudioImportFileCopyTests.main()
-        try LatestValueProgressCoalescerTests.main()
-        try await AppStateTranscriptionConfigurationTests.main()
-        try await AppStateAIProcessingBackendTests.main()
-        try await MeetingSummaryAppStateTests.main()
+        if !isValidIsolatedChildEnvironment() {
+            try runInIsolatedProcess()
+            return
+        }
+
+        try await AppStateTestStorage.withIsolatedStorage { _ in
+            try await AudioImportFileCopyTests.main()
+            try LatestValueProgressCoalescerTests.main()
+            try await AppStateStorageSafetyTests.main()
+            try AppStateHistoryProtectionSourceTests.main()
+            try await AppStateTranscriptionConfigurationTests.main()
+            try await AppStateAIProcessingBackendTests.main()
+            try await MeetingSummaryAppStateTests.main()
+        }
+    }
+
+    private static func isValidIsolatedChildEnvironment() -> Bool {
+        let environment = ProcessInfo.processInfo.environment
+        guard CommandLine.arguments.contains(isolatedChildArgument),
+              let rootPath = environment[isolatedRootEnvironmentKey],
+              let userHomePath = environment["CFFIXED_USER_HOME"],
+              let temporaryDirectoryPath = environment["TMPDIR"] else {
+            return false
+        }
+
+        let rootDirectory = URL(fileURLWithPath: rootPath).standardizedFileURL
+        guard rootDirectory.lastPathComponent.hasPrefix("quill-app-state-runner-") else {
+            return false
+        }
+        let expectedTemporaryDirectory = rootDirectory
+            .appendingPathComponent("tmp")
+            .standardizedFileURL
+        return URL(fileURLWithPath: userHomePath).standardizedFileURL == rootDirectory
+            && URL(fileURLWithPath: temporaryDirectoryPath).standardizedFileURL == expectedTemporaryDirectory
+            && FileManager.default.fileExists(atPath: expectedTemporaryDirectory.path)
+    }
+
+    private static func runInIsolatedProcess() throws {
+        let isolatedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "quill-app-state-runner-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        defer { try? FileManager.default.removeItem(at: isolatedHome) }
+        try FileManager.default.createDirectory(
+            at: isolatedHome.appendingPathComponent("tmp", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: CommandLine.arguments[0])
+        process.arguments = Array(CommandLine.arguments.dropFirst()) + [isolatedChildArgument]
+        var environment = ProcessInfo.processInfo.environment
+        environment[isolatedRootEnvironmentKey] = isolatedHome.path
+        environment["CFFIXED_USER_HOME"] = isolatedHome.path
+        environment["TMPDIR"] = isolatedHome.appendingPathComponent("tmp").path
+        process.environment = environment
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw TestRunnerFailure(status: process.terminationStatus)
+        }
+    }
+
+    private struct TestRunnerFailure: Error, CustomStringConvertible {
+        let status: Int32
+
+        var description: String {
+            "FullSourceAppStateTestRunner child failed with status \(status)"
+        }
     }
 }

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -288,7 +288,9 @@ struct LocalizationResourceTests {
             "Audio recording",
             "Not transcribed",
             "Saved without transcription. You can transcribe it later.",
-            "Transcribe audio"
+            "Transcribe audio",
+            "Audio file unavailable",
+            "This recording's audio file is unavailable, so it can't be transcribed."
         ]
         for key in noteBrowserKeys {
             let localizations = (strings[key] as? [String: Any])?["localizations"]

--- a/Tests/MCPLocalAccessPolicyTests.swift
+++ b/Tests/MCPLocalAccessPolicyTests.swift
@@ -11,6 +11,7 @@ struct MCPLocalAccessPolicyTests {
         testListenerIsRestrictedToLoopback()
         try testMCPServerUsesPolicyAndDoesNotEmitCORSHeaders()
         try testMCPStopRecordingCopySupportsRecordOnly()
+        try testMCPHistoryUnavailableNeverClaimsAnEmptyHistory()
         print("MCPLocalAccessPolicyTests passed")
     }
 
@@ -110,6 +111,36 @@ struct MCPLocalAccessPolicyTests {
         assertContains(handler, "Recording stopped. Transcription in progress — listen for recording/completed event.")
         assertContains(handler, "Recording stopped. Audio note is being saved.")
         assertDoesNotContain(handler, "appState.transcriptionEnabled")
+    }
+
+    private static func testMCPHistoryUnavailableNeverClaimsAnEmptyHistory() throws {
+        let source = try String(contentsOfFile: "Sources/MCPServer.swift", encoding: .utf8)
+        guard let start = source.range(of: "case \"start_recording\":"),
+              let end = source.range(
+                of: "case \"add_context\":",
+                range: start.upperBound..<source.endIndex
+              ) else {
+            fatalError("Unable to locate start_recording handler")
+        }
+        let startHandler = String(source[start.lowerBound..<end.lowerBound])
+        assertContains(startHandler, "if appState.isHistoryUnavailable")
+        assertContains(startHandler, "appState.historyUnavailableMessage")
+        assertContains(startHandler, "guard appState.startRecordingFromMCP() else")
+        assertDoesNotContain(startHandler, "appState.mcpAdditionalContext = context\n            }\n            appState.startRecordingFromMCP()")
+
+        for marker in ["case \"list_transcripts\":", "case \"get_transcript\":", "case \"get_meeting_source\":"] {
+            guard let range = source.range(of: marker) else {
+                fatalError("Missing \(marker)")
+            }
+            let handler = String(source[range.lowerBound...].prefix(320))
+            assertContains(handler, "if appState.isHistoryUnavailable")
+            assertContains(handler, "appState.historyUnavailableMessage")
+        }
+        guard let statusRange = source.range(of: "case \"get_status\":") else {
+            fatalError("Missing get_status handler")
+        }
+        let statusHandler = String(source[statusRange.lowerBound...].prefix(360))
+        assertContains(statusHandler, "status: history_unavailable")
     }
 
     private static func assertTrue(_ condition: @autoclosure () -> Bool, _ message: String) {

--- a/Tests/MeetingSummaryAppStateTests.swift
+++ b/Tests/MeetingSummaryAppStateTests.swift
@@ -1,8 +1,7 @@
 import Foundation
 
-#if !QUILL_GROUPED_TEST_RUNNER
-@main
-#endif
+// AppState tests run only through FullSourceAppStateTestRunner so its process
+// isolation always protects production preferences and stored recordings.
 struct MeetingSummaryAppStateTests {
     static func main() async throws {
         let originalFactory = await MainActor.run {
@@ -10,8 +9,7 @@ struct MeetingSummaryAppStateTests {
         }
         do {
             try await testGenerationPersistsOnlyAfterSuccess()
-            try await testNonDurableHistoryWarningPreventsSummaryPersistence()
-            try await testRecoveredHistoryWarningAllowsSummaryPersistence()
+            try await testUnavailableHistoryPreventsSummaryPersistence()
             try await testFailurePreservesExistingSummary()
             try await testGroundingFailurePreservesExistingSummaryAndCompletion()
             try await testTranscriptChangeDiscardsInflightResult()
@@ -137,7 +135,7 @@ struct MeetingSummaryAppStateTests {
         }
     }
 
-    private static func testNonDurableHistoryWarningPreventsSummaryPersistence() async throws {
+    private static func testUnavailableHistoryPreventsSummaryPersistence() async throws {
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(
@@ -164,6 +162,7 @@ struct MeetingSummaryAppStateTests {
             )
             appState.disableMeetingSummary = false
             appState.pipelineHistory = [item]
+            precondition(appState.isHistoryUnavailable, "failed history enters protection mode")
             precondition(
                 appState.historyPersistenceWarning?.code
                     == .historyPersistenceUnavailable,
@@ -192,61 +191,6 @@ struct MeetingSummaryAppStateTests {
                     "new summary is not claimed as durably saved"
                 )
             }
-        }
-    }
-
-    private static func testRecoveredHistoryWarningAllowsSummaryPersistence() async throws {
-        let directoryURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: directoryURL,
-            withIntermediateDirectories: true
-        )
-        defer { try? FileManager.default.removeItem(at: directoryURL) }
-        let store = try makeRecoveredStore(at: directoryURL)
-        let item = makeItem()
-        _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
-
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-        defer {
-            AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
-        }
-        AppState.pipelineHistoryStoreFactory = { store }
-
-        let appState = await MainActor.run {
-            AppState()
-        }
-        await MainActor.run {
-            appState.apiKey = "configured-key"
-            appState.selectAIProcessingBackendChoice(
-                .cloud(modelID: "summary/model"),
-                for: .meetingSummary
-            )
-            appState.disableMeetingSummary = false
-            precondition(
-                appState.historyPersistenceWarning?.code
-                    == .historyRecovered,
-                "recovered history warns without being treated as non-durable"
-            )
-            precondition(
-                appState.pipelineHistory.contains(where: { $0.id == item.id }),
-                "recovered durable history loads previously saved notes"
-            )
-        }
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in
-                MeetingSummaryGeneratorStub { _ in generationResult }
-            }
-        }
-
-        try await appState.generateMeetingSummary(id: item.id)
-
-        await MainActor.run {
-            precondition(
-                appState.pipelineHistory.first(where: { $0.id == item.id })?
-                    .meetingSummary != nil,
-                "recovered durable history accepts persisted summaries"
-            )
         }
     }
 
@@ -369,32 +313,6 @@ struct MeetingSummaryAppStateTests {
             persistentStoreLoader: { container in
                 persistentLoadAttempts += 1
                 if persistentLoadAttempts <= 2 {
-                    return MeetingSummaryAppStateTestFailure(
-                        "Injected persistent-store load failure"
-                    )
-                }
-                return PipelineHistoryStore.loadPersistentStoresSynchronously(
-                    container: container
-                )
-            }
-        )
-    }
-
-    private static func makeRecoveredStore(
-        at directoryURL: URL
-    ) throws -> PipelineHistoryStore {
-        let storeURL = directoryURL.appendingPathComponent("PipelineHistory.sqlite")
-        for suffix in ["", "-wal", "-shm"] {
-            try Data("invalid SQLite store".utf8).write(
-                to: URL(fileURLWithPath: storeURL.path + suffix)
-            )
-        }
-        var persistentLoadAttempts = 0
-        return PipelineHistoryStore(
-            storeURL: storeURL,
-            persistentStoreLoader: { container in
-                persistentLoadAttempts += 1
-                if persistentLoadAttempts == 1 {
                     return MeetingSummaryAppStateTestFailure(
                         "Injected persistent-store load failure"
                     )

--- a/Tests/NoteBrowserRecoveryTests.swift
+++ b/Tests/NoteBrowserRecoveryTests.swift
@@ -28,7 +28,7 @@ struct NoteBrowserRecoveryTests {
             transcript: " transcript ",
             retryAvailability: .noAudio
         )
-        precondition(!transcriptOnly.showsRetryButton)
+        precondition(transcriptOnly.showsRetryButton)
         precondition(transcriptOnly.canCopy)
         precondition(transcriptOnly.canSaveFiles)
     }

--- a/Tests/PipelineHistoryStoreRecoveryTests.swift
+++ b/Tests/PipelineHistoryStoreRecoveryTests.swift
@@ -7,10 +7,13 @@ struct PipelineHistoryStoreRecoveryTests {
         try testFreshDurableStoreIsReady()
         try testAssetReferenceSnapshotDetectsHistoryLoss()
         try testMetadataOnlyUpdateDoesNotRewriteAssetSnapshot()
+        try testSnapshotSynchronizationFetchesOnlyAssetFileNames()
+        try testApplicationSupportDirectoryHasDeterministicFallback()
         try testUnavailableStorePreservesDatabaseComponentsAndRejectsMutations()
         try testReadFailureEntersProtectionMode()
         try testReadabilityProbeUsesBoundedFetch()
         try testClearAllPropagatesReadFailure()
+        try testTrimPropagatesReadFailure()
         try testHealthyHistoryIsRetriedOnNextLaunch()
         try testExplicitInMemoryStoreRejectsDurableWrites()
         print("PipelineHistoryStoreRecoveryTests passed")
@@ -91,6 +94,34 @@ struct PipelineHistoryStoreRecoveryTests {
         try expect(
             modifiedAt == snapshotDate,
             "metadata-only updates do not rebuild the asset reference snapshot"
+        )
+    }
+
+    private static func testSnapshotSynchronizationFetchesOnlyAssetFileNames() throws {
+        let source = try String(contentsOfFile: "Sources/PipelineHistoryStore.swift", encoding: .utf8)
+        guard let start = source.range(of: "private func synchronizeAssetReferenceSnapshot()"),
+              let end = source.range(
+                of: "private func pipelineHistoryRequest()",
+                range: start.upperBound..<source.endIndex
+              ) else {
+            throw RecoveryTestFailure("missing asset snapshot synchronization helpers")
+        }
+        let synchronization = String(source[start.lowerBound..<end.lowerBound])
+        try expect(
+            synchronization.contains("loadAssetReferenceFileNames()")
+                && !synchronization.contains("let history = loadAllHistory()")
+                && synchronization.contains("request.resultType = .dictionaryResultType")
+                && synchronization.contains("request.propertiesToFetch = [\"audioFileName\", \"transcriptFileName\"]"),
+            "snapshot synchronization fetches only asset filenames"
+        )
+    }
+
+    private static func testApplicationSupportDirectoryHasDeterministicFallback() throws {
+        let source = try String(contentsOfFile: "Sources/AppName.swift", encoding: .utf8)
+        try expect(
+            source.contains(".first ?? URL(fileURLWithPath: NSHomeDirectory())")
+                && source.contains(".appendingPathComponent(\"Library/Application Support\", isDirectory: true)"),
+            "Application Support lookup falls back without force-unwrapping"
         )
     }
 
@@ -206,6 +237,24 @@ struct PipelineHistoryStoreRecoveryTests {
             return
         }
         throw RecoveryTestFailure("clearAll must not report a failed read as an empty deletion")
+    }
+
+    private static func testTrimPropagatesReadFailure() throws {
+        let fixture = try PersistentStoreFixture()
+        defer { fixture.remove() }
+        let store = PipelineHistoryStore(
+            storeURL: fixture.storeURL,
+            historyFetcher: { _, _ in
+                throw RecoveryTestFailure("Injected trim read failure")
+            }
+        )
+
+        do {
+            _ = try store.trim(to: 1)
+        } catch is RecoveryTestFailure {
+            return
+        }
+        throw RecoveryTestFailure("trim must not report a failed read as an empty deletion")
     }
 
     private static func testHealthyHistoryIsRetriedOnNextLaunch() throws {

--- a/Tests/PipelineHistoryStoreRecoveryTests.swift
+++ b/Tests/PipelineHistoryStoreRecoveryTests.swift
@@ -4,206 +4,311 @@ import Foundation
 @main
 struct PipelineHistoryStoreRecoveryTests {
     static func main() throws {
-        try testRecoveryMovesAllSQLiteComponentsBeforeLoadingReplacementStore()
-        try testRecoveredStoreRemainsDurableAndReloadsNewHistory()
+        try testFreshDurableStoreIsReady()
+        try testAssetReferenceSnapshotDetectsHistoryLoss()
+        try testMetadataOnlyUpdateDoesNotRewriteAssetSnapshot()
+        try testUnavailableStorePreservesDatabaseComponentsAndRejectsMutations()
+        try testReadFailureEntersProtectionMode()
+        try testReadabilityProbeUsesBoundedFetch()
+        try testClearAllPropagatesReadFailure()
+        try testHealthyHistoryIsRetriedOnNextLaunch()
         try testExplicitInMemoryStoreRejectsDurableWrites()
-        try testFailedBackupKeepsRemainingOriginalFilesAndUsesInMemoryStore()
         print("PipelineHistoryStoreRecoveryTests passed")
     }
 
-    private static func testRecoveryMovesAllSQLiteComponentsBeforeLoadingReplacementStore() throws {
-        let fixture = try StoreFixture()
+    private static func testFreshDurableStoreIsReady() throws {
+        let fixture = try PersistentStoreFixture()
         defer { fixture.remove() }
-        var loadAttempts = 0
-        var sourceFilesAtBackupStart: Set<String> = []
 
-        let store = PipelineHistoryStore(
-            storeURL: fixture.storeURL,
-            persistentStoreLoader: { container in
-                loadAttempts += 1
-                if loadAttempts == 1 {
-                    return RecoveryTestFailure("Injected persistent-store load failure")
-                }
-                return PipelineHistoryStore.loadPersistentStoresSynchronously(
-                    container: container
-                )
-            },
-            moveItem: { sourceURL, destinationURL in
-                if sourceFilesAtBackupStart.isEmpty {
-                    sourceFilesAtBackupStart = Set(
-                        fixture.componentURLs.filter {
-                            FileManager.default.fileExists(atPath: $0.path)
-                        }.map(\.lastPathComponent)
-                    )
-                }
-                try FileManager.default.moveItem(
-                    at: sourceURL,
-                    to: destinationURL
-                )
-            }
-        )
-
-        guard case let .recovered(backupName) = store.durability else {
-            throw RecoveryTestFailure("Persistent recovery exposes its backup state")
-        }
-        let backupURL = fixture.recoveryRootURL.appendingPathComponent(
-            backupName,
-            isDirectory: true
-        )
-
-        let backupContents = Set(try FileManager.default.contentsOfDirectory(
-            atPath: backupURL.path
-        ))
+        let store = PipelineHistoryStore(storeURL: fixture.storeURL)
+        try expect(store.availability == .ready, "fresh persistent store is ready")
+        try expect(store.durability == .durable, "fresh persistent store is durable")
         try expect(
-            backupContents == Set(fixture.componentURLs.map(\.lastPathComponent)),
-            "failed store is backed up together"
+            store.referenceTrust == .complete,
+            "fresh persistent store has complete asset references"
         )
-        try expect(
-            sourceFilesAtBackupStart == Set(fixture.componentURLs.map(\.lastPathComponent)),
-            "recovery never destroys originals first"
-        )
-        try expect(store.durability != .durable, "fallback state is observable")
     }
 
-    private static func testRecoveredStoreRemainsDurableAndReloadsNewHistory() throws {
-        let fixture = try StoreFixture()
+    private static func testAssetReferenceSnapshotDetectsHistoryLoss() throws {
+        let fixture = try PersistentStoreFixture()
         defer { fixture.remove() }
+        let store = PipelineHistoryStore(storeURL: fixture.storeURL)
+        let knownAudioFileNames: Set<String> = ["recording.wav"]
+
+        try expect(
+            store.assetReferenceSnapshotState(
+                audioFileNames: knownAudioFileNames,
+                transcriptFileNames: []
+            ) == .missing,
+            "a new history store has no reference snapshot"
+        )
+        try expect(
+            store.bootstrapAssetReferenceSnapshot(
+                audioFileNames: knownAudioFileNames,
+                transcriptFileNames: []
+            ),
+            "a missing reference snapshot can be seeded without deleting assets"
+        )
+        try expect(
+            store.assetReferenceSnapshotState(
+                audioFileNames: knownAudioFileNames,
+                transcriptFileNames: []
+            ) == .matches,
+            "seeded reference snapshots match their history references"
+        )
+        try expect(
+            store.assetReferenceSnapshotState(
+                audioFileNames: [],
+                transcriptFileNames: []
+            ) == .mismatch,
+            "missing history rows cannot pass reference validation"
+        )
+    }
+
+    private static func testMetadataOnlyUpdateDoesNotRewriteAssetSnapshot() throws {
+        let fixture = try PersistentStoreFixture()
+        defer { fixture.remove() }
+        let store = PipelineHistoryStore(storeURL: fixture.storeURL)
+        let item = makeHistoryItem()
+        _ = try store.upsert(item, maxCount: 10)
+        try expect(
+            store.bootstrapAssetReferenceSnapshot(audioFileNames: [], transcriptFileNames: []),
+            "metadata-only update test seeds a matching asset snapshot"
+        )
+        let snapshotURL = fixture.directoryURL
+            .appendingPathComponent("PipelineHistory-asset-references.json")
+        let snapshotDate = Date(timeIntervalSince1970: 1_000)
+        try FileManager.default.setAttributes(
+            [.modificationDate: snapshotDate],
+            ofItemAtPath: snapshotURL.path
+        )
+
+        try store.update(item.withCustomTitle("Updated title"))
+        let attributes = try FileManager.default.attributesOfItem(atPath: snapshotURL.path)
+        guard let modifiedAt = attributes[.modificationDate] as? Date else {
+            throw RecoveryTestFailure("missing asset snapshot modification date")
+        }
+        try expect(
+            modifiedAt == snapshotDate,
+            "metadata-only updates do not rebuild the asset reference snapshot"
+        )
+    }
+
+    private static func testUnavailableStorePreservesDatabaseComponentsAndRejectsMutations() throws {
+        let fixture = try FailedStoreFixture()
+        defer { fixture.remove() }
+        let originalBytes = try fixture.componentURLs.map { try Data(contentsOf: $0) }
         var loadAttempts = 0
         let store = PipelineHistoryStore(
             storeURL: fixture.storeURL,
-            persistentStoreLoader: { container in
+            persistentStoreLoader: { _ in
                 loadAttempts += 1
-                if loadAttempts == 1 {
-                    return RecoveryTestFailure("Injected persistent-store load failure")
-                }
-                return PipelineHistoryStore.loadPersistentStoresSynchronously(
-                    container: container
-                )
+                return RecoveryTestFailure("Injected persistent-store load failure")
             }
         )
-        guard case .recovered = store.durability else {
-            throw RecoveryTestFailure("Expected a recovered durable store")
+
+        try expect(store.availability == .unavailable, "failed history store is unavailable")
+        try expect(store.loadError != nil, "failed history retains diagnostic error")
+        try expect(loadAttempts == 1, "failed history never retries the canonical store")
+        try expect(
+            store.referenceTrust == .unavailable,
+            "unavailable history is not trusted for asset cleanup"
+        )
+        try expect(
+            !FileManager.default.fileExists(atPath: fixture.recoveryRootURL.path),
+            "unavailable history does not create a recovery replacement directory"
+        )
+        for (index, componentURL) in fixture.componentURLs.enumerated() {
+            try expect(
+                try Data(contentsOf: componentURL) == originalBytes[index],
+                "unavailable history preserves component \(componentURL.lastPathComponent)"
+            )
         }
 
-        let item = PipelineHistoryItem(
-            id: UUID(),
-            timestamp: Date(timeIntervalSince1970: 1_000),
-            rawTranscript: "Recovered history item.",
-            postProcessedTranscript: "Recovered history item.",
-            postProcessingPrompt: nil,
-            contextSummary: "",
-            contextScreenshotDataURL: nil,
-            contextScreenshotStatus: "No screenshot",
-            postProcessingStatus: "succeeded",
-            debugStatus: "",
-            customVocabulary: "",
-            usedPostProcessing: false
-        )
-        _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
+        let item = makeHistoryItem()
+        try expectStoreUnavailable("append") {
+            _ = try store.append(item, maxCount: 10)
+        }
+        try expectStoreUnavailable("upsert") {
+            _ = try store.upsert(item, maxCount: 10)
+        }
+        try expectStoreUnavailable("update") {
+            try store.update(item)
+        }
+        try expectStoreUnavailable("delete") {
+            _ = try store.delete(id: item.id)
+        }
+        try expectStoreUnavailable("clear") {
+            _ = try store.clearAll()
+        }
+        try expectStoreUnavailable("trim") {
+            _ = try store.trim(to: 10)
+        }
+    }
 
-        let reopened = PipelineHistoryStore(
+    private static func testReadFailureEntersProtectionMode() throws {
+        let fixture = try PersistentStoreFixture()
+        defer { fixture.remove() }
+        var fetchAttempts = 0
+        let store = PipelineHistoryStore(
             storeURL: fixture.storeURL,
-            persistentStoreLoader: PipelineHistoryStore.loadPersistentStoresSynchronously
+            historyFetcher: { _, _ in
+                fetchAttempts += 1
+                throw RecoveryTestFailure("Injected history read failure")
+            }
+        )
+
+        try expect(store.availability == .ready, "read failure is deferred until history access")
+        try expect(store.loadAllHistory().isEmpty, "failed history reads have no usable entries")
+        try expect(fetchAttempts == 1, "history read is attempted once")
+        try expect(store.availability == .unavailable, "read failure enters protection mode")
+        try expect(store.loadError != nil, "read failure retains diagnostic error")
+        try expect(
+            store.referenceTrust == .unavailable,
+            "read failure never trusts history asset references"
+        )
+        _ = store.loadAllHistory()
+        try expect(fetchAttempts == 1, "unavailable history does not retry reads during the launch")
+        try expectStoreUnavailable("read-failed upsert") {
+            _ = try store.upsert(makeHistoryItem(), maxCount: 10)
+        }
+    }
+
+    private static func testReadabilityProbeUsesBoundedFetch() throws {
+        let fixture = try PersistentStoreFixture()
+        defer { fixture.remove() }
+        var fetchLimit: Int?
+        let store = PipelineHistoryStore(
+            storeURL: fixture.storeURL,
+            historyFetcher: { _, request in
+                fetchLimit = request.fetchLimit
+                return []
+            }
+        )
+
+        try expect(store.verifyHistoryReadable(), "readability probe accepts a readable history")
+        try expect(fetchLimit == 1, "readability probe fetches at most one history entry")
+    }
+
+    private static func testClearAllPropagatesReadFailure() throws {
+        let fixture = try PersistentStoreFixture()
+        defer { fixture.remove() }
+        let store = PipelineHistoryStore(
+            storeURL: fixture.storeURL,
+            historyFetcher: { _, _ in
+                throw RecoveryTestFailure("Injected clear-history read failure")
+            }
+        )
+
+        do {
+            _ = try store.clearAll()
+        } catch is RecoveryTestFailure {
+            return
+        }
+        throw RecoveryTestFailure("clearAll must not report a failed read as an empty deletion")
+    }
+
+    private static func testHealthyHistoryIsRetriedOnNextLaunch() throws {
+        let fixture = try PersistentStoreFixture()
+        defer { fixture.remove() }
+        _ = PipelineHistoryStore(storeURL: fixture.storeURL)
+
+        let unavailable = PipelineHistoryStore(
+            storeURL: fixture.storeURL,
+            persistentStoreLoader: { _ in
+                RecoveryTestFailure("Injected one-launch load failure")
+            }
+        )
+        try expect(
+            unavailable.availability == .unavailable,
+            "one failed launch enters protection mode"
+        )
+
+        let reopened = PipelineHistoryStore(storeURL: fixture.storeURL)
+        try expect(
+            reopened.availability == .ready,
+            "later launches retry the unchanged canonical history"
         )
         try expect(
             reopened.durability == .durable,
-            "new history store opens durably after recovery"
-        )
-        try expect(
-            reopened.loadAllHistory().contains(where: { $0.id == item.id }),
-            "new history written after recovery reloads from SQLite"
+            "later healthy launch remains durable"
         )
     }
 
     private static func testExplicitInMemoryStoreRejectsDurableWrites() throws {
         let store = PipelineHistoryStore(inMemory: true)
-        try expect(store.durability == .inMemory, "explicit in-memory store has distinct durability")
-        let item = PipelineHistoryItem(
-            id: UUID(),
-            timestamp: Date(timeIntervalSince1970: 1_000),
-            rawTranscript: "In-memory history item.",
-            postProcessedTranscript: "In-memory history item.",
-            postProcessingPrompt: nil,
-            contextSummary: "",
-            contextScreenshotDataURL: nil,
-            contextScreenshotStatus: "No screenshot",
-            postProcessingStatus: "succeeded",
-            debugStatus: "",
-            customVocabulary: "",
-            usedPostProcessing: false
+        try expect(store.availability == .ready, "explicit in-memory test store is ready")
+        try expect(store.durability == .inMemory, "explicit in-memory store is distinct")
+        try expect(
+            store.referenceTrust == .unavailable,
+            "explicit in-memory history is not trusted for asset cleanup"
         )
 
         do {
-            _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
+            _ = try store.upsert(makeHistoryItem(), maxCount: 10, requiresDurableStore: true)
             throw RecoveryTestFailure("Explicit in-memory stores must reject durable writes")
         } catch PipelineHistoryStoreError.durableStoreUnavailable {
             // expected
         }
     }
 
-    private static func testFailedBackupKeepsRemainingOriginalFilesAndUsesInMemoryStore() throws {
-        let fixture = try StoreFixture()
-        defer { fixture.remove() }
-        var loadAttempts = 0
+    private static func makeHistoryItem() -> PipelineHistoryItem {
+        PipelineHistoryItem(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            rawTranscript: "History item.",
+            postProcessedTranscript: "History item.",
+            postProcessingPrompt: nil,
+            contextSummary: "",
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "No screenshot",
+            postProcessingStatus: "succeeded",
+            debugStatus: "",
+            customVocabulary: "",
+            usedPostProcessing: false
+        )
+    }
 
-        let store = PipelineHistoryStore(
-            storeURL: fixture.storeURL,
-            persistentStoreLoader: { container in
-                loadAttempts += 1
-                if loadAttempts == 1 {
-                    return RecoveryTestFailure("Injected persistent-store load failure")
-                }
-                return PipelineHistoryStore.loadPersistentStoresSynchronously(
-                    container: container
-                )
-            },
-            moveItem: { sourceURL, destinationURL in
-                if sourceURL.lastPathComponent.hasSuffix("-wal") {
-                    throw RecoveryTestFailure("Injected backup move failure")
-                }
-                try FileManager.default.moveItem(
-                    at: sourceURL,
-                    to: destinationURL
-                )
-            }
-        )
-
-        try expect(
-            store.durability == .inMemoryFallback,
-            "failed backup uses observable in-memory fallback"
-        )
-        try expect(
-            FileManager.default.fileExists(
-                atPath: fixture.componentURLs[0].path
-            ),
-            "failed backup restores the main SQLite database"
-        )
-        try expect(
-            FileManager.default.fileExists(
-                atPath: fixture.componentURLs[1].path
-            ),
-            "failed move leaves the WAL original intact"
-        )
-        try expect(
-            FileManager.default.fileExists(
-                atPath: fixture.componentURLs[2].path
-            ),
-            "failed move leaves the SHM original intact"
-        )
+    private static func expectStoreUnavailable(
+        _ operation: String,
+        _ body: () throws -> Void
+    ) throws {
+        do {
+            try body()
+            throw RecoveryTestFailure("Unavailable history unexpectedly allowed \(operation)")
+        } catch PipelineHistoryStoreError.storeUnavailable {
+            // expected
+        }
     }
 
     private static func expect(
-        _ condition: @autoclosure () -> Bool,
+        _ condition: @autoclosure () throws -> Bool,
         _ label: String
     ) throws {
-        guard condition() else { throw RecoveryTestFailure(label) }
+        guard try condition() else { throw RecoveryTestFailure(label) }
     }
 }
 
-private final class StoreFixture {
+private class PersistentStoreFixture {
     let directoryURL: URL
     let storeURL: URL
 
+    init() throws {
+        directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        storeURL = directoryURL.appendingPathComponent("PipelineHistory.sqlite")
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true
+        )
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: directoryURL)
+    }
+}
+
+private final class FailedStoreFixture: PersistentStoreFixture {
     var recoveryRootURL: URL {
         directoryURL.appendingPathComponent("History Recovery", isDirectory: true)
     }
@@ -216,21 +321,11 @@ private final class StoreFixture {
         ]
     }
 
-    init() throws {
-        directoryURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        storeURL = directoryURL.appendingPathComponent("PipelineHistory.sqlite")
-        try FileManager.default.createDirectory(
-            at: directoryURL,
-            withIntermediateDirectories: true
-        )
+    override init() throws {
+        try super.init()
         for (index, componentURL) in componentURLs.enumerated() {
             try Data("component-\(index)".utf8).write(to: componentURL)
         }
-    }
-
-    func remove() {
-        try? FileManager.default.removeItem(at: directoryURL)
     }
 }
 

--- a/Tests/QuillUserIssueTests.swift
+++ b/Tests/QuillUserIssueTests.swift
@@ -6,6 +6,7 @@ struct QuillUserIssueTests {
         let bundle = try compiledLocalizationBundle()
         try testEveryCodeHasCompleteEnglishAndKoreanPresentation(bundle: bundle)
         try testSeverityAndRecoveryActions()
+        try testHistoryUnavailablePresentation(bundle: bundle)
         try testVersionedPersistenceRoundTripAndRejection()
         try testPersistedPayloadExcludesPrivateDiagnostics()
         try testLocalIssueUsesBoundedDiagnosticCategoryAndExcerpt()
@@ -134,6 +135,29 @@ struct QuillUserIssueTests {
         try expect(
             QuillUserIssueRecord(code: .contextUnavailable).recoveryAction == .none,
             "context unavailable is informational only, no recovery action"
+        )
+    }
+
+    private static func testHistoryUnavailablePresentation(bundle: Bundle) throws {
+        let record = QuillUserIssueRecord(code: .historyPersistenceUnavailable)
+        let english = record.presentation(language: "en", bundle: bundle)
+        let korean = record.presentation(language: "ko", bundle: bundle)
+
+        try expect(
+            english.title == "Recording history couldn’t be opened",
+            "history-unavailable English title explains protected state"
+        )
+        try expect(
+            english.body == "Your notes and audio files were not deleted. Restart Quill to try again, or open the data folder for support and recovery.",
+            "history-unavailable English body confirms asset preservation"
+        )
+        try expect(
+            korean.title == "녹음 기록을 열 수 없음",
+            "history-unavailable Korean title is localized"
+        )
+        try expect(
+            korean.body == "노트와 오디오 파일은 삭제되지 않았습니다. Quill을 다시 시작해 재시도하거나 데이터 폴더를 열어 지원 및 복구에 사용할 수 있습니다.",
+            "history-unavailable Korean body confirms asset preservation"
         )
     }
 

--- a/Tests/QuillUserIssueUIContractTests.swift
+++ b/Tests/QuillUserIssueUIContractTests.swift
@@ -231,8 +231,8 @@ struct QuillUserIssueUIContractTests {
         _ appState: String
     ) throws {
         try expect(
-            appState.contains("var isHistoryUnavailable: Bool"),
-            "AppState exposes an explicit history-unavailable state"
+            appState.contains("@Published private(set) var isHistoryUnavailable = false"),
+            "AppState publishes an explicit history-unavailable state"
         )
         try expect(
             appState.contains(".historyPersistenceUnavailable"),

--- a/Tests/QuillUserIssueUIContractTests.swift
+++ b/Tests/QuillUserIssueUIContractTests.swift
@@ -18,7 +18,9 @@ struct QuillUserIssueUIContractTests {
         try testRunLogSanitizesMachineStatuses(settings)
         try testRecoveryActionsUseExistingRoutes(noteBrowser, appState)
         try testDismissibleBannerScopedToWarningStyle(issueView, noteBrowser, appState)
-        try testNonDurableHistoryWarningIsVisibleAndDoesNotExposeBackups(
+        try testHistoryUnavailableProtectionIsVisibleAndDoesNotExposeRecoveryPaths(
+            noteBrowser,
+            settings,
             menuBar,
             appState
         )
@@ -222,34 +224,41 @@ struct QuillUserIssueUIContractTests {
         )
     }
 
-    private static func testNonDurableHistoryWarningIsVisibleAndDoesNotExposeBackups(
+    private static func testHistoryUnavailableProtectionIsVisibleAndDoesNotExposeRecoveryPaths(
+        _ noteBrowser: String,
+        _ settings: String,
         _ menuBar: String,
         _ appState: String
     ) throws {
         try expect(
-            appState.contains("@Published private(set) var historyPersistenceWarning"),
-            "AppState publishes a session-only history persistence warning"
+            appState.contains("var isHistoryUnavailable: Bool"),
+            "AppState exposes an explicit history-unavailable state"
         )
         try expect(
             appState.contains(".historyPersistenceUnavailable"),
-            "AppState uses the structured non-durable history warning"
+            "AppState uses the structured unavailable-history issue"
+        )
+        for source in [noteBrowser, settings, menuBar] {
+            try expect(
+                source.contains("appState.isHistoryUnavailable"),
+                "every history surface renders the protected state"
+            )
+            try expect(source.contains("Open Data Folder"), "protected state opens the data folder")
+            try expect(source.contains("Quit Quill"), "protected state provides a safe quit action")
+        }
+        try expect(
+            menuBar.contains(".disabled(appState.isTranscribing || appState.isHistoryUnavailable)"),
+            "Menu Bar disables recording while history is unavailable"
         )
         try expect(
-            appState.contains(".historyRecovered"),
-            "AppState publishes a distinct warning after durable history recovery"
+            noteBrowser.contains("if appState.isHistoryUnavailable"),
+            "Note Browser checks protected state before normal empty history"
         )
-        try expect(
-            menuBar.contains("appState.historyPersistenceWarning"),
-            "Menu Bar shows the non-durable history warning"
-        )
-        try expect(
-            !menuBar.contains("backupName"),
-            "Menu Bar never exposes a history recovery backup name"
-        )
-        try expect(
-            !menuBar.contains("History Recovery"),
-            "Menu Bar never exposes a history recovery path"
-        )
+        for source in [noteBrowser, settings, menuBar] {
+            try expect(!source.contains("backupName"), "protected UI never exposes a backup name")
+            try expect(!source.contains("History Recovery"), "protected UI never exposes a recovery path")
+            try expect(!source.contains("start fresh"), "protected UI never offers a replacement history")
+        }
     }
 
     private static func source(_ path: String) throws -> String {

--- a/Tests/RecoveredRecordingNoteBrowserSourceTests.swift
+++ b/Tests/RecoveredRecordingNoteBrowserSourceTests.swift
@@ -42,6 +42,8 @@ struct RecoveredRecordingNoteBrowserSourceTests {
         precondition(source.contains("Image(systemName: \"square.and.arrow.down\")"))
         precondition(source.contains("Image(systemName: \"ellipsis\")"))
         try testRetryWithoutReadyModelUsesToast(source)
+        try testRetryWithoutAudioExplainsWhy(source)
+        try testRetryWithoutAudioUsesAccessibleHelp(source)
         try testAudioOnlyNoteUsesDedicatedNormalState()
         try testInputPickerSwitchesActiveRecordingInput(source)
         try testInputMenuCatcherDisablesAndLocalizesSources(source)
@@ -69,6 +71,39 @@ struct RecoveredRecordingNoteBrowserSourceTests {
             )
         )
         precondition(!providerBranch.contains("appState.openProviderSettings()"))
+    }
+
+    private static func testRetryWithoutAudioExplainsWhy(
+        _ source: String
+    ) throws {
+        let retryAction = block(
+            source,
+            from: "private func retryTranscription()",
+            to: "private func showToast("
+        )
+        let missingAudioBranch = block(
+            retryAction,
+            from: "case .noAudio:",
+            to: "\n        }\n    }"
+        )
+        precondition(missingAudioBranch.contains("showToast("))
+        precondition(
+            missingAudioBranch.contains(
+                "This recording's audio file is unavailable, so it can't be transcribed."
+            )
+        )
+    }
+
+    private static func testRetryWithoutAudioUsesAccessibleHelp(
+        _ source: String
+    ) throws {
+        let actionHelp = block(
+            source,
+            from: "private var transcriptionActionHelp: LocalizedStringKey {",
+            to: "private var isCloudTranscribing"
+        )
+        precondition(actionHelp.contains("if retryAvailability == .noAudio"))
+        precondition(actionHelp.contains("return \"Audio file unavailable\""))
     }
 
     private static func testInputPickerSwitchesActiveRecordingInput(


### PR DESCRIPTION
## Summary
- enter a non-destructive protection mode when recording history cannot be loaded or read
- block history mutations and startup cleanup/recovery work while protected, with dedicated UI and truthful MCP responses
- preserve existing recording assets across failed history updates and keep orphan cleanup tied to the startup reference snapshot
- isolate direct AppState tests from production storage and add persistence, startup, MCP, and UI regression coverage

## Validation
- `make test`
- `make all CODESIGN_IDENTITY=Quill`
- `make localization-bundle-test CODESIGN_IDENTITY=Quill`
- isolated `FullSourceAppStateTestRunner` runs with and without inherited isolation variables
- clean copied bundle: `codesign --verify --deep --strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 기록 저장소를 사용할 수 없을 때 데이터 손실을 방지하도록 기록 변경, 녹음, 요약 생성을 차단합니다.
  * 저장소 오류 발생 시 기존 데이터와 오디오 파일을 보존하고 안전 모드로 전환합니다.
  * 오디오 파일이 없는 전사 재시도 상태를 명확히 안내합니다.

* **사용자 경험 개선**
  * 저장소 오류 화면에 데이터 폴더 열기 및 앱 종료 기능을 추가했습니다.
  * 메뉴 막대와 설정 화면에서 상태별 경고와 비활성화 동작을 제공합니다.
  * 관련 영어·한국어 안내 문구를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #241