### PR TITLE
Fix Local AI post-processing timeout and history accuracy

### DIFF
--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -11701,6 +11701,54 @@
         }
       }
     },
+    "Transcript cleanup timed out": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcript cleanup timed out"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사문 정리 시간이 초과되었습니다"
+          }
+        }
+      }
+    },
+    "Quill kept the original transcript because cleanup did not finish in time.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill kept the original transcript because cleanup did not finish in time."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정리가 제시간에 끝나지 않아 Quill이 원본 전사문을 유지했습니다."
+          }
+        }
+      }
+    },
+    "Use the original transcript or try cleanup again later.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use the original transcript or try cleanup again later."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "원본 전사문을 사용하거나 나중에 다시 정리해 보세요."
+          }
+        }
+      }
+    },
     "Transcript cleanup is temporarily limited": {
       "localizations": {
         "en": {

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -11749,6 +11749,54 @@
         }
       }
     },
+    "Text edit timed out": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text edit timed out"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "텍스트 편집 시간이 초과되었습니다"
+          }
+        }
+      }
+    },
+    "Quill kept the selected text because the edit did not finish in time.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill kept the selected text because the edit did not finish in time."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집이 제시간에 끝나지 않아 Quill이 선택한 텍스트를 유지했습니다."
+          }
+        }
+      }
+    },
+    "Use the selected text or try the edit again later.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use the selected text or try the edit again later."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택한 텍스트를 사용하거나 나중에 편집을 다시 시도해 보세요."
+          }
+        }
+      }
+    },
     "Transcript cleanup is temporarily limited": {
       "localizations": {
         "en": {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -145,12 +145,8 @@ private struct AudioImportTaskConfiguration {
     let outputLanguage: String
     let postProcessingEnabled: Bool
     let pressEnterCommandEnabled: Bool
-    let postProcessingAPIKey: String
-    let postProcessingBaseURL: String
-    let postProcessingBackendChoice: AIProcessingBackendChoice
-    let postProcessingFallbackModel: String
-    let instructionExecutionGuardEnabled: Bool
-    let localAIServerManager: LocalAIServerManager
+    let cloudDependencies: CloudTranscriptionDependencies
+    let postProcessingService: PostProcessingService
 
     init(
         transcriptionConfiguration: AudioImportTranscriptionConfiguration,
@@ -163,12 +159,8 @@ private struct AudioImportTaskConfiguration {
         outputLanguage: String,
         postProcessingEnabled: Bool,
         pressEnterCommandEnabled: Bool,
-        postProcessingAPIKey: String,
-        postProcessingBaseURL: String,
-        postProcessingBackendChoice: AIProcessingBackendChoice,
-        postProcessingFallbackModel: String,
-        instructionExecutionGuardEnabled: Bool,
-        localAIServerManager: LocalAIServerManager
+        cloudDependencies: CloudTranscriptionDependencies,
+        postProcessingService: PostProcessingService
     ) {
         self.mode = transcriptionConfiguration.mode
         self.useLocalTranscription = transcriptionConfiguration.useLocalTranscription
@@ -184,12 +176,8 @@ private struct AudioImportTaskConfiguration {
         self.outputLanguage = outputLanguage
         self.postProcessingEnabled = postProcessingEnabled
         self.pressEnterCommandEnabled = pressEnterCommandEnabled
-        self.postProcessingAPIKey = postProcessingAPIKey
-        self.postProcessingBaseURL = postProcessingBaseURL
-        self.postProcessingBackendChoice = postProcessingBackendChoice
-        self.postProcessingFallbackModel = postProcessingFallbackModel
-        self.instructionExecutionGuardEnabled = instructionExecutionGuardEnabled
-        self.localAIServerManager = localAIServerManager
+        self.cloudDependencies = cloudDependencies
+        self.postProcessingService = postProcessingService
     }
 
     var systemPrompt: String {
@@ -197,14 +185,7 @@ private struct AudioImportTaskConfiguration {
     }
 
     func makePostProcessingService() -> PostProcessingService {
-        AppState.makePostProcessingService(
-            choice: postProcessingBackendChoice,
-            apiKey: postProcessingAPIKey,
-            baseURL: postProcessingBaseURL,
-            cloudFallbackModelID: postProcessingFallbackModel,
-            instructionExecutionGuardEnabled: instructionExecutionGuardEnabled,
-            localServerManager: localAIServerManager
-        )
+        postProcessingService
     }
 
     func makeTranscriptionService(
@@ -219,8 +200,7 @@ private struct AudioImportTaskConfiguration {
             transcriptionLanguage: transcriptionLanguage,
             localTranscriptionModel: localTranscriptionModel,
             transcriptionModel: transcriptionModel,
-            cloudDependencies: AppState
-                .audioImportCloudTranscriptionDependenciesFactory(),
+            cloudDependencies: cloudDependencies,
             cloudExecutionContext: cloudExecutionContext
         )
     }
@@ -3108,8 +3088,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
         scheduleNoteBrowserTranscriptionModeNormalizationForSelectedInput()
         self.precomputeMacros()
         if let cloudReconciliation {
+            let cloudDependenciesFactory = Self
+                .retryCloudTranscriptionDependenciesFactory
+            let postProcessingService = makePostProcessingService()
             Task { @MainActor [weak self] in
-                self?.scheduleCloudTranscriptionAutoResume(cloudReconciliation)
+                self?.scheduleCloudTranscriptionAutoResume(
+                    cloudReconciliation,
+                    cloudDependenciesFactory: cloudDependenciesFactory,
+                    postProcessingService: postProcessingService
+                )
             }
         }
 
@@ -7328,12 +7315,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
             outputLanguage: outputLanguage,
             postProcessingEnabled: !disablePostProcessing,
             pressEnterCommandEnabled: isPressEnterVoiceCommandEnabled,
-            postProcessingAPIKey: apiKey,
-            postProcessingBaseURL: apiBaseURL,
-            postProcessingBackendChoice: postProcessingBackendChoice,
-            postProcessingFallbackModel: postProcessingFallbackModel,
-            instructionExecutionGuardEnabled: instructionExecutionGuardEnabled,
-            localAIServerManager: localAIServerManager
+            cloudDependencies: Self
+                .audioImportCloudTranscriptionDependenciesFactory(),
+            postProcessingService: makePostProcessingService()
         )
         let jobID = UUID()
         let noteID = UUID()
@@ -7629,6 +7613,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         incrementNoteRetryGeneration(for: item.id)
 
         let postProcessingService = makePostProcessingService()
+        let cloudDependencies = Self
+            .retryCloudTranscriptionDependenciesFactory()
 
         let task = Task { [weak self] in
             guard let self else { return }
@@ -7639,7 +7625,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 let completion = snapshot.execution.completion
                 let transcriptionService = try snapshot.execution
                     .makeTranscriptionService(
-                        cloudDependencies: Self.retryCloudTranscriptionDependenciesFactory(),
+                        cloudDependencies: cloudDependencies,
                         cloudExecutionContext: snapshot.cloudExecutionContext
                     )
                 let transcription = try await transcriptionService.transcribe(fileURL: snapshot.audioURL)
@@ -10943,7 +10929,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func scheduleCloudTranscriptionAutoResume(
-        _ reconciliation: CloudTranscriptionReconciliation
+        _ reconciliation: CloudTranscriptionReconciliation,
+        cloudDependenciesFactory: @escaping () -> CloudTranscriptionDependencies,
+        postProcessingService: PostProcessingService
     ) {
         guard hasTranscriptionAPIKey else { return }
 
@@ -10981,6 +10969,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 self.resumeCloudTranscriptionAfterLaunch(
                     record,
                     runtime: runtime,
+                    cloudDependencies: cloudDependenciesFactory(),
+                    postProcessingService: postProcessingService,
                     completionDelivery: .historyOnly
                 )
             }
@@ -10991,6 +10981,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func resumeCloudTranscriptionAfterLaunch(
         _ record: CloudTranscriptionJobRecord,
         runtime: CloudTranscriptionExecutionSnapshot,
+        cloudDependencies: CloudTranscriptionDependencies,
+        postProcessingService: PostProcessingService,
         completionDelivery: TranscriptionCompletionDeliveryPolicy
     ) {
         guard completionDelivery == .historyOnly,
@@ -11016,7 +11008,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
             session: session,
             completion: completion
         )
-        let postProcessingService = makePostProcessingService()
         let task = Task { [weak self] in
             guard let self else { return }
             do {
@@ -11024,6 +11015,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     runtime,
                     completion
                 ).makeTranscriptionService(
+                    cloudDependencies: cloudDependencies,
                     cloudExecutionContext: context
                 )
                 let transcription = try await service.transcribe(

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -9937,6 +9937,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }?.original
     }
 
+    static func aiProcessingFailureReason(
+        for error: Error,
+        fallback: String
+    ) -> String {
+        if case .requestTimedOut = error as? PostProcessingError {
+            return "request-timed-out"
+        }
+        return fallback
+    }
+
     private enum TranscriptProcessingOutcome {
         case skippedEmptyRawTranscript
         case voiceMacro(command: String)
@@ -10013,7 +10023,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     : .commandModeSucceeded(invocation: invocation)
                 return (result.transcript, outcome, result.prompt, nil, .succeeded)
             } catch {
-                let issue = postProcessingService.userIssue(for: error)
+                let issue = postProcessingService.userIssue(
+                    for: error,
+                    operation: .commandTransform
+                )
                 os_log(
                     .error,
                     log: recordingLog,
@@ -10025,7 +10038,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     .commandModeFailedFallback(invocation: invocation),
                     "",
                     issue.record,
-                    .failed(reason: "command-transform-failed")
+                    .failed(
+                        reason: Self.aiProcessingFailureReason(
+                            for: error,
+                            fallback: "command-transform-failed"
+                        )
+                    )
                 )
             }
         }
@@ -10068,15 +10086,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     .rawFallback(reason: reason)
                 )
             }
-            let failureReason: String
-            switch error as? PostProcessingError {
-            case .some(.requestTimedOut):
-                failureReason = "request-timed-out"
-            case .some(.emptyOutput):
-                failureReason = "empty-output"
-            default:
-                failureReason = "post-processing-failed"
+            let fallbackReason: String
+            if case .emptyOutput = error as? PostProcessingError {
+                fallbackReason = "empty-output"
+            } else {
+                fallbackReason = "post-processing-failed"
             }
+            let failureReason = Self.aiProcessingFailureReason(
+                for: error,
+                fallback: fallbackReason
+            )
             return (
                 trimmedRawTranscript,
                 .postProcessingFailedFallback,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -219,6 +219,8 @@ private struct AudioImportTaskConfiguration {
             transcriptionLanguage: transcriptionLanguage,
             localTranscriptionModel: localTranscriptionModel,
             transcriptionModel: transcriptionModel,
+            cloudDependencies: AppState
+                .audioImportCloudTranscriptionDependenciesFactory(),
             cloudExecutionContext: cloudExecutionContext
         )
     }
@@ -411,6 +413,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         () -> CloudTranscriptionDependencies = {
             .live
         }
+    static var audioImportCloudTranscriptionDependenciesFactory:
+        () -> CloudTranscriptionDependencies = {
+            .live
+        }
+    static var postProcessingTransport: PostProcessingService.Transport = { request in
+        try await LLMAPITransport.data(for: request)
+    }
 
     static var googleCalendarTokenLoader: (Bool) -> GoogleCalendarOAuthToken? = { allowsAuthenticationUI in
         GoogleCalendarTokenStore.load(allowsAuthenticationUI: allowsAuthenticationUI)
@@ -4493,7 +4502,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 localServerManager: localServerManager
             ),
             cloudFallbackModelID: choice.isLocal ? nil : cloudFallbackModelID,
-            instructionExecutionGuardEnabled: instructionExecutionGuardEnabled
+            instructionExecutionGuardEnabled: instructionExecutionGuardEnabled,
+            transport: postProcessingTransport
         )
     }
 
@@ -7476,7 +7486,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         transcriptionLanguageCodeOverride: configuration.transcriptionLanguage.code,
                         spokenLanguage: transcription.spokenLanguage,
                         customVocabularyOverride: configuration.customVocabulary,
-                        customSystemPromptOverride: configuration.customSystemPrompt
+                        customSystemPromptOverride: configuration.customSystemPrompt,
+                        aiProcessingOutcome: result.aiProcessingOutcome
                     )
                     self.completeCloudTranscriptionHistory(
                         historyID: noteID,
@@ -7664,6 +7675,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             parsedTranscript: parsedTranscript,
                             isRetry: true
                         ),
+                    aiProcessingOutcome: result.aiProcessingOutcome
+                        .pipelineHistoryStatus,
                     debugStatus: "Retried",
                     transcriptFileName: transcriptFileName,
                     spokenLanguage: transcription.spokenLanguage
@@ -7685,6 +7698,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     postProcessedTranscript: snapshot.item.postProcessedTranscript,
                     postProcessingPrompt: snapshot.item.postProcessingPrompt,
                     postProcessingStatus: issue.persistedStatus,
+                    aiProcessingOutcome: snapshot.item.aiProcessingOutcome,
                     debugStatus: "Retry failed",
                     transcriptFileName: snapshot.item.transcriptFileName
                 )
@@ -7869,6 +7883,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         postProcessedTranscript: String,
         postProcessingPrompt: String?,
         postProcessingStatus: String,
+        aiProcessingOutcome: String,
         debugStatus: String,
         transcriptFileName: String?,
         spokenLanguage: SpokenLanguageResolution? = nil
@@ -7894,6 +7909,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             contextScreenshotDataURL: snapshot.item.contextScreenshotDataURL,
             contextScreenshotStatus: snapshot.item.contextScreenshotStatus,
             postProcessingStatus: postProcessingStatus,
+            aiProcessingOutcome: aiProcessingOutcome,
             debugStatus: debugStatus,
             customVocabulary: snapshot.customVocabulary,
             customSystemPrompt: snapshot.customSystemPrompt,
@@ -11071,6 +11087,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             parsedTranscript: parsed,
                             isRetry: true
                         ),
