### PR TITLE
Improve retry warning diagnostics

### DIFF
--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -11653,6 +11653,294 @@
         }
       }
     },
+    "Transcript cleanup instructions are too large": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcript cleanup instructions are too large"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사문 정리 지침 또는 문맥이 너무 큽니다"
+          }
+        }
+      }
+    },
+    "Quill kept the original transcript because the cleanup instructions or context could not fit safely in the selected model.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill kept the original transcript because the cleanup instructions or context could not fit safely in the selected model."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정리 지침 또는 문맥이 선택한 모델에 안전하게 들어가지 않아 Quill이 원본 전사문을 유지했습니다."
+          }
+        }
+      }
+    },
+    "Review the cleanup prompt, context, and vocabulary before trying again.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review the cleanup prompt, context, and vocabulary before trying again."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다시 시도하기 전에 정리 프롬프트, 문맥, 사용자 지정 어휘를 검토하세요."
+          }
+        }
+      }
+    },
+    "Transcript cleanup returned no text": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcript cleanup returned no text"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사문 정리 결과가 비어 있습니다"
+          }
+        }
+      }
+    },
+    "Quill kept the original transcript because the model returned no cleanup text.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill kept the original transcript because the model returned no cleanup text."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모델이 사용할 수 있는 정리 결과를 반환하지 않아 Quill이 원본 전사문을 유지했습니다."
+          }
+        }
+      }
+    },
+    "Transcript cleanup response could not be read": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcript cleanup response could not be read"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사문 정리 응답을 읽을 수 없습니다"
+          }
+        }
+      }
+    },
+    "Quill kept the original transcript because the model response was not usable.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill kept the original transcript because the model response was not usable."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모델 응답을 사용할 수 없어 Quill이 원본 전사문을 유지했습니다."
+          }
+        }
+      }
+    },
+    "Transcript cleanup request failed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcript cleanup request failed"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사문 정리 요청에 실패했습니다"
+          }
+        }
+      }
+    },
+    "Quill kept the original transcript because the cleanup service rejected or could not complete the request.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill kept the original transcript because the cleanup service rejected or could not complete the request."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정리 서비스가 요청을 처리하지 못해 Quill이 원본 전사문을 유지했습니다."
+          }
+        }
+      }
+    },
+    "Operation": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operation"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업"
+          }
+        }
+      }
+    },
+    "Transcript cleanup": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcript cleanup"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전사문 정리"
+          }
+        }
+      }
+    },
+    "Request timeout": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Request timeout"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요청 제한 시간"
+          }
+        }
+      }
+    },
+    "%g seconds": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%g seconds"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%g초"
+          }
+        }
+      }
+    },
+    "Request timed out": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Request timed out"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요청 시간이 초과되었습니다"
+          }
+        }
+      }
+    },
+    "Cleanup instructions or context are too large": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cleanup instructions or context are too large"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정리 지침 또는 문맥이 너무 큽니다"
+          }
+        }
+      }
+    },
+    "Model returned no cleanup text": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model returned no cleanup text"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모델이 정리 결과를 반환하지 않았습니다"
+          }
+        }
+      }
+    },
+    "Model response could not be read": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model response could not be read"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모델 응답을 읽을 수 없습니다"
+          }
+        }
+      }
+    },
+    "Cleanup service request failed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cleanup service request failed"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정리 서비스 요청에 실패했습니다"
+          }
+        }
+      }
+    },
     "Transcript cleanup was skipped": {
       "localizations": {
         "en": {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -7610,7 +7610,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         retryingItemIDs.insert(item.id)
-        incrementNoteRetryGeneration(for: item.id)
 
         let postProcessingService = makePostProcessingService()
         let cloudDependencies = Self
@@ -7706,6 +7705,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 }
                 do {
                     try self.pipelineHistoryStore.update(updatedItem, requiresDurableStore: true)
+                    self.incrementNoteRetryGeneration(for: snapshot.item.id)
                     self.pipelineHistory = self.pipelineHistoryStore.loadAllHistory()
                     if retrySucceeded {
                         self.invalidateMeetingSummaryGeneration(for: snapshot.item.id)
@@ -10995,6 +10995,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let audioURL = Self.audioStorageDirectory().appendingPathComponent(
             audioFileName
         )
+        retryingItemIDs.insert(record.historyID)
         let session = cloudTranscriptionJobStore.beginSession(
             historyID: record.historyID
         )
@@ -11394,6 +11395,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
         cloudTranscriptionJobStore.invalidateSession(historyID: historyID)
         cloudTranscriptionProgressByHistoryID.removeValue(forKey: historyID)
+        retryingItemIDs.remove(historyID)
     }
 
     // 라이브 전사 시작 시 Note Browser에 즉시 표시될 예비 노트 생성

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -10995,7 +10995,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let audioURL = Self.audioStorageDirectory().appendingPathComponent(
             audioFileName
         )
-        retryingItemIDs.insert(record.historyID)
+        retryingItemIDs.insert(item.id)
         let session = cloudTranscriptionJobStore.beginSession(
             historyID: record.historyID
         )
@@ -11106,6 +11106,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     spokenLanguage: transcription.spokenLanguage
                 )
                 try pipelineHistoryStore.update(updated)
+                incrementNoteRetryGeneration(for: item.id)
                 pipelineHistory = pipelineHistoryStore.loadAllHistory()
                 completeCloudTranscriptionHistory(
                     historyID: record.historyID,

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -1492,7 +1492,6 @@ private struct NoteDetailView: View {
         guard let warningBannerCode else { return false }
         return appState.isWarningBannerDismissed(noteID: item.id, code: warningBannerCode)
     }
-
     private var suggestedCalendarTitle: String? {
         guard item.customTitle == nil,
               item.calendarMatch?.titleState == .suggested else {
@@ -1846,7 +1845,9 @@ private struct NoteDetailView: View {
             emptyContentState
         } else {
             VStack(spacing: 0) {
-                if let warningPresentation, !isWarningBannerDismissed {
+                if !isWarningBannerDismissed,
+                   !appState.retryingItemIDs.contains(item.id),
+                   let warningPresentation {
                     QuillUserIssueView(
                         presentation: warningPresentation,
                         style: .warningBanner,

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -5,6 +5,7 @@ enum PostProcessingError: LocalizedError {
     case rateLimited(model: String, retryAfter: TimeInterval)
     case invalidResponse(String)
     case invalidInput(String)
+    case contextBudgetExceeded
     case emptyOutput
     case requestTimedOut(TimeInterval, modelID: String? = nil)
     case suspectedInstructionExecution
@@ -23,6 +24,8 @@ enum PostProcessingError: LocalizedError {
             return "Invalid post-processing response: \(details)"
         case .invalidInput(let details):
             return "Invalid post-processing input: \(details)"
+        case .contextBudgetExceeded:
+            return "Post-processing request exceeds the safe context budget"
         case .emptyOutput:
             return "Post-processing returned empty output"
         case .requestTimedOut(let seconds, _):
@@ -41,34 +44,84 @@ enum PostProcessingError: LocalizedError {
         return fallback
     }
 
+    private var userIssueCode: QuillUserIssueCode {
+        switch self {
+        case .requestFailed(let statusCode, let providerCode):
+            if ProviderDiagnosticCode.normalized(providerCode) == "context_length_exceeded" {
+                return .postProcessingFailed
+            }
+            switch statusCode {
+            case 400, 404, 415, 422:
+                return .providerConfigurationInvalid
+            case 401, 403:
+                return .authenticationFailed
+            case 408:
+                return .requestTimedOut
+            case 429:
+                return .postProcessingRateLimited
+            default:
+                return .postProcessingFailed
+            }
+        case .rateLimited:
+            return .postProcessingRateLimited
+        case .suspectedInstructionExecution, .outputRejected:
+            return .postProcessingGuardFallback
+        case .requestTimedOut:
+            return .requestTimedOut
+        case .invalidResponse, .invalidInput, .contextBudgetExceeded, .emptyOutput:
+            return .postProcessingFailed
+        }
+    }
+
+    private var postProcessingFailureReason: PostProcessingFailureReason? {
+        switch self {
+        case .requestTimedOut:
+            return .requestTimedOut
+        case .contextBudgetExceeded:
+            return .contextBudgetExceeded
+        case .emptyOutput:
+            return .emptyOutput
+        case .invalidResponse:
+            return .invalidResponse
+        case .requestFailed:
+            switch userIssueCode {
+            case .requestTimedOut:
+                return .requestTimedOut
+            case .postProcessingFailed:
+                return ProviderDiagnosticCode.normalized(requestFailureProviderCode)
+                    == "context_length_exceeded"
+                    ? .contextBudgetExceeded
+                    : .serviceRequestFailed
+            default:
+                return nil
+            }
+        case .rateLimited, .invalidInput, .suspectedInstructionExecution,
+             .outputRejected:
+            return nil
+        }
+    }
+
+    private var requestTimeoutSeconds: TimeInterval? {
+        if case .requestTimedOut(let seconds, _) = self {
+            return seconds
+        }
+        return nil
+    }
+
+    private var requestFailureProviderCode: String? {
+        if case .requestFailed(_, let providerCode) = self {
+            return providerCode
+        }
+        return nil
+    }
+
     func userIssue(
         providerHost: String?,
         modelID: String,
         localBackend: String? = nil,
         operation: QuillUserIssueOperation = .postProcessing
     ) -> QuillUserIssueError {
-        let code: QuillUserIssueCode
-        switch self {
-        case .requestFailed(let statusCode, _):
-            switch statusCode {
-            case 400, 404, 415, 422:
-                code = .providerConfigurationInvalid
-            case 401, 403:
-                code = .authenticationFailed
-            case 429:
-                code = .postProcessingRateLimited
-            default:
-                code = .postProcessingFailed
-            }
-        case .rateLimited:
-            code = .postProcessingRateLimited
-        case .suspectedInstructionExecution, .outputRejected:
-            code = .postProcessingGuardFallback
-        case .requestTimedOut:
-            code = .requestTimedOut
-        case .invalidResponse, .invalidInput, .emptyOutput:
-            code = .postProcessingFailed
-        }
+        let code = userIssueCode
         let statusCode: Int?
         if case .requestFailed(let status, _) = self {
             statusCode = status
@@ -82,9 +135,12 @@ enum PostProcessingError: LocalizedError {
                 context: QuillUserIssueContext(
                     httpStatus: statusCode,
                     providerHost: providerHost,
+                    providerCode: requestFailureProviderCode,
                     modelID: effectiveModelID(fallback: modelID),
                     localBackend: localBackend,
-                    operation: operation
+                    operation: operation,
+                    postProcessingFailureReason: postProcessingFailureReason,
+                    requestTimeoutSeconds: requestTimeoutSeconds
                 )
             ),
             privateDiagnostic: localizedDescription
@@ -847,7 +903,7 @@ Behavior:
             role: .postProcessing(inputReservation: 8_000)
         )
         guard let budget else {
-            throw PostProcessingError.invalidInput("Post-processing request exceeds the safe context budget")
+            throw PostProcessingError.contextBudgetExceeded
         }
 
         // JSON escaping can double an ASCII character (for example, `"` or
@@ -892,6 +948,8 @@ Behavior:
                 transcript: accepted,
                 prompt: prompts.joined(separator: "\n\n---\n\n")
             )
+        case .failure(.nonFillerEmpty):
+            throw PostProcessingError.emptyOutput
         case .failure(let failure):
             throw PostProcessingError.outputRejected(failure)
         }
@@ -1005,7 +1063,13 @@ Model: \(model)
             )
         }
 
-        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let responseObject: Any
+        do {
+            responseObject = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw PostProcessingError.invalidResponse("Response JSON could not be decoded")
+        }
+        guard let json = responseObject as? [String: Any],
               let choices = json["choices"] as? [[String: Any]],
               let firstChoice = choices.first,
               let message = firstChoice["message"] as? [String: Any],
@@ -1029,6 +1093,8 @@ Model: \(model)
         ) {
         case .success(let accepted):
             acceptedTranscript = accepted
+        case .failure(.nonFillerEmpty):
+            throw PostProcessingError.emptyOutput
         case .failure(let failure):
             throw PostProcessingError.outputRejected(failure)
         }
@@ -1254,7 +1320,13 @@ Model: \(model)
             )
         }
 
-        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let responseObject: Any
+        do {
+            responseObject = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw PostProcessingError.invalidResponse("Response JSON could not be decoded")
+        }
+        guard let json = responseObject as? [String: Any],
               let choices = json["choices"] as? [[String: Any]],
               let firstChoice = choices.first,
               let message = firstChoice["message"] as? [String: Any],

--- a/Sources/QuillUserIssue.swift
+++ b/Sources/QuillUserIssue.swift
@@ -59,6 +59,17 @@ enum MeetingSummaryFailureSubtype: String, Codable, Equatable, Sendable {
     case languageMismatch
 }
 
+/// A finite, source-text-free explanation for a cleanup failure.
+/// Unlike the underlying transport or model error, this is safe to persist
+/// and display in history and warning-banner details.
+enum PostProcessingFailureReason: String, Codable, Equatable, Sendable {
+    case requestTimedOut
+    case contextBudgetExceeded
+    case emptyOutput
+    case invalidResponse
+    case serviceRequestFailed
+}
+
 enum ProviderDiagnosticCode {
     private static let allowedCodes: Set<String> = [
         "context_length_exceeded",
@@ -97,6 +108,8 @@ struct QuillUserIssueContext: Codable, Equatable, Sendable {
         case retryExhausted
         case meetingSummaryFailureSubtype
         case operation
+        case postProcessingFailureReason
+        case requestTimeoutSeconds
     }
 
     let httpStatus: Int?
@@ -108,6 +121,8 @@ struct QuillUserIssueContext: Codable, Equatable, Sendable {
     let retryExhausted: Bool?
     let meetingSummaryFailureSubtype: MeetingSummaryFailureSubtype?
     let operation: QuillUserIssueOperation?
+    let postProcessingFailureReason: PostProcessingFailureReason?
+    let requestTimeoutSeconds: TimeInterval?
 
     init(
         httpStatus: Int? = nil,
@@ -118,7 +133,9 @@ struct QuillUserIssueContext: Codable, Equatable, Sendable {
         processExitCode: Int32? = nil,
         retryExhausted: Bool? = nil,
         meetingSummaryFailureSubtype: MeetingSummaryFailureSubtype? = nil,
-        operation: QuillUserIssueOperation? = nil
+        operation: QuillUserIssueOperation? = nil,
+        postProcessingFailureReason: PostProcessingFailureReason? = nil,
+        requestTimeoutSeconds: TimeInterval? = nil
     ) {
         self.httpStatus = httpStatus
         self.providerHost = providerHost
@@ -129,6 +146,8 @@ struct QuillUserIssueContext: Codable, Equatable, Sendable {
         self.retryExhausted = retryExhausted
         self.meetingSummaryFailureSubtype = meetingSummaryFailureSubtype
         self.operation = operation
+        self.postProcessingFailureReason = postProcessingFailureReason
+        self.requestTimeoutSeconds = requestTimeoutSeconds
     }
 
     init(from decoder: Decoder) throws {
@@ -148,6 +167,14 @@ struct QuillUserIssueContext: Codable, Equatable, Sendable {
             operation: try? container.decodeIfPresent(
                 QuillUserIssueOperation.self,
                 forKey: .operation
+            ),
+            postProcessingFailureReason: try? container.decodeIfPresent(
+                PostProcessingFailureReason.self,
+                forKey: .postProcessingFailureReason
+            ),
+            requestTimeoutSeconds: try? container.decodeIfPresent(
+                TimeInterval.self,
+                forKey: .requestTimeoutSeconds
             )
         )
     }
@@ -230,6 +257,10 @@ struct QuillUserIssueRecord: Codable, Equatable, Sendable {
     }
 
     var recoveryAction: QuillUserRecoveryAction {
+        if context.operation == .postProcessing,
+           context.postProcessingFailureReason == .contextBudgetExceeded {
+            return .none
+        }
         switch code {
         case .authenticationFailed, .quotaExceeded,
              .providerConfigurationInvalid:
@@ -263,7 +294,7 @@ struct QuillUserIssueRecord: Codable, Equatable, Sendable {
         language: String = preferredLocalizedStringLanguage(),
         bundle: Bundle = .main
     ) -> QuillUserIssuePresentation {
-        let copy = code.copy(for: context.operation)
+        let copy = code.copy(for: context)
         let title = localizedCatalogString(
             copy.titleKey,
             language: language,
@@ -525,7 +556,7 @@ private extension QuillUserIssueCode {
     }
 
     func copy(
-        for operation: QuillUserIssueOperation?
+        for context: QuillUserIssueContext
     ) -> QuillUserIssueCopy {
         switch self {
         case .networkUnavailable:
@@ -535,7 +566,7 @@ private extension QuillUserIssueCode {
                 suggestionKey: "Check your internet connection, then try again."
             )
         case .requestTimedOut:
-            switch operation {
+            switch context.operation {
             case .postProcessing:
                 return QuillUserIssueCopy(
                     titleKey: "Transcript cleanup timed out",
@@ -676,11 +707,45 @@ private extension QuillUserIssueCode {
                 suggestionKey: "Check the selected input and permissions, then try again."
             )
         case .postProcessingFailed:
-            return QuillUserIssueCopy(
-                titleKey: "Transcript cleanup was skipped",
-                bodyKey: "Quill kept the original transcript because cleanup could not complete.",
-                suggestionKey: "You can use the transcript as-is or try cleanup again later."
-            )
+            guard context.operation == .postProcessing else {
+                return QuillUserIssueCopy(
+                    titleKey: "Transcript cleanup was skipped",
+                    bodyKey: "Quill kept the original transcript because cleanup could not complete.",
+                    suggestionKey: "You can use the transcript as-is or try cleanup again later."
+                )
+            }
+            switch context.postProcessingFailureReason {
+            case .contextBudgetExceeded:
+                return QuillUserIssueCopy(
+                    titleKey: "Transcript cleanup instructions are too large",
+                    bodyKey: "Quill kept the original transcript because the cleanup instructions or context could not fit safely in the selected model.",
+                    suggestionKey: "Review the cleanup prompt, context, and vocabulary before trying again."
+                )
+            case .emptyOutput:
+                return QuillUserIssueCopy(
+                    titleKey: "Transcript cleanup returned no text",
+                    bodyKey: "Quill kept the original transcript because the model returned no cleanup text.",
+                    suggestionKey: "Use the original transcript or try cleanup again later."
+                )
+            case .invalidResponse:
+                return QuillUserIssueCopy(
+                    titleKey: "Transcript cleanup response could not be read",
+                    bodyKey: "Quill kept the original transcript because the model response was not usable.",
+                    suggestionKey: "Use the original transcript or try cleanup again later."
+                )
+            case .serviceRequestFailed:
+                return QuillUserIssueCopy(
+                    titleKey: "Transcript cleanup request failed",
+                    bodyKey: "Quill kept the original transcript because the cleanup service rejected or could not complete the request.",
+                    suggestionKey: "Use the original transcript or try cleanup again later."
+                )
+            case .requestTimedOut, nil:
+                return QuillUserIssueCopy(
+                    titleKey: "Transcript cleanup was skipped",
+                    bodyKey: "Quill kept the original transcript because cleanup could not complete.",
+                    suggestionKey: "You can use the transcript as-is or try cleanup again later."
+                )
+            }
         case .postProcessingRateLimited:
             return QuillUserIssueCopy(
                 titleKey: "Transcript cleanup is temporarily limited",
@@ -784,6 +849,25 @@ private extension MeetingSummaryFailureSubtype {
     }
 }
 
+private extension PostProcessingFailureReason {
+    func localizedDetailsValue(language: String, bundle: Bundle) -> String {
+        let key: String
+        switch self {
+        case .requestTimedOut:
+            key = "Request timed out"
+        case .contextBudgetExceeded:
+            key = "Cleanup instructions or context are too large"
+        case .emptyOutput:
+            key = "Model returned no cleanup text"
+        case .invalidResponse:
+            key = "Model response could not be read"
+        case .serviceRequestFailed:
+            key = "Cleanup service request failed"
+        }
+        return localizedCatalogString(key, language: language, bundle: bundle)
+    }
+}
+
 private extension QuillUserIssueContext {
     func detailsRows(
         for issueCode: QuillUserIssueCode,
@@ -822,6 +906,41 @@ private extension QuillUserIssueContext {
                     value: modelID
                 )
             )
+        }
+        if operation == .postProcessing {
+            rows.append(
+                QuillUserIssueDetailsRow(
+                    label: localizedCatalogString("Operation", language: language, bundle: bundle),
+                    value: localizedCatalogString("Transcript cleanup", language: language, bundle: bundle)
+                )
+            )
+            if let postProcessingFailureReason {
+                rows.append(
+                    QuillUserIssueDetailsRow(
+                        label: localizedCatalogString("Failure reason", language: language, bundle: bundle),
+                        value: postProcessingFailureReason.localizedDetailsValue(
+                            language: language,
+                            bundle: bundle
+                        )
+                    )
+                )
+            }
+            if let requestTimeoutSeconds,
+               requestTimeoutSeconds.isFinite,
+               requestTimeoutSeconds > 0 {
+                let timeoutValue = localizedCatalogFormat(
+                    "%g seconds",
+                    requestTimeoutSeconds,
+                    language: language,
+                    bundle: bundle
+                )
+                rows.append(
+                    QuillUserIssueDetailsRow(
+                        label: localizedCatalogString("Request timeout", language: language, bundle: bundle),
+                        value: timeoutValue
+                    )
+                )
+            }
         }
         if issueCode == .meetingSummaryInvalidResponse,
            let meetingSummaryFailureSubtype {

--- a/Sources/QuillUserIssueView.swift
+++ b/Sources/QuillUserIssueView.swift
@@ -57,23 +57,26 @@ struct QuillUserIssueView: View {
     }
 
     private var bannerView: some View {
-        HStack(alignment: .top, spacing: 10) {
-            Image(systemName: iconName)
-                .foregroundStyle(accentColor)
-                .padding(.top, 1)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: iconName)
+                    .foregroundStyle(accentColor)
+                    .padding(.top, 1)
 
-            VStack(alignment: .leading, spacing: 3) {
-                Text(presentation.title)
-                    .font(.caption.weight(.semibold))
-                Text(presentation.body)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(presentation.title)
+                        .font(.caption.weight(.semibold))
+                    Text(presentation.body)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 8)
+                actionButton
+                dismissButton
             }
-
-            Spacer(minLength: 8)
-            actionButton
-            dismissButton
+            detailsView
         }
         .padding(10)
         .background(

--- a/Tests/AppStateUserIssueLifecycleSourceTests.swift
+++ b/Tests/AppStateUserIssueLifecycleSourceTests.swift
@@ -64,8 +64,19 @@ struct AppStateUserIssueLifecycleSourceTests {
             to: "@MainActor\n    private func installCloudTranscriptionTask"
         )
         try expect(
-            resumedRetry.contains("retryingItemIDs.insert(record.historyID)"),
-            "resumed cloud retry suppresses its previous warning while it runs"
+            resumedRetry.contains("retryingItemIDs.insert(item.id)"),
+            "resumed cloud retry uses the Note Browser item identifier"
+        )
+        guard let resumedUpdate = resumedRetry.range(
+            of: "try pipelineHistoryStore.update(updated)"
+        ), let resumedIncrement = resumedRetry.range(
+            of: "incrementNoteRetryGeneration(for: item.id)"
+        ) else {
+            throw TestFailure("resumed retry persists a replacement before invalidating warning dismissal")
+        }
+        try expect(
+            resumedUpdate.lowerBound < resumedIncrement.lowerBound,
+            "resumed retry keeps an old dismissal when saving the replacement fails"
         )
         let finishCloudJob = block(
             source,

--- a/Tests/AppStateUserIssueLifecycleSourceTests.swift
+++ b/Tests/AppStateUserIssueLifecycleSourceTests.swift
@@ -9,6 +9,7 @@ struct AppStateUserIssueLifecycleSourceTests {
         )
 
         try testImportAndRetryPersistVersionedIssues(source)
+        try testRetryInvalidatesWarningsOnlyAfterSavingAReplacement(source)
         try testStoppedRecordingPersistsAndPresentsOneIssue(source)
         try testPostProcessingFallbackPersistsWarningRecord(source)
         try testCorePreparationAndSaveFailuresUseSafePresentation(source)
@@ -35,6 +36,46 @@ struct AppStateUserIssueLifecycleSourceTests {
         try expect(importFlow.contains("processingStatus: issue.persistedStatus"), "import persists v1 issue")
         try expect(retryFlow.contains("let issue = self.userIssue("), "retry uses the same classifier")
         try expect(retryFlow.contains("postProcessingStatus: issue.persistedStatus"), "retry persists v1 issue")
+    }
+
+    private static func testRetryInvalidatesWarningsOnlyAfterSavingAReplacement(
+        _ source: String
+    ) throws {
+        let retryFlow = block(
+            source,
+            from: "func retryTranscription(item: PipelineHistoryItem)",
+            to: "private func copyRetryTranscriptToPasteboardIfNeeded"
+        )
+        guard let update = retryFlow.range(
+            of: "try self.pipelineHistoryStore.update(updatedItem, requiresDurableStore: true)"
+        ), let increment = retryFlow.range(
+            of: "self.incrementNoteRetryGeneration(for: snapshot.item.id)"
+        ) else {
+            throw TestFailure("retry persists a replacement before invalidating warning dismissal")
+        }
+        try expect(
+            update.lowerBound < increment.lowerBound,
+            "retry keeps an old dismissal when saving the replacement fails"
+        )
+
+        let resumedRetry = block(
+            source,
+            from: "private func resumeCloudTranscriptionAfterLaunch(",
+            to: "@MainActor\n    private func installCloudTranscriptionTask"
+        )
+        try expect(
+            resumedRetry.contains("retryingItemIDs.insert(record.historyID)"),
+            "resumed cloud retry suppresses its previous warning while it runs"
+        )
+        let finishCloudJob = block(
+            source,
+            from: "private func finishCloudTranscriptionJob(",
+            to: "// 라이브 전사 시작 시 Note Browser에 즉시 표시될 예비 노트 생성"
+        )
+        try expect(
+            finishCloudJob.contains("retryingItemIDs.remove(historyID)"),
+            "finished cloud retry clears warning suppression"
+        )
     }
 
     private static func testStoppedRecordingPersistsAndPresentsOneIssue(

--- a/Tests/PostProcessingBackendTests.swift
+++ b/Tests/PostProcessingBackendTests.swift
@@ -24,7 +24,9 @@ struct PostProcessingBackendTests {
         try await testLeakedRawTranscriptionTemplateIsTreatedAsFailure()
         try await testStandaloneRawTranscriptionWordIsNotTreatedAsLeak()
         try await testDelimiterInjectionCannotReplaceTheRawTranscript()
-        try await testMeaningfulLongTranscriptReturningEmptyIsRejected()
+        try await testMeaningfulLongTranscriptReturningEmptyIsReportedAsEmptyOutput()
+        try await testMalformedCleanupResponseUsesInvalidResponseIssue()
+        try await testOversizedStaticCleanupPromptExplainsTheActualLimit()
         print("PostProcessingBackendTests passed")
     }
 
@@ -265,6 +267,26 @@ struct PostProcessingBackendTests {
                 try expect(
                     modelID == LocalAIModelCatalog.quality.id,
                     "Local timeout reports the endpoint model"
+                )
+                let issue = service.userIssue(for: error)
+                let presentation = issue.record.presentation(language: "en")
+                try expect(
+                    presentation.detailsRows.contains(
+                        QuillUserIssueDetailsRow(
+                            label: "Request timeout",
+                            value: "120 seconds"
+                        )
+                    ),
+                    "Local timeout presentation includes its effective limit"
+                )
+                try expect(
+                    presentation.detailsRows.contains(
+                        QuillUserIssueDetailsRow(
+                            label: "Model",
+                            value: LocalAIModelCatalog.quality.id
+                        )
+                    ),
+                    "Local timeout presentation includes the model that timed out"
                 )
             }
         }
@@ -620,17 +642,97 @@ struct PostProcessingBackendTests {
         try expect(!userMessage.contains("<<<RAW_TRANSCRIPTION"), "request omits raw transcription delimiter")
     }
 
-    private static func testMeaningfulLongTranscriptReturningEmptyIsRejected() async throws {
+    private static func testMeaningfulLongTranscriptReturningEmptyIsReportedAsEmptyOutput() async throws {
         let rawTranscript = String(repeating: "This is meaningful transcript content. ", count: 250)
         let service = makeLocalService { request in
             try successResponse(request: request, content: "EMPTY")
         }
 
-        try await expectFailure("meaningful transcript replaced with EMPTY") {
+        do {
             _ = try await service.postProcess(
                 transcript: rawTranscript,
                 context: testContext,
                 customVocabulary: ""
+            )
+            throw PostProcessingBackendTestFailure(
+                "Expected meaningful empty cleanup result to fail"
+            )
+        } catch let error as PostProcessingError {
+            guard case .emptyOutput = error else {
+                throw PostProcessingBackendTestFailure(
+                    "Expected empty cleanup output, got \(error)"
+                )
+            }
+        }
+    }
+
+    private static func testMalformedCleanupResponseUsesInvalidResponseIssue() async throws {
+        let service = makeCloudService(
+            cloudBaseURL: "https://api.example.com/openai/v1/\(UUID().uuidString)"
+        ) { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (Data("not-json".utf8), response)
+        }
+
+        do {
+            _ = try await service.postProcess(
+                transcript: "Meaningful transcript.",
+                context: testContext,
+                customVocabulary: ""
+            )
+            throw PostProcessingBackendTestFailure(
+                "Expected malformed cleanup response to fail"
+            )
+        } catch let error as PostProcessingError {
+            guard case .invalidResponse = error else {
+                throw PostProcessingBackendTestFailure(
+                    "Expected invalid cleanup response, got \(error)"
+                )
+            }
+            let presentation = service.userIssue(for: error).record.presentation(language: "en")
+            try expect(
+                presentation.title == "Transcript cleanup response could not be read",
+                "malformed cleanup response has a specific user-facing explanation"
+            )
+        }
+    }
+
+    private static func testOversizedStaticCleanupPromptExplainsTheActualLimit() async throws {
+        let service = makeLocalService { request in
+            try successResponse(request: request, content: "unused")
+        }
+        let oversizedPrompt = String(repeating: "instruction ", count: 2_000)
+
+        do {
+            _ = try await service.postProcess(
+                transcript: "Short transcript.",
+                context: testContext,
+                customVocabulary: "",
+                customSystemPrompt: oversizedPrompt
+            )
+            throw PostProcessingBackendTestFailure(
+                "Expected oversized static cleanup prompt to fail"
+            )
+        } catch let error as PostProcessingError {
+            guard case .contextBudgetExceeded = error else {
+                throw PostProcessingBackendTestFailure(
+                    "Expected cleanup context budget failure, got \(error)"
+                )
+            }
+            let issue = service.userIssue(for: error)
+            let presentation = issue.record.presentation(language: "en")
+            try expect(
+                presentation.title == "Transcript cleanup instructions are too large",
+                "static cleanup prompt failure does not blame the transcript"
+            )
+            try expect(
+                issue.record.recoveryAction == .none,
+                "static cleanup prompt failure does not offer a futile retry"
             )
         }
     }
@@ -688,12 +790,13 @@ struct PostProcessingBackendTests {
     }
 
     private static func makeCloudService(
+        cloudBaseURL: String = "https://api.example.com/openai/v1",
         transport: @escaping PostProcessingService.Transport
     ) -> PostProcessingService {
         PostProcessingService(
             backendExecutor: AIProcessingBackendExecutor(
                 choice: .cloud(modelID: "primary/model"),
-                cloudBaseURL: "https://api.example.com/openai/v1",
+                cloudBaseURL: cloudBaseURL,
                 cloudAPIKey: "cloud-secret"
             ),
             cloudFallbackModelID: nil,

--- a/Tests/PostProcessingUserIssueTests.swift
+++ b/Tests/PostProcessingUserIssueTests.swift
@@ -6,6 +6,8 @@ import Foundation
 struct PostProcessingUserIssueTests {
     static func main() throws {
         try testPostProcessingErrorsMapToWarningRecords()
+        try testPostProcessingFailureReasonsStayStructured()
+        try testProviderContextLimitAndHTTPTimeoutUseAccurateIssues()
         try testCommandTimeoutUsesEditSpecificCopy()
         try testRawFallbackOutcomeIsPersistedWithTheOriginalTranscript()
         try testRequestFailuresKeepOnlyAllowlistedProviderCode()
@@ -62,6 +64,97 @@ struct PostProcessingUserIssueTests {
                 )
             }
         }
+    }
+
+    private static func testPostProcessingFailureReasonsStayStructured() throws {
+        let cases: [(PostProcessingError, PostProcessingFailureReason, TimeInterval?)] = [
+            (.requestTimedOut(120, modelID: "local-qwen"), .requestTimedOut, 120),
+            (.contextBudgetExceeded, .contextBudgetExceeded, nil),
+            (.emptyOutput, .emptyOutput, nil),
+            (.invalidResponse("missing content"), .invalidResponse, nil),
+            (.requestFailed(statusCode: 500, providerCode: "server_error"), .serviceRequestFailed, nil)
+        ]
+
+        for (error, expectedReason, expectedTimeout) in cases {
+            let issue = error.userIssue(
+                providerHost: "api.example.com",
+                modelID: "provider/model"
+            )
+            try expect(
+                issue.record.context.postProcessingFailureReason == expectedReason,
+                "\(error) uses a bounded post-processing failure reason"
+            )
+            try expect(
+                issue.record.context.requestTimeoutSeconds == expectedTimeout,
+                "\(error) keeps only its effective timeout"
+            )
+        }
+
+        let timedOut = PostProcessingError.requestTimedOut(
+            120,
+            modelID: "local-qwen"
+        ).userIssue(
+            providerHost: nil,
+            modelID: "provider/model"
+        )
+        try expect(
+            timedOut.record.context.modelID == "local-qwen",
+            "timeout retains the model that timed out"
+        )
+
+        let requestFailed = PostProcessingError.requestFailed(
+            statusCode: 500,
+            providerCode: "server_error"
+        ).userIssue(
+            providerHost: "api.example.com",
+            modelID: "provider/model"
+        )
+        try expect(
+            requestFailed.record.context.providerCode == "server_error",
+            "request failure keeps only the allowlisted provider code"
+        )
+    }
+
+    private static func testProviderContextLimitAndHTTPTimeoutUseAccurateIssues() throws {
+        let contextLimit = PostProcessingError.requestFailed(
+            statusCode: 400,
+            providerCode: "context_length_exceeded"
+        ).userIssue(
+            providerHost: "api.example.com",
+            modelID: "provider/model"
+        )
+        try expect(
+            contextLimit.record.code == .postProcessingFailed,
+            "provider context limit is not misclassified as provider setup"
+        )
+        try expect(
+            contextLimit.record.context.postProcessingFailureReason == .contextBudgetExceeded,
+            "provider context limit identifies the cleanup context limit"
+        )
+        try expect(
+            contextLimit.record.recoveryAction == .none,
+            "provider context limit does not offer a futile retry"
+        )
+
+        let serverTimeout = PostProcessingError.requestFailed(
+            statusCode: 408,
+            providerCode: nil
+        ).userIssue(
+            providerHost: "api.example.com",
+            modelID: "provider/model"
+        )
+        try expect(
+            serverTimeout.record.code == .requestTimedOut,
+            "HTTP 408 maps to the timeout issue"
+        )
+        try expect(
+            serverTimeout.record.context.postProcessingFailureReason == .requestTimedOut,
+            "HTTP 408 records the timeout reason"
+        )
+        try expect(
+            serverTimeout.record.context.requestTimeoutSeconds == nil,
+            "HTTP 408 does not invent a client request limit"
+        )
     }
 
     private static func testCommandTimeoutUsesEditSpecificCopy() throws {

--- a/Tests/QuillUserIssueTests.swift
+++ b/Tests/QuillUserIssueTests.swift
@@ -14,6 +14,9 @@ struct QuillUserIssueTests {
         try testCompactMessageAndSafeDetailsAreDeterministic(bundle: bundle)
         try testMeetingSummaryLanguageUnavailableAndProviderCodeDetails(bundle: bundle)
         try testMeetingSummaryFailureSubtypeUsesSafeLocalizedDetails(bundle: bundle)
+        try testPostProcessingFailureReasonUsesLocalizedCopyAndDetails(bundle: bundle)
+        try testPostProcessingDiagnosticFieldsRemainBackwardCompatible(bundle: bundle)
+        try testFractionalPostProcessingTimeoutIsNotTruncated(bundle: bundle)
         try testMeetingSummaryIssueActionResolver()
         print("QuillUserIssueTests passed")
     }
@@ -194,6 +197,140 @@ struct QuillUserIssueTests {
             legacy.meetingSummaryFailureSubtype == nil
                 && unknown.meetingSummaryFailureSubtype == nil,
             "legacy and unknown summary failure subtypes decode without discarding the issue"
+        )
+    }
+
+    private static func testPostProcessingFailureReasonUsesLocalizedCopyAndDetails(
+        bundle: Bundle
+    ) throws {
+        let emptyOutput = QuillUserIssueRecord(
+            code: .postProcessingFailed,
+            context: QuillUserIssueContext(
+                modelID: "qwen2.5-7b",
+                localBackend: "Local AI",
+                operation: .postProcessing,
+                postProcessingFailureReason: .emptyOutput
+            )
+        )
+        let english = emptyOutput.presentation(language: "en", bundle: bundle)
+        let korean = emptyOutput.presentation(language: "ko", bundle: bundle)
+
+        try expect(
+            english.title == "Transcript cleanup returned no text",
+            "empty cleanup output has a specific English title"
+        )
+        try expect(
+            korean.title == "전사문 정리 결과가 비어 있습니다",
+            "empty cleanup output has a specific Korean title"
+        )
+        try expect(
+            english.detailsRows.contains(
+                QuillUserIssueDetailsRow(
+                    label: "Failure reason",
+                    value: "Model returned no cleanup text"
+                )
+            ),
+            "empty cleanup output exposes a safe English reason"
+        )
+        try expect(
+            korean.detailsRows.contains(
+                QuillUserIssueDetailsRow(
+                    label: "실패 원인",
+                    value: "모델이 정리 결과를 반환하지 않았습니다"
+                )
+            ),
+            "empty cleanup output exposes a safe Korean reason"
+        )
+    }
+
+    private static func testPostProcessingDiagnosticFieldsRemainBackwardCompatible(
+        bundle: Bundle
+    ) throws {
+        let timeout = QuillUserIssueRecord(
+            code: .requestTimedOut,
+            context: QuillUserIssueContext(
+                modelID: "qwen2.5-7b",
+                localBackend: "Local AI",
+                operation: .postProcessing,
+                postProcessingFailureReason: .requestTimedOut,
+                requestTimeoutSeconds: 120
+            )
+        )
+        let english = timeout.presentation(language: "en", bundle: bundle)
+        let korean = timeout.presentation(language: "ko", bundle: bundle)
+
+        try expect(
+            english.detailsRows.contains(
+                QuillUserIssueDetailsRow(
+                    label: "Request timeout",
+                    value: "120 seconds"
+                )
+            ),
+            "cleanup timeout exposes the English effective timeout"
+        )
+        try expect(
+            korean.detailsRows.contains(
+                QuillUserIssueDetailsRow(
+                    label: "요청 제한 시간",
+                    value: "120초"
+                )
+            ),
+            "cleanup timeout exposes the Korean effective timeout"
+        )
+
+        let legacy = try JSONDecoder().decode(
+            QuillUserIssueContext.self,
+            from: Data(#"{"modelID":"legacy/model"}"#.utf8)
+        )
+        try expect(
+            legacy.postProcessingFailureReason == nil
+                && legacy.requestTimeoutSeconds == nil,
+            "legacy issue context omits new optional diagnostics"
+        )
+        let legacyPresentation = QuillUserIssueRecord(
+            code: .postProcessingFailed,
+            context: QuillUserIssueContext(
+                modelID: legacy.modelID,
+                operation: .postProcessing
+            )
+        ).presentation(language: "en", bundle: bundle)
+        try expect(
+            legacyPresentation.title == "Transcript cleanup was skipped",
+            "legacy cleanup issue keeps compatible generic copy"
+        )
+    }
+
+    private static func testFractionalPostProcessingTimeoutIsNotTruncated(
+        bundle: Bundle
+    ) throws {
+        let timeout = QuillUserIssueRecord(
+            code: .requestTimedOut,
+            context: QuillUserIssueContext(
+                operation: .postProcessing,
+                postProcessingFailureReason: .requestTimedOut,
+                requestTimeoutSeconds: 0.5
+            )
+        )
+        let english = timeout.presentation(language: "en", bundle: bundle)
+        let korean = timeout.presentation(language: "ko", bundle: bundle)
+
+        try expect(
+            english.detailsRows.contains(
+                QuillUserIssueDetailsRow(
+                    label: "Request timeout",
+                    value: "0.5 seconds"
+                )
+            ),
+            "fractional English timeout is not truncated"
+        )
+        try expect(
+            korean.detailsRows.contains(
+                QuillUserIssueDetailsRow(
+                    label: "요청 제한 시간",
+                    value: "0.5초"
+                )
+            ),
+            "fractional Korean timeout is not truncated"
         )
     }
 

--- a/Tests/QuillUserIssueUIContractTests.swift
+++ b/Tests/QuillUserIssueUIContractTests.swift
@@ -187,6 +187,10 @@ struct QuillUserIssueUIContractTests {
             to: "private var inlineView: some View {"
         )
         try expect(bannerView.contains("dismissButton"), "banner style renders the dismiss control")
+        try expect(
+            bannerView.contains("detailsView"),
+            "banner style renders shared structured details"
+        )
         let fullView = block(
             issueView,
             from: "private var fullView: some View {",
@@ -195,10 +199,22 @@ struct QuillUserIssueUIContractTests {
         try expect(!fullView.contains("dismissButton"), "centered error card never renders a dismiss control")
         try expect(!fullView.contains("onDismiss"), "centered error card ignores onDismiss entirely")
 
+        try expect(
+            !noteBrowser.contains("private var shouldShowWarningBanner: Bool"),
+            "warning visibility does not calculate the presentation twice"
+        )
         let warningBannerUsage = block(
             noteBrowser,
-            from: "if let warningPresentation, !isWarningBannerDismissed {",
+            from: "if !isWarningBannerDismissed,",
             to: "NoteTextView("
+        )
+        try expect(
+            warningBannerUsage.contains("!appState.retryingItemIDs.contains(item.id)"),
+            "previous warning stays hidden while retranscription is in progress"
+        )
+        try expect(
+            warningBannerUsage.contains("let warningPresentation"),
+            "warning presentation is evaluated only after cheap visibility guards"
         )
         try expect(warningBannerUsage.contains("style: .warningBanner"), "sanity: this is the warning banner usage")
         try expect(warningBannerUsage.contains("onDismiss:"), "warning banner usage wires a dismiss handler")
@@ -225,8 +241,8 @@ struct QuillUserIssueUIContractTests {
             to: "private func copyRetryTranscriptToPasteboardIfNeeded"
         )
         try expect(
-            retryBody.contains("incrementNoteRetryGeneration(for: item.id)"),
-            "retry bumps the note's retry generation, invalidating stale dismissals"
+            retryBody.contains("incrementNoteRetryGeneration(for: snapshot.item.id)"),
+            "saved retry results invalidate stale dismissals"
         )
     }
 

--- a/docs/superpowers/specs/2026-08-06-retry-warning-error-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-08-06-retry-warning-error-diagnostics-design.md
@@ -1,0 +1,179 @@
+# Retry Warning Lifecycle and Post-processing Diagnostics — Design
+
+## Context
+
+When a completed note contains a persisted warning from post-processing, dismissing its warning banner records the dismissal against the note's current retry generation. Starting retranscription increments that generation before the new transcription or cleanup has produced a result. The note still carries the previous persisted warning at that moment, so its warning banner becomes eligible and appears immediately.
+
+This makes an earlier cleanup failure look like a failure of the new retranscription attempt. In particular, a previously stored timeout message can be shown immediately even though the Local AI request has not had time to reach its 120-second default timeout.
+
+The current compact warning banner also omits `QuillUserIssuePresentation.detailsRows`. Existing structured diagnostic metadata, such as model, Local AI backend, and HTTP status, is therefore unavailable in the place where a completed note's post-processing warning is shown. Several generic `post-processing-failed` paths are not further classified for user-facing copy.
+
+## Goals
+
+1. Do not show a dismissed warning from a prior attempt while retranscription is in progress.
+2. Keep a dismissed warning hidden when the user merely revisits the same note.
+3. Show a warning when the new retranscription attempt actually produces a new failure, including when its code matches a prior failure.
+4. Explain post-processing failures with bounded, actionable cause information rather than generic cleanup-skipped copy whenever the application can safely classify the cause.
+5. Show model, Local AI backend, effective timeout, and safe HTTP metadata in the warning banner's expandable details.
+6. Preserve the Local AI 120-second default, Cloud 20-second default, and valid explicit timeout override policy from v0.1.35.
+7. Keep persisted diagnostics free of transcript text, prompts, request/response bodies, credentials, and private file paths.
+8. Keep existing persisted user-issue records readable.
+
+## Non-goals
+
+- Change post-processing retry behavior, model selection, or Local AI server lifecycle.
+- Add a retranscription-attempt timeline or a separate error-history screen.
+- Expose raw error descriptions or provider response text.
+- Change the existing transcript fallback policy: a failed cleanup continues to retain the original transcript.
+- Alter warning behavior for unrelated meeting-summary or recording errors.
+
+## Root Cause and Corrected Warning Lifecycle
+
+### Current sequence
+
+```text
+Dismiss warning at retry generation N
+  ↓
+Dismissal stored for (note ID, warning code, N)
+  ↓
+Start retranscription
+  ↓
+Increment retry generation to N + 1
+  ↓
+Existing note still contains the old persisted warning
+  ↓
+Dismissal lookup no longer matches
+  ↓
+Old warning banner renders immediately
+```
+
+### Corrected sequence
+
+```text
+Dismiss warning at retry generation N
+  ↓
+Revisit note without retrying
+  ↓
+Dismissed warning remains hidden
+
+Start retranscription
+  ↓
+Retry is marked in progress
+  ↓
+Existing warning is suppressed only while that retry is in progress
+  ↓
+New result is saved
+  ├─ success: saved status has no warning → no banner
+  └─ new failure: saved status has the new warning → show banner
+```
+
+`AppState.retryingItemIDs` already identifies an in-progress retry. The Note Browser warning-banner condition will additionally require that the note is not in this set. The dismissal store and retry-generation behavior remain unchanged: a new failure after retry remains eligible to be shown, while an old dismissal remains effective when no retry is active.
+
+No old issue record is cleared at retry start. This avoids mutating durable history before the replacement result is available and keeps retry failure recovery intact.
+
+## Safe Post-processing Diagnostics
+
+### Persisted context
+
+`QuillUserIssueContext` will gain optional, backwards-compatible fields:
+
+- `postProcessingFailureReason`: a bounded application-owned reason enum;
+- `requestTimeoutSeconds`: the effective request timeout when the reason is timeout.
+
+The fields are optional. Existing version-1 records without them decode and retain their current generic presentation. The record schema version remains unchanged because the additional Codable fields are optional and do not alter existing fields.
+
+### Bounded failure reasons
+
+The application maps internal post-processing errors into a finite set of safe categories. The exact enum names may follow existing Swift naming conventions, but the user-visible meanings are:
+
+| Internal condition | User-visible cause |
+| --- | --- |
+| `URLError(.timedOut)` mapped to `PostProcessingError.requestTimedOut` | Cleanup request timed out |
+| Safe context-budget rejection | Transcript is too large for cleanup |
+| Missing or malformed completion envelope | Model response could not be read |
+| Empty completion output | Model returned no cleanup text |
+| Non-success HTTP result not already mapped to authentication, configuration, or rate limit | Cleanup request failed at the service |
+
+Existing specialized issue codes remain authoritative for authentication, configuration, rate limiting, Local AI runtime/model failures, and output-guard rejections. Unknown transport failures continue to use the existing generic safe fallback rather than exposing an unbounded underlying error.
+
+### Presentation
+
+`QuillUserIssueRecord.presentation` uses the bounded reason to select more specific localized cleanup copy. For example:
+
+- timeout: cleanup did not respond before the configured limit;
+- oversized input: cleanup could not safely fit the transcript in the selected model's context;
+- empty output: the model returned no usable cleanup text;
+- unreadable response: the model response could not be read.
+
+The warning-banner layout will render the shared expandable details view. Details may contain only structured metadata already approved for display:
+
+- operation (`Transcript cleanup`),
+- bounded failure reason,
+- effective timeout when present,
+- model ID,
+- Local AI backend marker,
+- HTTP status and allowlisted provider code when present.
+
+The raw transcript, prompt, request JSON, response body, authorization token, source error description, and filesystem paths are never persisted or displayed.
+
+## Components and Data Flow
+
+### `PostProcessingService`
+
+At the conversion from `PostProcessingError` to `QuillUserIssueError`, resolve the safe failure reason and, for a timeout, retain the effective `URLRequest.timeoutInterval`. Continue using the request endpoint model ID, so Local AI timeouts identify the actual selected Local model.
+
+### `QuillUserIssue`
+
+Add optional context fields, their Codable keys, and a finite failure-reason enum. Extend presentation generation to choose localized copy based on the post-processing operation and safe failure reason. Extend details-row generation with localized labels and values for the failure reason and timeout.
+
+### `QuillUserIssueView`
+
+For `.warningBanner`, include the existing shared `detailsView` beneath the compact title/body section. `.full` and `.inline` presentation styles retain their existing details behavior.
+
+### `NoteBrowserView`
+
+Keep decoding the note's persisted issue as it does today. Suppress the transcript warning banner whenever `appState.retryingItemIDs` contains the current note ID. Once retry finishes, reload the saved history item and render only its newly saved status.
+
+### `AppState`
+
+Continue incrementing retry generation so a genuinely new failure, including one with the same issue code, is visible after retry. Do not change the persisted note status when retry begins. The success and failure history replacement paths remain the single source of truth for what displays after the retry finishes.
+
+## Testing Strategy
+
+Tests are written before production changes.
+
+### Warning lifecycle
+
+1. A dismissed warning remains hidden when the note is revisited without retrying.
+2. With an old warning record present, an in-progress retry suppresses that banner.
+3. A successful retry replaces the warning status and leaves no banner.
+4. A failed retry produces a visible warning after retry completion, including when its issue code equals the prior warning's code.
+5. The dismiss behavior remains isolated to the note and warning occurrence/retry generation as existing behavior requires.
+
+Where direct SwiftUI interaction coverage is impractical, extract or extend a small display predicate and test it deterministically; retain source-contract coverage for the Note Browser wiring.
+
+### Diagnostics classification and presentation
+
+1. Each bounded post-processing reason maps to the expected structured record and localized Korean/English copy.
+2. A Local timeout records `request-timed-out`, the selected model, Local AI marker, and `120` seconds with no valid override.
+3. A valid timeout override records the override value rather than the default.
+4. Cloud timeout retains the existing 20-second default.
+5. Details rows include only approved bounded values.
+6. Synthetic transcript, prompt, credential, response-body, and local-path sentinels do not occur in encoded records, banner text, or details rows.
+7. Legacy version-1 records without the new optional fields remain decodable and use generic compatible copy.
+
+### Regression verification
+
+Run the focused post-processing, user-issue, Note Browser UI contract, and AppState retry tests, then run `make test`. Run the optional Local AI integration target only if the current machine has the required bundled server and Quality Qwen model prerequisites.
+
+## Acceptance Criteria
+
+- Clicking retranscription never immediately re-shows a previously dismissed warning while the new attempt is running.
+- Returning to a note after dismissing its warning does not re-show that same warning without a new retry result.
+- A new retry failure displays after completion, even if it has the same classification as the prior failure.
+- Timeout, context-budget, empty-output, malformed-response, and service-request cleanup failures have bounded and specific user-facing explanations.
+- Timeout details identify the actual model and effective timeout, including Local AI's default 120 seconds when applicable.
+- The existing Local/Cloud timeout policy and raw-transcript fallback behavior remain unchanged.
+- Existing persisted history remains readable.
+- No sensitive source or raw provider data enters persistence or UI.
+- Focused tests and `make test` pass.


### PR DESCRIPTION
## Summary
- Keep dismissed cleanup warnings hidden while a retranscription attempt is running, including resumed Cloud retries.
- Replace generic cleanup warnings with safe, specific diagnostics for timeouts, empty results, malformed responses, context limits, and service failures.
- Show the operation, model, bounded failure reason, and effective request timeout in expandable warning details.

## Testing
- `make test`
- `make test-local-ai-integration` *(skipped: built `llama-server` is unavailable)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 전사 후처리 실패 원인을 입력 초과, 빈 결과, 잘못된 응답, 요청 시간 초과 등으로 구분해 안내합니다.
  * 오류 화면에 모델, 실패 사유, 요청 제한 시간 등 안전한 진단 정보를 표시합니다.
  * 후처리 실패 시 원본 전사문을 유지하고, 재시도할 수 없는 오류를 명확히 안내합니다.
  * 재시도 중인 항목의 이전 경고 배너를 숨기고, 작업 완료 후 최신 상태를 표시합니다.
  * 관련 오류 메시지에 영어와 한국어 번역을 추가했습니다.

* **문서 및 테스트**
  * 재시도 경고와 오류 진단 동작에 대한 설계 문서 및 검증을 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->