### PR TITLE
Merge Freeflow Settings updates

### DIFF
--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -9989,6 +9989,22 @@
         }
       }
     },
+    "Used for context inference, with a text-only retry when screenshot analysis fails. Screenshot analysis requires a model that accepts image input.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Used for context inference, with a text-only retry when screenshot analysis fails. Screenshot analysis requires a model that accepts image input."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "컨텍스트 추론에 사용하며, 스크린샷 분석에 실패하면 텍스트 전용으로 다시 시도합니다. 스크린샷 분석에는 이미지 입력을 지원하는 모델이 필요합니다."
+          }
+        }
+      }
+    },
     "Post-Processing Fallback Model": {
       "localizations": {
         "en": {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2463,6 +2463,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private var contextService: AppContextService
+    private var settingsDraftCommits: [UUID: () -> Void] = [:]
     private var contextCaptureTask: Task<AppContext?, Never>?
     private var capturedContext: AppContext?
     private var googleCalendarConnectionTask: Task<Void, Never>?
@@ -8558,6 +8559,24 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
+    func registerSettingsDraftCommit(_ commit: @escaping () -> Void) -> UUID {
+        let registrationID = UUID()
+        settingsDraftCommits[registrationID] = commit
+        return registrationID
+    }
+
+    @MainActor
+    func unregisterSettingsDraftCommit(_ registrationID: UUID) {
+        settingsDraftCommits[registrationID] = nil
+    }
+
+    @MainActor
+    func commitSettingsDraftsBeforeRecordingStart() {
+        let commits = Array(settingsDraftCommits.values)
+        commits.forEach { $0() }
+    }
+
+    @MainActor
     func toggleRecording() {
         os_log(.info, log: recordingLog, "toggleRecording() called, isRecording=%{public}d", isRecording)
         cancelPendingShortcutStart()
@@ -8973,9 +8992,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @MainActor
     private func startRecording(triggerMode: RecordingTriggerMode, onStarted: (@MainActor () -> Void)? = nil) {
         guard requireAvailableHistoryForMutation() else { return }
+        guard !isRecording else { return }
+        commitSettingsDraftsBeforeRecordingStart()
         let t0 = CFAbsoluteTimeGetCurrent()
         os_log(.info, log: recordingLog, "startRecording() entered")
-        guard !isRecording else { return }
 
         // 전사 중이면 기존 transcribing overlay/indicator를 정리하고 소유권만 넘긴다.
         if isTranscribing {

--- a/Sources/ModelConfiguration.swift
+++ b/Sources/ModelConfiguration.swift
@@ -13,13 +13,15 @@ public struct ModelConfiguration {
         "openai/gpt-oss-120b",
         "openai/gpt-oss-safeguard-20b",
         "qwen/qwen3.6-27b",
-        "allam-2-7b",
         "groq/compound",
-        "groq/compound-mini",
-        "canopylabs/orpheus-arabic-saudi",
-        "canopylabs/orpheus-v1-english",
-        "meta-llama/llama-prompt-guard-2-22m",
-        "meta-llama/llama-prompt-guard-2-86m"
+        "groq/compound-mini"
+    ]
+
+    // MARK: - Vision-capable models
+
+    /// Models that accept image input. The context model must support vision for screenshot analysis to work.
+    public static let visionModels = [
+        "qwen/qwen3.6-27b"
     ]
 
     public static let transcriptionModels = [
@@ -59,7 +61,7 @@ public struct ModelConfiguration {
                 shouldStripThinkTags: false
             )
         } else if cleanModel == "qwen/qwen3-32b" {
- // Model that requires sanitization of thought tags
+            // Model that requires sanitization of thought tags
             return ModelConfig(
                 maxCompletionTokens: nil,
                 reasoningEffort: nil,
@@ -159,7 +161,7 @@ public struct ModelConfiguration {
             )
         }
         
-        // Fallback genérico para qualquer outro modelo que não esteja na lista acima
+        // Generic fallback for any model not explicitly listed above
         return ModelConfig(
             maxCompletionTokens: nil,
             reasoningEffort: nil,

--- a/Sources/ModelConfiguration.swift
+++ b/Sources/ModelConfiguration.swift
@@ -17,13 +17,15 @@ public struct ModelConfiguration {
         "openai/gpt-oss-safeguard-20b",
         "qwen/qwen3-32b",
         "qwen/qwen3.6-27b",
-        "allam-2-7b",
         "groq/compound",
-        "groq/compound-mini",
-        "canopylabs/orpheus-arabic-saudi",
-        "canopylabs/orpheus-v1-english",
-        "meta-llama/llama-prompt-guard-2-22m",
-        "meta-llama/llama-prompt-guard-2-86m"
+        "groq/compound-mini"
+    ]
+
+    // MARK: - Vision-capable models
+
+    /// Models that accept image input. The context model must support vision for screenshot analysis to work.
+    public static let visionModels = [
+        "qwen/qwen3.6-27b"
     ]
 
     static func capabilities(for modelID: String) -> AIModelCapabilities {
@@ -60,7 +62,7 @@ public struct ModelConfiguration {
                 shouldStripThinkTags: false
             )
         } else if cleanModel == "qwen/qwen3-32b" {
- // Model that requires sanitization of thought tags
+            // Model that requires sanitization of thought tags
             return ModelConfig(
                 maxCompletionTokens: nil,
                 reasoningEffort: nil,
@@ -160,7 +162,7 @@ public struct ModelConfiguration {
             )
         }
         
-        // Fallback genérico para qualquer outro modelo que não esteja na lista acima
+        // Generic fallback for any model not explicitly listed above
         return ModelConfig(
             maxCompletionTokens: nil,
             reasoningEffort: nil,

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -544,6 +544,7 @@ struct GeneralSettingsView: View {
     @State private var keyValidationError: String?
     @State private var keyValidationSuccess = false
     @State private var customVocabularyInput: String = ""
+    @FocusState private var customVocabularyFocused: Bool
     @State private var micPermissionGranted = false
     @State private var showMutedHint = false
     @State private var copiedBuildInfo = false
@@ -764,6 +765,9 @@ struct GeneralSettingsView: View {
             checkMicPermission()
             appState.refreshLaunchAtLoginStatus()
             Task { await githubCache.fetchIfNeeded() }
+        }
+        .onDisappear {
+            commitCustomVocabulary()
         }
         .onChange(of: appState.transcriptionAPIURL) { value in
             if transcriptionAPIURLInput != value {
@@ -1385,6 +1389,13 @@ struct GeneralSettingsView: View {
 
     // MARK: Custom Vocabulary
 
+    private func commitCustomVocabulary() {
+        let trimmed = customVocabularyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        if appState.customVocabulary != trimmed {
+            appState.customVocabulary = trimmed
+        }
+    }
+
     private var vocabularySection: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("Words and phrases to preserve during post-processing.")
@@ -1394,12 +1405,13 @@ struct GeneralSettingsView: View {
             TextEditor(text: $customVocabularyInput)
                 .font(.system(.body, design: .monospaced))
                 .frame(minHeight: 80, maxHeight: 140)
+                .focused($customVocabularyFocused)
                 .overlay(
                     RoundedRectangle(cornerRadius: 6)
                         .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
                 )
-                .onChange(of: customVocabularyInput) { newValue in
-                    appState.customVocabulary = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                .onChange(of: customVocabularyFocused) { focused in
+                    if !focused { commitCustomVocabulary() }
                 }
 
             Text("Separate entries with commas, new lines, or semicolons.")
@@ -1508,6 +1520,8 @@ struct PromptsSettingsView: View {
     @EnvironmentObject var appState: AppState
     @State private var customSystemPromptInput: String = ""
     @State private var customContextPromptInput: String = ""
+    @FocusState private var customSystemPromptFocused: Bool
+    @FocusState private var customContextPromptFocused: Bool
     @State private var showDefaultSystemPrompt = false
     @State private var showDefaultContextPrompt = false
 
@@ -1546,6 +1560,38 @@ struct PromptsSettingsView: View {
             customContextPromptInput = appState.customContextPrompt.isEmpty
                 ? AppContextService.defaultContextPrompt
                 : appState.customContextPrompt
+        }
+        .onDisappear {
+            commitCustomSystemPrompt()
+            commitCustomContextPrompt()
+        }
+    }
+
+    private func commitCustomSystemPrompt() {
+        let trimmed = customSystemPromptInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultTrimmed = PostProcessingService.defaultSystemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed == defaultTrimmed || trimmed.isEmpty {
+            if !appState.customSystemPrompt.isEmpty {
+                appState.customSystemPrompt = ""
+                appState.customSystemPromptLastModified = ""
+            }
+        } else if appState.customSystemPrompt != trimmed {
+            appState.customSystemPrompt = trimmed
+            appState.customSystemPromptLastModified = iso8601DayFormatter.string(from: Date())
+        }
+    }
+
+    private func commitCustomContextPrompt() {
+        let trimmed = customContextPromptInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultTrimmed = AppContextService.defaultContextPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed == defaultTrimmed || trimmed.isEmpty {
+            if !appState.customContextPrompt.isEmpty {
+                appState.customContextPrompt = ""
+                appState.customContextPromptLastModified = ""
+            }
+        } else if appState.customContextPrompt != trimmed {
+            appState.customContextPrompt = trimmed
+            appState.customContextPromptLastModified = iso8601DayFormatter.string(from: Date())
         }
     }
 
@@ -1609,25 +1655,13 @@ struct PromptsSettingsView: View {
             TextEditor(text: $customSystemPromptInput)
                 .font(.system(.body, design: .monospaced))
                 .frame(minHeight: 120, maxHeight: 200)
+                .focused($customSystemPromptFocused)
                 .overlay(
                     RoundedRectangle(cornerRadius: 6)
                         .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
                 )
-                .onChange(of: customSystemPromptInput) { newValue in
-                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let defaultTrimmed = PostProcessingService.defaultSystemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if trimmed == defaultTrimmed || trimmed.isEmpty {
-                        if !appState.customSystemPrompt.isEmpty {
-                            appState.customSystemPrompt = ""
-                            appState.customSystemPromptLastModified = ""
-                        }
-                    } else {
-                        appState.customSystemPrompt = trimmed
-                        let today = iso8601DayFormatter.string(from: Date())
-                        if appState.customSystemPromptLastModified != today {
-                            appState.customSystemPromptLastModified = today
-                        }
-                    }
+                .onChange(of: customSystemPromptFocused) { focused in
+                    if !focused { commitCustomSystemPrompt() }
                 }
 
             HStack {
@@ -1740,6 +1774,7 @@ struct PromptsSettingsView: View {
     }
 
     private func runSystemPromptTest() {
+        commitCustomSystemPrompt()
         systemTestRunning = true
         systemTestOutput = nil
         systemTestError = nil
@@ -1851,25 +1886,13 @@ struct PromptsSettingsView: View {
             TextEditor(text: $customContextPromptInput)
                 .font(.system(.body, design: .monospaced))
                 .frame(minHeight: 120, maxHeight: 200)
+                .focused($customContextPromptFocused)
                 .overlay(
                     RoundedRectangle(cornerRadius: 6)
                         .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
                 )
-                .onChange(of: customContextPromptInput) { newValue in
-                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let defaultTrimmed = AppContextService.defaultContextPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if trimmed == defaultTrimmed || trimmed.isEmpty {
-                        if !appState.customContextPrompt.isEmpty {
-                            appState.customContextPrompt = ""
-                            appState.customContextPromptLastModified = ""
-                        }
-                    } else {
-                        appState.customContextPrompt = trimmed
-                        let today = iso8601DayFormatter.string(from: Date())
-                        if appState.customContextPromptLastModified != today {
-                            appState.customContextPromptLastModified = today
-                        }
-                    }
+                .onChange(of: customContextPromptFocused) { focused in
+                    if !focused { commitCustomContextPrompt() }
                 }
 
             HStack {
@@ -1999,6 +2022,7 @@ struct PromptsSettingsView: View {
     }
 
     private func runContextPromptTest() {
+        commitCustomContextPrompt()
         contextTestRunning = true
         contextTestOutput = nil
         contextTestError = nil

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -238,8 +238,8 @@ struct ProviderSettingsFields: View {
 
             ModelDropdownView(
                 title: "Context Model",
-                subtitle: "Used for context inference, with a text-only retry when screenshot analysis fails.",
-                predefinedModels: ModelConfiguration.llmModels,
+                subtitle: "Used for context inference, with a text-only retry when screenshot analysis fails. Screenshot analysis requires a model that accepts image input.",
+                predefinedModels: ModelConfiguration.visionModels,
                 defaultModel: AppState.defaultContextModel,
                 textDraft: $contextModelDraft,
                 onCommit: commitContextModel,

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -2917,10 +2917,8 @@ struct PromptsSettingsView: View {
                 appState.customSystemPrompt = ""
                 appState.customSystemPromptLastModified = ""
             }
-        } else {
-            if appState.customSystemPrompt != trimmed {
-                appState.customSystemPrompt = trimmed
-            }
+        } else if appState.customSystemPrompt != trimmed {
+            appState.customSystemPrompt = trimmed
             let today = iso8601DayFormatter.string(from: Date())
             if appState.customSystemPromptLastModified != today {
                 appState.customSystemPromptLastModified = today
@@ -2937,10 +2935,8 @@ struct PromptsSettingsView: View {
                 appState.customContextPrompt = ""
                 appState.customContextPromptLastModified = ""
             }
-        } else {
-            if appState.customContextPrompt != trimmed {
-                appState.customContextPrompt = trimmed
-            }
+        } else if appState.customContextPrompt != trimmed {
+            appState.customContextPrompt = trimmed
             let today = iso8601DayFormatter.string(from: Date())
             if appState.customContextPromptLastModified != today {
                 appState.customContextPromptLastModified = today

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -39,318 +39,6 @@ private let iso8601DayFormatter: DateFormatter = {
     return formatter
 }()
 
-struct ProviderSettingsFields: View {
-    @EnvironmentObject var appState: AppState
-    @Binding var apiBaseURLInput: String
-    @Binding var transcriptionAPIURLInput: String
-    @Binding var transcriptionAPIKeyInput: String
-    @FocusState private var isEditingAPIBaseURL: Bool
-    @FocusState private var isEditingTranscriptionModel: Bool
-    @FocusState private var isEditingRealtimeStreamingModel: Bool
-    @FocusState private var isEditingPostProcessingModel: Bool
-    @FocusState private var isEditingPostProcessingFallbackModel: Bool
-    @FocusState private var isEditingContextModel: Bool
-    @FocusState private var transcriptionAPIURLFocused: Bool
-    @FocusState private var transcriptionAPIKeyFocused: Bool
-    @State private var transcriptionModelDraft: String = ""
-    @State private var realtimeStreamingModelDraft: String = ""
-    @State private var postProcessingModelDraft: String = ""
-    @State private var postProcessingFallbackModelDraft: String = ""
-    @State private var contextModelDraft: String = ""
-
-    let showsModelDescription: Bool
-    let showsTranscriptionLanguage: Bool
-
-    private func commitAPIBaseURL() {
-        let trimmed = apiBaseURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolvedBaseURL = trimmed.isEmpty ? AppState.defaultAPIBaseURL : trimmed
-        apiBaseURLInput = resolvedBaseURL
-        appState.apiBaseURL = resolvedBaseURL
-    }
-
-    private func commitTranscriptionModel() {
-        let trimmed = transcriptionModelDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolved = trimmed.isEmpty ? AppState.defaultTranscriptionModel : trimmed
-        transcriptionModelDraft = resolved
-        guard appState.transcriptionModel != resolved else { return }
-        appState.transcriptionModel = resolved
-    }
-
-    private func commitRealtimeStreamingModel() {
-        let trimmed = realtimeStreamingModelDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-        realtimeStreamingModelDraft = trimmed
-        guard appState.realtimeStreamingModel != trimmed else { return }
-        appState.realtimeStreamingModel = trimmed
-    }
-
-    private func commitPostProcessingModel() {
-        let trimmed = postProcessingModelDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolved = trimmed.isEmpty ? AppState.defaultPostProcessingModel : trimmed
-        postProcessingModelDraft = resolved
-        guard appState.postProcessingModel != resolved else { return }
-        appState.postProcessingModel = resolved
-    }
-
-    private func commitPostProcessingFallbackModel() {
-        let trimmed = postProcessingFallbackModelDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolved = trimmed.isEmpty ? AppState.defaultPostProcessingFallbackModel : trimmed
-        postProcessingFallbackModelDraft = resolved
-        guard appState.postProcessingFallbackModel != resolved else { return }
-        appState.postProcessingFallbackModel = resolved
-    }
-
-    private func commitContextModel() {
-        let trimmed = contextModelDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolved = trimmed.isEmpty ? AppState.defaultContextModel : trimmed
-        contextModelDraft = resolved
-        guard appState.contextModel != resolved else { return }
-        appState.contextModel = resolved
-    }
-
-    private func commitTranscriptionAPIURL() {
-        let trimmed = transcriptionAPIURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        transcriptionAPIURLInput = trimmed
-        guard appState.transcriptionAPIURL != trimmed else { return }
-        appState.transcriptionAPIURL = trimmed
-    }
-
-    private func commitTranscriptionAPIKey() {
-        let trimmed = transcriptionAPIKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        transcriptionAPIKeyInput = trimmed
-        guard appState.transcriptionAPIKey != trimmed else { return }
-        appState.transcriptionAPIKey = trimmed
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("API Base URL")
-                .font(.caption.weight(.semibold))
-
-            Text("Change this to use a different OpenAI-compatible API provider.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            HStack(spacing: 8) {
-                TextField(AppState.defaultAPIBaseURL, text: $apiBaseURLInput)
-                    .textFieldStyle(.roundedBorder)
-                    .font(.system(.body, design: .monospaced))
-                    .focused($isEditingAPIBaseURL)
-                    .onSubmit {
-                        commitAPIBaseURL()
-                    }
-                    .onChange(of: isEditingAPIBaseURL) { isEditing in
-                        if !isEditing {
-                            commitAPIBaseURL()
-                        }
-                    }
-
-                Button("Reset to Default") {
-                    apiBaseURLInput = AppState.defaultAPIBaseURL
-                    appState.apiBaseURL = AppState.defaultAPIBaseURL
-                }
-                .font(.caption)
-            }
-
-            if showsModelDescription {
-                Text("If you use another provider, enter that provider's model IDs here.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            ModelDropdownView(
-                title: "Post-Processing Model",
-                subtitle: "Used for transcript cleanup and Edit Mode transforms.",
-                predefinedModels: ModelConfiguration.llmModels,
-                defaultModel: AppState.defaultPostProcessingModel,
-                textDraft: $postProcessingModelDraft,
-                onCommit: commitPostProcessingModel,
-                onReset: {
-                    postProcessingModelDraft = AppState.defaultPostProcessingModel
-                    appState.postProcessingModel = AppState.defaultPostProcessingModel
-                }
-            )
-
-            ModelDropdownView(
-                title: "Post-Processing Fallback Model",
-                subtitle: "Used as the explicit retry model for transcript cleanup and Edit Mode transforms.",
-                predefinedModels: ModelConfiguration.llmModels,
-                defaultModel: AppState.defaultPostProcessingFallbackModel,
-                textDraft: $postProcessingFallbackModelDraft,
-                onCommit: commitPostProcessingFallbackModel,
-                onReset: {
-                    postProcessingFallbackModelDraft = AppState.defaultPostProcessingFallbackModel
-                    appState.postProcessingFallbackModel = AppState.defaultPostProcessingFallbackModel
-                }
-            )
-
-            ModelDropdownView(
-                title: "Context Model",
-                subtitle: "Used for context inference, with a text-only retry when screenshot analysis fails. Screenshot analysis requires a model that accepts image input.",
-                predefinedModels: ModelConfiguration.visionModels,
-                defaultModel: AppState.defaultContextModel,
-                textDraft: $contextModelDraft,
-                onCommit: commitContextModel,
-                onReset: {
-                    contextModelDraft = AppState.defaultContextModel
-                    appState.contextModel = AppState.defaultContextModel
-                }
-            )
-
-            ModelDropdownView(
-                title: "Transcription Model",
-                subtitle: "Used for speech-to-text transcription.",
-                predefinedModels: ModelConfiguration.transcriptionModels,
-                defaultModel: AppState.defaultTranscriptionModel,
-                textDraft: $transcriptionModelDraft,
-                onCommit: commitTranscriptionModel,
-                onReset: {
-                    transcriptionModelDraft = AppState.defaultTranscriptionModel
-                    appState.transcriptionModel = AppState.defaultTranscriptionModel
-                }
-            )
-
-            if showsTranscriptionLanguage {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Transcription Language")
-                        .font(.caption.weight(.semibold))
-                    Picker("", selection: $appState.transcriptionLanguage) {
-                        ForEach(TranscriptionLanguage.all) { option in
-                            Text(option.localizedDisplayName()).tag(option)
-                        }
-                    }
-                    .accessibilityLabel("Transcription Language")
-                    .labelsHidden()
-                    Text("Hint to the transcription model. Auto Detect works for most users. Pick a specific language if you see wrong-script characters appear in the output.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Transcription API URL")
-                    .font(.caption.weight(.semibold))
-                HStack(spacing: 8) {
-                    TextField("Uses API Base URL when empty", text: $transcriptionAPIURLInput)
-                        .textFieldStyle(.roundedBorder)
-                        .font(.system(.body, design: .monospaced))
-                        .focused($transcriptionAPIURLFocused)
-                        .onSubmit {
-                            commitTranscriptionAPIURL()
-                        }
-                        .onChange(of: transcriptionAPIURLFocused) { isFocused in
-                            if !isFocused {
-                                commitTranscriptionAPIURL()
-                            }
-                        }
-                    if !transcriptionAPIURLInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        Button("Clear") {
-                            transcriptionAPIURLInput = ""
-                            appState.transcriptionAPIURL = ""
-                        }
-                        .font(.caption)
-                    }
-                }
-            }
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Transcription API Key")
-                    .font(.caption.weight(.semibold))
-                HStack(spacing: 8) {
-                    SecureField("Uses API Key when empty", text: $transcriptionAPIKeyInput)
-                        .textFieldStyle(.roundedBorder)
-                        .font(.system(.body, design: .monospaced))
-                        .focused($transcriptionAPIKeyFocused)
-                        .onSubmit {
-                            commitTranscriptionAPIKey()
-                        }
-                        .onChange(of: transcriptionAPIKeyFocused) { isFocused in
-                            if !isFocused {
-                                commitTranscriptionAPIKey()
-                            }
-                        }
-                    if !transcriptionAPIKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        Button("Clear") {
-                            transcriptionAPIKeyInput = ""
-                            appState.transcriptionAPIKey = ""
-                        }
-                        .font(.caption)
-                    }
-                }
-            }
-
-            Divider()
-
-            Toggle(
-                "Stream audio while recording (realtime)",
-                isOn: $appState.realtimeStreamingEnabled
-            )
-            Text("Streams audio through the provider's OpenAI-compatible /v1/realtime WebSocket so transcription runs while you speak.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Realtime Transcription Model")
-                    .font(.caption.weight(.semibold))
-                HStack(spacing: 8) {
-                    TextField("Required by some providers, e.g. gpt-4o-transcribe", text: $realtimeStreamingModelDraft)
-                        .textFieldStyle(.roundedBorder)
-                        .focused($isEditingRealtimeStreamingModel)
-                        .onSubmit {
-                            commitRealtimeStreamingModel()
-                        }
-                        .onChange(of: isEditingRealtimeStreamingModel) { isEditing in
-                            if !isEditing {
-                                commitRealtimeStreamingModel()
-                            }
-                        }
-                    if !realtimeStreamingModelDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        Button("Reset") {
-                            realtimeStreamingModelDraft = ""
-                            appState.realtimeStreamingModel = ""
-                        }
-                        .font(.caption)
-                    }
-                }
-                Text("Used only for realtime streaming. Leave empty for providers that supply a server default.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .onAppear {
-            transcriptionModelDraft = appState.transcriptionModel
-            realtimeStreamingModelDraft = appState.realtimeStreamingModel
-            postProcessingModelDraft = appState.postProcessingModel
-            postProcessingFallbackModelDraft = appState.postProcessingFallbackModel
-            contextModelDraft = appState.contextModel
-        }
-        .onChange(of: appState.transcriptionModel) { value in
-            if !isEditingTranscriptionModel {
-                transcriptionModelDraft = value
-            }
-        }
-        .onChange(of: appState.realtimeStreamingModel) { value in
-            if !isEditingRealtimeStreamingModel {
-                realtimeStreamingModelDraft = value
-            }
-        }
-        .onChange(of: appState.postProcessingModel) { value in
-            if !isEditingPostProcessingModel {
-                postProcessingModelDraft = value
-            }
-        }
-        .onChange(of: appState.postProcessingFallbackModel) { value in
-            if !isEditingPostProcessingFallbackModel {
-                postProcessingFallbackModelDraft = value
-            }
-        }
-        .onChange(of: appState.contextModel) { value in
-            if !isEditingContextModel {
-                contextModelDraft = value
-            }
-        }
-    }
-}
-
 // MARK: - Settings
 
 struct SettingsView: View {
@@ -1549,6 +1237,7 @@ struct ModelsSettingsView: View {
     @State private var keyValidationIssue: QuillUserIssueRecord?
     @State private var customVocabularyInput: String = ""
     @FocusState private var customVocabularyFocused: Bool
+    @State private var settingsDraftCommitRegistrationID: UUID?
     @State private var advancedProviderSettingsExpanded = false
 
     private struct OutputLanguageOption {
@@ -1617,6 +1306,7 @@ struct ModelsSettingsView: View {
             )
             meetingSummaryFallbackModelDraft = appState.meetingSummaryFallbackModel
             customVocabularyInput = appState.customVocabulary
+            registerVocabularyDraftCommit()
             initializeManagedNativeModel()
             reconcileRetainedLocalAIModels()
         }
@@ -1684,6 +1374,7 @@ struct ModelsSettingsView: View {
         }
         .onDisappear {
             commitCustomVocabulary()
+            unregisterVocabularyDraftCommit()
             appState.commitModelSettingsDrafts(
                 transcriptionEnabled: transcriptionEnabledDraft,
                 transcriptionChoice: settingsTranscriptionChoice,
@@ -2489,6 +2180,10 @@ struct ModelsSettingsView: View {
             VStack(alignment: .leading, spacing: 12) {
                 aiProcessingChoicePicker(for: .context)
 
+                Text("Used for context inference, with a text-only retry when screenshot analysis fails. Screenshot analysis requires a model that accepts image input.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
                 if let warning = appState.contextModelCapabilityWarning {
                     Label(warning, systemImage: "exclamationmark.triangle")
                         .font(.caption)
@@ -3033,6 +2728,19 @@ struct ModelsSettingsView: View {
         }
     }
 
+    private func registerVocabularyDraftCommit() {
+        guard settingsDraftCommitRegistrationID == nil else { return }
+        settingsDraftCommitRegistrationID = appState.registerSettingsDraftCommit {
+            commitCustomVocabulary()
+        }
+    }
+
+    private func unregisterVocabularyDraftCommit() {
+        guard let settingsDraftCommitRegistrationID else { return }
+        appState.unregisterSettingsDraftCommit(settingsDraftCommitRegistrationID)
+        self.settingsDraftCommitRegistrationID = nil
+    }
+
     private func commitCustomVocabulary() {
         let trimmed = customVocabularyInput.trimmingCharacters(in: .whitespacesAndNewlines)
         if appState.customVocabulary != trimmed {
@@ -3141,6 +2849,7 @@ struct PromptsSettingsView: View {
     @State private var customContextPromptInput: String = ""
     @FocusState private var customSystemPromptFocused: Bool
     @FocusState private var customContextPromptFocused: Bool
+    @State private var settingsDraftCommitRegistrationID: UUID?
     @State private var showDefaultSystemPrompt = false
     @State private var showDefaultContextPrompt = false
     @State private var systemTestInput = "Um, so I was like, thinking we should uh, refactor the authentication module, you know?"
@@ -3176,11 +2885,27 @@ struct PromptsSettingsView: View {
             customContextPromptInput = appState.customContextPrompt.isEmpty
                 ? AppContextService.defaultContextPrompt
                 : appState.customContextPrompt
+            registerPromptDraftCommit()
         }
         .onDisappear {
             commitCustomSystemPrompt()
             commitCustomContextPrompt()
+            unregisterPromptDraftCommit()
         }
+    }
+
+    private func registerPromptDraftCommit() {
+        guard settingsDraftCommitRegistrationID == nil else { return }
+        settingsDraftCommitRegistrationID = appState.registerSettingsDraftCommit {
+            commitCustomSystemPrompt()
+            commitCustomContextPrompt()
+        }
+    }
+
+    private func unregisterPromptDraftCommit() {
+        guard let settingsDraftCommitRegistrationID else { return }
+        appState.unregisterSettingsDraftCommit(settingsDraftCommitRegistrationID)
+        self.settingsDraftCommitRegistrationID = nil
     }
 
     private func commitCustomSystemPrompt() {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -185,8 +185,8 @@ struct ProviderSettingsFields: View {
 
             ModelDropdownView(
                 title: "Context Model",
-                subtitle: "Used for context inference, with a text-only retry when screenshot analysis fails.",
-                predefinedModels: ModelConfiguration.llmModels,
+                subtitle: "Used for context inference, with a text-only retry when screenshot analysis fails. Screenshot analysis requires a model that accepts image input.",
+                predefinedModels: ModelConfiguration.visionModels,
                 defaultModel: AppState.defaultContextModel,
                 textDraft: $contextModelDraft,
                 onCommit: commitContextModel,
@@ -1548,6 +1548,7 @@ struct ModelsSettingsView: View {
     @State private var isValidatingKey = false
     @State private var keyValidationIssue: QuillUserIssueRecord?
     @State private var customVocabularyInput: String = ""
+    @FocusState private var customVocabularyFocused: Bool
     @State private var advancedProviderSettingsExpanded = false
 
     private struct OutputLanguageOption {
@@ -1682,6 +1683,7 @@ struct ModelsSettingsView: View {
             reconcileRetainedLocalAIModels()
         }
         .onDisappear {
+            commitCustomVocabulary()
             appState.commitModelSettingsDrafts(
                 transcriptionEnabled: transcriptionEnabledDraft,
                 transcriptionChoice: settingsTranscriptionChoice,
@@ -3016,17 +3018,25 @@ struct ModelsSettingsView: View {
             TextEditor(text: $customVocabularyInput)
                 .font(.system(.body, design: .monospaced))
                 .frame(minHeight: 80, maxHeight: 140)
+                .focused($customVocabularyFocused)
                 .overlay(
                     RoundedRectangle(cornerRadius: 6)
                         .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
                 )
-                .onChange(of: customVocabularyInput) { newValue in
-                    appState.customVocabulary = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                .onChange(of: customVocabularyFocused) { focused in
+                    if !focused { commitCustomVocabulary() }
                 }
 
             Text("Separate entries with commas, new lines, or semicolons.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+        }
+    }
+
+    private func commitCustomVocabulary() {
+        let trimmed = customVocabularyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        if appState.customVocabulary != trimmed {
+            appState.customVocabulary = trimmed
         }
     }
 
@@ -3129,6 +3139,8 @@ struct PromptsSettingsView: View {
     @EnvironmentObject var appState: AppState
     @State private var customSystemPromptInput: String = ""
     @State private var customContextPromptInput: String = ""
+    @FocusState private var customSystemPromptFocused: Bool
+    @FocusState private var customContextPromptFocused: Bool
     @State private var showDefaultSystemPrompt = false
     @State private var showDefaultContextPrompt = false
     @State private var systemTestInput = "Um, so I was like, thinking we should uh, refactor the authentication module, you know?"
@@ -3164,6 +3176,50 @@ struct PromptsSettingsView: View {
             customContextPromptInput = appState.customContextPrompt.isEmpty
                 ? AppContextService.defaultContextPrompt
                 : appState.customContextPrompt
+        }
+        .onDisappear {
+            commitCustomSystemPrompt()
+            commitCustomContextPrompt()
+        }
+    }
+
+    private func commitCustomSystemPrompt() {
+        let trimmed = customSystemPromptInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultTrimmed = PostProcessingService.defaultSystemPrompt
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed == defaultTrimmed || trimmed.isEmpty {
+            if !appState.customSystemPrompt.isEmpty {
+                appState.customSystemPrompt = ""
+                appState.customSystemPromptLastModified = ""
+            }
+        } else {
+            if appState.customSystemPrompt != trimmed {
+                appState.customSystemPrompt = trimmed
+            }
+            let today = iso8601DayFormatter.string(from: Date())
+            if appState.customSystemPromptLastModified != today {
+                appState.customSystemPromptLastModified = today
+            }
+        }
+    }
+
+    private func commitCustomContextPrompt() {
+        let trimmed = customContextPromptInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultTrimmed = AppContextService.defaultContextPrompt
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed == defaultTrimmed || trimmed.isEmpty {
+            if !appState.customContextPrompt.isEmpty {
+                appState.customContextPrompt = ""
+                appState.customContextPromptLastModified = ""
+            }
+        } else {
+            if appState.customContextPrompt != trimmed {
+                appState.customContextPrompt = trimmed
+            }
+            let today = iso8601DayFormatter.string(from: Date())
+            if appState.customContextPromptLastModified != today {
+                appState.customContextPromptLastModified = today
+            }
         }
     }
 
@@ -3270,22 +3326,10 @@ struct PromptsSettingsView: View {
             TextEditor(text: $customSystemPromptInput)
                 .font(.system(.body, design: .monospaced))
                 .frame(minHeight: 120, maxHeight: 200)
+                .focused($customSystemPromptFocused)
                 .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.3), lineWidth: 1))
-                .onChange(of: customSystemPromptInput) { newValue in
-                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let defaultTrimmed = PostProcessingService.defaultSystemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if trimmed == defaultTrimmed || trimmed.isEmpty {
-                        if !appState.customSystemPrompt.isEmpty {
-                            appState.customSystemPrompt = ""
-                            appState.customSystemPromptLastModified = ""
-                        }
-                    } else {
-                        appState.customSystemPrompt = trimmed
-                        let today = iso8601DayFormatter.string(from: Date())
-                        if appState.customSystemPromptLastModified != today {
-                            appState.customSystemPromptLastModified = today
-                        }
-                    }
+                .onChange(of: customSystemPromptFocused) { focused in
+                    if !focused { commitCustomSystemPrompt() }
                 }
 
             HStack {
@@ -3384,6 +3428,7 @@ struct PromptsSettingsView: View {
     }
 
     private func runSystemPromptTest() {
+        commitCustomSystemPrompt()
         systemTestRunning = true
         systemTestOutput = nil
         systemTestIssue = nil
@@ -3484,22 +3529,10 @@ struct PromptsSettingsView: View {
             TextEditor(text: $customContextPromptInput)
                 .font(.system(.body, design: .monospaced))
                 .frame(minHeight: 120, maxHeight: 200)
+                .focused($customContextPromptFocused)
                 .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.3), lineWidth: 1))
-                .onChange(of: customContextPromptInput) { newValue in
-                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let defaultTrimmed = AppContextService.defaultContextPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if trimmed == defaultTrimmed || trimmed.isEmpty {
-                        if !appState.customContextPrompt.isEmpty {
-                            appState.customContextPrompt = ""
-                            appState.customContextPromptLastModified = ""
-                        }
-                    } else {
-                        appState.customContextPrompt = trimmed
-                        let today = iso8601DayFormatter.string(from: Date())
-                        if appState.customContextPromptLastModified != today {
-                            appState.customContextPromptLastModified = today
-                        }
-                    }
+                .onChange(of: customContextPromptFocused) { focused in
+                    if !focused { commitCustomContextPrompt() }
                 }
 
             HStack {
@@ -3598,6 +3631,7 @@ struct PromptsSettingsView: View {
     }
 
     private func runContextPromptTest() {
+        commitCustomContextPrompt()
         contextTestRunning = true
         contextTestOutput = nil
         contextTestIssue = nil

--- a/Tests/AIModelCapabilitiesTests.swift
+++ b/Tests/AIModelCapabilitiesTests.swift
@@ -7,6 +7,7 @@ struct AIModelCapabilitiesTests {
         try testQualityQwenFeatures()
         try testRetiredQwenHasNoCapabilities()
         try testCloudCapabilitiesAreExplicit()
+        try testCuratedCloudModelCatalog()
         try testProviderlessCloudVisionAliasIsCanonicalized()
         print("AIModelCapabilitiesTests passed")
     }
@@ -50,6 +51,25 @@ struct AIModelCapabilitiesTests {
                 "\(modelID) is not Context-capable until explicitly declared"
             )
         }
+    }
+
+    private static func testCuratedCloudModelCatalog() throws {
+        for retiredModelID in [
+            "allam-2-7b",
+            "canopylabs/orpheus-arabic-saudi",
+            "canopylabs/orpheus-v1-english",
+            "meta-llama/llama-prompt-guard-2-22m",
+            "meta-llama/llama-prompt-guard-2-86m"
+        ] {
+            try expect(
+                !ModelConfiguration.llmModels.contains(retiredModelID),
+                "retired Cloud model \(retiredModelID) is not offered as a predefined choice"
+            )
+        }
+        try expect(
+            ModelConfiguration.visionModels == ["qwen/qwen3.6-27b"],
+            "the predefined Context model list contains only the declared Cloud vision model"
+        )
     }
 
     private static func testProviderlessCloudVisionAliasIsCanonicalized() throws {

--- a/Tests/AppStateAIProcessingBackendTests.swift
+++ b/Tests/AppStateAIProcessingBackendTests.swift
@@ -35,6 +35,7 @@ struct AppStateAIProcessingBackendTests {
         await testCorruptedChoicesFallbackAndPersistNormalizedCloudChoices()
         await testWhitespaceCloudIDsFallbackToRememberedOrDefaultModels()
         await testStoredCloudChoicesReconcileRememberedModels()
+        await testRetiredCloudChoiceRemainsVisibleForReplacement()
         await testStoredLocalChoicesPreserveRememberedCloudModels()
         await testIncompatibleLegacyContextSelectionIsPreservedAndDisabled()
         await testProviderlessQwenVisionCloudChoiceSupportsContext()
@@ -170,6 +171,33 @@ struct AppStateAIProcessingBackendTests {
         assert(defaults.string(forKey: "context_model") == "stored/context")
         assert(storedChoice(forKey: "post_processing_backend_choice") == .cloud(modelID: "stored/post"))
         assert(storedChoice(forKey: "context_backend_choice") == .cloud(modelID: "stored/context"))
+    }
+
+    private static func testRetiredCloudChoiceRemainsVisibleForReplacement() async {
+        resetAIProcessingDefaults()
+        let retiredModelID = "allam-2-7b"
+        precondition(
+            !ModelConfiguration.llmModels.contains(retiredModelID),
+            "the retired Cloud model is no longer offered as a predefined choice"
+        )
+        storeChoice(
+            .cloud(modelID: retiredModelID),
+            forKey: "post_processing_backend_choice"
+        )
+
+        let appState = await makeRefreshedAppState()
+        await MainActor.run {
+            let matches = appState.aiProcessingChoiceDisplays(for: .postProcessing)
+                .filter { $0.choice == .cloud(modelID: retiredModelID) }
+            precondition(
+                matches.count == 1 && matches[0].isAvailable,
+                "a saved retired Cloud model remains visible exactly once so it can be replaced"
+            )
+            precondition(
+                appState.postProcessingBackendChoice == .cloud(modelID: retiredModelID),
+                "catalog cleanup does not reset the saved Cloud selection"
+            )
+        }
     }
 
     private static func testStoredLocalChoicesPreserveRememberedCloudModels() async {

--- a/Tests/AppStateAIProcessingBackendTests.swift
+++ b/Tests/AppStateAIProcessingBackendTests.swift
@@ -35,6 +35,7 @@ struct AppStateAIProcessingBackendTests {
         await testCorruptedChoicesFallbackAndPersistNormalizedCloudChoices()
         await testWhitespaceCloudIDsFallbackToRememberedOrDefaultModels()
         await testStoredCloudChoicesReconcileRememberedModels()
+        try await testSettingsDraftCommittersFlushBeforeRecordingStart()
         await testRetiredCloudChoiceRemainsVisibleForReplacement()
         await testStoredLocalChoicesPreserveRememberedCloudModels()
         await testIncompatibleLegacyContextSelectionIsPreservedAndDisabled()
@@ -171,6 +172,46 @@ struct AppStateAIProcessingBackendTests {
         assert(defaults.string(forKey: "context_model") == "stored/context")
         assert(storedChoice(forKey: "post_processing_backend_choice") == .cloud(modelID: "stored/post"))
         assert(storedChoice(forKey: "context_backend_choice") == .cloud(modelID: "stored/context"))
+    }
+
+    private static func testSettingsDraftCommittersFlushBeforeRecordingStart() async throws {
+        resetAIProcessingDefaults()
+        let appState = await makeRefreshedAppState()
+
+        await MainActor.run {
+            var commitCount = 0
+            let registrationID = appState.registerSettingsDraftCommit {
+                commitCount += 1
+            }
+
+            appState.commitSettingsDraftsBeforeRecordingStart()
+            precondition(
+                commitCount == 1,
+                "recording start flushes the active Settings text draft"
+            )
+
+            appState.unregisterSettingsDraftCommit(registrationID)
+            appState.commitSettingsDraftsBeforeRecordingStart()
+            precondition(
+                commitCount == 1,
+                "a dismissed Settings view no longer receives recording-start flushes"
+            )
+        }
+
+        let recordingStart = sourceBlock(
+            in: try appStateSource(),
+            from: "private func startRecording(triggerMode: RecordingTriggerMode",
+            to: "/// Whether the configured recording flow will actually exercise Accessibility."
+        )
+        let flush = requiredRange(
+            of: "commitSettingsDraftsBeforeRecordingStart()",
+            in: recordingStart
+        )
+        let task = requiredRange(of: "Task { [weak self]", in: recordingStart)
+        assert(
+            flush.lowerBound < task.lowerBound,
+            "recording flushes Settings text drafts before capturing Context or starting async work"
+        )
     }
 
     private static func testRetiredCloudChoiceRemainsVisibleForReplacement() async {

--- a/Tests/LocalizationResourceTests.swift
+++ b/Tests/LocalizationResourceTests.swift
@@ -244,7 +244,8 @@ struct LocalizationResourceTests {
             "My calendars", "Shared calendars", "Primary", "My calendar", "Shared",
             "Use API Provider transcription to choose a final output language.",
             "Enable post-processing to choose a final output language.",
-            "Final transcript language for post-processing."
+            "Final transcript language for post-processing.",
+            "Used for context inference, with a text-only retry when screenshot analysis fails. Screenshot analysis requires a model that accepts image input."
         ] {
             let localizations = (strings[key] as? [String: Any])?["localizations"] as? [String: Any]
             assert(!(((localizations?["en"] as? [String: Any])?["stringUnit"] as? [String: Any])?["value"] as? String ?? "").isEmpty)

--- a/Tests/ModelsSettingsUIContractTests.swift
+++ b/Tests/ModelsSettingsUIContractTests.swift
@@ -16,6 +16,7 @@ struct ModelsSettingsUIContractTests {
         testUIOnlyBoundary(appState: appState)
         testExistingProviderRoutingRemains(postProcessing: postProcessing, context: context)
         testExistingModelCatalogRemains(modelConfiguration)
+        testProviderContextPickerRequiresVisionModels(settings)
         testExistingModelLifecycleRemains(settings)
         try testModelFirstTopLevelStructure(settings)
         testPromptControlsMovedOutOfModels(settings)
@@ -42,6 +43,7 @@ struct ModelsSettingsUIContractTests {
         testCurrentSpecDocumentsCorrectedLayout(currentSpec)
         try testSettingsDraftsApplyImmediatelyWhenReadyOrOff(settings)
         try testSettingsDraftsSyncFromExternalAppStateChanges(settings)
+        testVocabularyDraftCommitsOnFocusLoss(settings)
         try testNoteBrowserSharesStandardModelsAndGatesRealtime(appState)
         print("ModelsSettingsUIContractTests passed")
     }
@@ -101,6 +103,32 @@ struct ModelsSettingsUIContractTests {
         ] {
             precondition(source.contains("\"\(model)\""), "Missing existing model: \(model)")
         }
+    }
+
+    private static func testProviderContextPickerRequiresVisionModels(_ source: String) {
+        let provider = block(
+            in: source,
+            from: "struct ProviderSettingsFields",
+            to: "// MARK: - Settings"
+        )
+        let contextModel = block(
+            in: provider,
+            from: "ModelDropdownView(\n                title: \"Context Model\"",
+            to: "ModelDropdownView(\n                title: \"Transcription Model\""
+        )
+        for expected in [
+            "predefinedModels: ModelConfiguration.visionModels",
+            "Screenshot analysis requires a model that accepts image input."
+        ] {
+            precondition(
+                contextModel.contains(expected),
+                "Context model picker must require a vision-capable model: \(expected)"
+            )
+        }
+        precondition(
+            !contextModel.contains("predefinedModels: ModelConfiguration.llmModels"),
+            "Context model picker does not offer text-only models by default"
+        )
     }
 
     private static func testExistingModelLifecycleRemains(_ settings: String) {
@@ -1061,6 +1089,33 @@ struct ModelsSettingsUIContractTests {
         ] {
             precondition(source.contains(expected), "Missing external draft sync: \(expected)")
         }
+    }
+
+    private static func testVocabularyDraftCommitsOnFocusLoss(_ source: String) {
+        let models = block(
+            in: source,
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Prompts Settings"
+        )
+        let vocabulary = block(
+            in: models,
+            from: "private var vocabularySection: some View",
+            to: "private func commitAPIBaseURL()"
+        )
+        for expected in [
+            "@FocusState private var customVocabularyFocused: Bool",
+            "private func commitCustomVocabulary()",
+            ".onDisappear {",
+            "commitCustomVocabulary()",
+            ".focused($customVocabularyFocused)",
+            ".onChange(of: customVocabularyFocused)"
+        ] {
+            precondition(models.contains(expected), "Missing focus-loss vocabulary persistence: \(expected)")
+        }
+        precondition(
+            !vocabulary.contains(".onChange(of: customVocabularyInput)"),
+            "Vocabulary does not persist on every keystroke"
+        )
     }
 
     private static func testNoteBrowserSharesStandardModelsAndGatesRealtime(

--- a/Tests/ModelsSettingsUIContractTests.swift
+++ b/Tests/ModelsSettingsUIContractTests.swift
@@ -16,7 +16,8 @@ struct ModelsSettingsUIContractTests {
         testUIOnlyBoundary(appState: appState)
         testExistingProviderRoutingRemains(postProcessing: postProcessing, context: context)
         testExistingModelCatalogRemains(modelConfiguration)
-        testProviderContextPickerRequiresVisionModels(settings)
+        testLiveContextPickerRequiresVisionModels(settings)
+        testVocabularyDraftRegistersForRecordingStart(settings)
         testExistingModelLifecycleRemains(settings)
         try testModelFirstTopLevelStructure(settings)
         testPromptControlsMovedOutOfModels(settings)
@@ -105,30 +106,48 @@ struct ModelsSettingsUIContractTests {
         }
     }
 
-    private static func testProviderContextPickerRequiresVisionModels(_ source: String) {
-        let provider = block(
+    private static func testLiveContextPickerRequiresVisionModels(_ source: String) {
+        let models = block(
             in: source,
-            from: "struct ProviderSettingsFields",
-            to: "// MARK: - Settings"
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Prompts Settings"
         )
-        let contextModel = block(
-            in: provider,
-            from: "ModelDropdownView(\n                title: \"Context Model\"",
-            to: "ModelDropdownView(\n                title: \"Transcription Model\""
+        let context = block(
+            in: models,
+            from: "private var contextFeatureSection: some View",
+            to: "private var meetingSummaryEnabled"
+        )
+        precondition(
+            context.contains("aiProcessingChoicePicker(for: .context)"),
+            "the visible Context Settings section uses the capability-filtered model picker"
+        )
+        precondition(
+            context.contains("Screenshot analysis requires a model that accepts image input."),
+            "the visible Context Settings section explains its image-input requirement"
+        )
+        precondition(
+            !source.contains("struct ProviderSettingsFields"),
+            "the unused legacy provider Settings view is removed"
+        )
+    }
+
+    private static func testVocabularyDraftRegistersForRecordingStart(_ source: String) {
+        let models = block(
+            in: source,
+            from: "struct ModelsSettingsView",
+            to: "// MARK: - Prompts Settings"
         )
         for expected in [
-            "predefinedModels: ModelConfiguration.visionModels",
-            "Screenshot analysis requires a model that accepts image input."
+            "@State private var settingsDraftCommitRegistrationID: UUID?",
+            "appState.registerSettingsDraftCommit",
+            "commitCustomVocabulary()",
+            "appState.unregisterSettingsDraftCommit"
         ] {
             precondition(
-                contextModel.contains(expected),
-                "Context model picker must require a vision-capable model: \(expected)"
+                models.contains(expected),
+                "Vocabulary draft is registered for recording-start persistence: \(expected)"
             )
         }
-        precondition(
-            !contextModel.contains("predefinedModels: ModelConfiguration.llmModels"),
-            "Context model picker does not offer text-only models by default"
-        )
     }
 
     private static func testExistingModelLifecycleRemains(_ settings: String) {

--- a/Tests/PromptsSettingsUIContractTests.swift
+++ b/Tests/PromptsSettingsUIContractTests.swift
@@ -9,6 +9,7 @@ struct PromptsSettingsUIContractTests {
         testNavigation(tabs: tabs, settings: settings)
         testCardOrder(settings)
         testPromptPersistence(settings)
+        testPromptDraftsCommitOnFocusLoss(settings)
         testBackendAwareTests(settings)
         testInstructionGuard(settings)
         testScreenshotResolutionStaysOut(settings)
@@ -54,6 +55,52 @@ struct PromptsSettingsUIContractTests {
         ] {
             precondition(prompts.contains(expected), "Missing Prompt persistence behavior: \(expected)")
         }
+    }
+
+    private static func testPromptDraftsCommitOnFocusLoss(_ source: String) {
+        let prompts = promptsBlock(source)
+        for expected in [
+            "@FocusState private var customSystemPromptFocused: Bool",
+            "@FocusState private var customContextPromptFocused: Bool",
+            "private func commitCustomSystemPrompt()",
+            "private func commitCustomContextPrompt()",
+            ".onDisappear {",
+            "commitCustomSystemPrompt()",
+            "commitCustomContextPrompt()",
+            ".focused($customSystemPromptFocused)",
+            ".focused($customContextPromptFocused)",
+            ".onChange(of: customSystemPromptFocused)",
+            ".onChange(of: customContextPromptFocused)"
+        ] {
+            precondition(prompts.contains(expected), "Missing focus-loss prompt persistence: \(expected)")
+        }
+        precondition(
+            !prompts.contains(".onChange(of: customSystemPromptInput)"),
+            "System prompt does not persist on every keystroke"
+        )
+        precondition(
+            !prompts.contains(".onChange(of: customContextPromptInput)"),
+            "Context prompt does not persist on every keystroke"
+        )
+
+        let systemRunner = block(
+            in: prompts,
+            from: "private func runSystemPromptTest()",
+            to: "private var contextPromptSection"
+        )
+        let contextRunner = String(prompts[
+            prompts.range(of: "private func runContextPromptTest()")!.lowerBound...
+        ])
+        precondition(
+            systemRunner.range(of: "commitCustomSystemPrompt()")!.lowerBound
+                < systemRunner.range(of: "let service = appState.makePostProcessingService()")!.lowerBound,
+            "System prompt tests commit the latest draft before building a service"
+        )
+        precondition(
+            contextRunner.range(of: "commitCustomContextPrompt()")!.lowerBound
+                < contextRunner.range(of: "let service = appState.makeAppContextService()")!.lowerBound,
+            "Context prompt tests commit the latest draft before collecting context"
+        )
     }
 
     private static func testBackendAwareTests(_ source: String) {

--- a/Tests/PromptsSettingsUIContractTests.swift
+++ b/Tests/PromptsSettingsUIContractTests.swift
@@ -70,7 +70,10 @@ struct PromptsSettingsUIContractTests {
             ".focused($customSystemPromptFocused)",
             ".focused($customContextPromptFocused)",
             ".onChange(of: customSystemPromptFocused)",
-            ".onChange(of: customContextPromptFocused)"
+            ".onChange(of: customContextPromptFocused)",
+            "@State private var settingsDraftCommitRegistrationID: UUID?",
+            "appState.registerSettingsDraftCommit",
+            "appState.unregisterSettingsDraftCommit"
         ] {
             precondition(prompts.contains(expected), "Missing focus-loss prompt persistence: \(expected)")
         }

--- a/Tests/PromptsSettingsUIContractTests.swift
+++ b/Tests/PromptsSettingsUIContractTests.swift
@@ -9,6 +9,7 @@ struct PromptsSettingsUIContractTests {
         testNavigation(tabs: tabs, settings: settings)
         testCardOrder(settings)
         testPromptPersistence(settings)
+        testPromptModificationDatesRequireContentChange(settings)
         testPromptDraftsCommitOnFocusLoss(settings)
         testBackendAwareTests(settings)
         testInstructionGuard(settings)
@@ -54,6 +55,39 @@ struct PromptsSettingsUIContractTests {
             "Button(\"Reset to Default\")"
         ] {
             precondition(prompts.contains(expected), "Missing Prompt persistence behavior: \(expected)")
+        }
+    }
+
+    private static func testPromptModificationDatesRequireContentChange(_ source: String) {
+        let prompts = promptsBlock(source)
+        let systemCommit = block(
+            in: prompts,
+            from: "private func commitCustomSystemPrompt()",
+            to: "private func commitCustomContextPrompt()"
+        )
+        let contextCommit = block(
+            in: prompts,
+            from: "private func commitCustomContextPrompt()",
+            to: "private var hasConfiguredCloudAPIKey"
+        )
+
+        for (commit, storedPrompt, lastModified) in [
+            (systemCommit, "appState.customSystemPrompt", "appState.customSystemPromptLastModified"),
+            (contextCommit, "appState.customContextPrompt", "appState.customContextPromptLastModified")
+        ] {
+            let contentChange = "} else if \(storedPrompt) != trimmed {"
+            guard let contentChangeRange = commit.range(of: contentChange),
+                  let dateRange = commit.range(of: "let today = iso8601DayFormatter"),
+                  let lastModifiedWrite = commit.range(of: "\(lastModified) = today") else {
+                preconditionFailure(
+                    "Prompt modification dates must be written only after a content change"
+                )
+            }
+            precondition(
+                contentChangeRange.lowerBound < dateRange.lowerBound
+                    && dateRange.lowerBound < lastModifiedWrite.lowerBound,
+                "Prompt modification dates are not refreshed by view dismissal, tests, or recording-start draft flushes"
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- Merge the current Freeflow `main` history so future upstream comparisons have no remaining upstream-only commits.
- Preserve Quill’s model-first Settings, Calendar, Recovery, Local AI, and remembered Cloud model behavior while applying upstream editor persistence and curated Cloud model updates.
- Flush active Vocabulary and Prompt drafts before recording begins, and show Context’s image-input requirement in the live Models Settings UI.

## Validation
- `make test`
- `make all CODESIGN_IDENTITY=Quill`
- `make localization-bundle-test CODESIGN_IDENTITY=Quill`
- metadata-free app-copy `codesign --verify --deep --strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 컨텍스트 추론 및 스크린샷 분석에 사용할 이미지 입력 지원 모델을 선택할 수 있습니다.
  - 스크린샷 분석 실패 시 텍스트 전용 재시도 안내가 추가되었습니다.

- **개선 사항**
  - 사용자 지정 어휘와 시스템·컨텍스트 프롬프트가 입력 중 매번 저장되지 않고, 포커스를 잃거나 화면을 종료할 때 안정적으로 저장됩니다.
  - 녹음 시작 전에 최신 설정 초안이 자동으로 반영됩니다.
  - 사용 가능한 클라우드 모델 목록을 최신 상태로 정리했습니다.

- **번역**
  - 관련 안내 문구의 영어 및 한국어 번역을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->