### PR TITLE
Archive unavailable history and start fresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -410,6 +410,9 @@ $(TEST_BUILD_DIR)/PipelineHistoryMeetingSummaryTests: Sources/RecordingJournalFa
 $(TEST_BUILD_DIR)/PipelineHistoryStoreRecoveryTests: Sources/RecordingJournalFailure.swift Sources/RecoveredRecordingContext.swift Sources/RecoveredRecordingMode.swift Sources/RecordingJournalModels.swift Sources/LocalizedStringLookup.swift Sources/AppName.swift Sources/CalendarIntegrationModels.swift Sources/QuillUserIssue.swift Sources/PipelineHistoryItem.swift Sources/TranscriptionModel.swift Sources/PipelineHistoryStore.swift Tests/PipelineHistoryStoreRecoveryTests.swift | $(TEST_BUILD_DIR)
 	@swiftc -parse-as-library Sources/RecordingJournalFailure.swift Sources/RecoveredRecordingContext.swift Sources/RecoveredRecordingMode.swift Sources/RecordingJournalModels.swift Sources/LocalizedStringLookup.swift Sources/AppName.swift Sources/CalendarIntegrationModels.swift Sources/QuillUserIssue.swift Sources/PipelineHistoryItem.swift Sources/TranscriptionModel.swift Sources/PipelineHistoryStore.swift Tests/PipelineHistoryStoreRecoveryTests.swift -o "$@"
 
+$(TEST_BUILD_DIR)/HistoryArchiveTransitionTests: Sources/RecordingJournalFailure.swift Sources/RecoveredRecordingContext.swift Sources/RecoveredRecordingMode.swift Sources/RecordingJournalModels.swift Sources/LocalizedStringLookup.swift Sources/AppName.swift Sources/CalendarIntegrationModels.swift Sources/QuillUserIssue.swift Sources/PipelineHistoryItem.swift Sources/TranscriptionModel.swift Sources/PipelineHistoryStore.swift Sources/HistoryArchiveTransition.swift Tests/HistoryArchiveTransitionTests.swift | $(TEST_BUILD_DIR)
+	@swiftc -parse-as-library Sources/RecordingJournalFailure.swift Sources/RecoveredRecordingContext.swift Sources/RecoveredRecordingMode.swift Sources/RecordingJournalModels.swift Sources/LocalizedStringLookup.swift Sources/AppName.swift Sources/CalendarIntegrationModels.swift Sources/QuillUserIssue.swift Sources/PipelineHistoryItem.swift Sources/TranscriptionModel.swift Sources/PipelineHistoryStore.swift Sources/HistoryArchiveTransition.swift Tests/HistoryArchiveTransitionTests.swift -o "$@"
+
 $(TEST_BUILD_DIR)/MeetingSummaryUIContractTests: Tests/MeetingSummaryUIContractTests.swift | $(TEST_BUILD_DIR)
 	@swiftc -parse-as-library Tests/MeetingSummaryUIContractTests.swift -o "$@"
 
@@ -632,9 +635,10 @@ _test-recording: | $(TEST_BUILD_DIR)
 	@$(TEST_BUILD_DIR)/AudioWaveformHeightsTests
 	@swiftc -parse-as-library Sources/AudioInputDevice.swift Tests/SystemAudioAppStateRoutingTests.swift -o $(TEST_BUILD_DIR)/SystemAudioAppStateRoutingTests
 	@$(TEST_BUILD_DIR)/SystemAudioAppStateRoutingTests
-_test-transcription: $(SPARKLE_STAMP) $(LOCALIZATION_STAMP) $(FULL_SOURCE_TRANSCRIPTION_RUNNER) $(FULL_SOURCE_APP_STATE_RUNNER) $(TEST_BUILD_DIR)/PipelineHistoryMeetingSummaryTests $(TEST_BUILD_DIR)/PipelineHistoryStoreRecoveryTests | $(TEST_BUILD_DIR)
+_test-transcription: $(SPARKLE_STAMP) $(LOCALIZATION_STAMP) $(FULL_SOURCE_TRANSCRIPTION_RUNNER) $(FULL_SOURCE_APP_STATE_RUNNER) $(TEST_BUILD_DIR)/PipelineHistoryMeetingSummaryTests $(TEST_BUILD_DIR)/PipelineHistoryStoreRecoveryTests $(TEST_BUILD_DIR)/HistoryArchiveTransitionTests | $(TEST_BUILD_DIR)
 	@$(TEST_BUILD_DIR)/PipelineHistoryMeetingSummaryTests
 	@$(TEST_BUILD_DIR)/PipelineHistoryStoreRecoveryTests
+	@$(TEST_BUILD_DIR)/HistoryArchiveTransitionTests
 	@swiftc -parse-as-library Sources/RecordingJournalFailure.swift Sources/RecoveredRecordingContext.swift Sources/RecoveredRecordingMode.swift Sources/RecordingJournalModels.swift Sources/LocalizedStringLookup.swift Sources/AppName.swift Sources/CalendarIntegrationModels.swift Sources/QuillUserIssue.swift Sources/PipelineHistoryItem.swift Sources/TranscriptionModel.swift Sources/PipelineHistoryStore.swift Tests/PipelineHistoryCalendarMetadataTests.swift -o $(TEST_BUILD_DIR)/PipelineHistoryCalendarMetadataTests
 	@$(TEST_BUILD_DIR)/PipelineHistoryCalendarMetadataTests
 	@swiftc -parse-as-library Sources/CalendarIntegrationModels.swift Sources/GoogleCalendarTokenStore.swift Sources/GoogleCalendarAuthService.swift Sources/GoogleCalendarService.swift Tests/GoogleCalendarServiceTests.swift -o $(TEST_BUILD_DIR)/GoogleCalendarServiceTests

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -14789,6 +14789,182 @@
         }
       }
     },
+    "Archive Old History and Start Fresh…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archive Old History and Start Fresh…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이전 기록을 보관하고 새로 시작…"
+          }
+        }
+      }
+    },
+    "Archive and Start Fresh": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archive and Start Fresh"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보관하고 새로 시작"
+          }
+        }
+      }
+    },
+    "Archive old history?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archive old history?"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이전 기록을 보관할까요?"
+          }
+        }
+      }
+    },
+    "Archiving recording history…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archiving recording history…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 기록을 보관하는 중…"
+          }
+        }
+      }
+    },
+    "Finish the current recording or transcription before archiving history.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finish the current recording or transcription before archiving history."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기록을 보관하기 전에 현재 녹음 또는 전사를 완료하세요."
+          }
+        }
+      }
+    },
+    "Archiving recording history is still in progress.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archiving recording history is still in progress."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹음 기록을 보관하는 작업이 아직 진행 중입니다."
+          }
+        }
+      }
+    },
+    "Old history was archived": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Old history was archived"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이전 기록을 보관함"
+          }
+        }
+      }
+    },
+    "New history is saving separately. Restore, import, and merge are not available yet.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New history is saving separately. Restore, import, and merge are not available yet."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새 기록은 별도로 저장 중입니다. 복원, 가져오기, 병합은 아직 제공되지 않습니다."
+          }
+        }
+      }
+    },
+    "Open Recovery Folder": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Recovery Folder"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복구 폴더 열기"
+          }
+        }
+      }
+    },
+    "Open the recovery folder to keep the archived history available for a future recovery.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open the recovery folder to keep the archived history available for a future recovery."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "향후 복구에 사용할 수 있도록 보관된 기록을 복구 폴더에서 유지하세요."
+          }
+        }
+      }
+    },
+    "Your earlier notes will not appear in the new history. The original database, audio, transcripts, and recovery metadata will be kept in a recovery snapshot. Restore, import, and merge are not available yet. Cancel to leave everything unchanged.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your earlier notes will not appear in the new history. The original database, audio, transcripts, and recovery metadata will be kept in a recovery snapshot. Restore, import, and merge are not available yet. Cancel to leave everything unchanged."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이전 노트는 새 기록에 표시되지 않습니다. 원본 데이터베이스, 오디오, 전사문, 복구 메타데이터는 복구 스냅샷에 보관됩니다. 복원, 가져오기, 병합은 아직 제공되지 않습니다. 취소하면 아무 데이터도 이동하지 않습니다."
+          }
+        }
+      }
+    },
     "Recording history couldn’t be opened": {
       "localizations": {
         "en": {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -5519,13 +5519,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
         for url in temporaryURLs {
             try? FileManager.default.removeItem(at: url)
         }
-        let journalStore = recordingJournalStore
+        activeSegmentedJournalController = nil
+        activeRecordingID = nil
+        let finalizationWork = RecordingJournalFinalizationWork(
+            controller: controller,
+            store: recordingJournalStore
+        )
         pendingRecordingJournalFinalizationCount += 1
         recordingJournalFinalizationQueue.async {
-            let result = self.recoverRecordingAfterJournalPersistenceFailure(
-                controller: controller,
-                store: journalStore
-            )
+            let result = finalizationWork.recoverAfterPersistenceFailure()
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.pendingRecordingJournalFinalizationCount -= 1
@@ -5534,31 +5536,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     sourceFailure: sourceFailure
                 )
             }
-        }
-    }
-
-    private func recoverRecordingAfterJournalPersistenceFailure(
-        controller: SegmentedRecordingJournalController,
-        store: RecordingJournalStore
-    ) -> Result<RecoveredRecordingArtifact, Error> {
-        do {
-            _ = try controller.closeAfterPersistenceFailure()
-            let artifact = try SegmentedRecordingArtifactFinalizer(
-                store: store,
-                mixdownService: AudioMixdownService()
-            ).finalizeAndPromote(recordingID: controller.recordingID)
-            let manifest = try store.loadManifest(
-                recordingID: controller.recordingID
-            )
-            return .success(RecoveredRecordingArtifact(
-                recordingID: artifact.recordingID,
-                audioURL: artifact.destinationURL,
-                promotion: artifact.promotion,
-                manifest: manifest,
-                mode: artifact.mode
-            ))
-        } catch {
-            return .failure(error)
         }
     }
 