+                    aiProcessingOutcome: result.aiProcessingOutcome
+                        .pipelineHistoryStatus,
                     debugStatus: "Resumed after relaunch",
                     transcriptFileName: item.transcriptFileName,
                     spokenLanguage: transcription.spokenLanguage

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -385,9 +385,7 @@ Behavior:
     private func postProcessingTimeoutSeconds(
         for endpoint: AIProcessingEndpoint
     ) -> TimeInterval {
-        let override = UserDefaults.standard.double(
-            forKey: "post_processing_timeout_seconds"
-        )
+        let override = UserDefaults.standard.double(forKey: "post_processing_timeout_seconds")
         if override.isFinite, override > 0 {
             return override
         }

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -333,10 +333,8 @@ Behavior:
     private let defaultFallbackModel = AppState.defaultPostProcessingFallbackModel
     private let defaultModelReasoningEffort = "low"
     private let postProcessingMaxCompletionTokens = 4096
-    private var postProcessingTimeoutSeconds: TimeInterval {
-        let override = UserDefaults.standard.double(forKey: "post_processing_timeout_seconds")
-        return override > 0 ? override : 20
-    }
+    private static let cloudPostProcessingTimeoutSeconds: TimeInterval = 20
+    private static let localPostProcessingTimeoutSeconds: TimeInterval = 120
     private var isLocalBackend: Bool { backendExecutor.choice.isLocal }
     private var selectedModelID: String { backendExecutor.choice.modelID }
     private var cloudBaseURL: String { backendExecutor.cloudBaseURL }
@@ -379,6 +377,30 @@ Behavior:
             : nil
         self.instructionExecutionGuardEnabled = instructionExecutionGuardEnabled
         self.transport = transport
+    }
+
+    private func postProcessingTimeoutSeconds(
+        for endpoint: AIProcessingEndpoint
+    ) -> TimeInterval {
+        let override = UserDefaults.standard.double(
+            forKey: "post_processing_timeout_seconds"
+        )
+        if override.isFinite, override > 0 {
+            return override
+        }
+        return endpoint.kind == .local
+            ? Self.localPostProcessingTimeoutSeconds
+            : Self.cloudPostProcessingTimeoutSeconds
+    }
+
+    private func performTransport(
+        for request: URLRequest
+    ) async throws -> (Data, URLResponse) {
+        do {
+            return try await transport(request)
+        } catch let error as URLError where error.code == .timedOut {
+            throw PostProcessingError.requestTimedOut(request.timeoutInterval)
+        }
     }
 
     func userIssue(for error: Error) -> QuillUserIssueError {
@@ -876,7 +898,7 @@ Behavior:
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = postProcessingTimeoutSeconds
+        request.timeoutInterval = postProcessingTimeoutSeconds(for: endpoint)
         let model = endpoint.selectedModelID
 
         let systemPrompt = postProcessingSystemPrompt(
@@ -938,7 +960,7 @@ Model: \(model)
 
         request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
 
-        let (data, response) = try await transport(request)
+        let (data, response) = try await performTransport(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw PostProcessingError.invalidResponse("No HTTP response")
         }
@@ -1076,7 +1098,7 @@ Model: \(model)
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = postProcessingTimeoutSeconds
+        request.timeoutInterval = postProcessingTimeoutSeconds(for: endpoint)
         let model = endpoint.selectedModelID
 
         let normalizedVocabulary = normalizedVocabularyText(customVocabulary)
@@ -1184,7 +1206,7 @@ Model: \(model)
 
         request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
 
-        let (data, response) = try await transport(request)
+        let (data, response) = try await performTransport(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw PostProcessingError.invalidResponse("No HTTP response")
         }

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -56,7 +56,9 @@ enum PostProcessingError: LocalizedError {
             code = .postProcessingRateLimited
         case .suspectedInstructionExecution, .outputRejected:
             code = .postProcessingGuardFallback
-        case .invalidResponse, .invalidInput, .emptyOutput, .requestTimedOut:
+        case .requestTimedOut:
+            code = .requestTimedOut
+        case .invalidResponse, .invalidInput, .emptyOutput:
             code = .postProcessingFailed
         }
         let statusCode: Int?
@@ -73,7 +75,8 @@ enum PostProcessingError: LocalizedError {
                     httpStatus: statusCode,
                     providerHost: providerHost,
                     modelID: modelID,
-                    localBackend: localBackend
+                    localBackend: localBackend,
+                    operation: .postProcessing
                 )
             ),
             privateDiagnostic: localizedDescription

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -37,7 +37,8 @@ enum PostProcessingError: LocalizedError {
     func userIssue(
         providerHost: String?,
         modelID: String,
-        localBackend: String? = nil
+        localBackend: String? = nil,
+        operation: QuillUserIssueOperation = .postProcessing
     ) -> QuillUserIssueError {
         let code: QuillUserIssueCode
         switch self {
@@ -76,7 +77,7 @@ enum PostProcessingError: LocalizedError {
                     providerHost: providerHost,
                     modelID: modelID,
                     localBackend: localBackend,
-                    operation: .postProcessing
+                    operation: operation
                 )
             ),
             privateDiagnostic: localizedDescription
@@ -404,7 +405,10 @@ Behavior:
         }
     }
 
-    func userIssue(for error: Error) -> QuillUserIssueError {
+    func userIssue(
+        for error: Error,
+        operation: QuillUserIssueOperation = .postProcessing
+    ) -> QuillUserIssueError {
         if let issue = error as? QuillUserIssueError {
             return issue
         }
@@ -459,7 +463,8 @@ Behavior:
             return postProcessingError.userIssue(
                 providerHost: providerHost,
                 modelID: resolvedPrimaryModel(),
-                localBackend: isLocalBackend ? "Local AI" : nil
+                localBackend: isLocalBackend ? "Local AI" : nil,
+                operation: operation
             )
         }
         let nsError = error as NSError
@@ -469,7 +474,8 @@ Behavior:
                 severity: .warning,
                 context: QuillUserIssueContext(
                     providerHost: providerHost,
-                    modelID: resolvedPrimaryModel()
+                    modelID: resolvedPrimaryModel(),
+                    operation: operation
                 )
             ),
             privateDiagnostic: "\(nsError.domain) \(nsError.code)"

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -6,7 +6,7 @@ enum PostProcessingError: LocalizedError {
     case invalidResponse(String)
     case invalidInput(String)
     case emptyOutput
-    case requestTimedOut(TimeInterval)
+    case requestTimedOut(TimeInterval, modelID: String? = nil)
     case suspectedInstructionExecution
     case outputRejected(AIValidationFailure)
 
@@ -25,13 +25,20 @@ enum PostProcessingError: LocalizedError {
             return "Invalid post-processing input: \(details)"
         case .emptyOutput:
             return "Post-processing returned empty output"
-        case .requestTimedOut(let seconds):
+        case .requestTimedOut(let seconds, _):
             return "Post-processing timed out after \(Int(seconds))s"
         case .suspectedInstructionExecution:
             return "Post-processing output looked like it answered the transcript instead of cleaning it"
         case .outputRejected(let failure):
             return "Post-processing output rejected: \(String(describing: failure))"
         }
+    }
+
+    func effectiveModelID(fallback: String) -> String {
+        if case .requestTimedOut(_, let modelID) = self {
+            return modelID ?? fallback
+        }
+        return fallback
     }
 
     func userIssue(
@@ -75,7 +82,7 @@ enum PostProcessingError: LocalizedError {
                 context: QuillUserIssueContext(
                     httpStatus: statusCode,
                     providerHost: providerHost,
-                    modelID: modelID,
+                    modelID: effectiveModelID(fallback: modelID),
                     localBackend: localBackend,
                     operation: operation
                 )
@@ -396,12 +403,16 @@ Behavior:
     }
 
     private func performTransport(
-        for request: URLRequest
+        for request: URLRequest,
+        endpoint: AIProcessingEndpoint
     ) async throws -> (Data, URLResponse) {
         do {
             return try await transport(request)
         } catch let error as URLError where error.code == .timedOut {
-            throw PostProcessingError.requestTimedOut(request.timeoutInterval)
+            throw PostProcessingError.requestTimedOut(
+                request.timeoutInterval,
+                modelID: endpoint.selectedModelID
+            )
         }
     }
 
@@ -967,7 +978,10 @@ Model: \(model)
 
         request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
 
-        let (data, response) = try await performTransport(for: request)
+        let (data, response) = try await performTransport(
+            for: request,
+            endpoint: endpoint
+        )
         guard let httpResponse = response as? HTTPURLResponse else {
             throw PostProcessingError.invalidResponse("No HTTP response")
         }
@@ -1213,7 +1227,10 @@ Model: \(model)
 
         request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
 
-        let (data, response) = try await performTransport(for: request)
+        let (data, response) = try await performTransport(
+            for: request,
+            endpoint: endpoint
+        )
         guard let httpResponse = response as? HTTPURLResponse else {
             throw PostProcessingError.invalidResponse("No HTTP response")
         }

--- a/Sources/QuillUserIssue.swift
+++ b/Sources/QuillUserIssue.swift
@@ -81,6 +81,10 @@ enum ProviderDiagnosticCode {
     }
 }
 
+enum QuillUserIssueOperation: String, Codable, Equatable, Sendable {
+    case postProcessing
+}
+
 struct QuillUserIssueContext: Codable, Equatable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case httpStatus
@@ -91,6 +95,7 @@ struct QuillUserIssueContext: Codable, Equatable, Sendable {
         case processExitCode
         case retryExhausted
         case meetingSummaryFailureSubtype
+        case operation
     }
 
     let httpStatus: Int?
@@ -101,6 +106,7 @@ struct QuillUserIssueContext: Codable, Equatable, Sendable {
     let processExitCode: Int32?
     let retryExhausted: Bool?
     let meetingSummaryFailureSubtype: MeetingSummaryFailureSubtype?
+    let operation: QuillUserIssueOperation?
 
     init(
         httpStatus: Int? = nil,
@@ -110,7 +116,8 @@ struct QuillUserIssueContext: Codable, Equatable, Sendable {
         localBackend: String? = nil,
         processExitCode: Int32? = nil,
         retryExhausted: Bool? = nil,
-        meetingSummaryFailureSubtype: MeetingSummaryFailureSubtype? = nil
+        meetingSummaryFailureSubtype: MeetingSummaryFailureSubtype? = nil,
+        operation: QuillUserIssueOperation? = nil
     ) {
         self.httpStatus = httpStatus
         self.providerHost = providerHost
@@ -120,6 +127,7 @@ struct QuillUserIssueContext: Codable, Equatable, Sendable {
         self.processExitCode = processExitCode
         self.retryExhausted = retryExhausted
         self.meetingSummaryFailureSubtype = meetingSummaryFailureSubtype
+        self.operation = operation
     }
 
     init(from decoder: Decoder) throws {
@@ -135,6 +143,10 @@ struct QuillUserIssueContext: Codable, Equatable, Sendable {
             meetingSummaryFailureSubtype: try? container.decodeIfPresent(
                 MeetingSummaryFailureSubtype.self,
                 forKey: .meetingSummaryFailureSubtype
+            ),
+            operation: try container.decodeIfPresent(
+                QuillUserIssueOperation.self,
+                forKey: .operation
             )
         )
     }
@@ -250,7 +262,17 @@ struct QuillUserIssueRecord: Codable, Equatable, Sendable {
         language: String = preferredLocalizedStringLanguage(),
         bundle: Bundle = .main
     ) -> QuillUserIssuePresentation {
-        let copy = code.copy
+        let copy: QuillUserIssueCopy
+        if code == .requestTimedOut,
+           context.operation == .postProcessing {
+            copy = QuillUserIssueCopy(
+                titleKey: "Transcript cleanup timed out",
+                bodyKey: "Quill kept the original transcript because cleanup did not finish in time.",
+                suggestionKey: "Use the original transcript or try cleanup again later."
+            )
+        } else {
+            copy = code.copy
+        }
         let title = localizedCatalogString(
             copy.titleKey,
             language: language,

--- a/Sources/QuillUserIssue.swift
+++ b/Sources/QuillUserIssue.swift
@@ -83,6 +83,7 @@ enum ProviderDiagnosticCode {
 
 enum QuillUserIssueOperation: String, Codable, Equatable, Sendable {
     case postProcessing
+    case commandTransform
 }
 
 struct QuillUserIssueContext: Codable, Equatable, Sendable {
@@ -269,6 +270,13 @@ struct QuillUserIssueRecord: Codable, Equatable, Sendable {
                 titleKey: "Transcript cleanup timed out",
                 bodyKey: "Quill kept the original transcript because cleanup did not finish in time.",
                 suggestionKey: "Use the original transcript or try cleanup again later."
+            )
+        } else if code == .requestTimedOut,
+                  context.operation == .commandTransform {
+            copy = QuillUserIssueCopy(
+                titleKey: "Text edit timed out",
+                bodyKey: "Quill kept the selected text because the edit did not finish in time.",
+                suggestionKey: "Use the selected text or try the edit again later."
             )
         } else {
             copy = code.copy

--- a/Sources/QuillUserIssue.swift
+++ b/Sources/QuillUserIssue.swift
@@ -145,7 +145,7 @@ struct QuillUserIssueContext: Codable, Equatable, Sendable {
                 MeetingSummaryFailureSubtype.self,
                 forKey: .meetingSummaryFailureSubtype
             ),
-            operation: try container.decodeIfPresent(
+            operation: try? container.decodeIfPresent(
                 QuillUserIssueOperation.self,
                 forKey: .operation
             )
@@ -263,24 +263,7 @@ struct QuillUserIssueRecord: Codable, Equatable, Sendable {
         language: String = preferredLocalizedStringLanguage(),
         bundle: Bundle = .main
     ) -> QuillUserIssuePresentation {
-        let copy: QuillUserIssueCopy
-        if code == .requestTimedOut,
-           context.operation == .postProcessing {
-            copy = QuillUserIssueCopy(
-                titleKey: "Transcript cleanup timed out",
-                bodyKey: "Quill kept the original transcript because cleanup did not finish in time.",
-                suggestionKey: "Use the original transcript or try cleanup again later."
-            )
-        } else if code == .requestTimedOut,
-                  context.operation == .commandTransform {
-            copy = QuillUserIssueCopy(
-                titleKey: "Text edit timed out",
-                bodyKey: "Quill kept the selected text because the edit did not finish in time.",
-                suggestionKey: "Use the selected text or try the edit again later."
-            )
-        } else {
-            copy = code.copy
-        }
+        let copy = code.copy(for: context.operation)
         let title = localizedCatalogString(
             copy.titleKey,
             language: language,
@@ -541,7 +524,9 @@ private extension QuillUserIssueCode {
         }
     }
 
-    var copy: QuillUserIssueCopy {
+    func copy(
+        for operation: QuillUserIssueOperation?
+    ) -> QuillUserIssueCopy {
         switch self {
         case .networkUnavailable:
             return QuillUserIssueCopy(
@@ -550,11 +535,26 @@ private extension QuillUserIssueCode {
                 suggestionKey: "Check your internet connection, then try again."
             )
         case .requestTimedOut:
-            return QuillUserIssueCopy(
-                titleKey: "Transcription timed out",
-                bodyKey: "The transcription service did not respond in time.",
-                suggestionKey: "Try again. If this keeps happening, check the provider status or choose another configured model."
-            )
+            switch operation {
+            case .postProcessing:
+                return QuillUserIssueCopy(
+                    titleKey: "Transcript cleanup timed out",
+                    bodyKey: "Quill kept the original transcript because cleanup did not finish in time.",
+                    suggestionKey: "Use the original transcript or try cleanup again later."
+                )
+            case .commandTransform:
+                return QuillUserIssueCopy(
+                    titleKey: "Text edit timed out",
+                    bodyKey: "Quill kept the selected text because the edit did not finish in time.",
+                    suggestionKey: "Use the selected text or try the edit again later."
+                )
+            case nil:
+                return QuillUserIssueCopy(
+                    titleKey: "Transcription timed out",
+                    bodyKey: "The transcription service did not respond in time.",
+                    suggestionKey: "Try again. If this keeps happening, check the provider status or choose another configured model."
+                )
+            }
         case .rateLimited:
             return QuillUserIssueCopy(
                 titleKey: "Transcription is temporarily limited",

--- a/Tests/AppStateAIProcessingBackendTests.swift
+++ b/Tests/AppStateAIProcessingBackendTests.swift
@@ -2392,17 +2392,29 @@ struct AppStateAIProcessingBackendTests {
     }
 
     private static func testCloudResumeCapturesPostProcessingServiceBeforeTaskStarts() throws {
+        let source = try appStateSource()
+        let scheduling = sourceBlock(
+            in: source,
+            from: "if let cloudReconciliation {",
+            to: "speechRecognitionAuthorizationStatus ="
+        )
+        let serviceSnapshot = requiredRange(
+            of: "let postProcessingService = makePostProcessingService()",
+            in: scheduling
+        )
+        let schedulingTask = requiredRange(
+            of: "Task { @MainActor",
+            in: scheduling
+        )
+        assert(serviceSnapshot.lowerBound < schedulingTask.lowerBound)
+
         let body = sourceBlock(
-            in: try appStateSource(),
+            in: source,
             from: "private func resumeCloudTranscriptionAfterLaunch(",
             to: "private func installCloudTranscriptionTask("
         )
-        let snapshot = requiredRange(
-            of: "let postProcessingService = makePostProcessingService()",
-            in: body
-        )
+        assert(body.contains("postProcessingService: PostProcessingService"))
         let task = requiredRange(of: "let task = Task", in: body)
-        assert(snapshot.lowerBound < task.lowerBound)
         let taskBody = String(body[task.lowerBound...])
         assert(!taskBody.contains("makePostProcessingService()"))
         assert(taskBody.contains("postProcessingService: postProcessingService"))

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -135,6 +135,9 @@ struct AppStateTranscriptionConfigurationTests {
         await testRetryAvailabilityRequiresProviderConfiguration()
         await testRetryAvailabilityAcceptsConfiguredAPIStandard()
         try await testRetryPreservesMeetingSummaryMetadata()
+        try await testAudioImportTimeoutPreservesRawTranscriptAndFailedOutcome()
+        try await testRetryTimeoutPreservesRawTranscriptAndFailedOutcome()
+        try await testRetryTranscriptionFailurePreservesExistingAIOutcome()
         try testRetryUsesCurrentPostProcessingAndAudioOnlyMetadata()
         try testAudioOnlyRetryCreatesTranscriptFileAndPreservesMetadata()
         try testHistoryReconstructionPreservesMeetingSummaryMetadata()
@@ -2660,6 +2663,196 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(persisted.meetingSummaryAttempt == attempt)
     }
 
+    private static func testAudioImportTimeoutPreservesRawTranscriptAndFailedOutcome() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+            resetDefaults()
+            let rawTranscript = "가져온 원본 전사문"
+            let store = AppState.makeDefaultPipelineHistoryStore()
+            AppState.pipelineHistoryStoreFactory = { store }
+            let sourceURL = rootDirectory.appendingPathComponent(
+                "import-timeout-\(UUID().uuidString).wav"
+            )
+            try writeTestWAV(at: sourceURL)
+
+            let originalImportDependencies =
+                AppState.audioImportCloudTranscriptionDependenciesFactory
+            let originalTransport = AppState.postProcessingTransport
+            defer {
+                AppState.audioImportCloudTranscriptionDependenciesFactory =
+                    originalImportDependencies
+                AppState.postProcessingTransport = originalTransport
+            }
+            AppState.audioImportCloudTranscriptionDependenciesFactory = {
+                successfulCloudDependencies(transcript: rawTranscript)
+            }
+            AppState.postProcessingTransport = { _ in
+                throw URLError(.timedOut)
+            }
+
+            let appState = await MainActor.run { AppState() }
+            await MainActor.run {
+                appState.apiKey = "post-processing-key"
+                appState.transcriptionAPIKey = "transcription-key"
+                appState.transcriptionAPIURL = "https://api.example.com/openai/v1"
+                appState.postProcessingBackendChoice = .cloud(
+                    modelID: "provider/model"
+                )
+                appState.importAudioFile(
+                    sourceURL,
+                    choice: .apiStandard(modelID: "whisper-large-v3")
+                )
+            }
+
+            await waitUntil {
+                appState.pipelineHistory.contains {
+                    $0.rawTranscript == rawTranscript
+                        && $0.postProcessingStatus.hasPrefix(
+                            QuillUserIssueRecord.persistedStatusPrefix
+                        )
+                }
+            }
+            guard let item = appState.pipelineHistory.first(where: {
+                $0.rawTranscript == rawTranscript
+            }) else {
+                throw AppStateTranscriptionConfigurationTestError
+                    .missingHistoryItem
+            }
+            try assertTimeoutFallbackHistory(
+                item,
+                rawTranscript: rawTranscript
+            )
+            let persisted = try requireHistoryItem(
+                withID: item.id,
+                in: store.loadAllHistory()
+            )
+            try assertTimeoutFallbackHistory(
+                persisted,
+                rawTranscript: rawTranscript
+            )
+        }
+    }
+
+    private static func testRetryTimeoutPreservesRawTranscriptAndFailedOutcome() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { _ in
+            resetDefaults()
+            let rawTranscript = "재시도 원본 전사문"
+            let store = AppState.makeDefaultPipelineHistoryStore()
+            AppState.pipelineHistoryStoreFactory = { store }
+            let fileName = "retry-timeout-\(UUID().uuidString).wav"
+            let audioURL = AppState.audioStorageDirectory()
+                .appendingPathComponent(fileName)
+            try writeTestWAV(at: audioURL)
+            let originalItem = retryHistoryItem(
+                audioFileName: fileName,
+                aiProcessingOutcome: "failed:previous-processing-error"
+            )
+            _ = try store.append(originalItem, maxCount: 10)
+
+            let originalRetryDependencies =
+                AppState.retryCloudTranscriptionDependenciesFactory
+            let originalTransport = AppState.postProcessingTransport
+            defer {
+                AppState.retryCloudTranscriptionDependenciesFactory =
+                    originalRetryDependencies
+                AppState.postProcessingTransport = originalTransport
+            }
+            AppState.retryCloudTranscriptionDependenciesFactory = {
+                successfulCloudDependencies(transcript: rawTranscript)
+            }
+            AppState.postProcessingTransport = { _ in
+                throw URLError(.timedOut)
+            }
+
+            let appState = await MainActor.run { AppState() }
+            await MainActor.run {
+                appState.apiKey = "post-processing-key"
+                appState.transcriptionAPIKey = "transcription-key"
+                appState.transcriptionAPIURL = "https://api.example.com/openai/v1"
+                appState.postProcessingBackendChoice = .cloud(
+                    modelID: "provider/model"
+                )
+                appState.setNoteBrowserTranscriptionChoice(
+                    .apiStandard(modelID: "whisper-large-v3")
+                )
+                precondition(
+                    appState.noteBrowserRetryAvailability(for: originalItem)
+                        == .ready
+                )
+                appState.retryTranscription(item: originalItem)
+                precondition(
+                    appState.retryingItemIDs.contains(originalItem.id)
+                )
+            }
+
+            await waitUntil {
+                !appState.retryingItemIDs.contains(originalItem.id)
+            }
+            let item = try requireHistoryItem(
+                withID: originalItem.id,
+                in: store.loadAllHistory()
+            )
+            try assertTimeoutFallbackHistory(
+                item,
+                rawTranscript: rawTranscript
+            )
+        }
+    }
+
+    private static func testRetryTranscriptionFailurePreservesExistingAIOutcome() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { _ in
+            resetDefaults()
+            let previousOutcome = "failed:previous-processing-error"
+            let store = AppState.makeDefaultPipelineHistoryStore()
+            AppState.pipelineHistoryStoreFactory = { store }
+            let fileName = "retry-failure-\(UUID().uuidString).wav"
+            let audioURL = AppState.audioStorageDirectory()
+                .appendingPathComponent(fileName)
+            try writeTestWAV(at: audioURL)
+            let originalItem = retryHistoryItem(
+                audioFileName: fileName,
+                aiProcessingOutcome: previousOutcome
+            )
+            _ = try store.append(originalItem, maxCount: 10)
+
+            let originalRetryDependencies =
+                AppState.retryCloudTranscriptionDependenciesFactory
+            defer {
+                AppState.retryCloudTranscriptionDependenciesFactory =
+                    originalRetryDependencies
+            }
+            AppState.retryCloudTranscriptionDependenciesFactory = {
+                failingCloudDependencies()
+            }
+
+            let appState = await MainActor.run { AppState() }
+            await MainActor.run {
+                appState.transcriptionAPIKey = "transcription-key"
+                appState.transcriptionAPIURL =
+                    "https://api.example.com/openai/v1"
+                appState.setNoteBrowserTranscriptionChoice(
+                    .apiStandard(modelID: "whisper-large-v3")
+                )
+                precondition(
+                    appState.noteBrowserRetryAvailability(for: originalItem)
+                        == .ready
+                )
+                appState.retryTranscription(item: originalItem)
+                precondition(
+                    appState.retryingItemIDs.contains(originalItem.id)
+                )
+            }
+
+            await waitUntil {
+                !appState.retryingItemIDs.contains(originalItem.id)
+            }
+            let item = try requireHistoryItem(
+                withID: originalItem.id,
+                in: store.loadAllHistory()
+            )
+            precondition(item.aiProcessingOutcome == previousOutcome)
+        }
+    }
+
     private static func testRetryUsesCurrentPostProcessingAndAudioOnlyMetadata() throws {
         let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
         let retrySnapshot = sourceBlock(
@@ -2873,8 +3066,90 @@ struct AppStateTranscriptionConfigurationTests {
         }
     }
 
+    private static func writeTestWAV(at url: URL) throws {
+        var data = CanonicalPCM16WAV.header(dataByteCount: 8)
+        for sample: Int16 in [1, 1, 2, 2] {
+            var littleEndian = sample.littleEndian
+            withUnsafeBytes(of: &littleEndian) {
+                data.append(contentsOf: $0)
+            }
+        }
+        try data.write(to: url)
+    }
+
+    private static func successfulCloudDependencies(
+        transcript: String
+    ) -> CloudTranscriptionDependencies {
+        let temporaryRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "quill-timeout-history-\(UUID().uuidString)"
+            )
+        return CloudTranscriptionDependencies(
+            encodedUploadCeilingBytes: 20_000_000,
+            upload: { request, _ in
+                try await Task.sleep(nanoseconds: 10_000_000)
+                let data = try JSONSerialization.data(withJSONObject: [
+                    "text": transcript,
+                    "language": "ko",
+                    "segments": []
+                ])
+                return (
+                    data,
+                    HTTPURLResponse(
+                        url: request.url!,
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: nil
+                    )!
+                )
+            },
+            checkpointStore: InMemoryCloudTranscriptionCheckpointStore(),
+            progress: { _ in },
+            temporaryRoot: temporaryRoot,
+            sleep: { _ in }
+        )
+    }
+
+    private static func failingCloudDependencies() -> CloudTranscriptionDependencies {
+        let temporaryRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "quill-retry-failure-\(UUID().uuidString)"
+            )
+        return CloudTranscriptionDependencies(
+            encodedUploadCeilingBytes: 20_000_000,
+            upload: { _, _ in
+                try await Task.sleep(nanoseconds: 10_000_000)
+                throw URLError(.cannotConnectToHost)
+            },
+            checkpointStore: InMemoryCloudTranscriptionCheckpointStore(),
+            progress: { _ in },
+            temporaryRoot: temporaryRoot,
+            sleep: { _ in }
+        )
+    }
+
+    private static func assertTimeoutFallbackHistory(
+        _ item: PipelineHistoryItem,
+        rawTranscript: String
+    ) throws {
+        precondition(
+            item.rawTranscript == rawTranscript,
+            "Expected raw transcript \(rawTranscript), got \(item.rawTranscript); status=\(item.postProcessingStatus) outcome=\(item.aiProcessingOutcome)"
+        )
+        precondition(item.postProcessedTranscript == rawTranscript)
+        precondition(
+            item.aiProcessingOutcome == "failed:request-timed-out"
+        )
+        let issue = try QuillUserIssueRecord.decodePersistedStatus(
+            item.postProcessingStatus
+        )
+        precondition(issue.code == .requestTimedOut)
+        precondition(issue.context.operation == .postProcessing)
+    }
+
     private static func retryHistoryItem(
         audioFileName: String?,
+        aiProcessingOutcome: String = "succeeded",
         spokenLanguageCode: String? = nil,
         spokenLanguageResolution: SpokenLanguageResolutionSource? = nil,
         meetingSummaryAttempt: MeetingSummaryAttempt? = nil
@@ -2888,6 +3163,7 @@ struct AppStateTranscriptionConfigurationTests {
             contextScreenshotDataURL: nil,
             contextScreenshotStatus: "No screenshot",
             postProcessingStatus: QuillUserIssueRecord(code: .localModelMissing).persistedStatus,
+            aiProcessingOutcome: aiProcessingOutcome,
             debugStatus: "Failed",
             customVocabulary: "",
             audioFileName: audioFileName,

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -2685,6 +2685,10 @@ struct AppStateTranscriptionConfigurationTests {
             let rawTranscript = "가져온 원본 전사문"
             let replacementTranscript = "뒤늦게 설치된 다른 전사문"
             let store = AppState.makeDefaultPipelineHistoryStore()
+            let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
+            defer {
+                AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
+            }
             AppState.pipelineHistoryStoreFactory = { store }
             let sourceURL = rootDirectory.appendingPathComponent(
                 "import-timeout-\(UUID().uuidString).wav"
@@ -2773,6 +2777,10 @@ struct AppStateTranscriptionConfigurationTests {
             let rawTranscript = "재시도 원본 전사문"
             let replacementTranscript = "뒤늦게 설치된 재시도 전사문"
             let store = AppState.makeDefaultPipelineHistoryStore()
+            let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
+            defer {
+                AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
+            }
             AppState.pipelineHistoryStoreFactory = { store }
             let fileName = "retry-timeout-\(UUID().uuidString).wav"
             let audioURL = AppState.audioStorageDirectory()
@@ -2844,6 +2852,10 @@ struct AppStateTranscriptionConfigurationTests {
             resetDefaults()
             let previousOutcome = "failed:previous-processing-error"
             let store = AppState.makeDefaultPipelineHistoryStore()
+            let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
+            defer {
+                AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
+            }
             AppState.pipelineHistoryStoreFactory = { store }
             let fileName = "retry-failure-\(UUID().uuidString).wav"
             let audioURL = AppState.audioStorageDirectory()
@@ -3024,6 +3036,10 @@ struct AppStateTranscriptionConfigurationTests {
             try writeTestWAV(at: audioURL)
 
             let store = AppState.makeDefaultPipelineHistoryStore()
+            let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
+            defer {
+                AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
+            }
             AppState.pipelineHistoryStoreFactory = { store }
             let originalItem = PipelineHistoryItem(
                 id: historyID,

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -143,6 +143,7 @@ struct AppStateTranscriptionConfigurationTests {
         try testAudioOnlyRetryCreatesTranscriptFileAndPreservesMetadata()
         try testHistoryReconstructionPreservesMeetingSummaryMetadata()
         try testSuccessfulTranscriptionHistoryReceivesSpokenLanguage()
+        try testResumedRetryPassesAIProcessingOutcome()
         try testHistoryDeletionForgetsSummaryGenerationStateAfterPersistence()
         try testRealtimeConfiguredLanguageUsesOneRequestAndResolutionValue()
         try testAudioOnlyRetryDeletesNewTranscriptFileWhenStale()
@@ -2985,6 +2986,27 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(history.contains("let effectiveSpokenLanguage = spokenLanguage ??"))
         precondition(history.contains("spokenLanguageCode: effectiveSpokenLanguage?.languageCode"))
         precondition(history.contains("spokenLanguageResolution: effectiveSpokenLanguage?.source"))
+    }
+
+    private static func testResumedRetryPassesAIProcessingOutcome() throws {
+        let source = try String(
+            contentsOfFile: "Sources/AppState.swift",
+            encoding: .utf8
+        )
+        let resumedCloud = sourceBlock(
+            in: source,
+            from: "private func resumeCloudTranscriptionAfterLaunch(",
+            to: "\n    @MainActor\n    private func installCloudTranscriptionTask"
+        )
+
+        precondition(
+            resumedCloud.contains(
+                "aiProcessingOutcome: result.aiProcessingOutcome"
+            )
+        )
+        precondition(
+            resumedCloud.contains(".pipelineHistoryStatus")
+        )
     }
 
     private static func testHistoryDeletionForgetsSummaryGenerationStateAfterPersistence() throws {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -73,6 +73,7 @@ struct AppStateTranscriptionConfigurationTests {
         testStoppedTranscriptionCompletionSummaryTrimsFinalTranscript()
         testStoppedTranscriptionCompletionSummaryShowsFallbackIndicatorForNonEmptyRawFallback()
         testStoppedTranscriptionCompletionSummaryHidesFallbackIndicatorForEmptyRawFallback()
+        testTimeoutFailureReasonOverridesCommandFallback()
         testStoppedTranscriptionSettingsSnapshotCapturesHistoryMetadata()
         try testAppStateCreatedTranscriptionServicesPassLegacyMlxWhisperToggle()
         try testRetrySnapshotGatesStoredContextByCurrentToggleAndUsability()
@@ -1037,6 +1038,20 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(summary.finalTranscript.isEmpty)
         precondition(summary.shouldPressEnterAfterPaste)
         precondition(!summary.shouldPersistRawDictationFallback)
+    }
+
+    private static func testTimeoutFailureReasonOverridesCommandFallback() {
+        let timeoutReason = AppState.aiProcessingFailureReason(
+            for: PostProcessingError.requestTimedOut(20),
+            fallback: "command-transform-failed"
+        )
+        let genericReason = AppState.aiProcessingFailureReason(
+            for: URLError(.cannotConnectToHost),
+            fallback: "command-transform-failed"
+        )
+
+        precondition(timeoutReason == "request-timed-out")
+        precondition(genericReason == "command-transform-failed")
     }
 
     private static func testAppStateCreatedTranscriptionServicesPassLegacyMlxWhisperToggle() throws {

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -143,7 +143,7 @@ struct AppStateTranscriptionConfigurationTests {
         try testAudioOnlyRetryCreatesTranscriptFileAndPreservesMetadata()
         try testHistoryReconstructionPreservesMeetingSummaryMetadata()
         try testSuccessfulTranscriptionHistoryReceivesSpokenLanguage()
-        try testResumedRetryPassesAIProcessingOutcome()
+        try await testResumedRetryPersistsAIProcessingOutcome()
         try testHistoryDeletionForgetsSummaryGenerationStateAfterPersistence()
         try testRealtimeConfiguredLanguageUsesOneRequestAndResolutionValue()
         try testAudioOnlyRetryDeletesNewTranscriptFileWhenStale()
@@ -2683,6 +2683,7 @@ struct AppStateTranscriptionConfigurationTests {
         try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
             resetDefaults()
             let rawTranscript = "가져온 원본 전사문"
+            let replacementTranscript = "뒤늦게 설치된 다른 전사문"
             let store = AppState.makeDefaultPipelineHistoryStore()
             AppState.pipelineHistoryStoreFactory = { store }
             let sourceURL = rootDirectory.appendingPathComponent(
@@ -2717,18 +2718,36 @@ struct AppStateTranscriptionConfigurationTests {
                     sourceURL,
                     choice: .apiStandard(modelID: "whisper-large-v3")
                 )
+                AppState.audioImportCloudTranscriptionDependenciesFactory = {
+                    successfulCloudDependencies(
+                        transcript: replacementTranscript
+                    )
+                }
+                AppState.postProcessingTransport = { request in
+                    let data = try JSONSerialization.data(withJSONObject: [
+                        "choices": [[
+                            "message": ["content": replacementTranscript]
+                        ]]
+                    ])
+                    return (
+                        data,
+                        HTTPURLResponse(
+                            url: request.url!,
+                            statusCode: 200,
+                            httpVersion: nil,
+                            headerFields: nil
+                        )!
+                    )
+                }
             }
 
             await waitUntil {
                 appState.pipelineHistory.contains {
-                    $0.rawTranscript == rawTranscript
-                        && $0.postProcessingStatus.hasPrefix(
-                            QuillUserIssueRecord.persistedStatusPrefix
-                        )
+                    !$0.rawTranscript.isEmpty
                 }
             }
             guard let item = appState.pipelineHistory.first(where: {
-                $0.rawTranscript == rawTranscript
+                !$0.rawTranscript.isEmpty
             }) else {
                 throw AppStateTranscriptionConfigurationTestError
                     .missingHistoryItem
@@ -2752,6 +2771,7 @@ struct AppStateTranscriptionConfigurationTests {
         try await AppStateTestStorage.withIsolatedStorage { _ in
             resetDefaults()
             let rawTranscript = "재시도 원본 전사문"
+            let replacementTranscript = "뒤늦게 설치된 재시도 전사문"
             let store = AppState.makeDefaultPipelineHistoryStore()
             AppState.pipelineHistoryStoreFactory = { store }
             let fileName = "retry-timeout-\(UUID().uuidString).wav"
@@ -2795,6 +2815,11 @@ struct AppStateTranscriptionConfigurationTests {
                         == .ready
                 )
                 appState.retryTranscription(item: originalItem)
+                AppState.retryCloudTranscriptionDependenciesFactory = {
+                    successfulCloudDependencies(
+                        transcript: replacementTranscript
+                    )
+                }
                 precondition(
                     appState.retryingItemIDs.contains(originalItem.id)
                 )
@@ -2988,25 +3013,128 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(history.contains("spokenLanguageResolution: effectiveSpokenLanguage?.source"))
     }
 
-    private static func testResumedRetryPassesAIProcessingOutcome() throws {
-        let source = try String(
-            contentsOfFile: "Sources/AppState.swift",
-            encoding: .utf8
-        )
-        let resumedCloud = sourceBlock(
-            in: source,
-            from: "private func resumeCloudTranscriptionAfterLaunch(",
-            to: "\n    @MainActor\n    private func installCloudTranscriptionTask"
-        )
+    private static func testResumedRetryPersistsAIProcessingOutcome() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+            resetDefaults()
+            let rawTranscript = "재실행 후 복구된 원본 전사문"
+            let historyID = UUID()
+            let fileName = "\(historyID.uuidString).wav"
+            let audioURL = AppState.audioStorageDirectory()
+                .appendingPathComponent(fileName)
+            try writeTestWAV(at: audioURL)
 
-        precondition(
-            resumedCloud.contains(
-                "aiProcessingOutcome: result.aiProcessingOutcome"
+            let store = AppState.makeDefaultPipelineHistoryStore()
+            AppState.pipelineHistoryStoreFactory = { store }
+            let originalItem = PipelineHistoryItem(
+                id: historyID,
+                timestamp: Date(timeIntervalSince1970: 1),
+                rawTranscript: "",
+                postProcessedTranscript: "",
+                postProcessingPrompt: nil,
+                contextSummary: "",
+                contextScreenshotDataURL: nil,
+                contextScreenshotStatus: "No screenshot",
+                postProcessingStatus: PipelineHistoryItem
+                    .cloudTranscribingStatus,
+                aiProcessingOutcome: "succeeded",
+                debugStatus: "Cloud transcription in progress",
+                customVocabulary: "",
+                audioFileName: fileName,
+                usedLocalTranscription: false,
+                usedContextCapture: false,
+                usedPostProcessing: true,
+                transcriptionLanguageCode: "ko"
             )
-        )
-        precondition(
-            resumedCloud.contains(".pipelineHistoryStatus")
-        )
+            _ = try store.append(originalItem, maxCount: 10)
+
+            let jobStore = CloudTranscriptionJobStore(
+                jobsDirectory: rootDirectory
+                    .appendingPathComponent(
+                        "cloud-transcription/jobs",
+                        isDirectory: true
+                    ),
+                temporaryRoot: rootDirectory
+                    .appendingPathComponent(
+                        "cloud-transcription/tmp",
+                        isDirectory: true
+                    )
+            )
+            let record = try makeResumableCloudRecord(
+                historyID: historyID,
+                audioURL: audioURL
+            )
+            let session = jobStore.beginSession(historyID: historyID)
+            try jobStore.create(record, session: session)
+            jobStore.invalidateSession(historyID: historyID)
+
+            let defaults = UserDefaults.standard
+            defaults.set(true, forKey: "hasCompletedSetup")
+            defaults.set(true, forKey: "transcription_enabled")
+            defaults.set(false, forKey: "use_local_transcription")
+            defaults.set(false, forKey: "disable_post_processing")
+            defaults.set("whisper-large-v3", forKey: "transcription_model")
+            defaults.set("ko", forKey: "transcription_language")
+            AIProcessingBackendChoiceStore.save(
+                .cloud(modelID: "provider/model"),
+                defaults: defaults,
+                key: "post_processing_backend_choice"
+            )
+            AppSettingsStorage.save(
+                "post-processing-key",
+                account: "groq_api_key"
+            )
+            AppSettingsStorage.save(
+                "transcription-key",
+                account: "transcription_api_key"
+            )
+            AppSettingsStorage.save(
+                "http://127.0.0.1:1",
+                account: "api_base_url"
+            )
+            AppSettingsStorage.save(
+                "http://127.0.0.1:1",
+                account: "transcription_api_url"
+            )
+
+            let originalRetryDependencies =
+                AppState.retryCloudTranscriptionDependenciesFactory
+            let originalTransport = AppState.postProcessingTransport
+            defer {
+                AppState.retryCloudTranscriptionDependenciesFactory =
+                    originalRetryDependencies
+                AppState.postProcessingTransport = originalTransport
+            }
+            AppState.retryCloudTranscriptionDependenciesFactory = {
+                successfulCloudDependencies(transcript: rawTranscript)
+            }
+            AppState.postProcessingTransport = { _ in
+                throw URLError(.timedOut)
+            }
+
+            let appState = await MainActor.run { AppState() }
+            await waitUntil(timeoutNanoseconds: 3_000_000_000) {
+                store.loadAllHistory().contains {
+                    $0.id == historyID
+                        && $0.debugStatus == "Resumed after relaunch"
+                }
+            }
+
+            let inMemory = try requireHistoryItem(
+                withID: historyID,
+                in: appState.pipelineHistory
+            )
+            let persisted = try requireHistoryItem(
+                withID: historyID,
+                in: store.loadAllHistory()
+            )
+            for item in [inMemory, persisted] {
+                try assertTimeoutFallbackHistory(
+                    item,
+                    rawTranscript: rawTranscript
+                )
+                precondition(item.debugStatus == "Resumed after relaunch")
+            }
+        }
     }
 
     private static func testHistoryDeletionForgetsSummaryGenerationStateAfterPersistence() throws {
@@ -3101,6 +3229,60 @@ struct AppStateTranscriptionConfigurationTests {
             assert(cleanup.contains("let transcriptFileName = updatedItem.transcriptFileName"))
             assert(cleanup.contains("Self.deleteTranscriptFile(transcriptFileName)"))
         }
+    }
+
+    private static func makeResumableCloudRecord(
+        historyID: UUID,
+        audioURL: URL
+    ) throws -> CloudTranscriptionJobRecord {
+        let layout = try CanonicalPCM16WAV.validateFile(at: audioURL)
+        let source = try CloudTranscriptionSourceIdentityBuilder.make(
+            fileURL: audioURL,
+            layout: layout
+        )
+        let multipart = CloudTranscriptionMultipartLayout(
+            model: "whisper-large-v3",
+            responseFormat: "verbose_json",
+            language: "ko"
+        )
+        let plan = try CloudTranscriptionChunkPlanner().plan(
+            fileURL: audioURL,
+            source: source,
+            wavLayout: layout,
+            multipart: multipart,
+            encodedUploadCeilingBytes: 20_000_000
+        )
+        let runtime = try CloudTranscriptionExecutionSnapshot(
+            baseURL: "http://127.0.0.1:1",
+            apiKey: "transcription-key",
+            model: "whisper-large-v3",
+            language: "ko",
+            encodedUploadCeilingBytes: 20_000_000
+        )
+        return CloudTranscriptionJobRecord(
+            schemaVersion: CloudTranscriptionJobRecord.currentSchemaVersion,
+            historyID: historyID,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2),
+            phase: .interrupted,
+            identity: CloudTranscriptionJobIdentity(
+                providerID: runtime.providerID,
+                model: runtime.model,
+                language: runtime.language,
+                responseFormat: runtime.responseFormat,
+                source: source,
+                planID: plan.planID
+            ),
+            plan: plan,
+            completedChunks: [],
+            firstIncompleteChunkIndex: 0,
+            lastFailure: nil,
+            completionPolicy: CloudTranscriptionCompletionPolicy(
+                postProcessingEnabled: true,
+                outputLanguage: "",
+                pressEnterCommandEnabled: false
+            )
+        )
     }
 
     private static func writeTestWAV(at url: URL) throws {

--- a/Tests/LocalAIIntegrationTests.swift
+++ b/Tests/LocalAIIntegrationTests.swift
@@ -102,7 +102,15 @@ struct LocalAIIntegrationTests {
             tokenCounter: counter
         )
         let sizingPrompt = try MeetingSummaryPromptFactory.singlePass(
-            source: MeetingSummarySource(transcript: "", calendar: nil),
+            source: MeetingSummarySource(
+                transcript: "",
+                calendar: nil,
+                languageContext: MeetingSummaryLanguageContext(
+                    requestedOutputLanguage: "Korean",
+                    appliedLanguageCode: "ko",
+                    resolutionSource: .configured
+                )
+            ),
             outputLanguage: "Korean"
         )
         let budget = try await budgeter.budget(

--- a/Tests/PostProcessingBackendTests.swift
+++ b/Tests/PostProcessingBackendTests.swift
@@ -9,6 +9,11 @@ struct PostProcessingBackendTests {
         try await testCloudRequestOmitsLocalCompatibilityKey()
         try await testLocalFailureDoesNotInvokeCloudFallbackOrSetCooldown()
         try await testLocalCommandTransformUsesEndpointWithoutCloudFallback()
+        try await testBackendDefaultsUseLocal120AndCloud20()
+        try await testExplicitTimeoutOverrideAppliesToBothBackends()
+        try await testInvalidTimeoutOverrideUsesBackendDefaults()
+        try await testCleanupConvertsRealURLTimeout()
+        try await testCommandTransformConvertsRealURLTimeout()
         try await testSequentialChunksUsePerRequestTimeout()
         try await testCommandFallbackUsesPerRequestTimeout()
         try await testOversizedLocalCommandDoesNotReachTransport()
@@ -118,6 +123,174 @@ struct PostProcessingBackendTests {
             label: "command",
             expectedCompletionCeiling: 4_096
         )
+    }
+
+    private static func testBackendDefaultsUseLocal120AndCloud20() async throws {
+        try await withPostProcessingTimeoutOverride(nil) {
+            let localRecorder = PostProcessingRequestRecorder()
+            let localService = makeLocalService { request in
+                localRecorder.record(request)
+                return try successResponse(
+                    request: request,
+                    content: "Cleaned local result."
+                )
+            }
+            _ = try await localService.postProcess(
+                transcript: "clean this",
+                context: testContext,
+                customVocabulary: ""
+            )
+
+            let cloudRecorder = PostProcessingRequestRecorder()
+            let cloudService = makeCloudService { request in
+                cloudRecorder.record(request)
+                return try successResponse(
+                    request: request,
+                    content: "Cleaned cloud result."
+                )
+            }
+            _ = try await cloudService.postProcess(
+                transcript: "clean this",
+                context: testContext,
+                customVocabulary: ""
+            )
+
+            let localRequest = try localRecorder.request()
+            let cloudRequest = try cloudRecorder.request()
+            try expect(
+                localRequest.timeoutInterval == 120,
+                "Local cleanup defaults to 120 seconds"
+            )
+            try expect(
+                cloudRequest.timeoutInterval == 20,
+                "Cloud cleanup remains at 20 seconds"
+            )
+        }
+    }
+
+    private static func testExplicitTimeoutOverrideAppliesToBothBackends() async throws {
+        try await withPostProcessingTimeoutOverride(45) {
+            let localRecorder = PostProcessingRequestRecorder()
+            let localService = makeLocalService { request in
+                localRecorder.record(request)
+                return try successResponse(
+                    request: request,
+                    content: "Cleaned local result."
+                )
+            }
+            _ = try await localService.postProcess(
+                transcript: "clean this",
+                context: testContext,
+                customVocabulary: ""
+            )
+
+            let cloudRecorder = PostProcessingRequestRecorder()
+            let cloudService = makeCloudService { request in
+                cloudRecorder.record(request)
+                return try successResponse(
+                    request: request,
+                    content: "Cleaned cloud result."
+                )
+            }
+            _ = try await cloudService.postProcess(
+                transcript: "clean this",
+                context: testContext,
+                customVocabulary: ""
+            )
+
+            let localRequest = try localRecorder.request()
+            let cloudRequest = try cloudRecorder.request()
+            try expect(
+                localRequest.timeoutInterval == 45,
+                "Local uses explicit override"
+            )
+            try expect(
+                cloudRequest.timeoutInterval == 45,
+                "Cloud uses explicit override"
+            )
+        }
+    }
+
+    private static func testInvalidTimeoutOverrideUsesBackendDefaults() async throws {
+        for invalidValue: Double in [0, -1, .infinity, .nan] {
+            try await withPostProcessingTimeoutOverride(invalidValue) {
+                let localRecorder = PostProcessingRequestRecorder()
+                let service = makeLocalService { request in
+                    localRecorder.record(request)
+                    return try successResponse(
+                        request: request,
+                        content: "Cleaned local result."
+                    )
+                }
+                _ = try await service.postProcess(
+                    transcript: "clean this",
+                    context: testContext,
+                    customVocabulary: ""
+                )
+                let request = try localRecorder.request()
+                try expect(
+                    request.timeoutInterval == 120,
+                    "Invalid override uses Local default"
+                )
+            }
+        }
+    }
+
+    private static func testCleanupConvertsRealURLTimeout() async throws {
+        try await withPostProcessingTimeoutOverride(nil) {
+            let service = makeLocalService { _ in
+                throw URLError(.timedOut)
+            }
+            do {
+                _ = try await service.postProcess(
+                    transcript: "raw transcript",
+                    context: testContext,
+                    customVocabulary: ""
+                )
+                throw PostProcessingBackendTestFailure(
+                    "Expected Local cleanup timeout"
+                )
+            } catch let error as PostProcessingError {
+                guard case .requestTimedOut(let seconds) = error else {
+                    throw PostProcessingBackendTestFailure(
+                        "Expected requestTimedOut, got \(error)"
+                    )
+                }
+                try expect(
+                    seconds == 120,
+                    "Local timeout reports the effective request timeout"
+                )
+            }
+        }
+    }
+
+    private static func testCommandTransformConvertsRealURLTimeout() async throws {
+        try await withPostProcessingTimeoutOverride(nil) {
+            let service = makeCloudService { _ in
+                throw URLError(.timedOut)
+            }
+            do {
+                _ = try await service.commandTransform(
+                    selectedText: "Original text",
+                    voiceCommand: "Make it concise",
+                    context: testContext,
+                    customVocabulary: ""
+                )
+                throw PostProcessingBackendTestFailure(
+                    "Expected Cloud command timeout"
+                )
+            } catch let error as PostProcessingError {
+                guard case .requestTimedOut(let seconds) = error else {
+                    throw PostProcessingBackendTestFailure(
+                        "Expected requestTimedOut, got \(error)"
+                    )
+                }
+                try expect(
+                    seconds == 20,
+                    "Cloud timeout reports the effective request timeout"
+                )
+            }
+        }
     }
 
     private static func testSequentialChunksUsePerRequestTimeout() async throws {
@@ -390,6 +563,42 @@ struct PostProcessingBackendTests {
             issue.record.recoveryAction == .openProviderSettings,
             "invalid cloud URL opens provider settings"
         )
+    }
+
+    private static func makeCloudService(
+        transport: @escaping PostProcessingService.Transport
+    ) -> PostProcessingService {
+        PostProcessingService(
+            backendExecutor: AIProcessingBackendExecutor(
+                choice: .cloud(modelID: "primary/model"),
+                cloudBaseURL: "https://api.example.com/openai/v1",
+                cloudAPIKey: "cloud-secret"
+            ),
+            cloudFallbackModelID: nil,
+            instructionExecutionGuardEnabled: false,
+            transport: transport
+        )
+    }
+
+    private static func withPostProcessingTimeoutOverride(
+        _ value: Double?,
+        operation: () async throws -> Void
+    ) async throws {
+        let key = "post_processing_timeout_seconds"
+        let previous = UserDefaults.standard.object(forKey: key)
+        if let value {
+            UserDefaults.standard.set(value, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+        try await operation()
     }
 
     private static func makeLocalService(

--- a/Tests/PostProcessingBackendTests.swift
+++ b/Tests/PostProcessingBackendTests.swift
@@ -14,6 +14,7 @@ struct PostProcessingBackendTests {
         try await testInvalidTimeoutOverrideUsesBackendDefaults()
         try await testCleanupConvertsRealURLTimeout()
         try await testCommandTransformConvertsRealURLTimeout()
+        try await testTimeoutIssueDoesNotExposeRequestSourceData()
         try await testSequentialChunksUsePerRequestTimeout()
         try await testCommandFallbackUsesPerRequestTimeout()
         try await testOversizedLocalCommandDoesNotReachTransport()
@@ -290,6 +291,94 @@ struct PostProcessingBackendTests {
                     "Cloud timeout reports the effective request timeout"
                 )
             }
+        }
+    }
+
+    private static func testTimeoutIssueDoesNotExposeRequestSourceData() async throws {
+        let transcriptSentinel = "TRANSCRIPT_SENTINEL_7F1A"
+        let promptSentinel = "PROMPT_SENTINEL_8B2C"
+        let credentialSentinel = "sk-CREDENTIAL_SENTINEL_9D3E"
+        let errorSentinel = "ERROR_SENTINEL_/Users/private_4A5F"
+        let service = PostProcessingService(
+            backendExecutor: AIProcessingBackendExecutor(
+                choice: .cloud(modelID: "provider/model"),
+                cloudBaseURL: "https://api.example.com/openai/v1",
+                cloudAPIKey: credentialSentinel
+            ),
+            cloudFallbackModelID: nil,
+            instructionExecutionGuardEnabled: false,
+            transport: { request in
+                guard request.value(forHTTPHeaderField: "Authorization")
+                        == "Bearer \(credentialSentinel)" else {
+                    throw PostProcessingBackendTestFailure(
+                        "Expected credential sentinel in request header"
+                    )
+                }
+                guard let body = request.httpBody,
+                      let bodyText = String(data: body, encoding: .utf8),
+                      bodyText.contains(transcriptSentinel),
+                      bodyText.contains(promptSentinel) else {
+                    throw PostProcessingBackendTestFailure(
+                        "Expected transcript and prompt sentinels in request body"
+                    )
+                }
+                throw URLError(
+                    .timedOut,
+                    userInfo: [NSLocalizedDescriptionKey: errorSentinel]
+                )
+            }
+        )
+
+        let issue: QuillUserIssueError
+        do {
+            _ = try await service.postProcess(
+                transcript: transcriptSentinel,
+                context: testContext,
+                customVocabulary: "",
+                customSystemPrompt: promptSentinel
+            )
+            throw PostProcessingBackendTestFailure(
+                "Expected timeout while testing diagnostic privacy"
+            )
+        } catch let failure as PostProcessingBackendTestFailure {
+            throw failure
+        } catch {
+            issue = service.userIssue(for: error)
+        }
+
+        let encodedRecord = try JSONEncoder().encode(issue.record)
+        guard let recordText = String(data: encodedRecord, encoding: .utf8) else {
+            throw PostProcessingBackendTestFailure(
+                "Expected encoded issue record"
+            )
+        }
+        let presentation = issue.record.presentation(language: "en")
+        let visibleText = ([
+            presentation.title,
+            presentation.body,
+            presentation.suggestion,
+            presentation.compactMessage
+        ] + presentation.detailsRows.flatMap { [$0.label, $0.value] })
+            .joined(separator: " ")
+
+        for sentinel in [
+            transcriptSentinel,
+            promptSentinel,
+            credentialSentinel,
+            errorSentinel
+        ] {
+            try expect(
+                !recordText.contains(sentinel),
+                "timeout record excludes \(sentinel)"
+            )
+            try expect(
+                !issue.privateDiagnostic.contains(sentinel),
+                "timeout diagnostic excludes \(sentinel)"
+            )
+            try expect(
+                !visibleText.contains(sentinel),
+                "timeout presentation excludes \(sentinel)"
+            )
         }
     }
 

--- a/Tests/PostProcessingBackendTests.swift
+++ b/Tests/PostProcessingBackendTests.swift
@@ -14,6 +14,7 @@ struct PostProcessingBackendTests {
         try await testInvalidTimeoutOverrideUsesBackendDefaults()
         try await testCleanupConvertsRealURLTimeout()
         try await testCommandTransformConvertsRealURLTimeout()
+        try await testFallbackTimeoutReportsFallbackModel()
         try await testTimeoutIssueDoesNotExposeRequestSourceData()
         try await testSequentialChunksUsePerRequestTimeout()
         try await testCommandFallbackUsesPerRequestTimeout()
@@ -252,7 +253,7 @@ struct PostProcessingBackendTests {
                     "Expected Local cleanup timeout"
                 )
             } catch let error as PostProcessingError {
-                guard case .requestTimedOut(let seconds) = error else {
+                guard case .requestTimedOut(let seconds, let modelID) = error else {
                     throw PostProcessingBackendTestFailure(
                         "Expected requestTimedOut, got \(error)"
                     )
@@ -260,6 +261,10 @@ struct PostProcessingBackendTests {
                 try expect(
                     seconds == 120,
                     "Local timeout reports the effective request timeout"
+                )
+                try expect(
+                    modelID == LocalAIModelCatalog.quality.id,
+                    "Local timeout reports the endpoint model"
                 )
             }
         }
@@ -281,7 +286,7 @@ struct PostProcessingBackendTests {
                     "Expected Cloud command timeout"
                 )
             } catch let error as PostProcessingError {
-                guard case .requestTimedOut(let seconds) = error else {
+                guard case .requestTimedOut(let seconds, let modelID) = error else {
                     throw PostProcessingBackendTestFailure(
                         "Expected requestTimedOut, got \(error)"
                     )
@@ -290,7 +295,53 @@ struct PostProcessingBackendTests {
                     seconds == 20,
                     "Cloud timeout reports the effective request timeout"
                 )
+                try expect(
+                    modelID == "primary/model",
+                    "Cloud timeout reports the endpoint model"
+                )
             }
+        }
+    }
+
+    private static func testFallbackTimeoutReportsFallbackModel() async throws {
+        let service = PostProcessingService(
+            backendExecutor: AIProcessingBackendExecutor(
+                choice: .cloud(modelID: "primary/model"),
+                cloudBaseURL: "https://api.example.com/openai/v1/\(UUID().uuidString)",
+                cloudAPIKey: "cloud-secret"
+            ),
+            cloudFallbackModelID: "fallback/model",
+            instructionExecutionGuardEnabled: false,
+            transport: { request in
+                let body = try requestBody(request)
+                if body["model"] as? String == "primary/model" {
+                    return rateLimitedResponse(request: request)
+                }
+                throw URLError(.timedOut)
+            }
+        )
+
+        do {
+            _ = try await service.postProcess(
+                transcript: "raw transcript",
+                context: testContext,
+                customVocabulary: ""
+            )
+            throw PostProcessingBackendTestFailure(
+                "Expected fallback timeout"
+            )
+        } catch let failure as PostProcessingBackendTestFailure {
+            throw failure
+        } catch {
+            let issue = service.userIssue(for: error)
+            try expect(
+                issue.record.code == .requestTimedOut,
+                "fallback timeout keeps the timeout issue code"
+            )
+            try expect(
+                issue.record.context.modelID == "fallback/model",
+                "fallback timeout reports the model that timed out"
+            )
         }
     }
 
@@ -383,113 +434,95 @@ struct PostProcessingBackendTests {
     }
 
     private static func testSequentialChunksUsePerRequestTimeout() async throws {
-        let timeoutKey = "post_processing_timeout_seconds"
-        let previousTimeout = UserDefaults.standard.object(forKey: timeoutKey)
-        UserDefaults.standard.set(0.03, forKey: timeoutKey)
-        defer {
-            if let previousTimeout {
-                UserDefaults.standard.set(previousTimeout, forKey: timeoutKey)
-            } else {
-                UserDefaults.standard.removeObject(forKey: timeoutKey)
-            }
-        }
+        try await withPostProcessingTimeoutOverride(0.03) {
+            let recorder = PostProcessingRequestRecorder()
+            let service = PostProcessingService(
+                backendExecutor: AIProcessingBackendExecutor(
+                    choice: .cloud(modelID: "primary/model"),
+                    cloudBaseURL: "https://api.example.com/openai/v1",
+                    cloudAPIKey: "cloud-secret"
+                ),
+                cloudFallbackModelID: nil,
+                instructionExecutionGuardEnabled: false,
+                transport: { request in
+                    recorder.record(request)
+                    try await Task.sleep(nanoseconds: 20_000_000)
+                    return try successResponse(
+                        request: request,
+                        content: try transcriptFromPostProcessingRequest(request)
+                    )
+                }
+            )
+            let transcript = String(repeating: "Alpha ", count: 5_000)
+            let start = Date()
 
-        let recorder = PostProcessingRequestRecorder()
-        let service = PostProcessingService(
-            backendExecutor: AIProcessingBackendExecutor(
-                choice: .cloud(modelID: "primary/model"),
-                cloudBaseURL: "https://api.example.com/openai/v1",
-                cloudAPIKey: "cloud-secret"
-            ),
-            cloudFallbackModelID: nil,
-            instructionExecutionGuardEnabled: false,
-            transport: { request in
-                recorder.record(request)
-                try await Task.sleep(nanoseconds: 20_000_000)
-                return try successResponse(
-                    request: request,
-                    content: try transcriptFromPostProcessingRequest(request)
+            let result = try await service.postProcess(
+                transcript: transcript,
+                context: testContext,
+                customVocabulary: ""
+            )
+            let elapsed = Date().timeIntervalSince(start)
+            let requests = recorder.capturedRequests()
+
+            try expect(!result.transcript.isEmpty, "delayed chunks produce a combined result")
+            try expect(requests.count > 1, "transcript is processed as sequential chunks")
+            try expect(elapsed > 0.03, "total chunk processing exceeds one request timeout")
+            for request in requests {
+                try expect(
+                    abs(request.timeoutInterval - 0.03) < 0.001,
+                    "each chunk retains the per-request timeout"
                 )
             }
-        )
-        let transcript = String(repeating: "Alpha ", count: 5_000)
-        let start = Date()
-
-        let result = try await service.postProcess(
-            transcript: transcript,
-            context: testContext,
-            customVocabulary: ""
-        )
-        let elapsed = Date().timeIntervalSince(start)
-        let requests = recorder.capturedRequests()
-
-        try expect(!result.transcript.isEmpty, "delayed chunks produce a combined result")
-        try expect(requests.count > 1, "transcript is processed as sequential chunks")
-        try expect(elapsed > 0.03, "total chunk processing exceeds one request timeout")
-        for request in requests {
-            try expect(
-                abs(request.timeoutInterval - 0.03) < 0.001,
-                "each chunk retains the per-request timeout"
-            )
         }
     }
 
     private static func testCommandFallbackUsesPerRequestTimeout() async throws {
-        let timeoutKey = "post_processing_timeout_seconds"
-        let previousTimeout = UserDefaults.standard.object(forKey: timeoutKey)
-        UserDefaults.standard.set(0.03, forKey: timeoutKey)
-        defer {
-            if let previousTimeout {
-                UserDefaults.standard.set(previousTimeout, forKey: timeoutKey)
-            } else {
-                UserDefaults.standard.removeObject(forKey: timeoutKey)
-            }
-        }
-
-        let recorder = PostProcessingRequestRecorder()
-        let service = PostProcessingService(
-            backendExecutor: AIProcessingBackendExecutor(
-                choice: .cloud(modelID: "primary/model"),
-                cloudBaseURL: "https://api.example.com/openai/v1",
-                cloudAPIKey: "cloud-secret"
-            ),
-            cloudFallbackModelID: "fallback/model",
-            instructionExecutionGuardEnabled: false,
-            transport: { request in
-                recorder.record(request)
-                try await Task.sleep(nanoseconds: 20_000_000)
-                let body = try requestBody(request)
-                if body["model"] as? String == "primary/model" {
-                    return rateLimitedResponse(request: request)
+        try await withPostProcessingTimeoutOverride(0.03) {
+            let recorder = PostProcessingRequestRecorder()
+            let service = PostProcessingService(
+                backendExecutor: AIProcessingBackendExecutor(
+                    choice: .cloud(modelID: "primary/model"),
+                    cloudBaseURL: "https://api.example.com/openai/v1",
+                    cloudAPIKey: "cloud-secret"
+                ),
+                cloudFallbackModelID: "fallback/model",
+                instructionExecutionGuardEnabled: false,
+                transport: { request in
+                    recorder.record(request)
+                    try await Task.sleep(nanoseconds: 20_000_000)
+                    let body = try requestBody(request)
+                    if body["model"] as? String == "primary/model" {
+                        return rateLimitedResponse(request: request)
+                    }
+                    return try successResponse(
+                        request: request,
+                        content: "Cleaned fallback result."
+                    )
                 }
-                return try successResponse(
-                    request: request,
-                    content: "Cleaned fallback result."
-                )
-            }
-        )
-        let start = Date()
+            )
+            let start = Date()
 
-        let result = try await service.commandTransform(
-            selectedText: "Original text",
-            voiceCommand: "Make it concise",
-            context: testContext,
-            customVocabulary: ""
-        )
-        let elapsed = Date().timeIntervalSince(start)
+            let result = try await service.commandTransform(
+                selectedText: "Original text",
+                voiceCommand: "Make it concise",
+                context: testContext,
+                customVocabulary: ""
+            )
+            let elapsed = Date().timeIntervalSince(start)
 
-        try expect(
-            result.transcript == "Cleaned fallback result.",
-            "command fallback completes after a rate limit"
-        )
-        try expect(
-            recorder.count() == 2,
-            "command fallback uses two independently timed requests"
-        )
-        try expect(
-            elapsed > 0.03,
-            "command fallback can exceed a single request timeout"
-        )
+            try expect(
+                result.transcript == "Cleaned fallback result.",
+                "command fallback completes after a rate limit"
+            )
+            try expect(
+                recorder.count() == 2,
+                "command fallback uses two independently timed requests"
+            )
+            try expect(
+                elapsed > 0.03,
+                "command fallback can exceed a single request timeout"
+            )
+        }
     }
 
     private static func testOversizedLocalCommandDoesNotReachTransport() async throws {

--- a/Tests/PostProcessingUserIssueTests.swift
+++ b/Tests/PostProcessingUserIssueTests.swift
@@ -6,6 +6,7 @@ import Foundation
 struct PostProcessingUserIssueTests {
     static func main() throws {
         try testPostProcessingErrorsMapToWarningRecords()
+        try testCommandTimeoutUsesEditSpecificCopy()
         try testTimeoutIssueDoesNotPersistSourceContent()
         try testRawFallbackOutcomeIsPersistedWithTheOriginalTranscript()
         try testRequestFailuresKeepOnlyAllowlistedProviderCode()
@@ -62,6 +63,29 @@ struct PostProcessingUserIssueTests {
                 )
             }
         }
+    }
+
+    private static func testCommandTimeoutUsesEditSpecificCopy() throws {
+        let issue = PostProcessingError.requestTimedOut(20).userIssue(
+            providerHost: "api.example.com",
+            modelID: "provider/model",
+            operation: .commandTransform
+        )
+        let presentation = issue.record.presentation(language: "en")
+
+        try expect(issue.record.code == .requestTimedOut, "command timeout code")
+        try expect(
+            issue.record.context.operation == .commandTransform,
+            "command timeout operation"
+        )
+        try expect(
+            presentation.title == "Text edit timed out",
+            "command timeout uses edit-specific title"
+        )
+        try expect(
+            presentation.body.contains("selected text"),
+            "command timeout explains selected-text fallback"
+        )
     }
 
     private static func testTimeoutIssueDoesNotPersistSourceContent() throws {

--- a/Tests/PostProcessingUserIssueTests.swift
+++ b/Tests/PostProcessingUserIssueTests.swift
@@ -7,7 +7,6 @@ struct PostProcessingUserIssueTests {
     static func main() throws {
         try testPostProcessingErrorsMapToWarningRecords()
         try testCommandTimeoutUsesEditSpecificCopy()
-        try testTimeoutIssueDoesNotPersistSourceContent()
         try testRawFallbackOutcomeIsPersistedWithTheOriginalTranscript()
         try testRequestFailuresKeepOnlyAllowlistedProviderCode()
         try testNonSuccessResponsesDoNotStoreRawBodies()
@@ -85,38 +84,6 @@ struct PostProcessingUserIssueTests {
         try expect(
             presentation.body.contains("selected text"),
             "command timeout explains selected-text fallback"
-        )
-    }
-
-    private static func testTimeoutIssueDoesNotPersistSourceContent() throws {
-        let sentinel = "RAW_TRANSCRIPT PROMPT_SECRET sk-secret /Users/private RESPONSE_BODY"
-        let error = PostProcessingError.requestTimedOut(120)
-        let issue = error.userIssue(
-            providerHost: "api.example.com",
-            modelID: "provider/model",
-            localBackend: "Local AI"
-        )
-        let payload = try decodedPayloadString(issue.record.encodedStatus())
-
-        try expect(
-            issue.record.code == .requestTimedOut,
-            "timeout has dedicated stable code"
-        )
-        try expect(
-            issue.record.context.modelID == "provider/model",
-            "timeout keeps safe model metadata"
-        )
-        try expect(
-            issue.record.context.localBackend == "Local AI",
-            "timeout keeps safe backend metadata"
-        )
-        try expect(
-            !payload.contains(sentinel),
-            "timeout record excludes source sentinels"
-        )
-        try expect(
-            !issue.privateDiagnostic.contains(sentinel),
-            "timeout diagnostic excludes source sentinels"
         )
     }
 

--- a/Tests/PostProcessingUserIssueTests.swift
+++ b/Tests/PostProcessingUserIssueTests.swift
@@ -6,6 +6,7 @@ import Foundation
 struct PostProcessingUserIssueTests {
     static func main() throws {
         try testPostProcessingErrorsMapToWarningRecords()
+        try testTimeoutIssueDoesNotPersistSourceContent()
         try testRawFallbackOutcomeIsPersistedWithTheOriginalTranscript()
         try testRequestFailuresKeepOnlyAllowlistedProviderCode()
         try testNonSuccessResponsesDoNotStoreRawBodies()
@@ -19,7 +20,7 @@ struct PostProcessingUserIssueTests {
             (.rateLimited(model: "provider/model", retryAfter: 10), .postProcessingRateLimited, .retryTranscription),
             (.invalidResponse("missing content"), .postProcessingFailed, .retryTranscription),
             (.emptyOutput, .postProcessingFailed, .retryTranscription),
-            (.requestTimedOut(30), .postProcessingFailed, .retryTranscription),
+            (.requestTimedOut(30), .requestTimedOut, .retryTranscription),
             (.suspectedInstructionExecution, .postProcessingGuardFallback, .none),
             (.outputRejected(.languageMismatch), .postProcessingGuardFallback, .none)
         ]
@@ -34,7 +35,65 @@ struct PostProcessingUserIssueTests {
             try expect(issue.record.recoveryAction == expectedAction, "\(error) recovery action")
             try expect(issue.record.context.providerHost == "api.example.com", "safe provider context")
             try expect(issue.record.context.modelID == "provider/model", "safe model context")
+            if case .requestTimedOut = error {
+                try expect(
+                    issue.record.context.operation == .postProcessing,
+                    "timeout identifies post-processing operation"
+                )
+                let presentation = issue.record.presentation(language: "en")
+                try expect(
+                    presentation.title == "Transcript cleanup timed out",
+                    "timeout uses cleanup-specific copy"
+                )
+                try expect(
+                    presentation.body.contains("original transcript"),
+                    "timeout copy explains raw transcript preservation"
+                )
+                let decoded = try QuillUserIssueRecord.decodePersistedStatus(
+                    issue.record.persistedStatus
+                )
+                try expect(
+                    decoded.code == .requestTimedOut,
+                    "timeout code round-trips"
+                )
+                try expect(
+                    decoded.context.operation == .postProcessing,
+                    "timeout operation round-trips"
+                )
+            }
         }
+    }
+
+    private static func testTimeoutIssueDoesNotPersistSourceContent() throws {
+        let sentinel = "RAW_TRANSCRIPT PROMPT_SECRET sk-secret /Users/private RESPONSE_BODY"
+        let error = PostProcessingError.requestTimedOut(120)
+        let issue = error.userIssue(
+            providerHost: "api.example.com",
+            modelID: "provider/model",
+            localBackend: "Local AI"
+        )
+        let payload = try decodedPayloadString(issue.record.encodedStatus())
+
+        try expect(
+            issue.record.code == .requestTimedOut,
+            "timeout has dedicated stable code"
+        )
+        try expect(
+            issue.record.context.modelID == "provider/model",
+            "timeout keeps safe model metadata"
+        )
+        try expect(
+            issue.record.context.localBackend == "Local AI",
+            "timeout keeps safe backend metadata"
+        )
+        try expect(
+            !payload.contains(sentinel),
+            "timeout record excludes source sentinels"
+        )
+        try expect(
+            !issue.privateDiagnostic.contains(sentinel),
+            "timeout diagnostic excludes source sentinels"
+        )
     }
 
     private static func testRawFallbackOutcomeIsPersistedWithTheOriginalTranscript() throws {

--- a/Tests/QuillUserIssueTests.swift
+++ b/Tests/QuillUserIssueTests.swift
@@ -7,6 +7,7 @@ struct QuillUserIssueTests {
         try testEveryCodeHasCompleteEnglishAndKoreanPresentation(bundle: bundle)
         try testSeverityAndRecoveryActions()
         try testVersionedPersistenceRoundTripAndRejection()
+        try testUnknownFutureOperationPreservesPersistedIssue(bundle: bundle)
         try testPersistedPayloadExcludesPrivateDiagnostics()
         try testLocalIssueUsesBoundedDiagnosticCategoryAndExcerpt()
         try testMissingProviderAPIKeyFactory()
@@ -250,6 +251,29 @@ struct QuillUserIssueTests {
         try expectThrows(.invalidPrefix) {
             _ = try QuillUserIssueRecord.decodePersistedStatus("Error: legacy raw detail")
         }
+    }
+
+    private static func testUnknownFutureOperationPreservesPersistedIssue(
+        bundle: Bundle
+    ) throws {
+        let payload = #"{"schemaVersion":1,"code":"request-timed-out","severity":"warning","context":{"modelID":"future/model","operation":"futureOperation"}}"#
+        let encodedPayload = Data(payload.utf8).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        let status = QuillUserIssueRecord.persistedStatusPrefix + encodedPayload
+
+        let record = try QuillUserIssueRecord.decodePersistedStatus(status)
+
+        try expect(record.code == .requestTimedOut, "future operation preserves issue code")
+        try expect(record.severity == .warning, "future operation preserves issue severity")
+        try expect(record.context.modelID == "future/model", "future operation preserves safe context")
+        try expect(record.context.operation == nil, "future operation decodes as an unknown optional classifier")
+        try expect(
+            record.presentation(language: "en", bundle: bundle).title
+                == "Transcription timed out",
+            "future operation falls back to generic timeout copy"
+        )
     }
 
     private static func testPersistedPayloadExcludesPrivateDiagnostics() throws {

--- a/docs/superpowers/specs/2026-08-05-local-ai-timeout-history-design.md
+++ b/docs/superpowers/specs/2026-08-05-local-ai-timeout-history-design.md
@@ -1,0 +1,220 @@
+# Local AI Post-processing Timeout and History Accuracy — Design
+
+## Context
+
+Quill currently applies the same 20-second default request timeout to Cloud and Local post-processing. Production Local Qwen2.5 7B non-streaming completions can legitimately exceed 20 seconds, especially during a cold server start, and then fail with `NSURLErrorDomain -1001`.
+
+The transport layer already supports request-specific timeouts longer than 20 seconds. `LLMAPITransport` creates an ephemeral session whose request and resource timeouts match a longer `URLRequest.timeoutInterval`. The missing behavior is therefore in the post-processing service and its result propagation:
+
+1. `PostProcessingService` does not choose a timeout from `AIProcessingEndpoint.kind`.
+2. A real `URLError(.timedOut)` is not converted to `PostProcessingError.requestTimedOut` after the previous operation-wide watchdog was removed.
+3. Raw transcript fallback works, but the untyped network error becomes a generic `post-processing-failed` outcome.
+4. Audio import and retry history construction can omit the actual `aiProcessingOutcome`, allowing the default `succeeded` value to be persisted.
+
+## Goals
+
+1. Apply a 120-second default timeout to each Local post-processing request.
+2. Preserve the existing 20-second default for each Cloud post-processing request.
+3. Preserve the existing positive `post_processing_timeout_seconds` override for both backends.
+4. Convert real network timeouts into the post-processing timeout domain error.
+5. Keep the raw transcript whenever post-processing times out.
+6. Persist `request-timed-out` consistently as both the post-processing status code and failed AI processing outcome reason.
+7. Preserve the real AI processing outcome in audio import and retry history paths.
+8. Keep diagnostics useful without recording transcript text, prompt text, request bodies, response bodies, credentials, or private paths.
+
+## Non-goals
+
+- Streaming or SSE response parsing.
+- Adaptive timeout calculation based on transcript length, chunk count, or hardware.
+- Changing the Local AI five-minute idle shutdown policy.
+- Raising every Cloud request timeout to 120 seconds.
+- Restoring an operation-wide watchdog.
+- Large-scale `AppState` result-type or history-builder refactoring.
+- Changing the Core Data schema or the existing string representation of AI processing outcomes.
+- Redefining manual transcript editing outcomes.
+
+## Timeout Policy
+
+`PostProcessingService` computes an effective timeout after resolving the `AIProcessingEndpoint`.
+
+```text
+finite positive post_processing_timeout_seconds override
+  → use the override for Local and Cloud requests
+
+no valid override
+  ├─ endpoint.kind == .local → 120 seconds
+  └─ endpoint.kind == .cloud → 20 seconds
+```
+
+Zero, negative, non-finite, or missing override values are invalid and fall back to the backend default.
+
+The effective timeout is assigned to every post-processing `URLRequest.timeoutInterval`, including normal cleanup, command transforms, chunks, and backend fallback attempts. Each request keeps its own timeout:
+
+```text
+Local attempt  → up to 120 seconds by default
+Cloud fallback → up to 20 seconds by default
+```
+
+The combined operation may therefore exceed either individual timeout. No outer task-group watchdog is introduced.
+
+`LLMAPITransport.sharedRequestTimeout` remains 20 seconds. Requests longer than that continue using the existing ephemeral session path.
+
+## Transport Error Mapping
+
+The transport boundary converts only a real URL loading timeout into the post-processing domain error:
+
+```text
+transport throws URLError(.timedOut)
+  → PostProcessingError.requestTimedOut(effective timeout)
+```
+
+Other transport failures keep their existing behavior. The mapping is shared by cleanup and command-transform requests so both operations classify timeouts consistently.
+
+A timeout is exposed as a post-processing-specific user issue whose persisted code is `request-timed-out`. It does not reuse transcription-oriented timeout copy. The user-facing message explains that cleanup timed out and the original transcript was retained.
+
+Diagnostic context may contain only bounded operational metadata:
+
+- backend kind,
+- selected model ID,
+- effective timeout seconds,
+- stable error code.
+
+It must not contain transcript content, prompt content, request JSON, provider response text, authorization values, screenshot data, or absolute paths.
+
+## Raw Transcript Fallback
+
+The existing `AppState.processTranscript` fallback remains the source of truth.
+
+```text
+Raw transcript
+  ↓
+Local post-processing request
+  ↓ URLError(.timedOut)
+PostProcessingError.requestTimedOut
+  ↓
+Generated result is not accepted
+  ↓
+Raw transcript remains the final transcript
+  ↓
+postProcessingStatus = request-timed-out
+aiProcessingOutcome = failed:request-timed-out
+```
+
+The timeout correction changes classification and telemetry, not the fallback ownership or transcript-selection architecture.
+
+## History Accuracy
+
+### Audio import
+
+The audio import path passes `result.aiProcessingOutcome` explicitly to `recordPipelineHistoryEntry`. A successful transcription followed by post-processing timeout must not use the history API's `succeeded` default.
+
+### Retry and resumed retry
+
+`makeRetryHistoryItem` accepts the actual AI processing outcome as a required parameter. Every successful retry processing call, including the resumed Cloud transcription path that uses the same history builder, passes the outcome returned by `processTranscript`.
+
+When a retry fails before producing a new processing outcome, reconstruction preserves the previous history item's outcome instead of resetting it to `succeeded`.
+
+The persistence layer continues storing the existing strings, for example:
+
+```text
+succeeded
+failed:request-timed-out
+raw-fallback:<validation-reason>
+```
+
+Legacy stored rows may continue using the existing read-time fallback. This change removes default-success reliance only where a new or reconstructed history item has a known outcome.
+
+## Testing Strategy
+
+Tests are written before implementation and must begin from production seams rather than manually constructing the expected domain error.
+
+### Post-processing timeout conversion
+
+An injected transport throws `URLError(.timedOut)`.
+
+Expected result:
+
+```text
+PostProcessingError.requestTimedOut
+```
+
+The test covers normal cleanup and command transform so neither transport call site can bypass the mapping.
+
+### Backend timeout selection
+
+An injected transport records `URLRequest.timeoutInterval`.
+
+Expected defaults:
+
+```text
+Local endpoint → 120 seconds
+Cloud endpoint → 20 seconds
+```
+
+Expected explicit override:
+
+```text
+post_processing_timeout_seconds = 45
+Local endpoint → 45 seconds
+Cloud endpoint → 45 seconds
+```
+
+Tests remove the global `UserDefaults` key during cleanup. Invalid values fall back to backend defaults.
+
+Existing tests that allow multi-chunk and Local-to-Cloud fallback operations to exceed a single request timeout remain unchanged. They prevent accidental restoration of an operation-wide timeout.
+
+### Fallback classification
+
+A timeout-driven processing failure verifies together that:
+
+- the final transcript equals the raw transcript,
+- generated output is not adopted,
+- the issue code is `request-timed-out`,
+- the AI processing outcome is failed,
+- the failure reason is `request-timed-out`.
+
+A narrow result-conversion seam may be extracted if needed, but the implementation must avoid a broad `AppState` refactor.
+
+### Import and retry history
+
+History construction tests pass `.failed(reason: "request-timed-out")` and verify that the resulting history item stores `failed:request-timed-out` for:
+
+- audio import,
+- retry,
+- resumed retry using the same builder.
+
+Retry failures that do not produce a new outcome preserve the existing value.
+
+### Diagnostic privacy
+
+A timeout issue test uses synthetic transcript, prompt, credential, and response sentinels and verifies that none appear in user-visible or persisted diagnostic fields. Backend kind, bounded model ID, timeout, and stable issue code may appear.
+
+### Integration and production verification
+
+Deterministic unit tests verify the production `PostProcessingService` timeout policy. The existing Local Qwen integration target remains optional because it depends on the installed model, bundled server, and machine performance.
+
+After unit tests pass:
+
+1. Run the full test suite.
+2. Run `test-local-ai-integration` when prerequisites are available.
+3. Build and launch the production app using the repository's signed build workflow.
+4. Verify a cold Local AI request continues beyond 20 seconds and can succeed within 120 seconds.
+5. Verify a warm retry has lower latency and equivalent validation behavior.
+6. Force a short timeout override and verify raw transcript preservation, `request-timed-out`, failed outcome persistence, no crash, and a successful subsequent Local request.
+7. Inspect Pipeline History and Unified Log without exposing source text.
+
+## Completion Criteria
+
+The change is complete when:
+
+- Local post-processing requests default to 120 seconds.
+- Cloud post-processing requests remain at 20 seconds.
+- A positive finite override applies to both backends.
+- A real `URLError(.timedOut)` becomes `PostProcessingError.requestTimedOut`.
+- Timeout preserves the raw transcript.
+- Timeout records `request-timed-out` instead of a generic post-processing failure.
+- Audio import and retry history retain the actual AI processing outcome.
+- Meeting Summary behavior is unchanged.
+- Unit tests and available integration tests pass.
+- Cold and warm production verification succeeds where Local model prerequisites are available.
+- Diagnostics contain no transcript or prompt source content.


### PR DESCRIPTION
## Summary

- use a 120-second per-request default for Local AI post-processing while preserving the 20-second Cloud default and shared positive override
- map real URL loading timeouts to `request-timed-out`, retain the raw transcript, and persist the actual AI processing outcome across import, retry, and relaunch resume paths
- preserve operation-specific timeout copy, attribute fallback failures to the model that actually timed out, and keep diagnostic records free of transcript, prompt, credential, response-body, and private-path data
- snapshot injected dependencies before asynchronous import/retry work begins and replace source-only resume coverage with a durable runtime regression test

## Verification

- [x] `make test`
- [x] `make test-local-ai-integration`
- [x] signed app build and code-signature verification
- [x] isolated GUI cold and warm Local Qwen validation
- [x] forced short-timeout validation with raw transcript preservation and `failed:request-timed-out` history
- [x] post-fix code review found no additional verified correctness defects

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * AI 후처리 및 명령 변환 요청의 시간 초과를 구분해 안내합니다.
  * 시간 초과 시 원본 또는 선택한 텍스트를 유지하고 재시도할 수 있습니다.
  * 실패한 전사·후처리 결과와 복구 상태를 보다 정확하게 보존합니다.
  * 로컬 및 클라우드 처리에 적절한 시간 제한을 적용합니다.

* **버그 수정**
  * 오디오 가져오기, 재시도, 앱 재시작 후 작업 복구 과정에서 처리 결과가 누락되지 않도록 개선했습니다.

* **현지화**
  * 시간 초과 안내 문구를 영어와 한국어로 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->