@@ -5715,52 +5692,47 @@ final class AppState: ObservableObject, @unchecked Sendable {
         activeRecordingID = nil
         activeInputSwitchToken = nil
         isActiveInputSwitchPhysicalStopInProgress = false
-        let journalStore = recordingJournalStore
+        let finalizationWork = RecordingJournalFinalizationWork(
+            controller: controller,
+            store: recordingJournalStore
+        )
         pendingRecordingJournalFinalizationCount += 1
         recordingJournalFinalizationQueue.async {
             do {
-                try controller.stopAndClose()
-                let artifact = try SegmentedRecordingArtifactFinalizer(
-                    store: journalStore,
-                    mixdownService: AudioMixdownService()
-                ).finalizeAndPromote(recordingID: controller.recordingID)
-                let promotedManifest = try journalStore.loadManifest(
-                    recordingID: artifact.recordingID
-                )
-                DispatchQueue.main.async {
+                let finalized = try finalizationWork.finalizeStoppedRecording()
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
                     self.pendingRecordingJournalFinalizationCount -= 1
-                    for url in temporaryURLs where url.path != artifact.destinationURL.path {
+                    for url in temporaryURLs where url.path != finalized.artifact.destinationURL.path {
                         try? FileManager.default.removeItem(at: url)
                     }
-                    switch artifact.mode {
+                    switch finalized.artifact.mode {
                     case .complete:
                         completion(.transcribable(
-                            fileURL: artifact.destinationURL,
+                            fileURL: finalized.artifact.destinationURL,
                             recoverableJournalID: nil
                         ))
                     case .partial:
                         let recovered = RecoveredRecordingArtifact(
-                            recordingID: artifact.recordingID,
-                            audioURL: artifact.destinationURL,
-                            promotion: artifact.promotion,
-                            manifest: promotedManifest,
+                            recordingID: finalized.artifact.recordingID,
+                            audioURL: finalized.artifact.destinationURL,
+                            promotion: finalized.artifact.promotion,
+                            manifest: finalized.manifest,
                             mode: .partial
                         )
                         completion(.recoveredWithoutTranscription(recovered))
                     case .microphoneOnly, .systemAudioOnly:
                         completion(.preservedForRecovery(
-                            recordingID: controller.recordingID,
+                            recordingID: finalizationWork.recordingID,
                             message: "Unexpected segmented recovery mode"
                         ))
                     }
                 }
             } catch {
-                if controller.terminalPersistenceFailure != nil {
-                    let result = self.recoverRecordingAfterJournalPersistenceFailure(
-                        controller: controller,
-                        store: journalStore
-                    )
-                    DispatchQueue.main.async {
+                if finalizationWork.hasTerminalPersistenceFailure {
+                    let result = finalizationWork.recoverAfterPersistenceFailure()
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
                         self.pendingRecordingJournalFinalizationCount -= 1
                         for url in temporaryURLs { try? FileManager.default.removeItem(at: url) }
                         switch result {
@@ -5768,7 +5740,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             completion(.recoveredWithoutTranscription(recovered))
                         case .failure(let recoveryError):
                             completion(.preservedForRecovery(
-                                recordingID: controller.recordingID,
+                                recordingID: finalizationWork.recordingID,
                                 message: recoveryError.localizedDescription
                             ))
                         }
@@ -5781,12 +5753,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     "segmented journal finalization failed: %{public}@",
                     error.localizedDescription
                 )
-                try? controller.preserveForRecovery()
-                DispatchQueue.main.async {
+                try? finalizationWork.preserveForRecovery()
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
                     self.pendingRecordingJournalFinalizationCount -= 1
                     for url in temporaryURLs { try? FileManager.default.removeItem(at: url) }
                     completion(.preservedForRecovery(
-                        recordingID: controller.recordingID,
+                        recordingID: finalizationWork.recordingID,
                         message: error.localizedDescription
                     ))
                 }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -371,11 +371,32 @@ final class AppState: ObservableObject, @unchecked Sendable {
     static var pipelineHistoryStoreFactory: () -> PipelineHistoryStore = {
         makeDefaultPipelineHistoryStore()
     }
+    static var pipelineHistoryStoreAtURLFactory: (URL) -> PipelineHistoryStore = {
+        PipelineHistoryStore(storeURL: $0)
+    }
 
     static func makeDefaultPipelineHistoryStore() -> PipelineHistoryStore {
-        PipelineHistoryStore(
-            storeURL: appStorageRootDirectory()
-                .appendingPathComponent("PipelineHistory.sqlite")
+        pipelineHistoryStoreAtURLFactory(
+            appStorageRootDirectory().appendingPathComponent("PipelineHistory.sqlite")
+        )
+    }
+
+    private static func makeRecordingJournalStore() -> RecordingJournalStore {
+        RecordingJournalStore(audioDirectory: audioStorageDirectory())
+    }
+
+    private static func makeCloudTranscriptionJobStore() -> CloudTranscriptionJobStore {
+        let audioDirectory = audioStorageDirectory()
+        return CloudTranscriptionJobStore(
+            jobsDirectory: audioDirectory
+                .deletingLastPathComponent()
+                .appendingPathComponent("cloud-transcription/jobs", isDirectory: true),
+            temporaryRoot: FileManager.default.temporaryDirectory
+                .appendingPathComponent(
+                    Bundle.main.bundleIdentifier ?? "com.woosublee.quill",
+                    isDirectory: true
+                )
+                .appendingPathComponent("cloud-transcription", isDirectory: true)
         )
     }
 
@@ -2094,6 +2115,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var errorMessage: String?
     @Published private(set) var isHistoryUnavailable = false
     @Published private(set) var historyPersistenceWarning: QuillUserIssueRecord?
+    @Published private(set) var historyArchiveSafety: HistoryArchiveSafety = .normal
+    @Published private(set) var isHistoryArchiveTransitioning = false
     var historyUnavailableMessage: String {
         QuillUserIssueRecord(code: .historyPersistenceUnavailable)
             .presentation().compactMessage
@@ -2327,6 +2350,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var overlayTranscriptionID: UUID = UUID()
     private var foregroundTranscriptionJobID: UUID?
     private var activeTranscriptionJobs: [UUID: TranscriptionJob] = [:]
+    private var pendingAudioImportJobIDs: Set<UUID> = []
     let localAIServerManager: LocalAIServerManager
     @Published private(set) var localAIInstallStates: [String: LocalAIModelInstallViewState] = [:]
     @Published private(set) var contextModelCapabilityWarning: String?
@@ -2439,9 +2463,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var defaultInputDeviceListener: AudioObjectPropertyListenerBlock?
     private var defaultInputDeviceListenerAddress: AudioObjectPropertyAddress?
     private var needsMicrophoneRefreshAfterRecording = false
-    private let pipelineHistoryStore: PipelineHistoryStore
-    private let recordingJournalStore: RecordingJournalStore
-    private let cloudTranscriptionJobStore: CloudTranscriptionJobStore
+    private var pipelineHistoryStore: PipelineHistoryStore
+    private var recordingJournalStore: RecordingJournalStore
+    private var cloudTranscriptionJobStore: CloudTranscriptionJobStore
     @MainActor private let cloudTranscriptionHistoryCoordinator =
         CloudTranscriptionHistoryCoordinator()
     private var activeSegmentedJournalController: SegmentedRecordingJournalController?
@@ -2450,6 +2474,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         label: "com.woosublee.quill.recording-journal.finalization",
         qos: .userInitiated
     )
+    private var pendingRecordingJournalFinalizationCount = 0
+    private var pendingRecordingStartCount = 0
     private var activeRecordingID: UUID?
     private let shortcutSessionController = DictationShortcutSessionController()
     private var activeRecordingTriggerMode: RecordingTriggerMode?
@@ -2473,28 +2499,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let postTranscriptionUpdateReminderDuration: TimeInterval = 7
 
     init() {
+        let initialHistoryArchiveSafety = HistoryArchiveTransition
+            .rollbackInterruptedTransactions(at: Self.appStorageRootDirectory())
         pipelineHistoryStore = Self.pipelineHistoryStoreFactory()
         let audioDirectory = Self.audioStorageDirectory()
-        recordingJournalStore = RecordingJournalStore(
-            audioDirectory: audioDirectory
-        )
-        cloudTranscriptionJobStore = CloudTranscriptionJobStore(
-            jobsDirectory: audioDirectory
-                .deletingLastPathComponent()
-                .appendingPathComponent(
-                    "cloud-transcription/jobs",
-                    isDirectory: true
-                ),
-            temporaryRoot: FileManager.default.temporaryDirectory
-                .appendingPathComponent(
-                    Bundle.main.bundleIdentifier ?? "com.woosublee.quill",
-                    isDirectory: true
-                )
-                .appendingPathComponent(
-                    "cloud-transcription",
-                    isDirectory: true
-                )
-        )
+        recordingJournalStore = Self.makeRecordingJournalStore()
+        cloudTranscriptionJobStore = Self.makeCloudTranscriptionJobStore()
         UserDefaults.standard.removeObject(forKey: "force_http2_transcription")
         Self.migrateModelStorageKeys()
         let hasCompletedSetup = UserDefaults.standard.bool(forKey: "hasCompletedSetup")
@@ -2784,7 +2794,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         if pipelineHistoryStore.availability == .ready {
             pipelineHistoryStore.verifyHistoryReadable()
         }
-        if pipelineHistoryStore.availability == .ready {
+        if initialHistoryArchiveSafety == .normal,
+           pipelineHistoryStore.availability == .ready {
             Self.recoverRecordingJournalsBeforeHistoryLoad(
                 recordingJournalStore: recordingJournalStore,
                 historyStore: pipelineHistoryStore
@@ -2906,6 +2917,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
             } else {
                 print("Skipping history startup work because persistent history is unavailable.")
             }
+        } else if initialHistoryArchiveSafety == .unresolvedArchive,
+                  pipelineHistoryStore.availability == .ready {
+            savedHistory = pipelineHistoryStore.loadAllHistory()
+            if pipelineHistoryStore.availability == .ready {
+                try? cloudTranscriptionJobStore.removeStaleTemporaryArtifacts()
+                cloudReconciliation = cloudTranscriptionJobStore.reconcile(
+                    history: savedHistory,
+                    audioRoot: audioDirectory
+                )
+            }
+            print("Skipping automatic history recovery and cleanup because an archived history remains unresolved.")
         } else {
             print("Skipping history startup work because persistent history is unavailable.")
         }
@@ -3002,11 +3024,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.soundVolume = soundVolume
         self.voiceMacros = initialMacros
         let initialHistoryUnavailable = pipelineHistoryStore.availability == .unavailable
+            || initialHistoryArchiveSafety == .unresolvedInterruptedTransaction
         self.pipelineHistory = savedHistory
         self.isHistoryUnavailable = initialHistoryUnavailable
+        self.historyArchiveSafety = initialHistoryArchiveSafety
         self.historyPersistenceWarning = initialHistoryUnavailable
             ? QuillUserIssueRecord(code: .historyPersistenceUnavailable)
-            : nil
+            : initialHistoryArchiveSafety == .unresolvedArchive
+                ? QuillUserIssueRecord(code: .historyArchived)
+                : nil
         self.hasAccessibility = initialAccessibility
         self.hasScreenRecordingPermission = initialScreenCapturePermission
         self.launchAtLogin = SMAppService.mainApp.status == .enabled
@@ -4784,6 +4810,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         NSWorkspace.shared.open(Self.appStorageRootDirectory())
     }
 
+    func openHistoryRecoveryFolder() {
+        NSWorkspace.shared.open(
+            Self.appStorageRootDirectory().appendingPathComponent("Recovery", isDirectory: true)
+        )
+    }
+
     static func appStorageRootDirectory() -> URL {
         let rootDirectory = storageRootProvider()
         if !FileManager.default.fileExists(atPath: rootDirectory.path) {
@@ -5470,12 +5502,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
         for url in temporaryURLs {
             try? FileManager.default.removeItem(at: url)
         }
+        let journalStore = recordingJournalStore
+        pendingRecordingJournalFinalizationCount += 1
         recordingJournalFinalizationQueue.async {
             let result = self.recoverRecordingAfterJournalPersistenceFailure(
-                controller: controller
+                controller: controller,
+                store: journalStore
             )
             Task { @MainActor [weak self] in
-                self?.completeRecordingStorageFailureRecovery(
+                guard let self else { return }
+                self.pendingRecordingJournalFinalizationCount -= 1
+                self.completeRecordingStorageFailureRecovery(
                     result,
                     sourceFailure: sourceFailure
                 )
@@ -5484,15 +5521,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private func recoverRecordingAfterJournalPersistenceFailure(
-        controller: SegmentedRecordingJournalController
+        controller: SegmentedRecordingJournalController,
+        store: RecordingJournalStore
     ) -> Result<RecoveredRecordingArtifact, Error> {
         do {
             _ = try controller.closeAfterPersistenceFailure()
             let artifact = try SegmentedRecordingArtifactFinalizer(
-                store: recordingJournalStore,
+                store: store,
                 mixdownService: AudioMixdownService()
             ).finalizeAndPromote(recordingID: controller.recordingID)
-            let manifest = try recordingJournalStore.loadManifest(
+            let manifest = try store.loadManifest(
                 recordingID: controller.recordingID
             )
             return .success(RecoveredRecordingArtifact(
@@ -5657,17 +5695,20 @@ final class AppState: ObservableObject, @unchecked Sendable {
         activeRecordingID = nil
         activeInputSwitchToken = nil
         isActiveInputSwitchPhysicalStopInProgress = false
+        let journalStore = recordingJournalStore
+        pendingRecordingJournalFinalizationCount += 1
         recordingJournalFinalizationQueue.async {
             do {
                 try controller.stopAndClose()
                 let artifact = try SegmentedRecordingArtifactFinalizer(
-                    store: self.recordingJournalStore,
+                    store: journalStore,
                     mixdownService: AudioMixdownService()
                 ).finalizeAndPromote(recordingID: controller.recordingID)
-                let promotedManifest = try self.recordingJournalStore.loadManifest(
+                let promotedManifest = try journalStore.loadManifest(
                     recordingID: artifact.recordingID
                 )
                 DispatchQueue.main.async {
+                    self.pendingRecordingJournalFinalizationCount -= 1
                     for url in temporaryURLs where url.path != artifact.destinationURL.path {
                         try? FileManager.default.removeItem(at: url)
                     }
@@ -5696,9 +5737,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
             } catch {
                 if controller.terminalPersistenceFailure != nil {
                     let result = self.recoverRecordingAfterJournalPersistenceFailure(
-                        controller: controller
+                        controller: controller,
+                        store: journalStore
                     )
                     DispatchQueue.main.async {
+                        self.pendingRecordingJournalFinalizationCount -= 1
                         for url in temporaryURLs { try? FileManager.default.removeItem(at: url) }
                         switch result {
                         case .success(let recovered):
@@ -5720,6 +5763,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 )
                 try? controller.preserveForRecovery()
                 DispatchQueue.main.async {
+                    self.pendingRecordingJournalFinalizationCount -= 1
                     for url in temporaryURLs { try? FileManager.default.removeItem(at: url) }
                     completion(.preservedForRecovery(
                         recordingID: controller.recordingID,
@@ -6138,11 +6182,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func synchronizeHistoryPersistenceState() {
         let unavailable = pipelineHistoryStore.availability == .unavailable
-        guard isHistoryUnavailable != unavailable else { return }
+            || historyArchiveSafety == .unresolvedInterruptedTransaction
+        let warning: QuillUserIssueRecord?
+        if unavailable {
+            warning = QuillUserIssueRecord(code: .historyPersistenceUnavailable)
+        } else if historyArchiveSafety == .unresolvedArchive {
+            warning = QuillUserIssueRecord(code: .historyArchived)
+        } else {
+            warning = nil
+        }
+        guard isHistoryUnavailable != unavailable || historyPersistenceWarning != warning else { return }
         isHistoryUnavailable = unavailable
-        historyPersistenceWarning = isHistoryUnavailable
-            ? QuillUserIssueRecord(code: .historyPersistenceUnavailable)
-            : nil
+        historyPersistenceWarning = warning
     }
 
     private func loadPipelineHistory() -> [PipelineHistoryItem] {
@@ -6153,12 +6204,114 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @discardableResult
     private func requireAvailableHistoryForMutation() -> Bool {
+        guard !isHistoryArchiveTransitioning else {
+            errorMessage = localizedCatalogString("Archiving recording history is still in progress.")
+            return false
+        }
         synchronizeHistoryPersistenceState()
         guard !isHistoryUnavailable else {
             errorMessage = historyUnavailableMessage
             return false
         }
         return true
+    }
+
+    @MainActor
+    @discardableResult
+    func archiveOldHistoryAndStartFresh() -> Bool {
+        synchronizeHistoryPersistenceState()
+        guard isHistoryUnavailable,
+              historyArchiveSafety == .normal,
+              !isHistoryArchiveTransitioning else {
+            return false
+        }
+        guard !isRecording,
+              !isTranscribing,
+              retryingItemIDs.isEmpty,
+              activeTranscriptionJobs.isEmpty,
+              pendingAudioImportJobIDs.isEmpty,
+              !cloudTranscriptionHistoryCoordinator.hasActiveWork,
+              meetingSummaryGeneratingNoteIDs.isEmpty,
+              activeRecordingID == nil,
+              activeSegmentedJournalController == nil,
+              pendingRecordingJournalFinalizationCount == 0,
+              pendingRecordingStartCount == 0,
+              pendingAudioOnlyStopIDs.isEmpty else {
+            errorMessage = localizedCatalogString(
+                "Finish the current recording or transcription before archiving history."
+            )
+            return false
+        }
+
+        do {
+            try pipelineHistoryStore.detachForHistoryArchive()
+        } catch {
+            errorMessage = historyUnavailableMessage
+            return false
+        }
+
+        let storageRoot = Self.appStorageRootDirectory()
+        let makeStore = Self.pipelineHistoryStoreAtURLFactory
+        let appStateReference = WeakAppStateReference(self)
+        isHistoryArchiveTransitioning = true
+        historyArchiveSafety = .transitioning
+        Task.detached(priority: .userInitiated) {
+            do {
+                let result = try HistoryArchiveTransition(
+                    makeStore: makeStore
+                ).archiveAndCreateFreshHistory(at: storageRoot)
+                await MainActor.run {
+                    appStateReference.value?.completeHistoryArchiveTransition(
+                        result,
+                        storageRoot: storageRoot
+                    )
+                }
+            } catch {
+                await MainActor.run {
+                    appStateReference.value?.completeHistoryArchiveTransitionFailure(
+                        at: storageRoot
+                    )
+                }
+            }
+        }
+        return true
+    }
+
+    @MainActor
+    private func completeHistoryArchiveTransition(
+        _ result: HistoryArchiveTransitionResult,
+        storageRoot: URL
+    ) {
+        let activeStore = Self.pipelineHistoryStoreAtURLFactory(
+            storageRoot.appendingPathComponent("PipelineHistory.sqlite")
+        )
+        guard activeStore.availability == .ready,
+              activeStore.durability == .durable,
+              activeStore.verifyHistoryReadable() else {
+            completeHistoryArchiveTransitionFailure(at: storageRoot)
+            return
+        }
+        pipelineHistoryStore = activeStore
+        recordingJournalStore = Self.makeRecordingJournalStore()
+        cloudTranscriptionJobStore = Self.makeCloudTranscriptionJobStore()
+        pipelineHistory = []
+        retryingItemIDs = []
+        pendingAudioImportJobIDs = []
+        cloudTranscriptionProgressByHistoryID = [:]
+        meetingSummaryGeneratingNoteIDs = []
+        meetingSummaryPendingRevealNoteIDs = []
+        forgetAllWarningBannerState()
+        historyArchiveSafety = HistoryArchiveTransition.inspect(at: storageRoot)
+        isHistoryArchiveTransitioning = false
+        synchronizeHistoryPersistenceState()
+    }
+
+    @MainActor
+    private func completeHistoryArchiveTransitionFailure(at storageRoot: URL) {
+        historyArchiveSafety = HistoryArchiveTransition.inspect(at: storageRoot)
+        isHistoryArchiveTransitioning = false
+        synchronizeHistoryPersistenceState()
+        errorMessage = historyUnavailableMessage
     }
 
     @MainActor
@@ -6469,9 +6622,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let noteID = UUID()
         let startedAt = Date()
         let importContextSummary = AudioImportOptions.importContextSummary(for: fileURL.lastPathComponent)
+        pendingAudioImportJobIDs.insert(jobID)
 
         Task { [weak self] in
             guard let savedAudioFile = await Self.saveSecurityScopedAudioFileOffMain(from: fileURL) else {
+                self?.pendingAudioImportJobIDs.remove(jobID)
                 self?.errorMessage = localizedCatalogString("Unable to save the audio file. Check disk space or file permissions and try again.")
                 return
             }
@@ -6517,6 +6672,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     cleanupDeletedPipelineHistoryAssets(removedAssets)
                 }
             } catch {
+                self.pendingAudioImportJobIDs.remove(jobID)
                 Self.deleteAudioFile(savedAudioFile.fileName)
                 let issue = self.userIssue(for: error)
                 self.errorMessage = issue.record.presentation().compactMessage
@@ -6533,6 +6689,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 recordingEndedAt: nil,
                 isImportedAudio: true
             )
+            self.pendingAudioImportJobIDs.remove(jobID)
             self.updateTranscriptionJob(jobID) {
                 $0.liveNoteID = noteID
                 $0.audioFileName = savedAudioFile.fileName
@@ -8119,8 +8276,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let scheduledManualCommandInvocation = pendingManualCommandInvocation
         cancelPendingShortcutStart()
 
+        pendingRecordingStartCount += 1
         Task { [weak self] in
             guard let self else { return }
+            defer { self.pendingRecordingStartCount -= 1 }
             let manualCommandRequested = scheduledSelectionSnapshot != nil
                 ? scheduledManualCommandInvocation
                 : hotkeyManager.currentPressedModifiers.contains(commandModeManualModifier.shortcutModifier)
@@ -8134,10 +8293,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 activeRecordingCalendarSnapshot = nil
                 return
             }
+            guard requireAvailableHistoryForMutation() else {
+                activeRecordingCalendarSnapshot = nil
+                return
+            }
             guard let audioSelection = await accessibleCurrentRecordingAudioSelection() else {
                 if !isAwaitingMicrophonePermission {
                     activeRecordingCalendarSnapshot = nil
                 }
+                return
+            }
+            guard requireAvailableHistoryForMutation() else {
+                activeRecordingCalendarSnapshot = nil
                 return
             }
             os_log(.info, log: recordingLog, "audio input access check passed: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
@@ -8426,18 +8593,30 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     strongSelf.isAwaitingMicrophonePermission = false
                     strongSelf.restartHotkeyMonitoring()
 
-                    guard let pendingContext else { return }
+                    guard let pendingContext else {
+                        strongSelf.pendingRecordingStartCount -= 1
+                        return
+                    }
                     if granted {
                         strongSelf.errorMessage = nil
                         if pendingContext.triggerMode == .toggle {
                             Task { @MainActor [weak strongSelf] in
                                 guard let strongSelf else { return }
+                                defer { strongSelf.pendingRecordingStartCount -= 1 }
                                 guard await strongSelf.prepareRecordingStart(
                                     triggerMode: .toggle,
                                     selectionSnapshot: pendingContext.selectionSnapshot,
                                     manualCommandRequested: pendingContext.manualCommandRequested
                                 ) else { return }
+                                guard strongSelf.requireAvailableHistoryForMutation() else {
+                                    strongSelf.activeRecordingCalendarSnapshot = nil
+                                    return
+                                }
                                 guard let audioSelection = await strongSelf.accessibleCurrentRecordingAudioSelection() else { return }
+                                guard strongSelf.requireAvailableHistoryForMutation() else {
+                                    strongSelf.activeRecordingCalendarSnapshot = nil
+                                    return
+                                }
                                 strongSelf.shortcutSessionController.beginManual(mode: .toggle)
                                 if AudioInputDevice.isMicrophoneOnly(audioSelection.inputID) {
                                     strongSelf.applyAudioInterruptionIfNeeded()
@@ -8448,6 +8627,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                                 )
                             }
                         } else {
+                            strongSelf.pendingRecordingStartCount -= 1
                             strongSelf.currentSessionIntent = .dictation
                             strongSelf.statusText = localizedCatalogString("Microphone access granted. Press and hold again to record.")
                             strongSelf.scheduleReadyStatusReset(
@@ -8456,6 +8636,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             )
                         }
                     } else {
+                        strongSelf.pendingRecordingStartCount -= 1
                         strongSelf.activeRecordingCalendarSnapshot = nil
                         strongSelf.errorMessage = localizedCatalogString("Microphone permission denied. Grant access in System Settings > Privacy & Security > Microphone.")
                         strongSelf.statusText = localizedCatalogString("No Microphone")
@@ -8484,6 +8665,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         selectionSnapshot: AppSelectionSnapshot?,
         manualCommandRequested: Bool?
     ) {
+        pendingRecordingStartCount += 1
         isAwaitingMicrophonePermission = true
         pendingMicrophonePermissionContext = PendingRecordingPermissionContext(
             triggerMode: triggerMode,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2919,15 +2919,31 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
         } else if initialHistoryArchiveSafety == .unresolvedArchive,
                   pipelineHistoryStore.availability == .ready {
+            Self.recoverRecordingJournalsBeforeHistoryLoad(
+                recordingJournalStore: recordingJournalStore,
+                historyStore: pipelineHistoryStore
+            )
             savedHistory = pipelineHistoryStore.loadAllHistory()
             if pipelineHistoryStore.availability == .ready {
+                savedHistory = Self.markInterruptedRecoveryPlaceholders(
+                    in: savedHistory,
+                    store: pipelineHistoryStore
+                )
                 try? cloudTranscriptionJobStore.removeStaleTemporaryArtifacts()
                 cloudReconciliation = cloudTranscriptionJobStore.reconcile(
                     history: savedHistory,
                     audioRoot: audioDirectory
                 )
+                let historyStore = pipelineHistoryStore
+                do {
+                    savedHistory = try LegacyNoteTitleMigration.migrate(history: savedHistory) { item in
+                        try historyStore.update(item)
+                    }
+                } catch {
+                    print("Failed to migrate legacy note titles: \(error)")
+                }
             }
-            print("Skipping automatic history recovery and cleanup because an archived history remains unresolved.")
+            print("Skipping automatic archive snapshot cleanup because an archived history remains unresolved.")
         } else {
             print("Skipping history startup work because persistent history is unavailable.")
         }
@@ -5494,6 +5510,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
     }
 
+    @MainActor
     private func finishRecordingAfterJournalPersistenceFailure(
         controller: SegmentedRecordingJournalController,
         sourceFailure: RecordingJournalSourcePersistenceFailure,
@@ -5669,19 +5686,22 @@ final class AppState: ObservableObject, @unchecked Sendable {
     ) {
         let inputID = activeAudioInputID ?? selectedMicrophoneID
         stopPhysicalAudioRecorder(inputID: inputID) { [weak self] temporaryURLs in
-            guard let self else {
-                for url in temporaryURLs { try? FileManager.default.removeItem(at: url) }
-                completion(.empty)
-                return
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    for url in temporaryURLs { try? FileManager.default.removeItem(at: url) }
+                    completion(.empty)
+                    return
+                }
+                self.detachSegmentedJournalSinks()
+                self.finishStoppedSegmentedRecording(
+                    temporaryURLs: temporaryURLs,
+                    completion: completion
+                )
             }
-            self.detachSegmentedJournalSinks()
-            self.finishStoppedSegmentedRecording(
-                temporaryURLs: temporaryURLs,
-                completion: completion
-            )
         }
     }
 
+    @MainActor
     private func finishStoppedSegmentedRecording(
         temporaryURLs: [URL],
         completion: @escaping (StoppedAudioRecording) -> Void

--- a/Sources/CloudTranscriptionHistoryCoordinator.swift
+++ b/Sources/CloudTranscriptionHistoryCoordinator.swift
@@ -88,6 +88,10 @@ final class CloudTranscriptionHistoryCoordinator {
 
     private var activeSessions: [UUID: CloudTranscriptionJobSession] = [:]
 
+    var hasActiveWork: Bool {
+        !activeTasks.isEmpty || !activeSessions.isEmpty
+    }
+
     func activate(
         historyID: UUID,
         session: CloudTranscriptionJobSession

--- a/Sources/HistoryArchiveTransition.swift
+++ b/Sources/HistoryArchiveTransition.swift
@@ -9,33 +9,6 @@ enum HistoryArchiveSafety: Equatable, Sendable {
     case transitioning
 }
 
-struct HistoryArchiveSnapshotComponent: Codable, Equatable, Sendable {
-    enum Identifier: String, Codable, CaseIterable, Sendable {
-        case sqlite
-        case sqliteWAL
-        case sqliteSHM
-        case assetReferenceSnapshot
-        case audio
-        case transcripts
-        case cloudTranscriptionJobs
-        case legacyRecoveryEvidence
-    }
-
-    let identifier: Identifier
-    let relativePath: String
-    let byteCount: UInt64
-    let isDirectory: Bool
-}
-
-struct HistoryArchiveSnapshot: Codable, Equatable, Sendable {
-    static let currentSchemaVersion = 1
-
-    let schemaVersion: Int
-    let id: UUID
-    let archivedAt: Date
-    let components: [HistoryArchiveSnapshotComponent]
-}
-
 struct HistoryArchiveTransitionResult: Sendable {
     let snapshot: HistoryArchiveSnapshot
     let recoveryDirectory: URL
@@ -260,7 +233,7 @@ final class HistoryArchiveTransition {
                 let values = try entry.resourceValues(forKeys: [.isDirectoryKey])
                 guard values.isDirectory == true else { continue }
                 if entry.lastPathComponent.hasPrefix(Self.snapshotPrefix) {
-                    guard Self.isPublishedSnapshot(entry) else {
+                    guard isPublishedSnapshot(entry) else {
                         return .unresolvedInterruptedTransaction
                     }
                     hasPublishedSnapshot = true
@@ -315,7 +288,7 @@ final class HistoryArchiveTransition {
                     transaction.snapshotDirectoryName,
                     isDirectory: true
                 )
-                if Self.isPublishedSnapshot(snapshotDirectory) {
+                if isPublishedSnapshot(snapshotDirectory) {
                     try syncDirectory(recoveryDirectory)
                     try fileManager.removeItem(at: transactionURL)
                     continue
@@ -358,6 +331,7 @@ final class HistoryArchiveTransition {
     private func verifyFreshHistory(at storageRoot: URL) throws {
         let storeURL = storageRoot.appendingPathComponent("PipelineHistory.sqlite")
         let writer = makeStore(storeURL)
+        defer { try? writer.detachForArchiveVerification() }
         guard writer.availability == .ready,
               writer.durability == .durable,
               writer.verifyHistoryReadable() else {
@@ -379,22 +353,27 @@ final class HistoryArchiveTransition {
             usedPostProcessing: false
         )
         _ = try writer.upsert(probe, maxCount: Int.max, requiresDurableStore: true)
+        try writer.detachForArchiveVerification()
 
         let reader = makeStore(storeURL)
+        defer { try? reader.detachForArchiveVerification() }
         guard reader.availability == .ready,
               reader.verifyHistoryReadable(),
               reader.loadAllHistory().contains(where: { $0.id == probe.id }) else {
             throw HistoryArchiveTransitionError.probeDidNotPersist
         }
         _ = try reader.delete(id: probe.id)
+        try reader.detachForArchiveVerification()
 
         let activeStore = makeStore(storeURL)
+        defer { try? activeStore.detachForArchiveVerification() }
         guard activeStore.availability == .ready,
               activeStore.durability == .durable,
               activeStore.verifyHistoryReadable(),
               !activeStore.loadAllHistory().contains(where: { $0.id == probe.id }) else {
             throw HistoryArchiveTransitionError.probeDidNotDelete
         }
+        try activeStore.detachForArchiveVerification()
     }
 
     private func rollback(
@@ -488,11 +467,11 @@ final class HistoryArchiveTransition {
             + id.uuidString.lowercased()
     }
 
-    private static func isPublishedSnapshot(_ directory: URL) -> Bool {
+    private func isPublishedSnapshot(_ directory: URL) -> Bool {
         let manifestURL = directory.appendingPathComponent("manifest.json")
         let payloadURL = directory.appendingPathComponent("payload", isDirectory: true)
-        guard FileManager.default.fileExists(atPath: manifestURL.path),
-              FileManager.default.fileExists(atPath: payloadURL.path),
+        guard fileManager.fileExists(atPath: manifestURL.path),
+              fileManager.fileExists(atPath: payloadURL.path),
               let data = try? Data(contentsOf: manifestURL),
               let manifest = try? JSONDecoder().decode(HistoryArchiveSnapshot.self, from: data) else {
             return false
@@ -501,17 +480,26 @@ final class HistoryArchiveTransition {
     }
 
     private static func byteCount(at url: URL, fileManager: FileManager) -> UInt64 {
-        let attributes = try? fileManager.attributesOfItem(atPath: url.path)
-        if let size = attributes?[.size] as? NSNumber {
-            return size.uint64Value
+        let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory
+            ?? false
+        if !isDirectory {
+            let attributes = try? fileManager.attributesOfItem(atPath: url.path)
+            if let size = attributes?[.size] as? NSNumber {
+                return size.uint64Value
+            }
+            return 0
         }
-        guard let enumerator = fileManager.enumerator(at: url, includingPropertiesForKeys: [.fileSizeKey]) else {
+        guard let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.fileSizeKey, .isDirectoryKey]
+        ) else {
             return 0
         }
         var total: UInt64 = 0
         for case let fileURL as URL in enumerator {
-            let size = (try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
-            total += UInt64(max(0, size))
+            let values = try? fileURL.resourceValues(forKeys: [.fileSizeKey, .isDirectoryKey])
+            guard values?.isDirectory != true else { continue }
+            total += UInt64(max(0, values?.fileSize ?? 0))
         }
         return total
     }

--- a/Sources/HistoryArchiveTransition.swift
+++ b/Sources/HistoryArchiveTransition.swift
@@ -1,0 +1,633 @@
+import CoreData
+import Darwin
+import Foundation
+
+enum HistoryArchiveSafety: Equatable, Sendable {
+    case normal
+    case unresolvedArchive
+    case unresolvedInterruptedTransaction
+    case transitioning
+}
+
+struct HistoryArchiveSnapshotComponent: Codable, Equatable, Sendable {
+    enum Identifier: String, Codable, CaseIterable, Sendable {
+        case sqlite
+        case sqliteWAL
+        case sqliteSHM
+        case assetReferenceSnapshot
+        case audio
+        case transcripts
+        case cloudTranscriptionJobs
+        case legacyRecoveryEvidence
+    }
+
+    let identifier: Identifier
+    let relativePath: String
+    let byteCount: UInt64
+    let isDirectory: Bool
+}
+
+struct HistoryArchiveSnapshot: Codable, Equatable, Sendable {
+    static let currentSchemaVersion = 1
+
+    let schemaVersion: Int
+    let id: UUID
+    let archivedAt: Date
+    let components: [HistoryArchiveSnapshotComponent]
+}
+
+struct HistoryArchiveTransitionResult: Sendable {
+    let snapshot: HistoryArchiveSnapshot
+    let recoveryDirectory: URL
+}
+
+enum HistoryArchiveTransitionError: Error, LocalizedError {
+    case recoveryAlreadyRequiresAttention
+    case freshStoreUnavailable
+    case probeDidNotPersist
+    case probeDidNotDelete
+    case unexpectedActiveArtifact(String)
+    case rollbackFailed
+    case systemCall(String, Int32)
+
+    var errorDescription: String? {
+        switch self {
+        case .recoveryAlreadyRequiresAttention:
+            return "An existing history recovery needs attention before archiving again."
+        case .freshStoreUnavailable:
+            return "A new recording history could not be verified."
+        case .probeDidNotPersist:
+            return "A new recording history did not retain its verification record."
+        case .probeDidNotDelete:
+            return "A new recording history did not remove its verification record."
+        case .unexpectedActiveArtifact(let name):
+            return "An unexpected active history artifact exists at \(name)."
+        case .rollbackFailed:
+            return "The history archive could not be rolled back safely."
+        case .systemCall(let operation, let code):
+            return "\(operation) failed (errno \(code))."
+        }
+    }
+}
+
+final class HistoryArchiveTransition {
+    private static let recoveryDirectoryName = "Recovery"
+    private static let transactionDirectoryName = ".transactions"
+    private static let stagingPrefix = ".staging-"
+    private static let snapshotPrefix = "history-"
+
+    private let fileManager: FileManager
+    private let now: () -> Date
+    private let makeID: () -> UUID
+    private let makeStore: (URL) -> PipelineHistoryStore
+    private let moveItem: (FileManager, URL, URL) throws -> Void
+    private let syncDirectory: (URL) throws -> Void
+
+    init(
+        fileManager: FileManager = .default,
+        now: @escaping () -> Date = Date.init,
+        makeID: @escaping () -> UUID = UUID.init,
+        makeStore: @escaping (URL) -> PipelineHistoryStore = {
+            PipelineHistoryStore(storeURL: $0)
+        },
+        moveItem: @escaping (FileManager, URL, URL) throws -> Void = {
+            fileManager, sourceURL, destinationURL in
+            try fileManager.moveItem(at: sourceURL, to: destinationURL)
+        },
+        syncDirectory: @escaping (URL) throws -> Void = HistoryArchiveDurability.syncDirectory
+    ) {
+        self.fileManager = fileManager
+        self.now = now
+        self.makeID = makeID
+        self.makeStore = makeStore
+        self.moveItem = moveItem
+        self.syncDirectory = syncDirectory
+    }
+
+    static func inspect(at storageRoot: URL) -> HistoryArchiveSafety {
+        let transition = HistoryArchiveTransition()
+        return transition.inspectRecovery(at: storageRoot)
+    }
+
+    static func rollbackInterruptedTransactions(at storageRoot: URL) -> HistoryArchiveSafety {
+        let transition = HistoryArchiveTransition()
+        return transition.rollbackInterruptedTransactions(at: storageRoot)
+    }
+
+    func archiveAndCreateFreshHistory(
+        at storageRoot: URL
+    ) throws -> HistoryArchiveTransitionResult {
+        guard inspectRecovery(at: storageRoot) == .normal else {
+            throw HistoryArchiveTransitionError.recoveryAlreadyRequiresAttention
+        }
+
+        let archiveID = makeID()
+        let archiveDate = now()
+        let recoveryDirectory = storageRoot.appendingPathComponent(
+            Self.recoveryDirectoryName,
+            isDirectory: true
+        )
+        let transactionsDirectory = recoveryDirectory.appendingPathComponent(
+            Self.transactionDirectoryName,
+            isDirectory: true
+        )
+        let stagingDirectoryName = Self.stagingPrefix + archiveID.uuidString.lowercased()
+        let snapshotDirectoryName = Self.snapshotDirectoryName(
+            archivedAt: archiveDate,
+            id: archiveID
+        )
+        let stagingDirectory = recoveryDirectory.appendingPathComponent(
+            stagingDirectoryName,
+            isDirectory: true
+        )
+        let snapshotDirectory = recoveryDirectory.appendingPathComponent(
+            snapshotDirectoryName,
+            isDirectory: true
+        )
+        let transactionURL = transactionsDirectory.appendingPathComponent(
+            archiveID.uuidString.lowercased() + ".json"
+        )
+        let payloadDirectory = stagingDirectory.appendingPathComponent("payload", isDirectory: true)
+
+        try fileManager.createDirectory(at: transactionsDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: payloadDirectory, withIntermediateDirectories: true)
+        try syncDirectory(recoveryDirectory)
+
+        var transaction = HistoryArchiveTransaction(
+            id: archiveID,
+            createdAt: archiveDate,
+            stagingDirectoryName: stagingDirectoryName,
+            snapshotDirectoryName: snapshotDirectoryName,
+            components: makeTransactionComponents(at: storageRoot)
+        )
+        var snapshotWasRenamed = false
+        try writeTransaction(transaction, to: transactionURL)
+
+        do {
+            for index in transaction.components.indices where transaction.components[index].state != .absent {
+                transaction.components[index].state = .preparedToMove
+                try writeTransaction(transaction, to: transactionURL)
+
+                let component = transaction.components[index]
+                let sourceURL = storageRoot.appendingPathComponent(component.relativePath)
+                let destinationURL = payloadDirectory.appendingPathComponent(component.relativePath)
+                try fileManager.createDirectory(
+                    at: destinationURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try moveItem(fileManager, sourceURL, destinationURL)
+                try syncDirectory(sourceURL.deletingLastPathComponent())
+                try syncDirectory(destinationURL.deletingLastPathComponent())
+
+                transaction.components[index].state = .moved
+                try writeTransaction(transaction, to: transactionURL)
+            }
+
+            transaction.phase = .probingFreshHistory
+            try writeTransaction(transaction, to: transactionURL)
+            try verifyFreshHistory(at: storageRoot)
+
+            let snapshot = HistoryArchiveSnapshot(
+                schemaVersion: HistoryArchiveSnapshot.currentSchemaVersion,
+                id: archiveID,
+                archivedAt: archiveDate,
+                components: transaction.components.compactMap { component in
+                    guard component.state == .moved else { return nil }
+                    return HistoryArchiveSnapshotComponent(
+                        identifier: component.identifier,
+                        relativePath: component.relativePath,
+                        byteCount: component.byteCount,
+                        isDirectory: component.isDirectory
+                    )
+                }
+            )
+            let manifestURL = stagingDirectory.appendingPathComponent("manifest.json")
+            try HistoryArchiveDurability.write(
+                JSONEncoder().encode(snapshot),
+                to: manifestURL,
+                fileManager: fileManager
+            )
+
+            transaction.phase = .readyToPublish
+            try writeTransaction(transaction, to: transactionURL)
+            guard !fileManager.fileExists(atPath: snapshotDirectory.path) else {
+                throw HistoryArchiveTransitionError.unexpectedActiveArtifact(
+                    snapshotDirectory.lastPathComponent
+                )
+            }
+            try moveItem(fileManager, stagingDirectory, snapshotDirectory)
+            snapshotWasRenamed = true
+            try syncDirectory(recoveryDirectory)
+            try fileManager.removeItem(at: transactionURL)
+            try syncDirectory(transactionsDirectory)
+            return HistoryArchiveTransitionResult(
+                snapshot: snapshot,
+                recoveryDirectory: recoveryDirectory
+            )
+        } catch {
+            if snapshotWasRenamed {
+                throw error
+            }
+            do {
+                try rollback(
+                    transaction: transaction,
+                    storageRoot: storageRoot,
+                    stagingDirectory: stagingDirectory,
+                    transactionURL: transactionURL
+                )
+            } catch {
+                throw HistoryArchiveTransitionError.rollbackFailed
+            }
+            throw error
+        }
+    }
+
+    private func inspectRecovery(at storageRoot: URL) -> HistoryArchiveSafety {
+        let recoveryDirectory = storageRoot.appendingPathComponent(
+            Self.recoveryDirectoryName,
+            isDirectory: true
+        )
+        guard fileManager.fileExists(atPath: recoveryDirectory.path) else { return .normal }
+
+        do {
+            let entries = try fileManager.contentsOfDirectory(
+                at: recoveryDirectory,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+            var hasPublishedSnapshot = false
+            for entry in entries {
+                let values = try entry.resourceValues(forKeys: [.isDirectoryKey])
+                guard values.isDirectory == true else { continue }
+                if entry.lastPathComponent.hasPrefix(Self.snapshotPrefix) {
+                    guard Self.isPublishedSnapshot(entry) else {
+                        return .unresolvedInterruptedTransaction
+                    }
+                    hasPublishedSnapshot = true
+                }
+            }
+            let transactionsDirectory = recoveryDirectory.appendingPathComponent(
+                Self.transactionDirectoryName,
+                isDirectory: true
+            )
+            if fileManager.fileExists(atPath: transactionsDirectory.path),
+               try !fileManager.contentsOfDirectory(atPath: transactionsDirectory.path).isEmpty {
+                return .unresolvedInterruptedTransaction
+            }
+            return hasPublishedSnapshot ? .unresolvedArchive : .normal
+        } catch {
+            return .unresolvedInterruptedTransaction
+        }
+    }
+
+    func rollbackInterruptedTransactions(at storageRoot: URL) -> HistoryArchiveSafety {
+        let recoveryDirectory = storageRoot.appendingPathComponent(
+            Self.recoveryDirectoryName,
+            isDirectory: true
+        )
+        let transactionsDirectory = recoveryDirectory.appendingPathComponent(
+            Self.transactionDirectoryName,
+            isDirectory: true
+        )
+        guard fileManager.fileExists(atPath: transactionsDirectory.path) else {
+            return inspectRecovery(at: storageRoot)
+        }
+
+        do {
+            let transactionEntries = try fileManager.contentsOfDirectory(
+                at: transactionsDirectory,
+                includingPropertiesForKeys: nil,
+                options: []
+            )
+            for entry in transactionEntries where entry.lastPathComponent.hasPrefix(".")
+                && entry.pathExtension == "tmp" {
+                try fileManager.removeItem(at: entry)
+            }
+            let transactionURLs = transactionEntries.filter {
+                !$0.lastPathComponent.hasPrefix(".") && $0.pathExtension == "json"
+            }
+            for transactionURL in transactionURLs {
+                let transaction = try JSONDecoder().decode(
+                    HistoryArchiveTransaction.self,
+                    from: Data(contentsOf: transactionURL)
+                )
+                let snapshotDirectory = recoveryDirectory.appendingPathComponent(
+                    transaction.snapshotDirectoryName,
+                    isDirectory: true
+                )
+                if Self.isPublishedSnapshot(snapshotDirectory) {
+                    try syncDirectory(recoveryDirectory)
+                    try fileManager.removeItem(at: transactionURL)
+                    continue
+                }
+                let stagingDirectory = recoveryDirectory.appendingPathComponent(
+                    transaction.stagingDirectoryName,
+                    isDirectory: true
+                )
+                try rollback(
+                    transaction: transaction,
+                    storageRoot: storageRoot,
+                    stagingDirectory: stagingDirectory,
+                    transactionURL: transactionURL
+                )
+            }
+            try syncDirectory(transactionsDirectory)
+        } catch {
+            return .unresolvedInterruptedTransaction
+        }
+        return inspectRecovery(at: storageRoot)
+    }
+
+    private func makeTransactionComponents(at storageRoot: URL) -> [HistoryArchiveTransactionComponent] {
+        HistoryArchiveSnapshotComponent.Identifier.allCases.map { identifier in
+            let relativePath = Self.relativePath(for: identifier)
+            let sourceURL = storageRoot.appendingPathComponent(relativePath)
+            let exists = fileManager.fileExists(atPath: sourceURL.path)
+            let isDirectory = (try? sourceURL.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory
+                ?? false
+            return HistoryArchiveTransactionComponent(
+                identifier: identifier,
+                relativePath: relativePath,
+                byteCount: exists ? Self.byteCount(at: sourceURL, fileManager: fileManager) : 0,
+                isDirectory: isDirectory,
+                state: exists ? .pending : .absent
+            )
+        }
+    }
+
+    private func verifyFreshHistory(at storageRoot: URL) throws {
+        let storeURL = storageRoot.appendingPathComponent("PipelineHistory.sqlite")
+        let writer = makeStore(storeURL)
+        guard writer.availability == .ready,
+              writer.durability == .durable,
+              writer.verifyHistoryReadable() else {
+            throw HistoryArchiveTransitionError.freshStoreUnavailable
+        }
+
+        let probe = PipelineHistoryItem(
+            id: UUID(),
+            timestamp: now(),
+            rawTranscript: "",
+            postProcessedTranscript: "",
+            postProcessingPrompt: nil,
+            contextSummary: "",
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "",
+            postProcessingStatus: "",
+            debugStatus: "",
+            customVocabulary: "",
+            usedPostProcessing: false
+        )
+        _ = try writer.upsert(probe, maxCount: Int.max, requiresDurableStore: true)
+
+        let reader = makeStore(storeURL)
+        guard reader.availability == .ready,
+              reader.verifyHistoryReadable(),
+              reader.loadAllHistory().contains(where: { $0.id == probe.id }) else {
+            throw HistoryArchiveTransitionError.probeDidNotPersist
+        }
+        _ = try reader.delete(id: probe.id)
+
+        let activeStore = makeStore(storeURL)
+        guard activeStore.availability == .ready,
+              activeStore.durability == .durable,
+              activeStore.verifyHistoryReadable(),
+              !activeStore.loadAllHistory().contains(where: { $0.id == probe.id }) else {
+            throw HistoryArchiveTransitionError.probeDidNotDelete
+        }
+    }
+
+    private func rollback(
+        transaction: HistoryArchiveTransaction,
+        storageRoot: URL,
+        stagingDirectory: URL,
+        transactionURL: URL
+    ) throws {
+        if transaction.phase != .prepared {
+            try removeFreshStoreArtifacts(at: storageRoot)
+        }
+        for component in transaction.components.reversed() where component.state != .absent {
+            let sourceURL = storageRoot.appendingPathComponent(component.relativePath)
+            let stagedURL = stagingDirectory
+                .appendingPathComponent("payload", isDirectory: true)
+                .appendingPathComponent(component.relativePath)
+            guard fileManager.fileExists(atPath: stagedURL.path) else { continue }
+            guard !fileManager.fileExists(atPath: sourceURL.path) else {
+                throw HistoryArchiveTransitionError.unexpectedActiveArtifact(
+                    component.relativePath
+                )
+            }
+            try fileManager.createDirectory(
+                at: sourceURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try fileManager.moveItem(at: stagedURL, to: sourceURL)
+            try syncDirectory(sourceURL.deletingLastPathComponent())
+        }
+        try? fileManager.removeItem(at: stagingDirectory)
+        try? fileManager.removeItem(at: transactionURL)
+    }
+
+    private func removeFreshStoreArtifacts(at storageRoot: URL) throws {
+        let storeURL = storageRoot.appendingPathComponent("PipelineHistory.sqlite")
+        let freshArtifacts = [
+            storeURL,
+            URL(fileURLWithPath: storeURL.path + "-wal"),
+            URL(fileURLWithPath: storeURL.path + "-shm"),
+            storageRoot.appendingPathComponent("PipelineHistory-asset-references.json")
+        ]
+        for artifact in freshArtifacts where fileManager.fileExists(atPath: artifact.path) {
+            try fileManager.removeItem(at: artifact)
+        }
+        try syncDirectory(storageRoot)
+    }
+
+    private func writeTransaction(
+        _ transaction: HistoryArchiveTransaction,
+        to transactionURL: URL
+    ) throws {
+        try HistoryArchiveDurability.write(
+            JSONEncoder().encode(transaction),
+            to: transactionURL,
+            fileManager: fileManager
+        )
+    }
+
+    private static func relativePath(
+        for identifier: HistoryArchiveSnapshotComponent.Identifier
+    ) -> String {
+        switch identifier {
+        case .sqlite:
+            return "PipelineHistory.sqlite"
+        case .sqliteWAL:
+            return "PipelineHistory.sqlite-wal"
+        case .sqliteSHM:
+            return "PipelineHistory.sqlite-shm"
+        case .assetReferenceSnapshot:
+            return "PipelineHistory-asset-references.json"
+        case .audio:
+            return "audio"
+        case .transcripts:
+            return "transcripts"
+        case .cloudTranscriptionJobs:
+            return "cloud-transcription/jobs"
+        case .legacyRecoveryEvidence:
+            return "History Recovery"
+        }
+    }
+
+    private static func snapshotDirectoryName(archivedAt: Date, id: UUID) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
+        return Self.snapshotPrefix
+            + formatter.string(from: archivedAt)
+            + "-"
+            + id.uuidString.lowercased()
+    }
+
+    private static func isPublishedSnapshot(_ directory: URL) -> Bool {
+        let manifestURL = directory.appendingPathComponent("manifest.json")
+        let payloadURL = directory.appendingPathComponent("payload", isDirectory: true)
+        guard FileManager.default.fileExists(atPath: manifestURL.path),
+              FileManager.default.fileExists(atPath: payloadURL.path),
+              let data = try? Data(contentsOf: manifestURL),
+              let manifest = try? JSONDecoder().decode(HistoryArchiveSnapshot.self, from: data) else {
+            return false
+        }
+        return manifest.schemaVersion == HistoryArchiveSnapshot.currentSchemaVersion
+    }
+
+    private static func byteCount(at url: URL, fileManager: FileManager) -> UInt64 {
+        let attributes = try? fileManager.attributesOfItem(atPath: url.path)
+        if let size = attributes?[.size] as? NSNumber {
+            return size.uint64Value
+        }
+        guard let enumerator = fileManager.enumerator(at: url, includingPropertiesForKeys: [.fileSizeKey]) else {
+            return 0
+        }
+        var total: UInt64 = 0
+        for case let fileURL as URL in enumerator {
+            let size = (try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+            total += UInt64(max(0, size))
+        }
+        return total
+    }
+}
+
+struct HistoryArchiveTransaction: Codable {
+    static let currentSchemaVersion = 1
+
+    enum Phase: String, Codable {
+        case prepared
+        case probingFreshHistory
+        case readyToPublish
+    }
+
+    let schemaVersion: Int
+    let id: UUID
+    let createdAt: Date
+    var phase: Phase
+    let stagingDirectoryName: String
+    let snapshotDirectoryName: String
+    var components: [HistoryArchiveTransactionComponent]
+
+    init(
+        id: UUID,
+        createdAt: Date,
+        stagingDirectoryName: String,
+        snapshotDirectoryName: String,
+        components: [HistoryArchiveTransactionComponent]
+    ) {
+        schemaVersion = Self.currentSchemaVersion
+        self.id = id
+        self.createdAt = createdAt
+        phase = .prepared
+        self.stagingDirectoryName = stagingDirectoryName
+        self.snapshotDirectoryName = snapshotDirectoryName
+        self.components = components
+    }
+}
+
+struct HistoryArchiveTransactionComponent: Codable {
+    enum State: String, Codable {
+        case absent
+        case pending
+        case preparedToMove
+        case moved
+    }
+
+    let identifier: HistoryArchiveSnapshotComponent.Identifier
+    let relativePath: String
+    let byteCount: UInt64
+    let isDirectory: Bool
+    var state: State
+}
+
+private enum HistoryArchiveDurability {
+    static func write(_ data: Data, to targetURL: URL, fileManager: FileManager) throws {
+        let parentDirectory = targetURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parentDirectory, withIntermediateDirectories: true)
+        let temporaryURL = parentDirectory.appendingPathComponent(
+            ".\(targetURL.lastPathComponent).\(UUID().uuidString).tmp"
+        )
+        let descriptor = Darwin.open(
+            temporaryURL.path,
+            O_WRONLY | O_CREAT | O_EXCL,
+            mode_t(0o600)
+        )
+        guard descriptor >= 0 else {
+            throw HistoryArchiveTransitionError.systemCall("open archive metadata", errno)
+        }
+        var isOpen = true
+        defer {
+            if isOpen { Darwin.close(descriptor) }
+            try? fileManager.removeItem(at: temporaryURL)
+        }
+
+        try writeAll(data, to: descriptor)
+        try fullSync(descriptor)
+        guard Darwin.close(descriptor) == 0 else {
+            isOpen = false
+            throw HistoryArchiveTransitionError.systemCall("close archive metadata", errno)
+        }
+        isOpen = false
+        guard Darwin.rename(temporaryURL.path, targetURL.path) == 0 else {
+            throw HistoryArchiveTransitionError.systemCall("rename archive metadata", errno)
+        }
+        try syncDirectory(parentDirectory)
+    }
+
+    static func syncDirectory(_ directory: URL) throws {
+        let descriptor = Darwin.open(directory.path, O_RDONLY)
+        guard descriptor >= 0 else {
+            throw HistoryArchiveTransitionError.systemCall("open archive directory", errno)
+        }
+        defer { Darwin.close(descriptor) }
+        try fullSync(descriptor)
+    }
+
+    private static func writeAll(_ data: Data, to descriptor: Int32) throws {
+        try data.withUnsafeBytes { rawBuffer in
+            guard var pointer = rawBuffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return }
+            var remaining = rawBuffer.count
+            while remaining > 0 {
+                let written = Darwin.write(descriptor, pointer, remaining)
+                guard written > 0 else {
+                    throw HistoryArchiveTransitionError.systemCall("write archive metadata", errno)
+                }
+                remaining -= written
+                pointer = pointer.advanced(by: written)
+            }
+        }
+    }
+
+    private static func fullSync(_ descriptor: Int32) throws {
+        if fcntl(descriptor, F_FULLFSYNC) == 0 { return }
+        guard fsync(descriptor) == 0 else {
+            throw HistoryArchiveTransitionError.systemCall("sync archive metadata", errno)
+        }
+    }
+}

--- a/Sources/HistoryRecoveryView.swift
+++ b/Sources/HistoryRecoveryView.swift
@@ -1,0 +1,68 @@
+import AppKit
+import SwiftUI
+
+struct HistoryUnavailableRecoveryActions: View {
+    @EnvironmentObject private var appState: AppState
+    @State private var showsArchiveConfirmation = false
+
+    var body: some View {
+        Group {
+            if appState.isHistoryArchiveTransitioning {
+                ProgressView("Archiving recording history…")
+                    .controlSize(.small)
+            } else {
+                HStack(spacing: 10) {
+                    Button("Open Data Folder") {
+                        appState.openHistoryDataFolder()
+                    }
+                    if appState.historyArchiveSafety == .normal {
+                        Button("Archive Old History and Start Fresh…") {
+                            showsArchiveConfirmation = true
+                        }
+                        .disabled(!appState.isHistoryUnavailable)
+                    }
+                    Button("Quit Quill") {
+                        NSApplication.shared.terminate(nil)
+                    }
+                }
+            }
+        }
+        .confirmationDialog(
+            "Archive old history?",
+            isPresented: $showsArchiveConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Archive and Start Fresh", role: .destructive) {
+                _ = appState.archiveOldHistoryAndStartFresh()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(
+                "Your earlier notes will not appear in the new history. The original database, audio, transcripts, and recovery metadata will be kept in a recovery snapshot. Restore, import, and merge are not available yet. Cancel to leave everything unchanged."
+            )
+        }
+    }
+}
+
+struct HistoryArchiveNoticeView: View {
+    @EnvironmentObject private var appState: AppState
+
+    var body: some View {
+        if appState.historyArchiveSafety == .unresolvedArchive {
+            let presentation = QuillUserIssueRecord(code: .historyArchived).presentation()
+            VStack(alignment: .leading, spacing: 6) {
+                Label(presentation.title, systemImage: "archivebox.fill")
+                    .font(.caption.weight(.semibold))
+                Text(presentation.body)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Button("Open Recovery Folder") {
+                    appState.openHistoryRecoveryFolder()
+                }
+                .controlSize(.small)
+            }
+            .foregroundStyle(.orange)
+        }
+    }
+}

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -150,19 +150,17 @@ struct MenuBarView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
-                    HStack {
-                        Button("Open Data Folder") {
-                            appState.openHistoryDataFolder()
-                        }
-                        Button("Quit Quill") {
-                            NSApplication.shared.terminate(nil)
-                        }
-                    }
-                    .controlSize(.small)
+                    HistoryUnavailableRecoveryActions()
+                        .controlSize(.small)
                 }
                 .foregroundStyle(.orange)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 4)
+            } else if appState.historyArchiveSafety == .unresolvedArchive {
+                Divider()
+                HistoryArchiveNoticeView()
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 4)
             } else if let warning = appState.historyPersistenceWarning {
                 Divider()
                 Label(

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -484,9 +484,11 @@ struct NoteBrowserView: View {
                 historyUnavailableView
             } else {
                 VStack(spacing: 0) {
-                    HistoryArchiveNoticeView()
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 8)
+                    if appState.historyArchiveSafety == .unresolvedArchive {
+                        HistoryArchiveNoticeView()
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                    }
                     HStack(spacing: 0) {
             sidebarPanel
             detailPanel

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -483,7 +483,11 @@ struct NoteBrowserView: View {
             if appState.isHistoryUnavailable {
                 historyUnavailableView
             } else {
-                HStack(spacing: 0) {
+                VStack(spacing: 0) {
+                    HistoryArchiveNoticeView()
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                    HStack(spacing: 0) {
             sidebarPanel
             detailPanel
         }
@@ -521,6 +525,7 @@ struct NoteBrowserView: View {
             knownHistoryIDs = Set(ids)
         }
             }
+                }
         }
     }
 
@@ -537,15 +542,8 @@ struct NoteBrowserView: View {
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 440)
-            HStack(spacing: 10) {
-                Button("Open Data Folder") {
-                    appState.openHistoryDataFolder()
-                }
-                Button("Quit Quill") {
-                    NSApplication.shared.terminate(nil)
-                }
-            }
-            .controlSize(.large)
+            HistoryUnavailableRecoveryActions()
+                .controlSize(.large)
             Spacer()
         }
         .padding(32)

--- a/Sources/PipelineHistoryStore.swift
+++ b/Sources/PipelineHistoryStore.swift
@@ -12,6 +12,33 @@ enum PipelineHistoryStoreError: Error {
     case durableStoreUnavailable
 }
 
+struct HistoryArchiveSnapshotComponent: Codable, Equatable, Sendable {
+    enum Identifier: String, Codable, CaseIterable, Sendable {
+        case sqlite
+        case sqliteWAL
+        case sqliteSHM
+        case assetReferenceSnapshot
+        case audio
+        case transcripts
+        case cloudTranscriptionJobs
+        case legacyRecoveryEvidence
+    }
+
+    let identifier: Identifier
+    let relativePath: String
+    let byteCount: UInt64
+    let isDirectory: Bool
+}
+
+struct HistoryArchiveSnapshot: Codable, Equatable, Sendable {
+    static let currentSchemaVersion = 1
+
+    let schemaVersion: Int
+    let id: UUID
+    let archivedAt: Date
+    let components: [HistoryArchiveSnapshotComponent]
+}
+
 enum PipelineHistoryStoreAvailability: Equatable, Sendable {
     case ready
     case unavailable
@@ -230,6 +257,16 @@ final class PipelineHistoryStore {
         guard availability == .unavailable else {
             throw PipelineHistoryStoreError.storeUnavailable
         }
+        try detachPersistentStores()
+        isStoreLoaded = false
+        canSynchronizeAssetReferenceSnapshot = false
+    }
+
+    func detachForArchiveVerification() throws {
+        try detachPersistentStores()
+    }
+
+    private func detachPersistentStores() throws {
         var thrownError: Error?
         container.viewContext.performAndWait {
             do {
@@ -243,8 +280,6 @@ final class PipelineHistoryStore {
             }
         }
         if let thrownError { throw thrownError }
-        isStoreLoaded = false
-        canSynchronizeAssetReferenceSnapshot = false
     }
 
     func assetReferenceSnapshotState(
@@ -692,12 +727,6 @@ final class PipelineHistoryStore {
         )
     }
 
-    private struct HistoryArchiveManifestInspection: Decodable {
-        let schemaVersion: Int
-        let id: UUID
-        let archivedAt: Date
-    }
-
     private static func inspectRecoveryBackups(
         near storeURL: URL?
     ) -> RecoveryBackupInspection {
@@ -761,10 +790,10 @@ final class PipelineHistoryStore {
                     return .unavailable
                 }
                 let manifest = try JSONDecoder().decode(
-                    HistoryArchiveManifestInspection.self,
+                    HistoryArchiveSnapshot.self,
                     from: Data(contentsOf: manifestURL)
                 )
-                guard manifest.schemaVersion == 1,
+                guard manifest.schemaVersion == HistoryArchiveSnapshot.currentSchemaVersion,
                       entry.lastPathComponent.hasSuffix(
                         "-\(manifest.id.uuidString.lowercased())"
                       ) else {

--- a/Sources/PipelineHistoryStore.swift
+++ b/Sources/PipelineHistoryStore.swift
@@ -226,6 +226,27 @@ final class PipelineHistoryStore {
         canSynchronizeAssetReferenceSnapshot = false
     }
 
+    func detachForHistoryArchive() throws {
+        guard availability == .unavailable else {
+            throw PipelineHistoryStoreError.storeUnavailable
+        }
+        var thrownError: Error?
+        container.viewContext.performAndWait {
+            do {
+                container.viewContext.reset()
+                let coordinator = container.persistentStoreCoordinator
+                for store in coordinator.persistentStores {
+                    try coordinator.remove(store)
+                }
+            } catch {
+                thrownError = error
+            }
+        }
+        if let thrownError { throw thrownError }
+        isStoreLoaded = false
+        canSynchronizeAssetReferenceSnapshot = false
+    }
+
     func assetReferenceSnapshotState(
         audioFileNames: Set<String>,
         transcriptFileNames: Set<String>
@@ -671,10 +692,95 @@ final class PipelineHistoryStore {
         )
     }
 
+    private struct HistoryArchiveManifestInspection: Decodable {
+        let schemaVersion: Int
+        let id: UUID
+        let archivedAt: Date
+    }
+
     private static func inspectRecoveryBackups(
         near storeURL: URL?
     ) -> RecoveryBackupInspection {
         guard let storeURL else { return .absent }
+        let archiveInspection = inspectPublishedHistoryArchives(near: storeURL)
+        switch archiveInspection {
+        case .present, .unavailable:
+            return archiveInspection
+        case .absent:
+            return inspectLegacyRecoveryEvidence(near: storeURL)
+        }
+    }
+
+    private static func inspectPublishedHistoryArchives(
+        near storeURL: URL
+    ) -> RecoveryBackupInspection {
+        let recoveryRootURL = storeURL.deletingLastPathComponent()
+            .appendingPathComponent("Recovery", isDirectory: true)
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: recoveryRootURL.path) else {
+            return .absent
+        }
+        let transactionsURL = recoveryRootURL.appendingPathComponent(
+            ".transactions",
+            isDirectory: true
+        )
+        if fileManager.fileExists(atPath: transactionsURL.path) {
+            do {
+                guard try transactionsURL.resourceValues(forKeys: [.isDirectoryKey])
+                    .isDirectory == true,
+                      try fileManager.contentsOfDirectory(atPath: transactionsURL.path).isEmpty else {
+                    return .unavailable
+                }
+            } catch {
+                return .unavailable
+            }
+        }
+        do {
+            let entries = try fileManager.contentsOfDirectory(
+                at: recoveryRootURL,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+            var hasPublishedArchive = false
+            for entry in entries {
+                let isDirectory = try entry.resourceValues(forKeys: [.isDirectoryKey])
+                    .isDirectory == true
+                if entry.lastPathComponent == ".transactions" {
+                    guard isDirectory else { return .unavailable }
+                    if try !fileManager.contentsOfDirectory(atPath: entry.path).isEmpty {
+                        return .unavailable
+                    }
+                    continue
+                }
+                guard entry.lastPathComponent.hasPrefix("history-") else { continue }
+                guard isDirectory else { return .unavailable }
+                let manifestURL = entry.appendingPathComponent("manifest.json")
+                let payloadURL = entry.appendingPathComponent("payload", isDirectory: true)
+                guard fileManager.fileExists(atPath: manifestURL.path),
+                      fileManager.fileExists(atPath: payloadURL.path) else {
+                    return .unavailable
+                }
+                let manifest = try JSONDecoder().decode(
+                    HistoryArchiveManifestInspection.self,
+                    from: Data(contentsOf: manifestURL)
+                )
+                guard manifest.schemaVersion == 1,
+                      entry.lastPathComponent.hasSuffix(
+                        "-\(manifest.id.uuidString.lowercased())"
+                      ) else {
+                    return .unavailable
+                }
+                hasPublishedArchive = true
+            }
+            return hasPublishedArchive ? .present : .absent
+        } catch {
+            return .unavailable
+        }
+    }
+
+    private static func inspectLegacyRecoveryEvidence(
+        near storeURL: URL
+    ) -> RecoveryBackupInspection {
         let recoveryRootURL = storeURL.deletingLastPathComponent()
             .appendingPathComponent("History Recovery", isDirectory: true)
         let fileManager = FileManager.default

--- a/Sources/QuillUserIssue.swift
+++ b/Sources/QuillUserIssue.swift
@@ -31,6 +31,7 @@ enum QuillUserIssueCode: String, Codable, CaseIterable, Sendable {
     case meetingSummaryInvalidResponse = "meeting-summary-invalid-response"
     case historyPersistenceUnavailable = "history-persistence-unavailable"
     case historyRecovered = "history-recovered"
+    case historyArchived = "history-archived"
     case unknown
     case legacy
 }
@@ -141,7 +142,7 @@ struct QuillUserIssueRecord: Codable, Equatable, Sendable {
             return .openScreenRecordingSettings
         case .postProcessingGuardFallback, .contextUnavailable,
              .meetingSummaryUnavailable, .meetingSummaryInvalidResponse,
-             .historyPersistenceUnavailable, .historyRecovered:
+             .historyPersistenceUnavailable, .historyRecovered, .historyArchived:
             return .none
         case .networkUnavailable, .requestTimedOut, .rateLimited,
              .providerUnavailable, .audioFileTooLarge,
@@ -404,7 +405,7 @@ private extension QuillUserIssueCode {
              .localAIStartFailed, .localAIProcessExited,
              .contextUnavailable, .meetingSummaryUnavailable,
              .meetingSummaryInvalidResponse, .historyPersistenceUnavailable,
-             .historyRecovered:
+             .historyRecovered, .historyArchived:
             return .warning
         default:
             return .error
@@ -592,6 +593,12 @@ private extension QuillUserIssueCode {
                 titleKey: "History was recovered",
                 bodyKey: "Quill couldn't open earlier history. A recovery backup was retained, and new notes will keep saving.",
                 suggestionKey: "No action is needed. Your new notes and history are being saved."
+            )
+        case .historyArchived:
+            return QuillUserIssueCopy(
+                titleKey: "Old history was archived",
+                bodyKey: "New history is saving separately. Restore, import, and merge are not available yet.",
+                suggestionKey: "Open the recovery folder to keep the archived history available for a future recovery."
             )
         case .unknown:
             return QuillUserIssueCopy(

--- a/Sources/RecordingJournalFinalizationWork.swift
+++ b/Sources/RecordingJournalFinalizationWork.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+struct RecordingJournalStoppedFinalizationResult {
+    let artifact: FinalizedSegmentedRecordingArtifact
+    let manifest: RecordingJournalManifest
+}
+
+/// Transfers a stopped segmented journal from the MainActor to the serial
+/// recording-journal finalization queue. The controller is removed from
+/// AppState and its audio sinks are detached before this work item is made.
+/// `SegmentedRecordingJournalController` serializes lifecycle access internally,
+/// and `RecordingJournalStore` serializes filesystem access with its lock.
+/// The work item itself must run on only that finalization queue.
+final class RecordingJournalFinalizationWork: @unchecked Sendable {
+    private let controller: SegmentedRecordingJournalController
+    private let store: RecordingJournalStore
+
+    init(
+        controller: SegmentedRecordingJournalController,
+        store: RecordingJournalStore
+    ) {
+        self.controller = controller
+        self.store = store
+    }
+
+    var recordingID: UUID {
+        controller.recordingID
+    }
+
+    var hasTerminalPersistenceFailure: Bool {
+        controller.terminalPersistenceFailure != nil
+    }
+
+    func recoverAfterPersistenceFailure() -> Result<RecoveredRecordingArtifact, Error> {
+        do {
+            _ = try controller.closeAfterPersistenceFailure()
+            let artifact = try SegmentedRecordingArtifactFinalizer(
+                store: store,
+                mixdownService: AudioMixdownService()
+            ).finalizeAndPromote(recordingID: controller.recordingID)
+            let manifest = try store.loadManifest(recordingID: artifact.recordingID)
+            return .success(RecoveredRecordingArtifact(
+                recordingID: artifact.recordingID,
+                audioURL: artifact.destinationURL,
+                promotion: artifact.promotion,
+                manifest: manifest,
+                mode: artifact.mode
+            ))
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    func finalizeStoppedRecording() throws -> RecordingJournalStoppedFinalizationResult {
+        try controller.stopAndClose()
+        let artifact = try SegmentedRecordingArtifactFinalizer(
+            store: store,
+            mixdownService: AudioMixdownService()
+        ).finalizeAndPromote(recordingID: controller.recordingID)
+        let manifest = try store.loadManifest(recordingID: artifact.recordingID)
+        return RecordingJournalStoppedFinalizationResult(
+            artifact: artifact,
+            manifest: manifest
+        )
+    }
+
+    func preserveForRecovery() throws {
+        try controller.preserveForRecovery()
+    }
+}

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -4230,9 +4230,11 @@ struct RunLogView: View {
                 .frame(maxWidth: .infinity)
             } else {
                 VStack(spacing: 0) {
-                    HistoryArchiveNoticeView()
-                        .padding(.horizontal, 24)
-                        .padding(.vertical, 12)
+                    if appState.historyArchiveSafety == .unresolvedArchive {
+                        HistoryArchiveNoticeView()
+                            .padding(.horizontal, 24)
+                            .padding(.vertical, 12)
+                    }
                     if appState.pipelineHistory.isEmpty {
                         VStack {
                             Spacer()

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -4223,34 +4223,34 @@ struct RunLogView: View {
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                         .frame(maxWidth: 420)
-                    HStack {
-                        Button("Open Data Folder") {
-                            appState.openHistoryDataFolder()
-                        }
-                        Button("Quit Quill") {
-                            NSApplication.shared.terminate(nil)
-                        }
-                    }
+                    HistoryUnavailableRecoveryActions()
                     Spacer()
                 }
                 .padding(24)
                 .frame(maxWidth: .infinity)
-            } else if appState.pipelineHistory.isEmpty {
-                VStack {
-                    Spacer()
-                    Text("No runs yet. Use dictation to populate history.")
-                        .foregroundStyle(.secondary)
-                    Spacer()
-                }
-                .frame(maxWidth: .infinity)
             } else {
-                ScrollView {
-                    LazyVStack(spacing: 12) {
-                        ForEach(appState.pipelineHistory) { item in
-                            RunLogEntryView(item: item)
+                VStack(spacing: 0) {
+                    HistoryArchiveNoticeView()
+                        .padding(.horizontal, 24)
+                        .padding(.vertical, 12)
+                    if appState.pipelineHistory.isEmpty {
+                        VStack {
+                            Spacer()
+                            Text("No runs yet. Use dictation to populate history.")
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                        }
+                        .frame(maxWidth: .infinity)
+                    } else {
+                        ScrollView {
+                            LazyVStack(spacing: 12) {
+                                ForEach(appState.pipelineHistory) { item in
+                                    RunLogEntryView(item: item)
+                                }
+                            }
+                            .padding(20)
                         }
                     }
-                    .padding(20)
                 }
             }
         }

--- a/Tests/AppStateHistoryProtectionSourceTests.swift
+++ b/Tests/AppStateHistoryProtectionSourceTests.swift
@@ -59,10 +59,14 @@ struct AppStateHistoryProtectionSourceTests {
         )
         let archivedStartup = String(source[archivedStartupRange])
         try expect(
-            archivedStartup.contains("cloudTranscriptionJobStore.reconcile(")
-                && !archivedStartup.contains("recoverRecordingJournalsBeforeHistoryLoad(")
+            archivedStartup.contains("recoverRecordingJournalsBeforeHistoryLoad(")
+                && archivedStartup.contains("markInterruptedRecoveryPlaceholders(")
+                && archivedStartup.contains("LegacyNoteTitleMigration.migrate(")
+                && archivedStartup.contains("cloudTranscriptionJobStore.reconcile(")
+                && !archivedStartup.contains("pipelineHistoryStore.trim(")
+                && !archivedStartup.contains("bootstrapAssetReferenceSnapshot(")
                 && !archivedStartup.contains("sweepOrphanStoredFiles("),
-            "published archives preserve old-data cleanup safeguards while reconciling new-generation cloud jobs"
+            "published archives recover only the active generation while preserving old-data cleanup safeguards"
         )
         try expect(
             source.contains("func archiveOldHistoryAndStartFresh() -> Bool")
@@ -82,7 +86,7 @@ struct AppStateHistoryProtectionSourceTests {
         for requiredGuard in [
             "historyArchiveSafety == .normal",
             "pendingAudioImportJobIDs.isEmpty",
-            "cloudTranscriptionHistoryCoordinator.hasActiveWork",
+            "!cloudTranscriptionHistoryCoordinator.hasActiveWork",
             "meetingSummaryGeneratingNoteIDs.isEmpty",
             "pendingRecordingJournalFinalizationCount == 0",
             "pendingRecordingStartCount == 0"

--- a/Tests/AppStateHistoryProtectionSourceTests.swift
+++ b/Tests/AppStateHistoryProtectionSourceTests.swift
@@ -5,8 +5,9 @@ struct AppStateHistoryProtectionSourceTests {
         let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
 
         try expect(
-            source.contains("if pipelineHistoryStore.availability == .ready {"),
-            "startup work is gated by history availability"
+            source.contains("if initialHistoryArchiveSafety == .normal,")
+                && source.contains("pipelineHistoryStore.availability == .ready"),
+            "startup work is gated by history availability and archive safety"
         )
         let startupRange = try source.range(
             from: "var savedHistory: [PipelineHistoryItem] = []",
@@ -17,13 +18,15 @@ struct AppStateHistoryProtectionSourceTests {
             [
                 "if pipelineHistoryStore.availability == .ready {",
                 "pipelineHistoryStore.verifyHistoryReadable()",
+                "if initialHistoryArchiveSafety == .normal,",
+                "pipelineHistoryStore.availability == .ready {",
                 "recoverRecordingJournalsBeforeHistoryLoad(",
                 "cloudTranscriptionJobStore.reconcile(",
                 "sweepOrphanStoredFiles(",
                 "} else {\n            print(\"Skipping history startup work because persistent history is unavailable.\")"
             ],
             in: startup,
-            label: "ready startup work remains grouped behind availability gate"
+            label: "ready startup work remains grouped behind availability and archive-safety gates"
         )
         let initialHistoryRead = try startup.range(
             of: "pipelineHistoryStore.verifyHistoryReadable()"
@@ -41,13 +44,85 @@ struct AppStateHistoryProtectionSourceTests {
                 && source.contains("private func synchronizeHistoryPersistenceState()")
                 && source.contains("let unavailable = pipelineHistoryStore.availability == .unavailable")
                 && source.contains("isHistoryUnavailable = unavailable")
-                && source.contains("historyPersistenceWarning = isHistoryUnavailable"),
-            "history-unavailable transitions publish protection UI state"
+                && source.contains("historyArchiveSafety == .unresolvedArchive")
+                && source.contains("historyPersistenceWarning = warning"),
+            "history transitions publish protection and archived-history UI state"
         )
         try expect(
             source.contains("private func loadPipelineHistory() -> [PipelineHistoryItem]")
                 && source.contains("synchronizeHistoryPersistenceState()"),
             "runtime history reads synchronize the published protection state"
+        )
+        let archivedStartupRange = try source.range(
+            from: "} else if initialHistoryArchiveSafety == .unresolvedArchive,",
+            to: "        } else {\n            print(\"Skipping history startup work because persistent history is unavailable.\")"
+        )
+        let archivedStartup = String(source[archivedStartupRange])
+        try expect(
+            archivedStartup.contains("cloudTranscriptionJobStore.reconcile(")
+                && !archivedStartup.contains("recoverRecordingJournalsBeforeHistoryLoad(")
+                && !archivedStartup.contains("sweepOrphanStoredFiles("),
+            "published archives preserve old-data cleanup safeguards while reconciling new-generation cloud jobs"
+        )
+        try expect(
+            source.contains("func archiveOldHistoryAndStartFresh() -> Bool")
+                && source.contains("try pipelineHistoryStore.detachForHistoryArchive()")
+                && source.contains("HistoryArchiveTransition(")
+                && source.contains("Task.detached(priority: .userInitiated)")
+                && source.contains("completeHistoryArchiveTransition(")
+                && source.contains("let activeStore = Self.pipelineHistoryStoreAtURLFactory(")
+                && source.contains("historyArchiveSafety = HistoryArchiveTransition.inspect("),
+            "explicit archive transitions in the background and installs only a verified fresh history store"
+        )
+        let archiveRange = try source.range(
+            from: "func archiveOldHistoryAndStartFresh() -> Bool",
+            to: "@MainActor\n    func clearPipelineHistory()"
+        )
+        let archiveBody = String(source[archiveRange])
+        for requiredGuard in [
+            "historyArchiveSafety == .normal",
+            "pendingAudioImportJobIDs.isEmpty",
+            "cloudTranscriptionHistoryCoordinator.hasActiveWork",
+            "meetingSummaryGeneratingNoteIDs.isEmpty",
+            "pendingRecordingJournalFinalizationCount == 0",
+            "pendingRecordingStartCount == 0"
+        ] {
+            try expect(
+                archiveBody.contains(requiredGuard),
+                "archive waits for \(requiredGuard) before moving history files"
+            )
+        }
+        try expect(
+            source.contains("pendingAudioImportJobIDs.insert(jobID)")
+                && source.contains("pendingAudioImportJobIDs.remove(jobID)"),
+            "audio import is tracked before its detached audio copy can touch history storage"
+        )
+        let recordingStartRange = try source.range(
+            from: "private func startRecording(triggerMode: RecordingTriggerMode",
+            to: "/// Whether the configured recording flow will actually exercise Accessibility."
+        )
+        let recordingStart = String(source[recordingStartRange])
+        try expect(
+            source.contains("private var pendingRecordingStartCount = 0")
+                && recordingStart.contains("pendingRecordingStartCount += 1")
+                && recordingStart.contains("defer { self.pendingRecordingStartCount -= 1 }")
+                && recordingStart.components(separatedBy: "requireAvailableHistoryForMutation()").count >= 3
+                && recordingStart.contains("beginRecording("),
+            "an awaited recording start remains pending and rechecks archive protection before creating writers"
+        )
+        let microphonePermissionRange = try source.range(
+            from: "private func ensureMicrophoneAccess() -> Bool",
+            to: "private func applyAudioInterruptionIfNeeded()"
+        )
+        let microphonePermission = String(source[microphonePermissionRange])
+        try expect(
+            microphonePermission.contains("pendingRecordingStartCount += 1")
+                && microphonePermission.contains("defer { strongSelf.pendingRecordingStartCount -= 1 }")
+                && microphonePermission.components(
+                    separatedBy: "strongSelf.requireAvailableHistoryForMutation()"
+                ).count >= 3
+                && microphonePermission.contains("strongSelf.beginRecording("),
+            "microphone permission resumption remains pending and rechecks archive protection before creating writers"
         )
 
         let persistenceRange = try source.range(

--- a/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
+++ b/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
@@ -11,7 +11,16 @@ struct AppStateRecordingJournalIntegrationSourceTests {
             contentsOfFile: "Sources/AppleSpeechLiveTranscriber.swift",
             encoding: .utf8
         )
+        let finalizationWorkSource = try String(
+            contentsOfFile: "Sources/RecordingJournalFinalizationWork.swift",
+            encoding: .utf8
+        )
 
+        precondition(finalizationWorkSource.contains(
+            "final class RecordingJournalFinalizationWork: @unchecked Sendable"
+        ))
+        precondition(finalizationWorkSource.contains("private let controller: SegmentedRecordingJournalController"))
+        precondition(finalizationWorkSource.contains("private let store: RecordingJournalStore"))
         precondition(source.contains("private var recordingJournalStore: RecordingJournalStore"))
         precondition(source.contains("private var activeSegmentedJournalController: SegmentedRecordingJournalController?"))
         precondition(source.contains("private var activeRecordingID: UUID?"))
@@ -156,16 +165,14 @@ struct AppStateRecordingJournalIntegrationSourceTests {
             named: "finishRecordingAfterJournalPersistenceFailure",
             in: source
         )
-        precondition(finishFailureBody.contains("recoverRecordingAfterJournalPersistenceFailure("))
+        precondition(finishFailureBody.contains("RecordingJournalFinalizationWork("))
+        precondition(finishFailureBody.contains("recoverAfterPersistenceFailure()"))
         precondition(finishFailureBody.contains("controller.closeAfterPersistenceFailure()") == false)
         precondition(finishFailureBody.contains("SegmentedRecordingArtifactFinalizer(") == false)
         precondition(finishFailureBody.contains("completeRecordingStorageFailureRecovery("))
-        let coreFailureRecoveryBody = try functionBody(
-            named: "recoverRecordingAfterJournalPersistenceFailure",
-            in: source
-        )
-        precondition(coreFailureRecoveryBody.contains("controller.closeAfterPersistenceFailure()"))
-        precondition(coreFailureRecoveryBody.contains("SegmentedRecordingArtifactFinalizer("))
+        precondition(finalizationWorkSource.contains("func recoverAfterPersistenceFailure()"))
+        precondition(finalizationWorkSource.contains("controller.closeAfterPersistenceFailure()"))
+        precondition(finalizationWorkSource.contains("SegmentedRecordingArtifactFinalizer("))
 
         let completeFailureBody = try functionBody(
             named: "completeRecordingStorageFailureRecovery",
@@ -260,12 +267,13 @@ struct AppStateRecordingJournalIntegrationSourceTests {
             in: source
         )
         precondition(finishBody.contains("recordingJournalFinalizationQueue.async"))
-        precondition(finishBody.contains("controller.stopAndClose()"))
-        precondition(finishBody.contains("SegmentedRecordingArtifactFinalizer("))
+        precondition(finishBody.contains("RecordingJournalFinalizationWork("))
+        precondition(finishBody.contains("finalizeStoppedRecording()"))
         precondition(finishBody.contains("case .complete:"))
         precondition(finishBody.contains("case .partial:"))
-        precondition(finishBody.contains("controller.terminalPersistenceFailure"))
-        precondition(finishBody.contains("recoverRecordingAfterJournalPersistenceFailure("))
+        precondition(finishBody.contains("hasTerminalPersistenceFailure"))
+        precondition(finishBody.contains("recoverAfterPersistenceFailure()"))
+        precondition(finalizationWorkSource.contains("func finalizeStoppedRecording()"))
         precondition(finishBody.contains(".recoveredWithoutTranscription"))
         precondition(!finishBody.contains("temporaryCombinedFallback"))
 

--- a/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
+++ b/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
@@ -150,6 +150,8 @@ struct AppStateRecordingJournalIntegrationSourceTests {
             precondition(failurePreparationBody.contains(required))
         }
 
+        precondition(source.contains("@MainActor\n    private func finishRecordingAfterJournalPersistenceFailure("))
+        precondition(source.contains("@MainActor\n    private func finishStoppedSegmentedRecording("))
         let finishFailureBody = try functionBody(
             named: "finishRecordingAfterJournalPersistenceFailure",
             in: source

--- a/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
+++ b/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
@@ -12,7 +12,7 @@ struct AppStateRecordingJournalIntegrationSourceTests {
             encoding: .utf8
         )
 
-        precondition(source.contains("private let recordingJournalStore: RecordingJournalStore"))
+        precondition(source.contains("private var recordingJournalStore: RecordingJournalStore"))
         precondition(source.contains("private var activeSegmentedJournalController: SegmentedRecordingJournalController?"))
         precondition(source.contains("private var activeRecordingID: UUID?"))
         precondition(source.contains("private var activeInputSwitchToken: UUID?"))

--- a/Tests/AppStateStorageSafetyTests.swift
+++ b/Tests/AppStateStorageSafetyTests.swift
@@ -6,6 +6,8 @@ struct AppStateStorageSafetyTests {
         try await verifiesHistoryCreatedAfterAssetsDoesNotSweep()
         try await verifiesHistoryRowsLostAfterSnapshotDoesNotSweep()
         try await verifiesUnavailableHistoryBlocksMutatingActions()
+        try await verifiesExplicitArchiveCreatesFreshSeparatedHistory()
+        try await verifiesInterruptedArchiveKeepsHistoryProtected()
         try await verifiesMissingSnapshotWithUnreferencedAudioDoesNotSweep()
         try await verifiesMatchingHistorySnapshotSweepsOrphansAtStartup()
         try await verifiesTrustedHistorySweepsOrphans()
@@ -137,6 +139,155 @@ struct AppStateStorageSafetyTests {
         }
     }
 
+    private static func verifiesExplicitArchiveCreatesFreshSeparatedHistory() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+            let storeURL = rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
+            let originalSQLiteBytes = Data("unreadable original SQLite".utf8)
+            try originalSQLiteBytes.write(to: storeURL)
+            let audioURL = AppState.audioStorageDirectory().appendingPathComponent("archived.wav")
+            let transcriptURL = AppState.transcriptStorageDirectory().appendingPathComponent("archived.txt")
+            let cloudJobURL = rootDirectory
+                .appendingPathComponent("cloud-transcription/jobs/archived.json")
+            try Data("archived audio".utf8).write(to: audioURL)
+            try Data("archived transcript".utf8).write(to: transcriptURL)
+            try FileManager.default.createDirectory(
+                at: cloudJobURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data("archived cloud job".utf8).write(to: cloudJobURL)
+
+            let unavailableStore = PipelineHistoryStore(
+                storeURL: storeURL,
+                persistentStoreLoader: { _ in
+                    TestFailure("Injected unavailable history for explicit archive")
+                }
+            )
+            let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
+            AppState.pipelineHistoryStoreFactory = { unavailableStore }
+            defer {
+                AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
+            }
+
+            let appState = await MainActor.run { AppState() }
+            let archiveSucceeded = await MainActor.run {
+                appState.archiveOldHistoryAndStartFresh()
+            }
+
+            try expect(archiveSucceeded, "explicit archive is accepted from protection mode")
+            try await waitForArchiveCompletion(appState)
+            try expect(!appState.isHistoryUnavailable, "verified fresh history leaves protection mode")
+            try expect(
+                appState.historyArchiveSafety == .unresolvedArchive,
+                "published archive keeps automatic cleanup in its safe state"
+            )
+            try expect(
+                appState.historyPersistenceWarning?.code == .historyArchived,
+                "published archive keeps a persistent recovery-folder notice"
+            )
+            try expect(appState.pipelineHistory.isEmpty, "fresh history starts with no old notes")
+
+            let recoveryDirectory = rootDirectory.appendingPathComponent("Recovery", isDirectory: true)
+            guard let snapshotDirectory = try FileManager.default.contentsOfDirectory(
+                at: recoveryDirectory,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            ).first(where: { $0.lastPathComponent.hasPrefix("history-") }) else {
+                throw TestFailure("explicit archive did not publish a recovery snapshot")
+            }
+            let payload = snapshotDirectory.appendingPathComponent("payload", isDirectory: true)
+            let archivedSQLiteBytes = try Data(
+                contentsOf: payload.appendingPathComponent("PipelineHistory.sqlite")
+            )
+            let archivedAudioBytes = try Data(
+                contentsOf: payload.appendingPathComponent("audio/archived.wav")
+            )
+            let archivedTranscriptBytes = try Data(
+                contentsOf: payload.appendingPathComponent("transcripts/archived.txt")
+            )
+            let archivedCloudJobBytes = try Data(
+                contentsOf: payload.appendingPathComponent("cloud-transcription/jobs/archived.json")
+            )
+            try expect(
+                archivedSQLiteBytes == originalSQLiteBytes,
+                "archive preserves the original unavailable SQLite bytes"
+            )
+            try expect(
+                archivedAudioBytes == Data("archived audio".utf8),
+                "archive preserves old audio outside the active generation"
+            )
+            try expect(
+                archivedTranscriptBytes == Data("archived transcript".utf8),
+                "archive preserves old transcripts outside the active generation"
+            )
+            try expect(
+                archivedCloudJobBytes == Data("archived cloud job".utf8),
+                "archive preserves old cloud jobs outside the active generation"
+            )
+
+            let freshStore = PipelineHistoryStore(storeURL: storeURL)
+            try expect(freshStore.availability == .ready, "active store is fresh and readable")
+            try expect(freshStore.loadAllHistory().isEmpty, "active store contains no archive probe records")
+            let freshItem = PipelineHistoryItem(
+                timestamp: Date(),
+                rawTranscript: "new generation",
+                postProcessedTranscript: "new generation",
+                postProcessingPrompt: nil,
+                contextSummary: "",
+                contextScreenshotDataURL: nil,
+                contextScreenshotStatus: "No screenshot",
+                postProcessingStatus: "succeeded",
+                debugStatus: "",
+                customVocabulary: ""
+            )
+            _ = try freshStore.upsert(freshItem, maxCount: Int.max)
+            AppState.pipelineHistoryStoreFactory = {
+                AppState.makeDefaultPipelineHistoryStore()
+            }
+
+            let relaunchedAppState = await MainActor.run { AppState() }
+            try expect(
+                !relaunchedAppState.isHistoryUnavailable,
+                "published archive does not turn the fresh active store into protection mode"
+            )
+            try expect(
+                relaunchedAppState.pipelineHistory.map(\.id) == [freshItem.id],
+                "published archive still loads the new active generation on restart"
+            )
+        }
+    }
+
+    private static func verifiesInterruptedArchiveKeepsHistoryProtected() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+            _ = PipelineHistoryStore(
+                storeURL: rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
+            )
+            let transactionDirectory = rootDirectory
+                .appendingPathComponent("Recovery/.transactions", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: transactionDirectory,
+                withIntermediateDirectories: true
+            )
+            try Data("corrupt interrupted archive transaction".utf8).write(
+                to: transactionDirectory.appendingPathComponent("interrupted.json")
+            )
+
+            let appState = await MainActor.run { AppState() }
+
+            try expect(
+                appState.historyArchiveSafety == .unresolvedInterruptedTransaction,
+                "unreadable transaction journal remains explicitly unresolved"
+            )
+            try expect(
+                appState.isHistoryUnavailable,
+                "unresolved archive transaction blocks history mutations even with a readable store"
+            )
+            try expect(
+                appState.historyPersistenceWarning?.code == .historyPersistenceUnavailable,
+                "unresolved archive transaction shows the protected-history warning"
+            )
+        }
+    }
+
     private static func verifiesMissingSnapshotWithUnreferencedAudioDoesNotSweep() async throws {
         try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
             let historyStore = PipelineHistoryStore(
@@ -193,7 +344,7 @@ struct AppStateStorageSafetyTests {
             try setOldModificationDate(of: audioURL)
 
             _ = await MainActor.run { AppState() }
-            try await Task.sleep(nanoseconds: 1_200_000_000)
+            try await waitForFileRemoval(at: audioURL)
             try expect(
                 !FileManager.default.fileExists(atPath: audioURL.path),
                 "matching history snapshots sweep old unreferenced audio at startup"
@@ -286,6 +437,27 @@ struct AppStateStorageSafetyTests {
             ),
             "missing history records persistent incomplete-reference evidence"
         )
+    }
+
+    private static func waitForArchiveCompletion(_ appState: AppState) async throws {
+        let deadline = Date(timeIntervalSinceNow: 6)
+        while await MainActor.run(body: { appState.isHistoryArchiveTransitioning }), Date() < deadline {
+            try await Task.sleep(nanoseconds: 25_000_000)
+        }
+        let isStillTransitioning = await MainActor.run {
+            appState.isHistoryArchiveTransitioning
+        }
+        try expect(
+            !isStillTransitioning,
+            "archive transition completes within the test timeout"
+        )
+    }
+
+    private static func waitForFileRemoval(at fileURL: URL) async throws {
+        let deadline = Date(timeIntervalSinceNow: 6)
+        while FileManager.default.fileExists(atPath: fileURL.path), Date() < deadline {
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
     }
 
     private static func setOldModificationDate(of fileURL: URL) throws {

--- a/Tests/HistoryArchiveTransitionTests.swift
+++ b/Tests/HistoryArchiveTransitionTests.swift
@@ -1,0 +1,546 @@
+import CoreData
+import Foundation
+
+@main
+struct HistoryArchiveTransitionTests {
+    static func main() throws {
+        try testArchiveMovesAnEntireGenerationAndCreatesAnEmptyDurableStore()
+        try testArchiveAcceptsMissingSQLiteCompanions()
+        try testFreshStoreProbeFailureRollsBackTheOriginalGeneration()
+        try testFirstMoveFailurePreservesTheOriginalSQLite()
+        try testMoveFailureRollsBackEveryMovedComponent()
+        try testPublishSyncFailureLeavesTransactionForSafeStartupRecovery()
+        try testInterruptedTransactionRollsBackWithoutCreatingFreshHistory()
+        try testAbandonedTransactionTempFileDoesNotBlockStartup()
+        print("HistoryArchiveTransitionTests passed")
+    }
+
+    private static func testArchiveMovesAnEntireGenerationAndCreatesAnEmptyDurableStore() throws {
+        let fixture = try HistoryArchiveFixture()
+        defer { fixture.remove() }
+
+        let archiveID = UUID(uuidString: "A3E4BA14-2F2E-4724-BFCF-1F8F1667E577")!
+        let archiveDate = Date(timeIntervalSince1970: 1_754_010_203)
+        let transition = HistoryArchiveTransition(
+            now: { archiveDate },
+            makeID: { archiveID }
+        )
+
+        let result = try transition.archiveAndCreateFreshHistory(at: fixture.rootURL)
+        let snapshotDirectory = fixture.rootURL
+            .appendingPathComponent("Recovery", isDirectory: true)
+            .appendingPathComponent(
+                "history-20250801T010323Z-\(archiveID.uuidString.lowercased())",
+                isDirectory: true
+            )
+        let payloadURL = snapshotDirectory.appendingPathComponent("payload", isDirectory: true)
+
+        try expect(result.snapshot.id == archiveID, "archive reports the published snapshot")
+        try expect(
+            FileManager.default.fileExists(atPath: snapshotDirectory.path),
+            "archive publishes a recovery snapshot"
+        )
+        try expect(
+            !FileManager.default.fileExists(atPath: fixture.audioDirectory.path),
+            "old audio generation is removed from the active root"
+        )
+        try expect(
+            !FileManager.default.fileExists(atPath: fixture.transcriptsDirectory.path),
+            "old transcript generation is removed from the active root"
+        )
+        try expect(
+            !FileManager.default.fileExists(atPath: fixture.cloudJobsDirectory.path),
+            "old cloud job generation is removed from the active root"
+        )
+        try expect(
+            try Data(contentsOf: payloadURL.appendingPathComponent("PipelineHistory.sqlite"))
+                == fixture.sqliteBytes,
+            "archive preserves the original SQLite bytes"
+        )
+        try expect(
+            try Data(contentsOf: payloadURL.appendingPathComponent("PipelineHistory.sqlite-wal"))
+                == fixture.walBytes,
+            "archive preserves the original WAL bytes"
+        )
+        try expect(
+            try Data(contentsOf: payloadURL.appendingPathComponent("PipelineHistory.sqlite-shm"))
+                == fixture.shmBytes,
+            "archive preserves the original SHM bytes"
+        )
+        try expect(
+            try Data(contentsOf: payloadURL
+                .appendingPathComponent("audio", isDirectory: true)
+                .appendingPathComponent("inflight", isDirectory: true)
+                .appendingPathComponent("recording", isDirectory: true)
+                .appendingPathComponent("manifest.json")) == fixture.inflightBytes,
+            "archive preserves inflight recording journals"
+        )
+        try expect(
+            try Data(contentsOf: payloadURL
+                .appendingPathComponent("transcripts", isDirectory: true)
+                .appendingPathComponent("note.txt")) == fixture.transcriptBytes,
+            "archive preserves transcript content outside the manifest"
+        )
+        try expect(
+            try Data(contentsOf: payloadURL
+                .appendingPathComponent("cloud-transcription/jobs", isDirectory: true)
+                .appendingPathComponent("job.json")) == fixture.cloudJobBytes,
+            "archive preserves cloud job sidecars"
+        )
+        try expect(
+            FileManager.default.fileExists(atPath: payloadURL
+                .appendingPathComponent("History Recovery", isDirectory: true)
+                .appendingPathComponent("asset-references-incomplete", isDirectory: true)
+                .path),
+            "archive preserves legacy recovery evidence"
+        )
+
+        let manifestURL = snapshotDirectory.appendingPathComponent("manifest.json")
+        let manifestData = try Data(contentsOf: manifestURL)
+        let manifest = try JSONDecoder().decode(HistoryArchiveSnapshot.self, from: manifestData)
+        try expect(manifest.id == archiveID, "manifest identifies the published archive")
+        let manifestText = String(decoding: manifestData, as: UTF8.self)
+        try expect(
+            !manifestText.contains("Transcript content must not appear in metadata"),
+            "manifest excludes transcript content"
+        )
+        try expect(
+            !manifestText.contains("Bearer secret-token"),
+            "manifest excludes cloud authorization content"
+        )
+        try expect(
+            !manifestText.contains(fixture.rootURL.path),
+            "manifest excludes absolute paths"
+        )
+
+        let freshStore = PipelineHistoryStore(storeURL: fixture.storeURL)
+        try expect(
+            freshStore.referenceTrust == .recovered,
+            "active store recognizes the published archive as unresolved history"
+        )
+        try expect(freshStore.availability == .ready, "fresh active history is readable")
+        try expect(freshStore.durability == .durable, "fresh active history is durable")
+        try expect(freshStore.loadAllHistory().isEmpty, "fresh active history has no probe records")
+    }
+
+    private static func testArchiveAcceptsMissingSQLiteCompanions() throws {
+        let fixture = try HistoryArchiveFixture(includesSQLiteCompanions: false)
+        defer { fixture.remove() }
+
+        let result = try HistoryArchiveTransition().archiveAndCreateFreshHistory(at: fixture.rootURL)
+        let componentIDs = Set(result.snapshot.components.map(\.identifier))
+        let snapshotURL = try FileManager.default.contentsOfDirectory(
+            at: result.recoveryDirectory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ).first { $0.lastPathComponent.hasPrefix("history-") }
+        guard let snapshotURL else {
+            throw HistoryArchiveTestFailure("missing published snapshot for companion test")
+        }
+        let payloadURL = snapshotURL.appendingPathComponent("payload", isDirectory: true)
+
+        try expect(
+            !componentIDs.contains(.sqliteWAL) && !componentIDs.contains(.sqliteSHM),
+            "archive omits absent SQLite companions from its manifest"
+        )
+        try expect(
+            !FileManager.default.fileExists(atPath: payloadURL
+                .appendingPathComponent("PipelineHistory.sqlite-wal").path),
+            "archive does not fabricate a missing WAL payload"
+        )
+        try expect(
+            !FileManager.default.fileExists(atPath: payloadURL
+                .appendingPathComponent("PipelineHistory.sqlite-shm").path),
+            "archive does not fabricate a missing SHM payload"
+        )
+    }
+
+    private static func testInterruptedTransactionRollsBackWithoutCreatingFreshHistory() throws {
+        let fixture = try HistoryArchiveFixture()
+        defer { fixture.remove() }
+
+        let transactionID = UUID(uuidString: "730D385C-4EF4-4541-868B-18CA6D7B6F87")!
+        let recoveryDirectory = fixture.rootURL.appendingPathComponent("Recovery", isDirectory: true)
+        let stagingName = ".staging-\(transactionID.uuidString.lowercased())"
+        let stagingPayload = recoveryDirectory
+            .appendingPathComponent(stagingName, isDirectory: true)
+            .appendingPathComponent("payload", isDirectory: true)
+        try FileManager.default.createDirectory(at: stagingPayload, withIntermediateDirectories: true)
+        try fixture.sqliteBytes.write(to: stagingPayload.appendingPathComponent("PipelineHistory.sqlite"))
+        try Data("fresh history that must be removed".utf8).write(to: fixture.storeURL)
+
+        var transaction = HistoryArchiveTransaction(
+            id: transactionID,
+            createdAt: Date(timeIntervalSince1970: 1_754_010_203),
+            stagingDirectoryName: stagingName,
+            snapshotDirectoryName: "history-20250801T010323Z-\(transactionID.uuidString.lowercased())",
+            components: [
+                HistoryArchiveTransactionComponent(
+                    identifier: .sqlite,
+                    relativePath: "PipelineHistory.sqlite",
+                    byteCount: UInt64(fixture.sqliteBytes.count),
+                    isDirectory: false,
+                    state: .moved
+                )
+            ]
+        )
+        transaction.phase = .probingFreshHistory
+        let transactionDirectory = recoveryDirectory
+            .appendingPathComponent(".transactions", isDirectory: true)
+        try FileManager.default.createDirectory(at: transactionDirectory, withIntermediateDirectories: true)
+        try JSONEncoder().encode(transaction).write(
+            to: transactionDirectory.appendingPathComponent("\(transactionID.uuidString.lowercased()).json")
+        )
+
+        let safety = HistoryArchiveTransition.rollbackInterruptedTransactions(at: fixture.rootURL)
+
+        try expect(safety == .normal, "completed rollback restores normal archive safety")
+        try expect(
+            try Data(contentsOf: fixture.storeURL) == fixture.sqliteBytes,
+            "interrupted transaction restores the original SQLite bytes"
+        )
+        try expect(
+            !FileManager.default.fileExists(atPath: recoveryDirectory
+                .appendingPathComponent(stagingName, isDirectory: true)
+                .path),
+            "interrupted transaction removes only its staging directory"
+        )
+        try expect(
+            !FileManager.default.fileExists(atPath: recoveryDirectory
+                .appendingPathComponent("history-20250801T010323Z-\(transactionID.uuidString.lowercased())", isDirectory: true)
+                .path),
+            "interrupted transaction does not publish or complete a fresh archive"
+        )
+    }
+
+    private static func testAbandonedTransactionTempFileDoesNotBlockStartup() throws {
+        let fixture = try HistoryArchiveFixture()
+        defer { fixture.remove() }
+        let temporaryJournalURL = fixture.rootURL
+            .appendingPathComponent("Recovery/.transactions/.journal.partial.tmp")
+        try FileManager.default.createDirectory(
+            at: temporaryJournalURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("partial transaction journal".utf8).write(to: temporaryJournalURL)
+
+        let safety = HistoryArchiveTransition.rollbackInterruptedTransactions(at: fixture.rootURL)
+
+        try expect(safety == .normal, "abandoned transaction temp file does not block startup")
+        try expect(
+            !FileManager.default.fileExists(atPath: temporaryJournalURL.path),
+            "startup removes only the abandoned transaction temp file"
+        )
+    }
+
+    private static func testPublishSyncFailureLeavesTransactionForSafeStartupRecovery() throws {
+        let fixture = try HistoryArchiveFixture()
+        defer { fixture.remove() }
+        let archiveID = UUID(uuidString: "53A097CE-5A71-4A64-9B9E-A5B9B93DF9DE")!
+        let archiveDate = Date(timeIntervalSince1970: 1_754_010_203)
+        let recoveryDirectory = fixture.rootURL.appendingPathComponent("Recovery", isDirectory: true)
+        let transition = HistoryArchiveTransition(
+            now: { archiveDate },
+            makeID: { archiveID },
+            syncDirectory: { directory in
+                let publishedSnapshotExists = ((try? FileManager.default.contentsOfDirectory(
+                    atPath: recoveryDirectory.path
+                )) ?? []).contains(where: { $0.hasPrefix("history-") })
+                if directory == recoveryDirectory, publishedSnapshotExists {
+                    throw NSError(
+                        domain: "HistoryArchiveTransitionTests",
+                        code: 3,
+                        userInfo: nil
+                    )
+                }
+            }
+        )
+
+        do {
+            _ = try transition.archiveAndCreateFreshHistory(at: fixture.rootURL)
+            throw HistoryArchiveTestFailure("publish sync failure must not report archive success")
+        } catch is HistoryArchiveTestFailure {
+            throw HistoryArchiveTestFailure("publish sync failure unexpectedly reported archive success")
+        } catch {
+            // expected: the snapshot cannot be considered published until its directory sync succeeds.
+        }
+
+        let snapshotDirectory = recoveryDirectory.appendingPathComponent(
+            "history-20250801T010323Z-\(archiveID.uuidString.lowercased())",
+            isDirectory: true
+        )
+        let transactionURL = recoveryDirectory
+            .appendingPathComponent(".transactions", isDirectory: true)
+            .appendingPathComponent("\(archiveID.uuidString.lowercased()).json")
+        try expect(
+            FileManager.default.fileExists(atPath: snapshotDirectory.path),
+            "publish sync failure retains the snapshot payload for a safe later decision"
+        )
+        try expect(
+            FileManager.default.fileExists(atPath: transactionURL.path),
+            "publish sync failure retains the rollback journal until snapshot publication is durable"
+        )
+        try expect(
+            try Data(contentsOf: snapshotDirectory
+                .appendingPathComponent("payload/PipelineHistory.sqlite")) == fixture.sqliteBytes,
+            "publish sync failure preserves original SQLite in the retained snapshot"
+        )
+        try expect(
+            FileManager.default.fileExists(atPath: fixture.storeURL.path),
+            "publish sync failure preserves the verified fresh active store"
+        )
+
+        let unsyncedStartupSafety = transition.rollbackInterruptedTransactions(
+            at: fixture.rootURL
+        )
+        try expect(
+            unsyncedStartupSafety == .unresolvedInterruptedTransaction,
+            "startup keeps the journal when it cannot make a visible snapshot durable"
+        )
+        try expect(
+            FileManager.default.fileExists(atPath: transactionURL.path),
+            "startup does not remove the journal before the recovery directory sync succeeds"
+        )
+
+        let startupSafety = HistoryArchiveTransition.rollbackInterruptedTransactions(
+            at: fixture.rootURL
+        )
+        try expect(
+            startupSafety == .unresolvedArchive,
+            "a retained published snapshot becomes an archive notice after safe startup cleanup"
+        )
+        try expect(
+            !FileManager.default.fileExists(atPath: transactionURL.path),
+            "startup clears the journal only after it syncs the published snapshot"
+        )
+    }
+
+    private static func testFirstMoveFailurePreservesTheOriginalSQLite() throws {
+        let fixture = try HistoryArchiveFixture()
+        defer { fixture.remove() }
+        let transition = HistoryArchiveTransition(
+            moveItem: { _, _, _ in
+                throw NSError(
+                    domain: "HistoryArchiveTransitionTests",
+                    code: 4,
+                    userInfo: nil
+                )
+            }
+        )
+
+        do {
+            _ = try transition.archiveAndCreateFreshHistory(at: fixture.rootURL)
+            throw HistoryArchiveTestFailure("first move failure must fail the archive")
+        } catch is HistoryArchiveTestFailure {
+            throw HistoryArchiveTestFailure("first move failure unexpectedly succeeded")
+        } catch {
+            // expected
+        }
+
+        try expect(
+            try Data(contentsOf: fixture.storeURL) == fixture.sqliteBytes,
+            "first move failure preserves the original SQLite bytes"
+        )
+        let recoveryDirectory = fixture.rootURL.appendingPathComponent("Recovery", isDirectory: true)
+        let recoveryEntries = (try? FileManager.default.contentsOfDirectory(
+            atPath: recoveryDirectory.path
+        )) ?? []
+        try expect(
+            !recoveryEntries.contains(where: { $0.hasPrefix("history-") }),
+            "first move failure does not publish an archive"
+        )
+    }
+
+    private static func testMoveFailureRollsBackEveryMovedComponent() throws {
+        let fixture = try HistoryArchiveFixture()
+        defer { fixture.remove() }
+        var moveCount = 0
+        let transition = HistoryArchiveTransition(
+            moveItem: { fileManager, sourceURL, destinationURL in
+                moveCount += 1
+                if moveCount == 5 {
+                    throw NSError(
+                        domain: "HistoryArchiveTransitionTests",
+                        code: 2,
+                        userInfo: nil
+                    )
+                }
+                try fileManager.moveItem(at: sourceURL, to: destinationURL)
+            }
+        )
+
+        do {
+            _ = try transition.archiveAndCreateFreshHistory(at: fixture.rootURL)
+            throw HistoryArchiveTestFailure("move failure must fail the archive")
+        } catch is HistoryArchiveTestFailure {
+            throw HistoryArchiveTestFailure("move failure unexpectedly succeeded")
+        } catch {
+            // expected
+        }
+
+        try expect(
+            try Data(contentsOf: fixture.storeURL) == fixture.sqliteBytes,
+            "move failure restores SQLite after prior moves"
+        )
+        try expect(
+            try Data(contentsOf: fixture.audioDirectory.appendingPathComponent("recording.wav"))
+                == Data("audio".utf8),
+            "move failure leaves audio at the canonical root"
+        )
+        try expect(
+            try Data(contentsOf: fixture.transcriptsDirectory.appendingPathComponent("note.txt"))
+                == fixture.transcriptBytes,
+            "move failure leaves transcripts at the canonical root"
+        )
+        let recoveryDirectory = fixture.rootURL.appendingPathComponent("Recovery", isDirectory: true)
+        let recoveryEntries = (try? FileManager.default.contentsOfDirectory(atPath: recoveryDirectory.path)) ?? []
+        try expect(
+            !recoveryEntries.contains(where: { $0.hasPrefix("history-") }),
+            "move failure never publishes a recovery snapshot"
+        )
+    }
+
+    private static func testFreshStoreProbeFailureRollsBackTheOriginalGeneration() throws {
+        let fixture = try HistoryArchiveFixture()
+        defer { fixture.remove() }
+
+        let transition = HistoryArchiveTransition(
+            makeStore: { storeURL in
+                PipelineHistoryStore(
+                    storeURL: storeURL,
+                    persistentStoreLoader: { _ in
+                        NSError(
+                            domain: "HistoryArchiveTransitionTests",
+                            code: 1,
+                            userInfo: nil
+                        )
+                    }
+                )
+            }
+        )
+
+        do {
+            _ = try transition.archiveAndCreateFreshHistory(at: fixture.rootURL)
+            throw HistoryArchiveTestFailure("fresh store probe failure must fail the archive")
+        } catch is HistoryArchiveTestFailure {
+            throw HistoryArchiveTestFailure("fresh store probe failure unexpectedly succeeded")
+        } catch {
+            // expected
+        }
+
+        try expect(
+            try Data(contentsOf: fixture.storeURL) == fixture.sqliteBytes,
+            "probe failure restores original SQLite bytes"
+        )
+        try expect(
+            try Data(contentsOf: URL(fileURLWithPath: fixture.storeURL.path + "-wal"))
+                == fixture.walBytes,
+            "probe failure restores original WAL bytes"
+        )
+        try expect(
+            try Data(contentsOf: URL(fileURLWithPath: fixture.storeURL.path + "-shm"))
+                == fixture.shmBytes,
+            "probe failure restores original SHM bytes"
+        )
+        try expect(
+            try Data(contentsOf: fixture.audioDirectory.appendingPathComponent("recording.wav"))
+                == Data("audio".utf8),
+            "probe failure restores audio"
+        )
+        try expect(
+            try Data(contentsOf: fixture.transcriptsDirectory.appendingPathComponent("note.txt"))
+                == fixture.transcriptBytes,
+            "probe failure restores transcripts"
+        )
+        try expect(
+            try Data(contentsOf: fixture.cloudJobsDirectory.appendingPathComponent("job.json"))
+                == fixture.cloudJobBytes,
+            "probe failure restores cloud sidecars"
+        )
+        try expect(
+            FileManager.default.fileExists(atPath: fixture.rootURL
+                .appendingPathComponent("History Recovery/asset-references-incomplete", isDirectory: true)
+                .path),
+            "probe failure restores legacy recovery evidence"
+        )
+        let recoveryDirectory = fixture.rootURL.appendingPathComponent("Recovery", isDirectory: true)
+        let recoveryEntries = (try? FileManager.default.contentsOfDirectory(atPath: recoveryDirectory.path)) ?? []
+        try expect(
+            !recoveryEntries.contains(where: { $0.hasPrefix("history-") }),
+            "probe failure never publishes a partial archive"
+        )
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () throws -> Bool,
+        _ label: String
+    ) throws {
+        guard try condition() else { throw HistoryArchiveTestFailure(label) }
+    }
+}
+
+private final class HistoryArchiveFixture {
+    let rootURL: URL
+    let storeURL: URL
+    let audioDirectory: URL
+    let transcriptsDirectory: URL
+    let cloudJobsDirectory: URL
+    let sqliteBytes = Data("unreadable sqlite source".utf8)
+    let walBytes = Data("unreadable wal source".utf8)
+    let shmBytes = Data("unreadable shm source".utf8)
+    let inflightBytes = Data("inflight journal".utf8)
+    let transcriptBytes = Data("Transcript content must not appear in metadata".utf8)
+    let cloudJobBytes = Data("Bearer secret-token".utf8)
+
+    init(includesSQLiteCompanions: Bool = true) throws {
+        rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        storeURL = rootURL.appendingPathComponent("PipelineHistory.sqlite")
+        audioDirectory = rootURL.appendingPathComponent("audio", isDirectory: true)
+        transcriptsDirectory = rootURL.appendingPathComponent("transcripts", isDirectory: true)
+        cloudJobsDirectory = rootURL
+            .appendingPathComponent("cloud-transcription/jobs", isDirectory: true)
+
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        try sqliteBytes.write(to: storeURL)
+        if includesSQLiteCompanions {
+            try walBytes.write(to: URL(fileURLWithPath: storeURL.path + "-wal"))
+            try shmBytes.write(to: URL(fileURLWithPath: storeURL.path + "-shm"))
+        }
+        try Data("{\"audioFileNames\":[],\"transcriptFileNames\":[]}".utf8).write(
+            to: rootURL.appendingPathComponent("PipelineHistory-asset-references.json")
+        )
+        try fileManager.createDirectory(
+            at: audioDirectory
+                .appendingPathComponent("inflight/recording", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try Data("audio".utf8).write(to: audioDirectory.appendingPathComponent("recording.wav"))
+        try inflightBytes.write(
+            to: audioDirectory
+                .appendingPathComponent("inflight/recording/manifest.json")
+        )
+        try fileManager.createDirectory(at: transcriptsDirectory, withIntermediateDirectories: true)
+        try transcriptBytes.write(to: transcriptsDirectory.appendingPathComponent("note.txt"))
+        try fileManager.createDirectory(at: cloudJobsDirectory, withIntermediateDirectories: true)
+        try cloudJobBytes.write(to: cloudJobsDirectory.appendingPathComponent("job.json"))
+        try fileManager.createDirectory(
+            at: rootURL
+                .appendingPathComponent("History Recovery/asset-references-incomplete", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: rootURL)
+    }
+}
+
+private struct HistoryArchiveTestFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/Tests/HistoryArchiveTransitionTests.swift
+++ b/Tests/HistoryArchiveTransitionTests.swift
@@ -99,6 +99,14 @@ struct HistoryArchiveTransitionTests {
         let manifestData = try Data(contentsOf: manifestURL)
         let manifest = try JSONDecoder().decode(HistoryArchiveSnapshot.self, from: manifestData)
         try expect(manifest.id == archiveID, "manifest identifies the published archive")
+        let expectedAudioByteCount = UInt64(
+            Data("audio".utf8).count + fixture.inflightBytes.count
+        )
+        try expect(
+            manifest.components.first(where: { $0.identifier == .audio })?.byteCount
+                == expectedAudioByteCount,
+            "manifest recursively records every archived audio byte"
+        )
         let manifestText = String(decoding: manifestData, as: UTF8.self)
         try expect(
             !manifestText.contains("Transcript content must not appear in metadata"),

--- a/Tests/PipelineHistoryStoreRecoveryTests.swift
+++ b/Tests/PipelineHistoryStoreRecoveryTests.swift
@@ -12,6 +12,7 @@ struct PipelineHistoryStoreRecoveryTests {
         try testPublishedArchiveLowersReferenceTrust()
         try testUnfinishedArchiveTransactionDisablesReferenceCleanup()
         try testArchivePreparationDetachesReadFailedStoreWithoutMutatingCanonicalFiles()
+        try testArchiveVerificationDetachesReadyStoreWithoutMutatingCanonicalFiles()
         try testUnavailableStorePreservesDatabaseComponentsAndRejectsMutations()
         try testReadFailureEntersProtectionMode()
         try testReadabilityProbeUsesBoundedFetch()
@@ -145,7 +146,7 @@ struct PipelineHistoryStoreRecoveryTests {
             withIntermediateDirectories: true
         )
         let manifest = try JSONSerialization.data(withJSONObject: [
-            "schemaVersion": 1,
+            "schemaVersion": HistoryArchiveSnapshot.currentSchemaVersion,
             "id": archiveID.uuidString,
             "archivedAt": 1_754_010_203,
             "components": []
@@ -197,6 +198,20 @@ struct PipelineHistoryStoreRecoveryTests {
         try expect(
             try Data(contentsOf: fixture.storeURL) == originalBytes,
             "archive preparation does not modify the canonical SQLite file"
+        )
+    }
+
+    private static func testArchiveVerificationDetachesReadyStoreWithoutMutatingCanonicalFiles() throws {
+        let fixture = try PersistentStoreFixture()
+        defer { fixture.remove() }
+        let store = PipelineHistoryStore(storeURL: fixture.storeURL)
+        let originalBytes = try Data(contentsOf: fixture.storeURL)
+
+        try store.detachForArchiveVerification()
+
+        try expect(
+            try Data(contentsOf: fixture.storeURL) == originalBytes,
+            "archive verification detaches a ready store without rewriting canonical SQLite"
         )
     }
 

--- a/Tests/PipelineHistoryStoreRecoveryTests.swift
+++ b/Tests/PipelineHistoryStoreRecoveryTests.swift
@@ -9,6 +9,9 @@ struct PipelineHistoryStoreRecoveryTests {
         try testMetadataOnlyUpdateDoesNotRewriteAssetSnapshot()
         try testSnapshotSynchronizationFetchesOnlyAssetFileNames()
         try testApplicationSupportDirectoryHasDeterministicFallback()
+        try testPublishedArchiveLowersReferenceTrust()
+        try testUnfinishedArchiveTransactionDisablesReferenceCleanup()
+        try testArchivePreparationDetachesReadFailedStoreWithoutMutatingCanonicalFiles()
         try testUnavailableStorePreservesDatabaseComponentsAndRejectsMutations()
         try testReadFailureEntersProtectionMode()
         try testReadabilityProbeUsesBoundedFetch()
@@ -122,6 +125,78 @@ struct PipelineHistoryStoreRecoveryTests {
             source.contains(".first ?? URL(fileURLWithPath: NSHomeDirectory())")
                 && source.contains(".appendingPathComponent(\"Library/Application Support\", isDirectory: true)"),
             "Application Support lookup falls back without force-unwrapping"
+        )
+    }
+
+    private static func testPublishedArchiveLowersReferenceTrust() throws {
+        let fixture = try PersistentStoreFixture()
+        defer { fixture.remove() }
+        _ = PipelineHistoryStore(storeURL: fixture.storeURL)
+
+        let archiveID = UUID(uuidString: "56B46A6B-8EF0-4BB6-AC13-5A4653133F1D")!
+        let snapshotDirectory = fixture.directoryURL
+            .appendingPathComponent("Recovery", isDirectory: true)
+            .appendingPathComponent(
+                "history-20250801T010323Z-\(archiveID.uuidString.lowercased())",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: snapshotDirectory.appendingPathComponent("payload", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        let manifest = try JSONSerialization.data(withJSONObject: [
+            "schemaVersion": 1,
+            "id": archiveID.uuidString,
+            "archivedAt": 1_754_010_203,
+            "components": []
+        ])
+        try manifest.write(to: snapshotDirectory.appendingPathComponent("manifest.json"))
+
+        let reopened = PipelineHistoryStore(storeURL: fixture.storeURL)
+        try expect(
+            reopened.referenceTrust == .recovered,
+            "published archive blocks automatic cleanup for the active history"
+        )
+    }
+
+    private static func testUnfinishedArchiveTransactionDisablesReferenceCleanup() throws {
+        let fixture = try PersistentStoreFixture()
+        defer { fixture.remove() }
+        _ = PipelineHistoryStore(storeURL: fixture.storeURL)
+
+        let transactionDirectory = fixture.directoryURL
+            .appendingPathComponent("Recovery/.transactions", isDirectory: true)
+        try FileManager.default.createDirectory(at: transactionDirectory, withIntermediateDirectories: true)
+        try Data("incomplete archive journal".utf8).write(
+            to: transactionDirectory.appendingPathComponent("unfinished.json")
+        )
+
+        let reopened = PipelineHistoryStore(storeURL: fixture.storeURL)
+        try expect(
+            reopened.referenceTrust == .unavailable,
+            "unfinished archive transaction never permits automatic cleanup"
+        )
+    }
+
+    private static func testArchivePreparationDetachesReadFailedStoreWithoutMutatingCanonicalFiles() throws {
+        let fixture = try PersistentStoreFixture()
+        defer { fixture.remove() }
+        _ = PipelineHistoryStore(storeURL: fixture.storeURL)
+        let originalBytes = try Data(contentsOf: fixture.storeURL)
+        let store = PipelineHistoryStore(
+            storeURL: fixture.storeURL,
+            historyFetcher: { _, _ in
+                throw RecoveryTestFailure("Injected read failure before archive preparation")
+            }
+        )
+        _ = store.loadAllHistory()
+        try expect(store.availability == .unavailable, "read failure enters protection mode")
+
+        try store.detachForHistoryArchive()
+
+        try expect(
+            try Data(contentsOf: fixture.storeURL) == originalBytes,
+            "archive preparation does not modify the canonical SQLite file"
         )
     }
 

--- a/Tests/QuillUserIssueTests.swift
+++ b/Tests/QuillUserIssueTests.swift
@@ -7,6 +7,7 @@ struct QuillUserIssueTests {
         try testEveryCodeHasCompleteEnglishAndKoreanPresentation(bundle: bundle)
         try testSeverityAndRecoveryActions()
         try testHistoryUnavailablePresentation(bundle: bundle)
+        try testHistoryArchivedPresentation(bundle: bundle)
         try testVersionedPersistenceRoundTripAndRejection()
         try testPersistedPayloadExcludesPrivateDiagnostics()
         try testLocalIssueUsesBoundedDiagnosticCategoryAndExcerpt()
@@ -51,7 +52,8 @@ struct QuillUserIssueTests {
             .meetingSummaryUnavailable,
             .meetingSummaryInvalidResponse,
             .historyPersistenceUnavailable,
-            .historyRecovered
+            .historyRecovered,
+            .historyArchived
         ]
 
         for code in QuillUserIssueCode.allCases {
@@ -158,6 +160,31 @@ struct QuillUserIssueTests {
         try expect(
             korean.body == "노트와 오디오 파일은 삭제되지 않았습니다. Quill을 다시 시작해 재시도하거나 데이터 폴더를 열어 지원 및 복구에 사용할 수 있습니다.",
             "history-unavailable Korean body confirms asset preservation"
+        )
+    }
+
+    private static func testHistoryArchivedPresentation(bundle: Bundle) throws {
+        let record = QuillUserIssueRecord(code: .historyArchived)
+        let english = record.presentation(language: "en", bundle: bundle)
+        let korean = record.presentation(language: "ko", bundle: bundle)
+
+        try expect(record.severity == .warning, "archived history is an informational warning")
+        try expect(record.recoveryAction == .none, "archived history has no automatic recovery action")
+        try expect(
+            english.title == "Old history was archived",
+            "archived-history English title distinguishes archive from restore"
+        )
+        try expect(
+            english.body == "New history is saving separately. Restore, import, and merge are not available yet.",
+            "archived-history English body states the #243 boundary"
+        )
+        try expect(
+            korean.title == "이전 기록을 보관함",
+            "archived-history Korean title is localized"
+        )
+        try expect(
+            korean.body == "새 기록은 별도로 저장 중입니다. 복원, 가져오기, 병합은 아직 제공되지 않습니다.",
+            "archived-history Korean body states the #243 boundary"
         )
     }
 

--- a/Tests/QuillUserIssueUIContractTests.swift
+++ b/Tests/QuillUserIssueUIContractTests.swift
@@ -9,6 +9,7 @@ struct QuillUserIssueUIContractTests {
         let settings = try source("Sources/SettingsView.swift")
         let menuBar = try source("Sources/MenuBarView.swift")
         let appState = try source("Sources/AppState.swift")
+        let historyRecovery = try source("Sources/HistoryRecoveryView.swift")
 
         try testSharedRenderer(issueView)
         try testNoteBrowserUsesStructuredErrorAndWarningUI(noteBrowser)
@@ -18,11 +19,12 @@ struct QuillUserIssueUIContractTests {
         try testRunLogSanitizesMachineStatuses(settings)
         try testRecoveryActionsUseExistingRoutes(noteBrowser, appState)
         try testDismissibleBannerScopedToWarningStyle(issueView, noteBrowser, appState)
-        try testHistoryUnavailableProtectionIsVisibleAndDoesNotExposeRecoveryPaths(
+        try testHistoryUnavailableProtectionAndArchiveNotice(
             noteBrowser,
             settings,
             menuBar,
-            appState
+            appState,
+            historyRecovery
         )
         print("QuillUserIssueUIContractTests passed")
     }
@@ -224,41 +226,69 @@ struct QuillUserIssueUIContractTests {
         )
     }
 
-    private static func testHistoryUnavailableProtectionIsVisibleAndDoesNotExposeRecoveryPaths(
+    private static func testHistoryUnavailableProtectionAndArchiveNotice(
         _ noteBrowser: String,
         _ settings: String,
         _ menuBar: String,
-        _ appState: String
+        _ appState: String,
+        _ historyRecovery: String
     ) throws {
         try expect(
             appState.contains("@Published private(set) var isHistoryUnavailable = false"),
             "AppState publishes an explicit history-unavailable state"
         )
         try expect(
-            appState.contains(".historyPersistenceUnavailable"),
-            "AppState uses the structured unavailable-history issue"
+            appState.contains("func archiveOldHistoryAndStartFresh() -> Bool")
+                && appState.contains("func openHistoryRecoveryFolder()"),
+            "AppState exposes explicit archive and recovery-folder actions"
+        )
+        try expect(
+            appState.contains(".historyArchived"),
+            "AppState publishes a persistent archived-history notice"
         )
         for source in [noteBrowser, settings, menuBar] {
             try expect(
                 source.contains("appState.isHistoryUnavailable"),
                 "every history surface renders the protected state"
             )
-            try expect(source.contains("Open Data Folder"), "protected state opens the data folder")
-            try expect(source.contains("Quit Quill"), "protected state provides a safe quit action")
+            try expect(
+                source.contains("HistoryUnavailableRecoveryActions"),
+                "every protected history surface uses shared archive actions"
+            )
+            try expect(
+                source.contains("HistoryArchiveNoticeView"),
+                "every history surface renders the persistent archive notice"
+            )
         }
         try expect(
-            menuBar.contains(".disabled(appState.isTranscribing || appState.isHistoryUnavailable)"),
+            menuBar.contains(".disabled(appState.isTranscribing || appState.isHistoryUnavailable"),
             "Menu Bar disables recording while history is unavailable"
         )
         try expect(
             noteBrowser.contains("if appState.isHistoryUnavailable"),
             "Note Browser checks protected state before normal empty history"
         )
-        for source in [noteBrowser, settings, menuBar] {
-            try expect(!source.contains("backupName"), "protected UI never exposes a backup name")
-            try expect(!source.contains("History Recovery"), "protected UI never exposes a recovery path")
-            try expect(!source.contains("start fresh"), "protected UI never offers a replacement history")
+        for marker in [
+            "Archive Old History and Start Fresh…",
+            "Archive and Start Fresh",
+            "Open Data Folder",
+            "Open Recovery Folder",
+            ".confirmationDialog(",
+            "role: .destructive",
+            "appState.archiveOldHistoryAndStartFresh()"
+        ] {
+            try expect(historyRecovery.contains(marker), "shared recovery UI contains \(marker)")
         }
+        try expect(
+            !historyRecovery.contains("Button(\"Restore")
+                && !historyRecovery.contains("Button(\"Import")
+                && !historyRecovery.contains("Button(\"Merge"),
+            "#242 recovery UI does not expose #243 restore, import, or merge actions"
+        )
+        try expect(
+            !historyRecovery.contains("backupName") && !historyRecovery.contains("History Recovery"),
+            "recovery UI does not expose internal backup names or legacy paths"
+        )
     }
 
     private static func source(_ path: String) throws -> String {

--- a/Tests/QuillUserIssueUIContractTests.swift
+++ b/Tests/QuillUserIssueUIContractTests.swift
@@ -264,6 +264,12 @@ struct QuillUserIssueUIContractTests {
             menuBar.contains(".disabled(appState.isTranscribing || appState.isHistoryUnavailable"),
             "Menu Bar disables recording while history is unavailable"
         )
+        for source in [noteBrowser, settings] {
+            try expect(
+                source.contains("if appState.historyArchiveSafety == .unresolvedArchive {\n                        HistoryArchiveNoticeView()"),
+                "archive notice padding renders only when an archive notice is visible"
+            )
+        }
         try expect(
             noteBrowser.contains("if appState.isHistoryUnavailable"),
             "Note Browser checks protected state before normal empty history"


### PR DESCRIPTION
## Summary
- Add an explicit, confirmed archive flow for unavailable history generations.
- Preserve SQLite, assets, transcripts, cloud sidecars, and recovery evidence in a durable recovery snapshot before creating a probed fresh history.
- Keep recovery journals until snapshot publication is durable, and block archive while recording, import, cloud, journal-finalization, or permission-resumption writers are active.
- Add protected-state archive actions, persistent recovery-folder notice, and English/Korean copy without adding restore, import, or merge.

## Testing
- `make test`
- `make all CODESIGN_IDENTITY=Quill`
- `make localization-bundle-test CODESIGN_IDENTITY=Quill`
- `env -u CFFIXED_USER_HOME -u TMPDIR build/tests/FullSourceAppStateTestRunner`
- `QUILL_APP_STATE_TEST_ISOLATED=1 env -u CFFIXED_USER_HOME -u TMPDIR build/tests/FullSourceAppStateTestRunner`
- Clean-copy `codesign --verify --deep --strict`
- Manual: isolated Quill Dev protection-state UI with a deliberately unreadable test history

Fixes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 기존 기록을 안전하게 보관하고 새 기록으로 시작할 수 있습니다.
  * 보관 진행 상태와 완료 안내, 기록 복구 안내를 확인할 수 있습니다.
  * 기록을 사용할 수 없거나 보관 상태를 해결할 수 없는 경우 복구 폴더를 열 수 있습니다.
  * 보관 중에는 녹음·가져오기 등 기록 변경 작업이 보호됩니다.
  * 보관된 기록과 복구 제한을 안내하는 영어·한국어 메시지가 추가되었습니다.

* **버그 수정**
  * 중단된 보관 작업을 감지해 기록 손상과 잘못된 자동 복구를 방지합니다.
  * 보관 실패 시 기존 기록과 새 저장소를 안전하게 복원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->