### PR TITLE
Move AppState history dependencies to instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ FULL_SOURCE_APP_STATE_TESTS = \
 	Tests/AudioImportFileCopyTests.swift \
 	Tests/LatestValueProgressCoalescerTests.swift \
 	Tests/AppStateTestStorage.swift \
+	Tests/AppStateDependenciesTests.swift \
 	Tests/AppStateStorageSafetyTests.swift \
 	Tests/AppStateHistoryProtectionSourceTests.swift \
 	Tests/AppStateTranscriptionConfigurationTests.swift \

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -350,11 +350,6 @@ enum MeetingSummaryAvailability: Equatable {
 }
 
 final class AppState: ObservableObject, @unchecked Sendable {
-    @MainActor
-    static var meetingSummaryGeneratorFactory:
-        (AppState) -> any MeetingSummaryGenerating = { appState in
-            appState.makeMeetingSummaryService()
-        }
     static var retryCloudTranscriptionDependenciesFactory:
         () -> CloudTranscriptionDependencies = {
             .live
@@ -7084,7 +7079,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 languageContext: resolvedLanguage.context
             )
             attemptSourceFingerprint = source.fingerprint
-            result = try await Self.meetingSummaryGeneratorFactory(self)
+            result = try await dependencies.makeMeetingSummaryGenerator(self)
                 .generate(source: source)
 
             guard let index = pipelineHistory.firstIndex(where: { $0.id == id }) else {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -5305,19 +5305,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         try? FileManager.default.removeItem(at: fileURL)
     }
 
-    static func loadTranscript(
-        from fileName: String,
-        transcriptDirectory: URL
-    ) -> String? {
-        let fileURL = transcriptDirectory.appendingPathComponent(fileName)
-        return try? String(contentsOf: fileURL, encoding: .utf8)
-    }
-
     func loadTranscript(from fileName: String) -> String? {
-        Self.loadTranscript(
-            from: fileName,
-            transcriptDirectory: storageLayout.transcriptDirectory
-        )
+        let fileURL = storageLayout.transcriptDirectory.appendingPathComponent(fileName)
+        return try? String(contentsOf: fileURL, encoding: .utf8)
     }
 
     static func fileSizeBytes(for fileURL: URL) -> Int64? {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -355,40 +355,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         (AppState) -> any MeetingSummaryGenerating = { appState in
             appState.makeMeetingSummaryService()
         }
-    static var storageRootProvider: () -> URL = {
-        AppName.applicationSupportDirectory
-    }
-    static var pipelineHistoryStoreFactory: () -> PipelineHistoryStore = {
-        makeDefaultPipelineHistoryStore()
-    }
-    static var pipelineHistoryStoreAtURLFactory: (URL) -> PipelineHistoryStore = {
-        PipelineHistoryStore(storeURL: $0)
-    }
-
-    static func makeDefaultPipelineHistoryStore() -> PipelineHistoryStore {
-        pipelineHistoryStoreAtURLFactory(
-            appStorageRootDirectory().appendingPathComponent("PipelineHistory.sqlite")
-        )
-    }
-
-    private static func makeRecordingJournalStore() -> RecordingJournalStore {
-        RecordingJournalStore(audioDirectory: audioStorageDirectory())
-    }
-
-    private static func makeCloudTranscriptionJobStore() -> CloudTranscriptionJobStore {
-        let audioDirectory = audioStorageDirectory()
-        return CloudTranscriptionJobStore(
-            jobsDirectory: audioDirectory
-                .deletingLastPathComponent()
-                .appendingPathComponent("cloud-transcription/jobs", isDirectory: true),
-            temporaryRoot: FileManager.default.temporaryDirectory
-                .appendingPathComponent(
-                    Bundle.main.bundleIdentifier ?? "com.woosublee.quill",
-                    isDirectory: true
-                )
-                .appendingPathComponent("cloud-transcription", isDirectory: true)
-        )
-    }
     static var retryCloudTranscriptionDependenciesFactory:
         () -> CloudTranscriptionDependencies = {
             .live
@@ -2475,6 +2441,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var defaultInputDeviceListener: AudioObjectPropertyListenerBlock?
     private var defaultInputDeviceListenerAddress: AudioObjectPropertyAddress?
     private var needsMicrophoneRefreshAfterRecording = false
+    private let dependencies: AppStateDependencies
+    var storageLayout: AppStateStorageLayout { dependencies.storageLayout }
     private var pipelineHistoryStore: PipelineHistoryStore
     private var recordingJournalStore: RecordingJournalStore
     private var cloudTranscriptionJobStore: CloudTranscriptionJobStore
@@ -2511,8 +2479,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var pendingSpeechPermissionContext: PendingRecordingPermissionContext?
     private let postTranscriptionUpdateReminderDuration: TimeInterval = 7
 
-    init() {
-        let storageRoot = Self.appStorageRootDirectory()
+    init(dependencies: AppStateDependencies = .live) {
+        self.dependencies = dependencies
+        let storageLayout = dependencies.storageLayout
+        let storageRoot = Self.preparedDirectory(storageLayout.rootDirectory)
+        let audioDirectory = Self.preparedDirectory(storageLayout.audioDirectory)
+        _ = Self.preparedDirectory(storageLayout.transcriptDirectory)
         let recoveredArchiveSafety = HistoryArchiveTransition
             .rollbackInterruptedTransactions(at: storageRoot)
         if recoveredArchiveSafety != .unresolvedInterruptedTransaction {
@@ -2520,12 +2492,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 .removeExpiredCompletedSnapshots()
         }
         let initialHistoryArchiveSafety = HistoryArchiveTransition.inspect(at: storageRoot)
-        pipelineHistoryStore = Self.pipelineHistoryStoreFactory()
+        pipelineHistoryStore = dependencies.makePipelineHistoryStore(
+            storageLayout.historyStoreURL
+        )
         let initialHistoryUnavailable = pipelineHistoryStore.availability == .unavailable
             || initialHistoryArchiveSafety == .unresolvedInterruptedTransaction
-        let audioDirectory = Self.audioStorageDirectory()
-        recordingJournalStore = Self.makeRecordingJournalStore()
-        cloudTranscriptionJobStore = Self.makeCloudTranscriptionJobStore()
+        recordingJournalStore = RecordingJournalStore(
+            audioDirectory: audioDirectory
+        )
+        cloudTranscriptionJobStore = CloudTranscriptionJobStore(
+            jobsDirectory: storageLayout.cloudTranscriptionJobsDirectory,
+            temporaryRoot: storageLayout.cloudTranscriptionTemporaryDirectory
+        )
         UserDefaults.standard.removeObject(forKey: "force_http2_transcription")
         Self.migrateModelStorageKeys()
         let hasCompletedSetup = UserDefaults.standard.bool(forKey: "hasCompletedSetup")
@@ -2819,9 +2797,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
            pipelineHistoryStore.availability == .ready {
             Self.recoverRecordingJournalsBeforeHistoryLoad(
                 recordingJournalStore: recordingJournalStore,
-                historyStore: pipelineHistoryStore
+                historyStore: pipelineHistoryStore,
+                storageLayout: storageLayout
             )
-            let transcriptDirectory = Self.transcriptStorageDirectory()
+            let transcriptDirectory = storageLayout.transcriptDirectory
             savedHistory = pipelineHistoryStore.loadAllHistory()
             if pipelineHistoryStore.availability == .ready {
                 var referenceTrust = pipelineHistoryStore.referenceTrust
@@ -2877,7 +2856,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         cloudTranscriptionJobStore.invalidateSession(
                             historyID: removedAssets.historyID
                         )
-                        Self.deleteStoredFiles(removedAssets)
+                        Self.deleteStoredFiles(removedAssets, storageLayout: storageLayout)
                         try? cloudTranscriptionJobStore.delete(
                             historyID: removedAssets.historyID,
                             session: nil
@@ -2940,7 +2919,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                   pipelineHistoryStore.availability == .ready {
             Self.recoverRecordingJournalsBeforeHistoryLoad(
                 recordingJournalStore: recordingJournalStore,
-                historyStore: pipelineHistoryStore
+                historyStore: pipelineHistoryStore,
+                storageLayout: storageLayout
             )
             savedHistory = pipelineHistoryStore.loadAllHistory()
             if pipelineHistoryStore.availability == .ready {
@@ -4857,12 +4837,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     func openHistoryDataFolder() {
-        NSWorkspace.shared.open(Self.appStorageRootDirectory())
+        NSWorkspace.shared.open(storageLayout.rootDirectory)
     }
 
     func openHistoryRecoveryFolder() {
         NSWorkspace.shared.open(
-            Self.appStorageRootDirectory().appendingPathComponent("Recovery", isDirectory: true)
+            storageLayout.rootDirectory.appendingPathComponent("Recovery", isDirectory: true)
         )
     }
 
@@ -4878,7 +4858,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @MainActor
     func refreshHistoryRecoverySnapshots() {
         historyRecoverySnapshots = HistoryRecoveryService(
-            storageRoot: Self.appStorageRootDirectory()
+            storageRoot: storageLayout.rootDirectory
         ).listSnapshots()
         let currentIDs = Set(historyRecoverySnapshots.map(\.id))
         historyRecoveryInspections = historyRecoveryInspections.filter {
@@ -4943,7 +4923,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             historyRecoveryInspectionAttemptedIDs.insert(snapshotID)
             historyRecoveryInspectionSnapshotID = snapshotID
             let inspectionRevision = historyRecoveryInspectionRevision
-            let storageRoot = Self.appStorageRootDirectory()
+            let storageRoot = dependencies.storageLayout.rootDirectory
             let activeHistory = pipelineHistory
             let appStateReference = WeakAppStateReference(self)
             Task.detached(priority: .userInitiated) {
@@ -5027,13 +5007,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return false
         }
 
-        let storageRoot = Self.appStorageRootDirectory()
-        let makeStore = Self.pipelineHistoryStoreAtURLFactory
+        let storageRoot = dependencies.storageLayout.rootDirectory
+        let storeURL = dependencies.storageLayout.historyStoreURL
+        let audioDirectory = dependencies.storageLayout.audioDirectory
+        let transcriptDirectory = dependencies.storageLayout.transcriptDirectory
+        let makeStore = dependencies.makePipelineHistoryStore
         let appStateReference = WeakAppStateReference(self)
         isHistoryRecoveryOperationInProgress = true
         historyRecoveryOperationMessage = localizedCatalogString("Recovering history…")
         Task.detached(priority: .userInitiated) {
-            let storeURL = storageRoot.appendingPathComponent("PipelineHistory.sqlite")
             let activeStore = makeStore(storeURL)
             do {
                 guard activeStore.availability == .ready,
@@ -5044,11 +5026,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 let result = try HistoryRecoveryService(storageRoot: storageRoot).importSnapshot(
                     id: id,
                     into: activeStore,
-                    audioDirectory: storageRoot.appendingPathComponent("audio", isDirectory: true),
-                    transcriptDirectory: storageRoot.appendingPathComponent(
-                        "transcripts",
-                        isDirectory: true
-                    )
+                    audioDirectory: audioDirectory,
+                    transcriptDirectory: transcriptDirectory
                 )
                 try activeStore.detachForArchiveVerification()
                 await MainActor.run {
@@ -5108,7 +5087,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         message: String,
         operation: @escaping @Sendable (HistoryRecoveryService) throws -> Void
     ) {
-        let storageRoot = Self.appStorageRootDirectory()
+        let storageRoot = dependencies.storageLayout.rootDirectory
         let appStateReference = WeakAppStateReference(self)
         historyRecoveryImportResult = nil
         isHistoryRecoveryOperationInProgress = true
@@ -5152,36 +5131,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
         errorMessage = localizedCatalogString("Recovery snapshot operation could not be completed.")
     }
 
-    static func appStorageRootDirectory() -> URL {
-        let rootDirectory = storageRootProvider()
-        if !FileManager.default.fileExists(atPath: rootDirectory.path) {
+    @discardableResult
+    private static func preparedDirectory(_ directory: URL) -> URL {
+        if !FileManager.default.fileExists(atPath: directory.path) {
             try? FileManager.default.createDirectory(
-                at: rootDirectory,
+                at: directory,
                 withIntermediateDirectories: true
             )
         }
-        return rootDirectory
-    }
-
-    static func audioStorageDirectory() -> URL {
-        let audioDir = appStorageRootDirectory().appendingPathComponent("audio", isDirectory: true)
-        if !FileManager.default.fileExists(atPath: audioDir.path) {
-            try? FileManager.default.createDirectory(at: audioDir, withIntermediateDirectories: true)
-        }
-        return audioDir
-    }
-
-    static func transcriptStorageDirectory() -> URL {
-        let dir = appStorageRootDirectory().appendingPathComponent("transcripts", isDirectory: true)
-        if !FileManager.default.fileExists(atPath: dir.path) {
-            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        }
-        return dir
+        return directory
     }
 
     private static func recoverRecordingJournalsBeforeHistoryLoad(
         recordingJournalStore: RecordingJournalStore,
-        historyStore: PipelineHistoryStore
+        historyStore: PipelineHistoryStore,
+        storageLayout: AppStateStorageLayout
     ) {
         let executor = RecordingJournalRecoveryExecutor(
             store: recordingJournalStore
@@ -5200,7 +5164,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     )
                     if historyStore.referenceTrust.permitsStartupReferenceCleanup {
                         for assets in removedAssets {
-                            Self.deleteStoredFiles(assets)
+                            Self.deleteStoredFiles(assets, storageLayout: storageLayout)
                         }
                     }
                 } catch {
@@ -5325,9 +5289,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    static func saveTranscriptFile(rawTranscript: String, postProcessedTranscript: String) -> String? {
+    static func saveTranscriptFile(
+        rawTranscript: String,
+        postProcessedTranscript: String,
+        transcriptDirectory: URL
+    ) -> String? {
         let fileName = UUID().uuidString + ".txt"
-        let fileURL = transcriptStorageDirectory().appendingPathComponent(fileName)
+        let fileURL = transcriptDirectory.appendingPathComponent(fileName)
         // postProcessedTranscript가 있으면 그걸, 없으면 rawTranscript 저장
         let content = postProcessedTranscript.isEmpty ? rawTranscript : postProcessedTranscript
         do {
@@ -5338,23 +5306,39 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    static func deleteTranscriptFile(_ fileName: String) {
-        let fileURL = transcriptStorageDirectory().appendingPathComponent(fileName)
+    static func deleteTranscriptFile(
+        _ fileName: String,
+        transcriptDirectory: URL
+    ) {
+        let fileURL = transcriptDirectory.appendingPathComponent(fileName)
         try? FileManager.default.removeItem(at: fileURL)
     }
 
-    static func loadTranscript(from fileName: String) -> String? {
-        let fileURL = transcriptStorageDirectory().appendingPathComponent(fileName)
+    static func loadTranscript(
+        from fileName: String,
+        transcriptDirectory: URL
+    ) -> String? {
+        let fileURL = transcriptDirectory.appendingPathComponent(fileName)
         return try? String(contentsOf: fileURL, encoding: .utf8)
+    }
+
+    func loadTranscript(from fileName: String) -> String? {
+        Self.loadTranscript(
+            from: fileName,
+            transcriptDirectory: storageLayout.transcriptDirectory
+        )
     }
 
     static func fileSizeBytes(for fileURL: URL) -> Int64? {
         (try? fileURL.resourceValues(forKeys: [.fileSizeKey]))?.fileSize.map { Int64($0) }
     }
 
-    static func saveAudioFile(from tempURL: URL) -> SavedAudioFile? {
+    static func saveAudioFile(
+        from tempURL: URL,
+        audioDirectory: URL
+    ) -> SavedAudioFile? {
         let fileName = UUID().uuidString + "." + AudioImportOptions.storageExtension(for: tempURL.lastPathComponent)
-        let destURL = audioStorageDirectory().appendingPathComponent(fileName)
+        let destURL = audioDirectory.appendingPathComponent(fileName)
         do {
             try? FileManager.default.removeItem(at: destURL)
             try FileManager.default.copyItem(at: tempURL, to: destURL)
@@ -5380,16 +5364,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private static func savedAudioFileForStoppedRecording(
-        _ fileURL: URL
+        _ fileURL: URL,
+        audioDirectory: URL
     ) -> SavedAudioFile? {
-        let audioDirectory = audioStorageDirectory().standardizedFileURL
+        let audioDirectory = audioDirectory.standardizedFileURL
         let standardizedURL = fileURL.standardizedFileURL
         guard standardizedURL.deletingLastPathComponent() == audioDirectory else {
-            return saveAudioFile(from: fileURL)
+            return saveAudioFile(from: fileURL, audioDirectory: audioDirectory)
         }
         guard standardizedURL.pathExtension.lowercased() == "wav",
               (try? RecordingCanonicalWAV.validateFile(at: standardizedURL)) != nil else {
-            return saveAudioFile(from: fileURL)
+            return saveAudioFile(from: fileURL, audioDirectory: audioDirectory)
         }
         return SavedAudioFile(
             fileName: standardizedURL.lastPathComponent,
@@ -5397,7 +5382,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
     }
 
-    static func saveSecurityScopedAudioFileOffMain(from fileURL: URL) async -> SavedAudioFile? {
+    static func saveSecurityScopedAudioFileOffMain(
+        from fileURL: URL,
+        audioDirectory: URL
+    ) async -> SavedAudioFile? {
         await Task.detached(priority: .userInitiated) {
             let accessGranted = fileURL.startAccessingSecurityScopedResource()
             defer {
@@ -5405,7 +5393,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     fileURL.stopAccessingSecurityScopedResource()
                 }
             }
-            return Self.saveAudioFile(from: fileURL)
+            return Self.saveAudioFile(
+                from: fileURL,
+                audioDirectory: audioDirectory
+            )
         }.value
     }
 
@@ -5421,29 +5412,49 @@ final class AppState: ObservableObject, @unchecked Sendable {
             forKey: assets.historyID
         )
         retryingItemIDs.remove(assets.historyID)
-        Self.deleteStoredFiles(assets)
+        Self.deleteStoredFiles(assets, storageLayout: storageLayout)
         try? cloudTranscriptionJobStore.delete(
             historyID: assets.historyID,
             session: nil
         )
     }
 
-    private static func deleteAudioFile(_ fileName: String) {
-        let fileURL = audioStorageDirectory().appendingPathComponent(fileName)
+    private static func deleteAudioFile(
+        _ fileName: String,
+        audioDirectory: URL
+    ) {
+        let fileURL = audioDirectory.appendingPathComponent(fileName)
         try? FileManager.default.removeItem(at: fileURL)
     }
 
-    private static func deleteStoredFiles(audioFileName: String?, transcriptFileName: String?) {
+    private static func deleteStoredFiles(
+        audioFileName: String?,
+        transcriptFileName: String?,
+        storageLayout: AppStateStorageLayout
+    ) {
         if let audioFileName {
-            deleteAudioFile(audioFileName)
+            deleteAudioFile(
+                audioFileName,
+                audioDirectory: storageLayout.audioDirectory
+            )
         }
         if let transcriptFileName {
-            deleteTranscriptFile(transcriptFileName)
+            deleteTranscriptFile(
+                transcriptFileName,
+                transcriptDirectory: storageLayout.transcriptDirectory
+            )
         }
     }
 
-    private static func deleteStoredFiles(_ assets: DeletedPipelineHistoryAssets) {
-        deleteStoredFiles(audioFileName: assets.audioFileName, transcriptFileName: assets.transcriptFileName)
+    private static func deleteStoredFiles(
+        _ assets: DeletedPipelineHistoryAssets,
+        storageLayout: AppStateStorageLayout
+    ) {
+        deleteStoredFiles(
+            audioFileName: assets.audioFileName,
+            transcriptFileName: assets.transcriptFileName,
+            storageLayout: storageLayout
+        )
     }
 
     static func normalizeInterruptedHistoryItem(
@@ -6571,8 +6582,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return false
         }
 
-        let storageRoot = Self.appStorageRootDirectory()
-        let makeStore = Self.pipelineHistoryStoreAtURLFactory
+        let storageRoot = dependencies.storageLayout.rootDirectory
+        let makeStore = dependencies.makePipelineHistoryStore
         let appStateReference = WeakAppStateReference(self)
         isHistoryArchiveTransitioning = true
         historyArchiveSafety = .transitioning
@@ -6605,8 +6616,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         storageRoot: URL,
         postAction: HistoryArchivePostAction
     ) {
-        let activeStore = Self.pipelineHistoryStoreAtURLFactory(
-            storageRoot.appendingPathComponent("PipelineHistory.sqlite")
+        let activeStore = dependencies.makePipelineHistoryStore(
+            dependencies.storageLayout.historyStoreURL
         )
         guard activeStore.availability == .ready,
               activeStore.durability == .durable,
@@ -6615,8 +6626,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return
         }
         pipelineHistoryStore = activeStore
-        recordingJournalStore = Self.makeRecordingJournalStore()
-        cloudTranscriptionJobStore = Self.makeCloudTranscriptionJobStore()
+        recordingJournalStore = RecordingJournalStore(
+            audioDirectory: dependencies.storageLayout.audioDirectory
+        )
+        cloudTranscriptionJobStore = CloudTranscriptionJobStore(
+            jobsDirectory: dependencies.storageLayout.cloudTranscriptionJobsDirectory,
+            temporaryRoot: dependencies.storageLayout.cloudTranscriptionTemporaryDirectory
+        )
         pipelineHistory = []
         retryingItemIDs = []
         pendingAudioImportJobIDs = []
@@ -6674,8 +6690,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         _ result: HistoryRecoveryImportResult,
         storageRoot: URL
     ) {
-        let activeStore = Self.pipelineHistoryStoreAtURLFactory(
-            storageRoot.appendingPathComponent("PipelineHistory.sqlite")
+        let activeStore = dependencies.makePipelineHistoryStore(
+            dependencies.storageLayout.historyStoreURL
         )
         guard activeStore.availability == .ready,
               activeStore.durability == .durable,
@@ -6700,8 +6716,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func completeHistoryRecoveryOperationFailure(at storageRoot: URL) {
-        let activeStore = Self.pipelineHistoryStoreAtURLFactory(
-            storageRoot.appendingPathComponent("PipelineHistory.sqlite")
+        let activeStore = dependencies.makePipelineHistoryStore(
+            dependencies.storageLayout.historyStoreURL
         )
         if activeStore.availability == .ready,
            activeStore.durability == .durable,
@@ -7228,7 +7244,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
               let item = pipelineHistory.first(where: { $0.id == id }) else { return }
         // 파일에도 동기화해서 앱 재시작 후 폴백 로딩 시에도 일관성 유지
         if let fileName = item.transcriptFileName {
-            let fileURL = Self.transcriptStorageDirectory().appendingPathComponent(fileName)
+            let fileURL = storageLayout.transcriptDirectory.appendingPathComponent(fileName)
             try? text.write(to: fileURL, atomically: true, encoding: .utf8)
         }
         let replacementSpokenLanguage: SpokenLanguageResolution?
@@ -7324,15 +7340,22 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let startedAt = Date()
         let importContextSummary = AudioImportOptions.importContextSummary(for: fileURL.lastPathComponent)
         pendingAudioImportJobIDs.insert(jobID)
+        let audioDirectory = storageLayout.audioDirectory
 
         Task { [weak self] in
-            guard let savedAudioFile = await Self.saveSecurityScopedAudioFileOffMain(from: fileURL) else {
+            guard let savedAudioFile = await Self.saveSecurityScopedAudioFileOffMain(
+                from: fileURL,
+                audioDirectory: audioDirectory
+            ) else {
                 self?.pendingAudioImportJobIDs.remove(jobID)
                 self?.errorMessage = localizedCatalogString("Unable to save the audio file. Check disk space or file permissions and try again.")
                 return
             }
             guard let self else {
-                Self.deleteAudioFile(savedAudioFile.fileName)
+                Self.deleteAudioFile(
+                    savedAudioFile.fileName,
+                    audioDirectory: audioDirectory
+                )
                 return
             }
 
@@ -7374,7 +7397,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 }
             } catch {
                 self.pendingAudioImportJobIDs.remove(jobID)
-                Self.deleteAudioFile(savedAudioFile.fileName)
+                Self.deleteAudioFile(
+                    savedAudioFile.fileName,
+                    audioDirectory: audioDirectory
+                )
                 let issue = self.userIssue(for: error)
                 self.errorMessage = issue.record.presentation().compactMessage
                 return
@@ -7547,11 +7573,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    func storedAudioURL(for item: PipelineHistoryItem) -> URL? {
+        guard let fileName = item.audioFileName else { return nil }
+        return storageLayout.audioDirectory.appendingPathComponent(fileName)
+    }
+
     @MainActor
     func noteBrowserStoredAudioURL(for item: PipelineHistoryItem) -> URL? {
-        guard let audioFileName = item.audioFileName else { return nil }
-        let audioURL = Self.audioStorageDirectory().appendingPathComponent(audioFileName)
-        guard FileManager.default.fileExists(atPath: audioURL.path) else { return nil }
+        guard let audioURL = storedAudioURL(for: item),
+              FileManager.default.fileExists(atPath: audioURL.path) else {
+            return nil
+        }
         return audioURL
     }
 
@@ -7615,6 +7647,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let postProcessingService = makePostProcessingService()
         let cloudDependencies = Self
             .retryCloudTranscriptionDependenciesFactory()
+        let transcriptDirectory = storageLayout.transcriptDirectory
 
         let task = Task { [weak self] in
             guard let self else { return }
@@ -7647,7 +7680,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 let transcriptFileName = snapshot.item.transcriptFileName == nil
                     ? Self.saveTranscriptFile(
                         rawTranscript: parsedTranscript.transcript,
-                        postProcessedTranscript: result.finalTranscript
+                        postProcessedTranscript: result.finalTranscript,
+                        transcriptDirectory: transcriptDirectory
                     )
                     : snapshot.item.transcriptFileName
                 updatedItem = self.makeRetryHistoryItem(
@@ -7700,7 +7734,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 ) else {
                     if snapshot.item.transcriptFileName == nil,
                        let transcriptFileName = updatedItem.transcriptFileName {
-                        Self.deleteTranscriptFile(transcriptFileName)
+                        Self.deleteTranscriptFile(
+                            transcriptFileName,
+                            transcriptDirectory: transcriptDirectory
+                        )
                     }
                     self.retryingItemIDs.remove(snapshot.item.id)
                     return
@@ -7730,7 +7767,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 } catch {
                     if snapshot.item.transcriptFileName == nil,
                        let transcriptFileName = updatedItem.transcriptFileName {
-                        Self.deleteTranscriptFile(transcriptFileName)
+                        Self.deleteTranscriptFile(
+                            transcriptFileName,
+                            transcriptDirectory: transcriptDirectory
+                        )
                     }
                     let issue = self.userIssue(for: error)
                     self.errorMessage = issue.record.presentation().compactMessage
@@ -8857,7 +8897,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         dismissTranscribingOverlay()
         cleanupActiveAudioRecordersIfIdle()
         if let audioFileName = job.audioFileName {
-            Self.deleteAudioFile(audioFileName)
+            Self.deleteAudioFile(audioFileName, audioDirectory: storageLayout.audioDirectory)
         }
         if let liveNoteID = job.liveNoteID {
             pipelineHistory.removeAll { $0.id == liveNoteID }
@@ -10471,6 +10511,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
         let capturedLiveTranscriber = liveTranscriber
         let capturedPressEnterCommandEnabled = isPressEnterVoiceCommandEnabled
+        let audioDirectory = storageLayout.audioDirectory
         liveTranscriber = nil
         setActiveRecorderPCMHandler(nil)
 
@@ -10491,7 +10532,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         )
                     )
                     let savedAudioFile = transcriber.recordedAudioURL.flatMap { url -> SavedAudioFile? in
-                        let saved = Self.saveAudioFile(from: url)
+                        let saved = Self.saveAudioFile(
+                            from: url,
+                            audioDirectory: audioDirectory
+                        )
                         try? FileManager.default.removeItem(at: url)
                         return saved
                     }
@@ -10542,7 +10586,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         inFlightContextTask: inFlightContextTask
                     )
                     let errorAudioFile = transcriber.recordedAudioURL.flatMap { url -> SavedAudioFile? in
-                        let saved = Self.saveAudioFile(from: url)
+                        let saved = Self.saveAudioFile(
+                            from: url,
+                            audioDirectory: audioDirectory
+                        )
                         try? FileManager.default.removeItem(at: url)
                         return saved
                     }
@@ -10631,7 +10678,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 return
             }
 
-            let savedAudioFile = Self.savedAudioFileForStoppedRecording(fileURL)
+            let savedAudioFile = Self.savedAudioFileForStoppedRecording(fileURL, audioDirectory: storageLayout.audioDirectory)
             let transcriptionFileURL = savedAudioFile?.fileURL ?? fileURL
             if let savedAudioFile {
                 let recoveryContext = sessionContext ?? self.fallbackContextAtStop()
@@ -10870,7 +10917,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             guard let self else { return }
             switch stoppedRecording {
             case .transcribable(let fileURL, _):
-                guard let savedAudioFile = Self.savedAudioFileForStoppedRecording(fileURL) else {
+                guard let savedAudioFile = Self.savedAudioFileForStoppedRecording(fileURL, audioDirectory: storageLayout.audioDirectory) else {
                     self.completeStoppedRecording(
                         .audioOnly(recordingID),
                         overlayID: overlayID
@@ -10954,7 +11001,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
         let compatible = CloudTranscriptionStartupReconciler(
             store: cloudTranscriptionJobStore,
-            audioRoot: Self.audioStorageDirectory()
+            audioRoot: storageLayout.audioDirectory
         ).reconcile(
             history: pipelineHistory,
             runtime: runtime
@@ -10997,7 +11044,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
               let audioFileName = item.audioFileName else {
             return
         }
-        let audioURL = Self.audioStorageDirectory().appendingPathComponent(
+        let audioURL = storageLayout.audioDirectory.appendingPathComponent(
             audioFileName
         )
         retryingItemIDs.insert(item.id)
@@ -11564,7 +11611,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                    !history.contains(where: { $0.id == recordingID }) {
                     Self.deleteStoredFiles(
                         audioFileName: audioFileName,
-                        transcriptFileName: nil
+                        transcriptFileName: nil,
+                        storageLayout: storageLayout
                     )
                 }
             }
@@ -11866,7 +11914,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let previousTranscriptFileName = existingEntry?.transcriptFileName
         let transcriptFileName = Self.saveTranscriptFile(
             rawTranscript: rawTranscript,
-            postProcessedTranscript: postProcessedTranscript
+            postProcessedTranscript: postProcessedTranscript,
+            transcriptDirectory: storageLayout.transcriptDirectory
         )
         updateTranscriptionJob(jobID) {
             $0.liveNoteID = nil
@@ -11924,7 +11973,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 try pipelineHistoryStore.update(entry)
                 if let previousTranscriptFileName,
                    previousTranscriptFileName != transcriptFileName {
-                    Self.deleteTranscriptFile(previousTranscriptFileName)
+                    Self.deleteTranscriptFile(
+                        previousTranscriptFileName,
+                        transcriptDirectory: storageLayout.transcriptDirectory
+                    )
                 }
             } else {
                 let removedStoredFiles = try appendPipelineHistoryItem(entry)
@@ -11943,10 +11995,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
             if existingID == nil, !isJournalAudioFile {
                 Self.deleteStoredFiles(
                     audioFileName: audioFileName,
-                    transcriptFileName: transcriptFileName
+                    transcriptFileName: transcriptFileName,
+                    storageLayout: storageLayout
                 )
             } else if let transcriptFileName {
-                Self.deleteTranscriptFile(transcriptFileName)
+                Self.deleteTranscriptFile(
+                    transcriptFileName,
+                    transcriptDirectory: storageLayout.transcriptDirectory
+                )
             }
             let issue = self.userIssue(for: error)
             errorMessage = issue.record.presentation().compactMessage

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -350,10 +350,6 @@ enum MeetingSummaryAvailability: Equatable {
 }
 
 final class AppState: ObservableObject, @unchecked Sendable {
-    static var retryCloudTranscriptionDependenciesFactory:
-        () -> CloudTranscriptionDependencies = {
-            .live
-        }
     static var audioImportCloudTranscriptionDependenciesFactory:
         () -> CloudTranscriptionDependencies = {
             .live
@@ -3063,8 +3059,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         scheduleNoteBrowserTranscriptionModeNormalizationForSelectedInput()
         self.precomputeMacros()
         if let cloudReconciliation {
-            let cloudDependenciesFactory = Self
-                .retryCloudTranscriptionDependenciesFactory
+            let cloudDependenciesFactory = dependencies
+                .makeRetryCloudTranscriptionDependencies
             let postProcessingService = makePostProcessingService()
             Task { @MainActor [weak self] in
                 self?.scheduleCloudTranscriptionAutoResume(
@@ -7644,8 +7640,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         retryingItemIDs.insert(item.id)
 
         let postProcessingService = makePostProcessingService()
-        let cloudDependencies = Self
-            .retryCloudTranscriptionDependenciesFactory()
+        let cloudDependencies = dependencies
+            .makeRetryCloudTranscriptionDependencies()
         let transcriptDirectory = storageLayout.transcriptDirectory
 
         let task = Task { [weak self] in

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -6626,12 +6626,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return
         }
         pipelineHistoryStore = activeStore
+        let storageLayout = dependencies.storageLayout
+        _ = Self.preparedDirectory(storageLayout.rootDirectory)
+        let audioDirectory = Self.preparedDirectory(storageLayout.audioDirectory)
+        _ = Self.preparedDirectory(storageLayout.transcriptDirectory)
         recordingJournalStore = RecordingJournalStore(
-            audioDirectory: dependencies.storageLayout.audioDirectory
+            audioDirectory: audioDirectory
         )
         cloudTranscriptionJobStore = CloudTranscriptionJobStore(
-            jobsDirectory: dependencies.storageLayout.cloudTranscriptionJobsDirectory,
-            temporaryRoot: dependencies.storageLayout.cloudTranscriptionTemporaryDirectory
+            jobsDirectory: storageLayout.cloudTranscriptionJobsDirectory,
+            temporaryRoot: storageLayout.cloudTranscriptionTemporaryDirectory
         )
         pipelineHistory = []
         retryingItemIDs = []

--- a/Sources/AppStateDependencies.swift
+++ b/Sources/AppStateDependencies.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+struct AppStateStorageLayout: Sendable {
+    let rootDirectory: URL
+
+    var audioDirectory: URL {
+        rootDirectory.appendingPathComponent("audio", isDirectory: true)
+    }
+
+    var transcriptDirectory: URL {
+        rootDirectory.appendingPathComponent("transcripts", isDirectory: true)
+    }
+
+    var historyStoreURL: URL {
+        rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
+    }
+
+    var cloudTranscriptionJobsDirectory: URL {
+        rootDirectory.appendingPathComponent(
+            "cloud-transcription/jobs",
+            isDirectory: true
+        )
+    }
+
+    var cloudTranscriptionTemporaryDirectory: URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                Bundle.main.bundleIdentifier ?? "com.woosublee.quill",
+                isDirectory: true
+            )
+            .appendingPathComponent("cloud-transcription", isDirectory: true)
+    }
+
+    static var live: AppStateStorageLayout {
+        AppStateStorageLayout(rootDirectory: AppName.applicationSupportDirectory)
+    }
+}
+
+struct AppStateDependencies {
+    var storageLayout: AppStateStorageLayout
+    var makePipelineHistoryStore:
+        @Sendable (URL) -> PipelineHistoryStore
+    var makeMeetingSummaryGenerator:
+        @MainActor (AppState) -> any MeetingSummaryGenerating
+    var makeRetryCloudTranscriptionDependencies:
+        @Sendable () -> CloudTranscriptionDependencies
+
+    static var live: AppStateDependencies {
+        AppStateDependencies(
+            storageLayout: .live,
+            makePipelineHistoryStore: { PipelineHistoryStore(storeURL: $0) },
+            makeMeetingSummaryGenerator: { appState in
+                appState.makeMeetingSummaryService()
+            },
+            makeRetryCloudTranscriptionDependencies: { .live }
+        )
+    }
+}

--- a/Sources/MCPServer.swift
+++ b/Sources/MCPServer.swift
@@ -369,7 +369,7 @@ final class MCPServer {
             isoFormatter.timeZone = TimeZone.current
             let payload = MeetingSourcePayload.make(
                 item: item,
-                audioDirectory: AppState.audioStorageDirectory(),
+                audioDirectory: appState.storageLayout.audioDirectory,
                 fileExists: { FileManager.default.fileExists(atPath: $0.path) },
                 formatter: isoFormatter
             )

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -1575,6 +1575,7 @@ private struct NoteDetailView: View {
                 item: item,
                 content: displayContent,
                 customTitle: item.customTitle,
+                audioDirectory: appState.storageLayout.audioDirectory,
                 onDismiss: { showObsidianExportSheet = false }
             )
         }
@@ -2214,12 +2215,16 @@ private struct NoteDetailView: View {
         let postProcessed = item.postProcessedTranscript
         let raw = item.rawTranscript
         let fileName = item.transcriptFileName
+        let transcriptDirectory = appState.storageLayout.transcriptDirectory
         Task.detached(priority: .userInitiated) {
             let text: String
             if !postProcessed.isEmpty {
                 text = postProcessed
             } else if let fileName {
-                text = AppState.loadTranscript(from: fileName) ?? raw
+                text = AppState.loadTranscript(
+                    from: fileName,
+                    transcriptDirectory: transcriptDirectory
+                ) ?? raw
             } else {
                 text = raw
             }
@@ -2867,6 +2872,7 @@ private struct ObsidianExportSheet: View {
     let item: PipelineHistoryItem
     let content: String
     var customTitle: String? = nil
+    let audioDirectory: URL
     let onDismiss: () -> Void
 
     @AppStorage("obsidian_vault_path") private var vaultPath: String = ""
@@ -2888,7 +2894,7 @@ private struct ObsidianExportSheet: View {
     private var hasAudio: Bool {
         guard let fileName = item.audioFileName else { return false }
         return FileManager.default.fileExists(
-            atPath: AppState.audioStorageDirectory().appendingPathComponent(fileName).path
+            atPath: audioDirectory.appendingPathComponent(fileName).path
         )
     }
 
@@ -3039,7 +3045,7 @@ private struct ObsidianExportSheet: View {
             .components(separatedBy: CharacterSet(charactersIn: "/\\:*?\"<>|"))
             .joined(separator: "-")
         let audioSrcURL: URL? = (includeAudio && hasAudio && item.audioFileName != nil)
-            ? AppState.audioStorageDirectory().appendingPathComponent(item.audioFileName!)
+            ? audioDirectory.appendingPathComponent(item.audioFileName!)
             : nil
         ObsidianExportManager.shared.export(
             itemID: item.id,

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -2221,10 +2221,8 @@ private struct NoteDetailView: View {
             if !postProcessed.isEmpty {
                 text = postProcessed
             } else if let fileName {
-                text = AppState.loadTranscript(
-                    from: fileName,
-                    transcriptDirectory: transcriptDirectory
-                ) ?? raw
+                let fileURL = transcriptDirectory.appendingPathComponent(fileName)
+                text = (try? String(contentsOf: fileURL, encoding: .utf8)) ?? raw
             } else {
                 text = raw
             }

--- a/Sources/PipelineDebugPanelView.swift
+++ b/Sources/PipelineDebugPanelView.swift
@@ -55,7 +55,7 @@ struct PipelineDebugPanelView: View {
         guard let item = appState.pipelineHistory.first else { return }
         TestCaseExporter.exportWithSavePanel(
             item: item,
-            audioDirURL: AppState.audioStorageDirectory()
+            audioDirURL: appState.storageLayout.audioDirectory
         )
     }
 }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -4094,10 +4094,14 @@ struct RunLogEntryView: View {
                         isExpanded.toggle()
                     }
                     if isExpanded && loadedTranscript == nil {
+                        let transcriptDirectory = appState.storageLayout.transcriptDirectory
                         Task.detached(priority: .userInitiated) {
                             let text: String
                             if let fileName = item.transcriptFileName {
-                                text = AppState.loadTranscript(from: fileName) ?? ""
+                                text = AppState.loadTranscript(
+                                    from: fileName,
+                                    transcriptDirectory: transcriptDirectory
+                                ) ?? ""
                             } else {
                                 // 구 항목: rawTranscript 또는 postProcessedTranscript에서 읽기
                                 let t = item.rawTranscript.isEmpty ? item.postProcessedTranscript : item.rawTranscript
@@ -4194,7 +4198,7 @@ struct RunLogEntryView: View {
                     actionIconButton(systemName: "square.and.arrow.up", help: "Export run log") {
                         TestCaseExporter.exportWithSavePanel(
                             item: item,
-                            audioDirURL: AppState.audioStorageDirectory()
+                            audioDirURL: appState.storageLayout.audioDirectory
                         )
                     }
 
@@ -4223,7 +4227,7 @@ struct RunLogEntryView: View {
                 VStack(alignment: .leading, spacing: 16) {
                     // Audio player
                     if let audioFileName = item.audioFileName {
-                        let audioURL = AppState.audioStorageDirectory().appendingPathComponent(audioFileName)
+                        let audioURL = appState.storageLayout.audioDirectory.appendingPathComponent(audioFileName)
                         AudioPlayerView(audioURL: audioURL)
                     } else {
                         HStack(spacing: 6) {
@@ -4451,7 +4455,7 @@ struct RunLogEntryView: View {
             return already
         }
         if let fileName = item.transcriptFileName,
-           let loaded = AppState.loadTranscript(from: fileName),
+           let loaded = appState.loadTranscript(from: fileName),
            !loaded.isEmpty {
             return loaded
         }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -4098,10 +4098,8 @@ struct RunLogEntryView: View {
                         Task.detached(priority: .userInitiated) {
                             let text: String
                             if let fileName = item.transcriptFileName {
-                                text = AppState.loadTranscript(
-                                    from: fileName,
-                                    transcriptDirectory: transcriptDirectory
-                                ) ?? ""
+                                let fileURL = transcriptDirectory.appendingPathComponent(fileName)
+                                text = (try? String(contentsOf: fileURL, encoding: .utf8)) ?? ""
                             } else {
                                 // 구 항목: rawTranscript 또는 postProcessedTranscript에서 읽기
                                 let t = item.rawTranscript.isEmpty ? item.postProcessedTranscript : item.rawTranscript

--- a/Tests/AppStateCloudTranscriptionCleanupSourceTests.swift
+++ b/Tests/AppStateCloudTranscriptionCleanupSourceTests.swift
@@ -28,7 +28,7 @@ struct AppStateCloudTranscriptionCleanupSourceTests {
             [
                 "cloudTranscriptionHistoryCoordinator.cancelAndInvalidate(",
                 "retryingItemIDs.remove(assets.historyID)",
-                "Self.deleteStoredFiles(assets)",
+                "Self.deleteStoredFiles(assets, storageLayout: storageLayout)",
                 "cloudTranscriptionJobStore.delete("
             ],
             in: cleanup,
@@ -77,14 +77,14 @@ struct AppStateCloudTranscriptionCleanupSourceTests {
     private static func verifiesTrimmedAssetsUseCommonCleanup(_ source: String) throws {
         let initializer = block(
             source,
-            from: "init() {",
+            from: "init(dependencies: AppStateDependencies = .live) {",
             to: "private static func loadShortcutConfiguration"
         )
         try expectOrdered(
             [
                 "pipelineHistoryStore.trim(to: maxPipelineHistoryCount)",
                 "cloudTranscriptionJobStore.invalidateSession(",
-                "Self.deleteStoredFiles(removedAssets)",
+                "Self.deleteStoredFiles(removedAssets, storageLayout: storageLayout)",
                 "cloudTranscriptionJobStore.delete("
             ],
             in: initializer,

--- a/Tests/AppStateCloudTranscriptionIntegrationSourceTests.swift
+++ b/Tests/AppStateCloudTranscriptionIntegrationSourceTests.swift
@@ -277,7 +277,7 @@ struct AppStateCloudTranscriptionIntegrationSourceTests {
     private static func verifiesStartupReconciliationOrder(_ source: String) throws {
         let initializer = block(
             source,
-            from: "init() {",
+            from: "init(dependencies: AppStateDependencies = .live) {",
             to: "private static func loadShortcutConfiguration"
         )
         try expectOrdered(

--- a/Tests/AppStateDependenciesTests.swift
+++ b/Tests/AppStateDependenciesTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+#if !QUILL_GROUPED_TEST_RUNNER
+@main
+#endif
+struct AppStateDependenciesTests {
+    static func main() throws {
+        try verifiesStorageLayoutPreservesCanonicalPaths()
+        try verifiesLiveDependenciesReturnFreshValues()
+        print("AppStateDependenciesTests passed")
+    }
+
+    private static func verifiesStorageLayoutPreservesCanonicalPaths() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-layout-contract", isDirectory: true)
+        let layout = AppStateStorageLayout(rootDirectory: root)
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.woosublee.quill"
+
+        try expect(layout.audioDirectory == root.appendingPathComponent("audio", isDirectory: true),
+                   "audio remains below the AppState root")
+        try expect(layout.transcriptDirectory == root.appendingPathComponent("transcripts", isDirectory: true),
+                   "transcripts remain below the AppState root")
+        try expect(layout.historyStoreURL == root.appendingPathComponent("PipelineHistory.sqlite"),
+                   "history keeps its existing file name")
+        try expect(layout.cloudTranscriptionJobsDirectory == root
+            .appendingPathComponent("cloud-transcription/jobs", isDirectory: true),
+                   "cloud jobs keep their existing relative path")
+        try expect(layout.cloudTranscriptionTemporaryDirectory == FileManager.default.temporaryDirectory
+            .appendingPathComponent(bundleID, isDirectory: true)
+            .appendingPathComponent("cloud-transcription", isDirectory: true),
+                   "cloud temporary files keep the bundle-scoped path")
+    }
+
+    private static func verifiesLiveDependenciesReturnFreshValues() throws {
+        var first = AppStateDependencies.live
+        let second = AppStateDependencies.live
+        let overriddenRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-overridden-layout", isDirectory: true)
+        first.storageLayout = AppStateStorageLayout(rootDirectory: overriddenRoot)
+
+        try expect(second.storageLayout.rootDirectory == AppName.applicationSupportDirectory,
+                   "mutating one dependency value does not alter a later live value")
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ message: String
+    ) throws {
+        guard condition() else { throw TestFailure(message) }
+    }
+
+    private struct TestFailure: Error {
+        let message: String
+        init(_ message: String) { self.message = message }
+    }
+}

--- a/Tests/AppStateHistoryProtectionSourceTests.swift
+++ b/Tests/AppStateHistoryProtectionSourceTests.swift
@@ -106,6 +106,25 @@ struct AppStateHistoryProtectionSourceTests {
                 && archiveBody.contains("let makeStore = dependencies.makePipelineHistoryStore"),
             "archive captures the originating storage layout and history-store factory"
         )
+        let archiveCompletionRange = try source.range(
+            from: "private func completeHistoryArchiveTransition(",
+            to: "private func completeHistoryRecoveryInspection("
+        )
+        let archiveCompletion = String(source[archiveCompletionRange])
+        try expectOrdered(
+            [
+                "pipelineHistoryStore = activeStore",
+                "let storageLayout = dependencies.storageLayout",
+                "_ = Self.preparedDirectory(storageLayout.rootDirectory)",
+                "let audioDirectory = Self.preparedDirectory(storageLayout.audioDirectory)",
+                "_ = Self.preparedDirectory(storageLayout.transcriptDirectory)",
+                "recordingJournalStore = RecordingJournalStore(",
+                "audioDirectory: audioDirectory",
+                "cloudTranscriptionJobStore = CloudTranscriptionJobStore("
+            ],
+            in: archiveCompletion,
+            label: "verified archive completion recreates active asset directories before runtime stores"
+        )
         for requiredGuard in [
             "historyArchiveSafety == .normal",
             "pendingAudioImportJobIDs.isEmpty",

--- a/Tests/AppStateHistoryProtectionSourceTests.swift
+++ b/Tests/AppStateHistoryProtectionSourceTests.swift
@@ -3,6 +3,28 @@ import Foundation
 struct AppStateHistoryProtectionSourceTests {
     static func main() throws {
         let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let repositorySwiftSource = try combinedSwiftSource(in: ["Sources", "Tests"])
+        let removedSeams = [
+            ["meeting", "Summary", "Generator", "Factory"].joined(),
+            ["storage", "Root", "Provider"].joined(),
+            ["pipeline", "History", "Store", "Factory"].joined(),
+            ["pipeline", "History", "Store", "At", "URL", "Factory"].joined(),
+            ["retry", "Cloud", "Transcription", "Dependencies", "Factory"].joined(),
+            ["make", "Default", "Pipeline", "History", "Store"].joined()
+        ]
+        let removedStaticReferences = [
+            ["App", "State", ".", "app", "Storage", "Root", "Directory"].joined(),
+            ["App", "State", ".", "audio", "Storage", "Directory"].joined(),
+            ["App", "State", ".", "transcript", "Storage", "Directory"].joined(),
+            ["App", "State", ".", "load", "Transcript"].joined(),
+            ["static func ", "load", "Transcript"].joined()
+        ]
+        for removedIdentifier in removedSeams + removedStaticReferences {
+            try expect(
+                !repositorySwiftSource.contains(removedIdentifier),
+                "removed AppState dependency seam remains absent: \(removedIdentifier)"
+            )
+        }
 
         try expect(
             source.contains("if initialHistoryArchiveSafety == .normal,")
@@ -265,6 +287,21 @@ struct AppStateHistoryProtectionSourceTests {
         )
 
         print("AppStateHistoryProtectionSourceTests passed")
+    }
+
+    private static func combinedSwiftSource(in directories: [String]) throws -> String {
+        let fileManager = FileManager.default
+        var source = ""
+        for directory in directories {
+            guard let enumerator = fileManager.enumerator(atPath: directory) else {
+                throw TestFailure("Missing source directory: \(directory)")
+            }
+            for case let relativePath as String in enumerator where relativePath.hasSuffix(".swift") {
+                let fileURL = URL(fileURLWithPath: directory).appendingPathComponent(relativePath)
+                source += try String(contentsOf: fileURL, encoding: .utf8)
+            }
+        }
+        return source
     }
 
     private static func expectOrdered(

--- a/Tests/AppStateHistoryProtectionSourceTests.swift
+++ b/Tests/AppStateHistoryProtectionSourceTests.swift
@@ -92,7 +92,7 @@ struct AppStateHistoryProtectionSourceTests {
                 && source.contains("HistoryArchiveTransition(")
                 && source.contains("Task.detached(priority: .userInitiated)")
                 && source.contains("completeHistoryArchiveTransition(")
-                && source.contains("let activeStore = Self.pipelineHistoryStoreAtURLFactory(")
+                && source.contains("let activeStore = dependencies.makePipelineHistoryStore(")
                 && source.contains("historyArchiveSafety = HistoryArchiveTransition.inspect("),
             "explicit archive transitions in the background and installs only a verified fresh history store"
         )
@@ -101,6 +101,11 @@ struct AppStateHistoryProtectionSourceTests {
             to: "@MainActor\n    func clearPipelineHistory()"
         )
         let archiveBody = String(source[archiveRange])
+        try expect(
+            archiveBody.contains("let storageRoot = dependencies.storageLayout.rootDirectory")
+                && archiveBody.contains("let makeStore = dependencies.makePipelineHistoryStore"),
+            "archive captures the originating storage layout and history-store factory"
+        )
         for requiredGuard in [
             "historyArchiveSafety == .normal",
             "pendingAudioImportJobIDs.isEmpty",
@@ -231,11 +236,11 @@ struct AppStateHistoryProtectionSourceTests {
         )
         let snapshotFailureRange = try source.range(
             from: "private func completeHistoryRecoverySnapshotOperationFailure(at storageRoot: URL)",
-            to: "static func appStorageRootDirectory() -> URL"
+            to: "@discardableResult\n    private static func preparedDirectory("
         )
         let snapshotFailure = String(source[snapshotFailureRange])
         try expect(
-            !snapshotFailure.contains("pipelineHistoryStoreAtURLFactory")
+            !snapshotFailure.contains("dependencies.makePipelineHistoryStore")
                 && !snapshotFailure.contains("pipelineHistoryStore ="),
             "snapshot-only recovery failure keeps the active Core Data store attached"
         )

--- a/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
+++ b/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
@@ -46,7 +46,10 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         ] {
             precondition(!startupRecoveryBody.contains(forbidden))
         }
-        let initializerBody = try body(startingWith: "init()", in: source)
+        let initializerBody = try body(
+            startingWith: "init(dependencies: AppStateDependencies = .live)",
+            in: source
+        )
         let recoveryRange = try requiredRange(
             of: "recoverRecordingJournalsBeforeHistoryLoad(",
             in: initializerBody
@@ -346,7 +349,7 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         assert(helper.contains("case .recoveredWithoutTranscription"))
         assert(helper.contains("case .preservedForRecovery"))
         assert(helper.contains("case .empty"))
-        assert(helper.contains("savedAudioFileForStoppedRecording"))
+        assert(helper.contains("savedAudioFileForStoppedRecording(fileURL, audioDirectory: storageLayout.audioDirectory)"))
         assert(helper.contains("persistAudioOnlyRecording("))
         assert(persist.contains("PipelineHistoryItem.audioOnly("))
         assert(!helper.contains("PipelineHistoryItem.audioOnly("))
@@ -397,7 +400,7 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         assert(catchBody.contains("Self.deleteStoredFiles("))
         assert(catchBody.contains("audioFileName: audioFileName"))
         assert(catchBody.contains("transcriptFileName: nil"))
-        assert(!catchBody.contains("Self.deleteAudioFile(audioFileName)"))
+        assert(!catchBody.contains("Self.deleteAudioFile(audioFileName, audioDirectory: storageLayout.audioDirectory)"))
     }
 
     private static func testAudioOnlyCompletionOwnsForegroundUIAndTermination() throws {

--- a/Tests/AppStateStorageSafetyTests.swift
+++ b/Tests/AppStateStorageSafetyTests.swift
@@ -4,6 +4,7 @@ import Foundation
 struct AppStateStorageSafetyTests {
     static func main() async throws {
         try verifiesDefaultAppStateUsesLiveStorageLayout()
+        try await verifiesAppStateInstancesKeepIndependentHistoryLayouts()
         try await verifiesHistoryCreatedAfterAssetsDoesNotSweep()
         try await verifiesHistoryRowsLostAfterSnapshotDoesNotSweep()
         try await verifiesUnavailableHistoryBlocksMutatingActions()
@@ -14,18 +15,19 @@ struct AppStateStorageSafetyTests {
         try await verifiesMissingSnapshotWithUnreferencedAudioDoesNotSweep()
         try await verifiesMatchingHistorySnapshotSweepsOrphansAtStartup()
         try await verifiesTrustedHistorySweepsOrphans()
-        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
-            let fallbackAudioURL = try await verifiesFallbackHistoryDoesNotSweepStoredAudio()
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try prepareStorageDirectories(for: environment.storageLayout)
+            let fallbackAudioURL = try await verifiesFallbackHistoryDoesNotSweepStoredAudio(
+                environment: environment
+            )
             try await verifiesMissingHistoryDoesNotSweepStoredAudio(
                 audioURL: fallbackAudioURL,
-                rootDirectory: rootDirectory
+                environment: environment
             )
 
-            let audioDirectory = AppState.audioStorageDirectory()
-                .standardizedFileURL
-            let transcriptDirectory = AppState.transcriptStorageDirectory()
-                .standardizedFileURL
-            let rootPath = rootDirectory.standardizedFileURL.path + "/"
+            let audioDirectory = environment.storageLayout.audioDirectory.standardizedFileURL
+            let transcriptDirectory = environment.storageLayout.transcriptDirectory.standardizedFileURL
+            let rootPath = environment.rootDirectory.standardizedFileURL.path + "/"
 
             try expect(
                 audioDirectory.path.hasPrefix(rootPath),
@@ -47,18 +49,81 @@ struct AppStateStorageSafetyTests {
         )
     }
 
+    private static func verifiesAppStateInstancesKeepIndependentHistoryLayouts() async throws {
+        let parent = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-instance-layouts-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let firstLayout = AppStateStorageLayout(
+            rootDirectory: parent.appendingPathComponent("first", isDirectory: true)
+        )
+        let secondLayout = AppStateStorageLayout(
+            rootDirectory: parent.appendingPathComponent("second", isDirectory: true)
+        )
+        for layout in [firstLayout, secondLayout] {
+            try FileManager.default.createDirectory(
+                at: layout.rootDirectory,
+                withIntermediateDirectories: true
+            )
+        }
+        let firstItem = PipelineHistoryItem(
+            timestamp: Date(timeIntervalSince1970: 1),
+            rawTranscript: "first",
+            postProcessedTranscript: "first",
+            postProcessingPrompt: nil,
+            contextSummary: "",
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "No screenshot",
+            postProcessingStatus: "succeeded",
+            debugStatus: "",
+            customVocabulary: ""
+        )
+        let secondItem = PipelineHistoryItem(
+            timestamp: Date(timeIntervalSince1970: 2),
+            rawTranscript: "second",
+            postProcessedTranscript: "second",
+            postProcessingPrompt: nil,
+            contextSummary: "",
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "No screenshot",
+            postProcessingStatus: "succeeded",
+            debugStatus: "",
+            customVocabulary: ""
+        )
+        _ = try PipelineHistoryStore(storeURL: firstLayout.historyStoreURL)
+            .upsert(firstItem, maxCount: 10, requiresDurableStore: true)
+        _ = try PipelineHistoryStore(storeURL: secondLayout.historyStoreURL)
+            .upsert(secondItem, maxCount: 10, requiresDurableStore: true)
+
+        var firstDependencies = AppStateDependencies.live
+        firstDependencies.storageLayout = firstLayout
+        var secondDependencies = AppStateDependencies.live
+        secondDependencies.storageLayout = secondLayout
+        let configuredFirstDependencies = firstDependencies
+        let configuredSecondDependencies = secondDependencies
+        let firstState = await MainActor.run {
+            AppState(dependencies: configuredFirstDependencies)
+        }
+        let secondState = await MainActor.run {
+            AppState(dependencies: configuredSecondDependencies)
+        }
+
+        try expect(firstState.pipelineHistory.map(\.id) == [firstItem.id],
+                   "first AppState loads only its history layout")
+        try expect(secondState.pipelineHistory.map(\.id) == [secondItem.id],
+                   "second AppState loads only its history layout")
+    }
+
     private static func verifiesHistoryCreatedAfterAssetsDoesNotSweep() async throws {
-        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
-            let audioURL = AppState.audioStorageDirectory()
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try prepareStorageDirectories(for: environment.storageLayout)
+            let audioURL = environment.storageLayout.audioDirectory
                 .appendingPathComponent("history-lost.wav")
             try Data("fixture".utf8).write(to: audioURL)
             try setOldModificationDate(of: audioURL)
             try await Task.sleep(nanoseconds: 1_200_000_000)
-            _ = PipelineHistoryStore(
-                storeURL: rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
-            )
+            _ = PipelineHistoryStore(storeURL: environment.storageLayout.historyStoreURL)
 
-            _ = await MainActor.run { AppState() }
+            _ = await MainActor.run { AppState(dependencies: environment.dependencies) }
             try await Task.sleep(nanoseconds: 1_200_000_000)
             try expect(
                 FileManager.default.fileExists(atPath: audioURL.path),
@@ -68,11 +133,12 @@ struct AppStateStorageSafetyTests {
     }
 
     private static func verifiesHistoryRowsLostAfterSnapshotDoesNotSweep() async throws {
-        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try prepareStorageDirectories(for: environment.storageLayout)
             let historyStore = PipelineHistoryStore(
-                storeURL: rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
+                storeURL: environment.storageLayout.historyStoreURL
             )
-            let audioURL = AppState.audioStorageDirectory()
+            let audioURL = environment.storageLayout.audioDirectory
                 .appendingPathComponent("history-row-lost.wav")
             try Data("fixture".utf8).write(to: audioURL)
             try setOldModificationDate(of: audioURL)
@@ -81,7 +147,7 @@ struct AppStateStorageSafetyTests {
                 transcriptFileNames: []
             )
 
-            _ = await MainActor.run { AppState() }
+            _ = await MainActor.run { AppState(dependencies: environment.dependencies) }
             try await Task.sleep(nanoseconds: 1_200_000_000)
             try expect(
                 FileManager.default.fileExists(atPath: audioURL.path),
@@ -91,23 +157,25 @@ struct AppStateStorageSafetyTests {
     }
 
     private static func verifiesUnavailableHistoryBlocksMutatingActions() async throws {
-        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
-            let audioURL = AppState.audioStorageDirectory()
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try prepareStorageDirectories(for: environment.storageLayout)
+            let audioURL = environment.storageLayout.audioDirectory
                 .appendingPathComponent("protected-audio.wav")
-            let transcriptURL = AppState.transcriptStorageDirectory()
+            let transcriptURL = environment.storageLayout.transcriptDirectory
                 .appendingPathComponent("protected-transcript.txt")
             try Data("audio".utf8).write(to: audioURL)
             try Data("original transcript".utf8).write(to: transcriptURL)
             let unavailableStore = PipelineHistoryStore(
-                storeURL: rootDirectory.appendingPathComponent("PipelineHistory.sqlite"),
+                storeURL: environment.storageLayout.historyStoreURL,
                 persistentStoreLoader: { _ in
                     TestFailure("Injected protected history failure")
                 }
             )
-            let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-            AppState.pipelineHistoryStoreFactory = { unavailableStore }
-            defer {
-                AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
+            var dependencies = environment.dependencies
+            dependencies.makePipelineHistoryStore = { url in
+                url == environment.storageLayout.historyStoreURL
+                    ? unavailableStore
+                    : PipelineHistoryStore(storeURL: url)
             }
 
             let item = PipelineHistoryItem(
@@ -124,7 +192,10 @@ struct AppStateStorageSafetyTests {
                 audioFileName: audioURL.lastPathComponent,
                 transcriptFileName: transcriptURL.lastPathComponent
             )
-            let appState = await MainActor.run { AppState() }
+            let configuredDependencies = dependencies
+            let appState = await MainActor.run {
+                AppState(dependencies: configuredDependencies)
+            }
             await MainActor.run {
                 appState.pipelineHistory = [item]
                 appState.clearPipelineHistory()
@@ -151,14 +222,15 @@ struct AppStateStorageSafetyTests {
     }
 
     private static func verifiesExplicitArchiveCreatesFreshSeparatedHistory() async throws {
-        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
-            let storeURL = rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try prepareStorageDirectories(for: environment.storageLayout)
+            let storeURL = environment.storageLayout.historyStoreURL
             let originalSQLiteBytes = Data("unreadable original SQLite".utf8)
             try originalSQLiteBytes.write(to: storeURL)
-            let audioURL = AppState.audioStorageDirectory().appendingPathComponent("archived.wav")
-            let transcriptURL = AppState.transcriptStorageDirectory().appendingPathComponent("archived.txt")
-            let cloudJobURL = rootDirectory
-                .appendingPathComponent("cloud-transcription/jobs/archived.json")
+            let audioURL = environment.storageLayout.audioDirectory.appendingPathComponent("archived.wav")
+            let transcriptURL = environment.storageLayout.transcriptDirectory.appendingPathComponent("archived.txt")
+            let cloudJobURL = environment.storageLayout.cloudTranscriptionJobsDirectory
+                .appendingPathComponent("archived.json")
             try Data("archived audio".utf8).write(to: audioURL)
             try Data("archived transcript".utf8).write(to: transcriptURL)
             try FileManager.default.createDirectory(
@@ -173,13 +245,16 @@ struct AppStateStorageSafetyTests {
                     TestFailure("Injected unavailable history for explicit archive")
                 }
             )
-            let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-            AppState.pipelineHistoryStoreFactory = { unavailableStore }
-            defer {
-                AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
-            }
+            var dependencies = environment.dependencies
+            dependencies.makePipelineHistoryStore = makeUnavailableStartupStoreFactory(
+                unavailableStore,
+                startupURL: environment.storageLayout.historyStoreURL
+            )
 
-            let appState = await MainActor.run { AppState() }
+            let configuredDependencies = dependencies
+            let appState = await MainActor.run {
+                AppState(dependencies: configuredDependencies)
+            }
             let archiveSucceeded = await MainActor.run {
                 appState.archiveOldHistoryAndStartFresh(postAction: .openRecovery)
             }
@@ -201,7 +276,7 @@ struct AppStateStorageSafetyTests {
             )
             try expect(appState.pipelineHistory.isEmpty, "fresh history starts with no old notes")
 
-            let recoveryDirectory = rootDirectory.appendingPathComponent("Recovery", isDirectory: true)
+            let recoveryDirectory = environment.rootDirectory.appendingPathComponent("Recovery", isDirectory: true)
             guard let snapshotDirectory = try FileManager.default.contentsOfDirectory(
                 at: recoveryDirectory,
                 includingPropertiesForKeys: nil,
@@ -255,11 +330,13 @@ struct AppStateStorageSafetyTests {
                 customVocabulary: ""
             )
             _ = try freshStore.upsert(freshItem, maxCount: Int.max)
-            AppState.pipelineHistoryStoreFactory = {
-                AppState.makeDefaultPipelineHistoryStore()
-            }
+            var relaunchDependencies = AppStateDependencies.live
+            relaunchDependencies.storageLayout = environment.storageLayout
+            let configuredRelaunchDependencies = relaunchDependencies
 
-            let relaunchedAppState = await MainActor.run { AppState() }
+            let relaunchedAppState = await MainActor.run {
+                AppState(dependencies: configuredRelaunchDependencies)
+            }
             try expect(
                 !relaunchedAppState.isHistoryUnavailable,
                 "published archive does not turn the fresh active store into protection mode"
@@ -272,10 +349,11 @@ struct AppStateStorageSafetyTests {
     }
 
     private static func verifiesArchivedNoteImportsIntoFreshHistory() async throws {
-        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
-            let storeURL = rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
-            let audioURL = AppState.audioStorageDirectory().appendingPathComponent("source.wav")
-            let transcriptURL = AppState.transcriptStorageDirectory().appendingPathComponent("source.txt")
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try prepareStorageDirectories(for: environment.storageLayout)
+            let storeURL = environment.storageLayout.historyStoreURL
+            let audioURL = environment.storageLayout.audioDirectory.appendingPathComponent("source.wav")
+            let transcriptURL = environment.storageLayout.transcriptDirectory.appendingPathComponent("source.txt")
             try Data("source audio".utf8).write(to: audioURL)
             try Data("source transcript".utf8).write(to: transcriptURL)
             let sourceItem = PipelineHistoryItem(
@@ -306,13 +384,16 @@ struct AppStateStorageSafetyTests {
                     TestFailure("Injected unavailable history for import recovery")
                 }
             )
-            let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-            AppState.pipelineHistoryStoreFactory = { unavailableStore }
-            defer {
-                AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
-            }
+            var dependencies = environment.dependencies
+            dependencies.makePipelineHistoryStore = makeUnavailableStartupStoreFactory(
+                unavailableStore,
+                startupURL: environment.storageLayout.historyStoreURL
+            )
 
-            let appState = await MainActor.run { AppState() }
+            let configuredDependencies = dependencies
+            let appState = await MainActor.run {
+                AppState(dependencies: configuredDependencies)
+            }
             let archiveAccepted = await MainActor.run {
                 appState.archiveOldHistoryAndStartFresh()
             }
@@ -341,10 +422,10 @@ struct AppStateStorageSafetyTests {
                     && importedItem.transcriptFileName != sourceItem.transcriptFileName,
                 "AppState recovery import remaps active asset ownership"
             )
-            let copiedAudioURL = AppState.audioStorageDirectory().appendingPathComponent(
+            let copiedAudioURL = environment.storageLayout.audioDirectory.appendingPathComponent(
                 try required(importedItem.audioFileName)
             )
-            let copiedTranscriptURL = AppState.transcriptStorageDirectory().appendingPathComponent(
+            let copiedTranscriptURL = environment.storageLayout.transcriptDirectory.appendingPathComponent(
                 try required(importedItem.transcriptFileName)
             )
             let copiedAudio = try Data(contentsOf: copiedAudioURL)
@@ -387,8 +468,9 @@ struct AppStateStorageSafetyTests {
     }
 
     private static func verifiesRecoverySettingsAutomaticallyInspectsSnapshots() async throws {
-        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
-            let storeURL = rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try prepareStorageDirectories(for: environment.storageLayout)
+            let storeURL = environment.storageLayout.historyStoreURL
             let sourceItem = PipelineHistoryItem(
                 id: UUID(uuidString: "4B5A73C8-59D4-4FDF-ABF7-2CD61094E3A8")!,
                 timestamp: Date(timeIntervalSince1970: 1_754_010_203),
@@ -415,13 +497,16 @@ struct AppStateStorageSafetyTests {
                     TestFailure("Injected unavailable history for automatic inspection")
                 }
             )
-            let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-            AppState.pipelineHistoryStoreFactory = { unavailableStore }
-            defer {
-                AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
-            }
+            var dependencies = environment.dependencies
+            dependencies.makePipelineHistoryStore = makeUnavailableStartupStoreFactory(
+                unavailableStore,
+                startupURL: environment.storageLayout.historyStoreURL
+            )
 
-            let appState = await MainActor.run { AppState() }
+            let configuredDependencies = dependencies
+            let appState = await MainActor.run {
+                AppState(dependencies: configuredDependencies)
+            }
             let archiveAccepted = await MainActor.run {
                 appState.archiveOldHistoryAndStartFresh(postAction: .openRecovery)
             }
@@ -456,11 +541,10 @@ struct AppStateStorageSafetyTests {
     }
 
     private static func verifiesInterruptedArchiveKeepsHistoryProtected() async throws {
-        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
-            _ = PipelineHistoryStore(
-                storeURL: rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
-            )
-            let transactionDirectory = rootDirectory
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try prepareStorageDirectories(for: environment.storageLayout)
+            _ = PipelineHistoryStore(storeURL: environment.storageLayout.historyStoreURL)
+            let transactionDirectory = environment.rootDirectory
                 .appendingPathComponent("Recovery/.transactions", isDirectory: true)
             try FileManager.default.createDirectory(
                 at: transactionDirectory,
@@ -470,7 +554,9 @@ struct AppStateStorageSafetyTests {
                 to: transactionDirectory.appendingPathComponent("interrupted.json")
             )
 
-            let appState = await MainActor.run { AppState() }
+            let appState = await MainActor.run {
+                AppState(dependencies: environment.dependencies)
+            }
 
             try expect(
                 appState.historyArchiveSafety == .unresolvedInterruptedTransaction,
@@ -488,13 +574,14 @@ struct AppStateStorageSafetyTests {
     }
 
     private static func verifiesMissingSnapshotWithUnreferencedAudioDoesNotSweep() async throws {
-        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try prepareStorageDirectories(for: environment.storageLayout)
             let historyStore = PipelineHistoryStore(
-                storeURL: rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
+                storeURL: environment.storageLayout.historyStoreURL
             )
-            let referencedAudioURL = AppState.audioStorageDirectory()
+            let referencedAudioURL = environment.storageLayout.audioDirectory
                 .appendingPathComponent("still-referenced.wav")
-            let unreferencedAudioURL = AppState.audioStorageDirectory()
+            let unreferencedAudioURL = environment.storageLayout.audioDirectory
                 .appendingPathComponent("history-row-lost-without-snapshot.wav")
             for fileURL in [referencedAudioURL, unreferencedAudioURL] {
                 try Data("fixture".utf8).write(to: fileURL)
@@ -517,9 +604,9 @@ struct AppStateStorageSafetyTests {
                 maxCount: 10
             )
 
-            _ = await MainActor.run { AppState() }
+            _ = await MainActor.run { AppState(dependencies: environment.dependencies) }
             try await Task.sleep(nanoseconds: 1_200_000_000)
-            _ = await MainActor.run { AppState() }
+            _ = await MainActor.run { AppState(dependencies: environment.dependencies) }
             try await Task.sleep(nanoseconds: 1_200_000_000)
             try expect(
                 FileManager.default.fileExists(atPath: unreferencedAudioURL.path),
@@ -529,20 +616,21 @@ struct AppStateStorageSafetyTests {
     }
 
     private static func verifiesMatchingHistorySnapshotSweepsOrphansAtStartup() async throws {
-        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try prepareStorageDirectories(for: environment.storageLayout)
             let historyStore = PipelineHistoryStore(
-                storeURL: rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
+                storeURL: environment.storageLayout.historyStoreURL
             )
             try historyStore.saveAssetReferenceSnapshot(
                 audioFileNames: [],
                 transcriptFileNames: []
             )
-            let audioURL = AppState.audioStorageDirectory()
+            let audioURL = environment.storageLayout.audioDirectory
                 .appendingPathComponent("known-orphan.wav")
             try Data("fixture".utf8).write(to: audioURL)
             try setOldModificationDate(of: audioURL)
 
-            _ = await MainActor.run { AppState() }
+            _ = await MainActor.run { AppState(dependencies: environment.dependencies) }
             try await waitForFileRemoval(at: audioURL)
             try expect(
                 !FileManager.default.fileExists(atPath: audioURL.path),
@@ -552,16 +640,17 @@ struct AppStateStorageSafetyTests {
     }
 
     private static func verifiesTrustedHistorySweepsOrphans() async throws {
-        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try prepareStorageDirectories(for: environment.storageLayout)
             let historyStore = PipelineHistoryStore(
-                storeURL: rootDirectory.appendingPathComponent("PipelineHistory.sqlite")
+                storeURL: environment.storageLayout.historyStoreURL
             )
             try expect(
                 historyStore.referenceTrust == .complete,
                 "new persistent history is trusted before recording files exist"
             )
-            let audioDirectory = AppState.audioStorageDirectory()
-            let transcriptDirectory = AppState.transcriptStorageDirectory()
+            let audioDirectory = environment.storageLayout.audioDirectory
+            let transcriptDirectory = environment.storageLayout.transcriptDirectory
             let audioURL = audioDirectory.appendingPathComponent("trusted-orphan.wav")
             let transcriptURL = transcriptDirectory.appendingPathComponent("trusted-orphan.txt")
             for fileURL in [audioURL, transcriptURL] {
@@ -588,26 +677,29 @@ struct AppStateStorageSafetyTests {
         }
     }
 
-    private static func verifiesFallbackHistoryDoesNotSweepStoredAudio() async throws -> URL {
-        let audioURL = AppState.audioStorageDirectory()
+    private static func verifiesFallbackHistoryDoesNotSweepStoredAudio(
+        environment: AppStateTestEnvironment
+    ) async throws -> URL {
+        let audioURL = environment.storageLayout.audioDirectory
             .appendingPathComponent("fallback-history.wav")
         try Data("fixture".utf8).write(to: audioURL)
         try setOldModificationDate(of: audioURL)
 
         let fallbackStore = PipelineHistoryStore(
-            storeURL: AppState.appStorageRootDirectory()
-                .appendingPathComponent("FallbackHistory.sqlite"),
+            storeURL: environment.rootDirectory.appendingPathComponent("FallbackHistory.sqlite"),
             persistentStoreLoader: { _ in
                 TestFailure("Injected history load failure")
             }
         )
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-        AppState.pipelineHistoryStoreFactory = { fallbackStore }
-        defer {
-            AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
+        var dependencies = environment.dependencies
+        dependencies.makePipelineHistoryStore = { url in
+            url == environment.storageLayout.historyStoreURL
+                ? fallbackStore
+                : PipelineHistoryStore(storeURL: url)
         }
 
-        _ = await MainActor.run { AppState() }
+        let configuredDependencies = dependencies
+        _ = await MainActor.run { AppState(dependencies: configuredDependencies) }
         try await Task.sleep(nanoseconds: 1_200_000_000)
         try expect(
             FileManager.default.fileExists(atPath: audioURL.path),
@@ -618,9 +710,9 @@ struct AppStateStorageSafetyTests {
 
     private static func verifiesMissingHistoryDoesNotSweepStoredAudio(
         audioURL: URL,
-        rootDirectory: URL
+        environment: AppStateTestEnvironment
     ) async throws {
-        _ = await MainActor.run { AppState() }
+        _ = await MainActor.run { AppState(dependencies: environment.dependencies) }
         try await Task.sleep(nanoseconds: 1_200_000_000)
         try expect(
             FileManager.default.fileExists(atPath: audioURL.path),
@@ -628,7 +720,7 @@ struct AppStateStorageSafetyTests {
         )
         try expect(
             FileManager.default.fileExists(
-                atPath: rootDirectory
+                atPath: environment.rootDirectory
                     .appendingPathComponent(
                         "History Recovery/asset-references-incomplete",
                         isDirectory: true
@@ -636,6 +728,31 @@ struct AppStateStorageSafetyTests {
             ),
             "missing history records persistent incomplete-reference evidence"
         )
+    }
+
+    private static func makeUnavailableStartupStoreFactory(
+        _ unavailableStore: PipelineHistoryStore,
+        startupURL: URL
+    ) -> @Sendable (URL) -> PipelineHistoryStore {
+        let state = UnavailableStartupStoreFactoryState(startupURL: startupURL)
+        return { url in
+            state.makeStore(for: url, unavailableStore: unavailableStore)
+        }
+    }
+
+    private static func prepareStorageDirectories(
+        for storageLayout: AppStateStorageLayout
+    ) throws {
+        for directory in [
+            storageLayout.audioDirectory,
+            storageLayout.transcriptDirectory,
+            storageLayout.cloudTranscriptionJobsDirectory
+        ] {
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+        }
     }
 
     private static func waitForArchiveCompletion(_ appState: AppState) async throws {
@@ -713,6 +830,29 @@ struct AppStateStorageSafetyTests {
         _ label: String
     ) throws {
         guard condition() else { throw TestFailure(label) }
+    }
+
+    private final class UnavailableStartupStoreFactoryState: @unchecked Sendable {
+        private let lock = NSLock()
+        private let startupURL: URL
+        private var didReturnUnavailableStore = false
+
+        init(startupURL: URL) {
+            self.startupURL = startupURL
+        }
+
+        func makeStore(
+            for url: URL,
+            unavailableStore: PipelineHistoryStore
+        ) -> PipelineHistoryStore {
+            lock.lock()
+            defer { lock.unlock() }
+            guard url == startupURL, !didReturnUnavailableStore else {
+                return PipelineHistoryStore(storeURL: url)
+            }
+            didReturnUnavailableStore = true
+            return unavailableStore
+        }
     }
 
     private struct TestFailure: Error, CustomStringConvertible {

--- a/Tests/AppStateStorageSafetyTests.swift
+++ b/Tests/AppStateStorageSafetyTests.swift
@@ -5,6 +5,7 @@ struct AppStateStorageSafetyTests {
     static func main() async throws {
         try verifiesDefaultAppStateUsesLiveStorageLayout()
         try await verifiesAppStateInstancesKeepIndependentHistoryLayouts()
+        try await verifiesArchiveUsesOriginatingHistoryStoreFactory()
         try await verifiesHistoryCreatedAfterAssetsDoesNotSweep()
         try await verifiesHistoryRowsLostAfterSnapshotDoesNotSweep()
         try await verifiesUnavailableHistoryBlocksMutatingActions()
@@ -111,6 +112,64 @@ struct AppStateStorageSafetyTests {
                    "first AppState loads only its history layout")
         try expect(secondState.pipelineHistory.map(\.id) == [secondItem.id],
                    "second AppState loads only its history layout")
+    }
+
+    private static func verifiesArchiveUsesOriginatingHistoryStoreFactory() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try prepareStorageDirectories(for: environment.storageLayout)
+            let layout = environment.storageLayout
+            try Data("unavailable canonical history".utf8).write(to: layout.historyStoreURL)
+            let unavailableStore = PipelineHistoryStore(
+                storeURL: layout.historyStoreURL,
+                persistentStoreLoader: { _ in
+                    TestFailure("Injected unavailable history for factory ownership")
+                }
+            )
+            let originatingRecorder = HistoryStoreURLRecorder()
+            let laterRecorder = HistoryStoreURLRecorder()
+            let startupFactory = UnavailableStartupStoreFactoryState(
+                startupURL: layout.historyStoreURL
+            )
+            var dependencies = environment.dependencies
+            dependencies.makePipelineHistoryStore = { url in
+                originatingRecorder.record(url)
+                return startupFactory.makeStore(
+                    for: url,
+                    unavailableStore: unavailableStore
+                )
+            }
+
+            let configuredDependencies = dependencies
+            let appState = await MainActor.run {
+                AppState(dependencies: configuredDependencies)
+            }
+            dependencies.makePipelineHistoryStore = { url in
+                laterRecorder.record(url)
+                return PipelineHistoryStore(storeURL: url)
+            }
+            let archiveAccepted = await MainActor.run {
+                appState.archiveOldHistoryAndStartFresh()
+            }
+
+            try expect(archiveAccepted, "factory ownership archive is accepted")
+            try await waitForArchiveCompletion(appState)
+            try expect(
+                originatingRecorder.contains(layout.historyStoreURL),
+                "archive replacement uses the originating AppState factory"
+            )
+            try expect(
+                originatingRecorder.count(of: layout.historyStoreURL) >= 5,
+                "originating factory receives startup, archive probe, and replacement requests"
+            )
+            try expect(
+                laterRecorder.isEmpty,
+                "later dependency mutation cannot redirect archive work"
+            )
+            try expect(
+                !appState.isHistoryUnavailable,
+                "originating factory installs the verified fresh active store"
+            )
+        }
     }
 
     private static func verifiesHistoryCreatedAfterAssetsDoesNotSweep() async throws {
@@ -830,6 +889,27 @@ struct AppStateStorageSafetyTests {
         _ label: String
     ) throws {
         guard condition() else { throw TestFailure(label) }
+    }
+
+    private final class HistoryStoreURLRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var urls: [URL] = []
+
+        var isEmpty: Bool {
+            lock.withLock { urls.isEmpty }
+        }
+
+        func record(_ url: URL) {
+            lock.withLock { urls.append(url) }
+        }
+
+        func contains(_ url: URL) -> Bool {
+            lock.withLock { urls.contains(url) }
+        }
+
+        func count(of url: URL) -> Int {
+            lock.withLock { urls.filter { $0 == url }.count }
+        }
     }
 
     private final class UnavailableStartupStoreFactoryState: @unchecked Sendable {

--- a/Tests/AppStateStorageSafetyTests.swift
+++ b/Tests/AppStateStorageSafetyTests.swift
@@ -3,6 +3,7 @@ import Foundation
 
 struct AppStateStorageSafetyTests {
     static func main() async throws {
+        try verifiesDefaultAppStateUsesLiveStorageLayout()
         try await verifiesHistoryCreatedAfterAssetsDoesNotSweep()
         try await verifiesHistoryRowsLostAfterSnapshotDoesNotSweep()
         try await verifiesUnavailableHistoryBlocksMutatingActions()
@@ -36,6 +37,14 @@ struct AppStateStorageSafetyTests {
             )
         }
         print("AppStateStorageSafetyTests passed")
+    }
+
+    private static func verifiesDefaultAppStateUsesLiveStorageLayout() throws {
+        let appState = AppState()
+        try expect(
+            appState.storageLayout.rootDirectory == AppName.applicationSupportDirectory,
+            "default AppState keeps the production storage root"
+        )
     }
 
     private static func verifiesHistoryCreatedAfterAssetsDoesNotSweep() async throws {

--- a/Tests/AppStateTestStorage.swift
+++ b/Tests/AppStateTestStorage.swift
@@ -1,36 +1,41 @@
 import Foundation
 
+struct AppStateTestEnvironment {
+    let rootDirectory: URL
+    let storageLayout: AppStateStorageLayout
+    let dependencies: AppStateDependencies
+}
+
 @MainActor
 enum AppStateTestStorage {
     static func withIsolatedStorage<T>(
-        _ operation: (URL) async throws -> T
+        _ operation: (AppStateTestEnvironment) async throws -> T
     ) async throws -> T {
         let rootDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent(
                 "quill-app-state-tests-\(UUID().uuidString)",
                 isDirectory: true
             )
-        let originalStorageRootProvider = AppState.storageRootProvider
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
         let originalSettingsDirectory = AppSettingsStorage.storageDirectoryOverride
-
         try FileManager.default.createDirectory(
             at: rootDirectory,
             withIntermediateDirectories: true
         )
-        AppState.storageRootProvider = { rootDirectory }
-        AppState.pipelineHistoryStoreFactory = {
-            AppState.makeDefaultPipelineHistoryStore()
-        }
+        let storageLayout = AppStateStorageLayout(rootDirectory: rootDirectory)
+        var dependencies = AppStateDependencies.live
+        dependencies.storageLayout = storageLayout
         AppSettingsStorage.storageDirectoryOverride = rootDirectory
             .appendingPathComponent("settings", isDirectory: true)
         defer {
-            AppState.storageRootProvider = originalStorageRootProvider
-            AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
             AppSettingsStorage.storageDirectoryOverride = originalSettingsDirectory
             try? FileManager.default.removeItem(at: rootDirectory)
         }
-
-        return try await operation(rootDirectory)
+        return try await operation(
+            AppStateTestEnvironment(
+                rootDirectory: rootDirectory,
+                storageLayout: storageLayout,
+                dependencies: dependencies
+            )
+        )
     }
 }

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -3266,9 +3266,10 @@ struct AppStateTranscriptionConfigurationTests {
         for cleanup in [staleGuard, storeUpdate] {
             assert(cleanup.contains("snapshot.item.transcriptFileName == nil"))
             assert(cleanup.contains("let transcriptFileName = updatedItem.transcriptFileName"))
-            assert(cleanup.contains("Self.deleteTranscriptFile("))
-            assert(cleanup.contains("transcriptFileName,"))
-            assert(cleanup.contains("transcriptDirectory: transcriptDirectory"))
+            let compactCleanup = cleanup.filter { !$0.isWhitespace }
+            assert(compactCleanup.contains(
+                "Self.deleteTranscriptFile(transcriptFileName,transcriptDirectory:transcriptDirectory)"
+            ))
         }
     }
 

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -2542,7 +2542,7 @@ struct AppStateTranscriptionConfigurationTests {
         await MainActor.run {
             let appState = AppState()
             let fileName = "retry-model-setup-\(UUID().uuidString).wav"
-            let audioURL = AppState.audioStorageDirectory().appendingPathComponent(fileName)
+            let audioURL = appState.storageLayout.audioDirectory.appendingPathComponent(fileName)
             try! Data([0]).write(to: audioURL)
             defer { try? FileManager.default.removeItem(at: audioURL) }
             let item = retryHistoryItem(audioFileName: fileName)
@@ -2568,7 +2568,7 @@ struct AppStateTranscriptionConfigurationTests {
             appState.apiKey = "test-api-key"
             appState.setNoteBrowserTranscriptionChoice(.appleLive)
             let fileName = "retry-model-selection-\(UUID().uuidString).wav"
-            let audioURL = AppState.audioStorageDirectory().appendingPathComponent(fileName)
+            let audioURL = appState.storageLayout.audioDirectory.appendingPathComponent(fileName)
             try! Data([0]).write(to: audioURL)
             defer { try? FileManager.default.removeItem(at: audioURL) }
             let item = retryHistoryItem(audioFileName: fileName)
@@ -2586,7 +2586,7 @@ struct AppStateTranscriptionConfigurationTests {
                 .apiStandard(modelID: "whisper-large-v3")
             )
             let fileName = "retry-provider-setup-\(UUID().uuidString).wav"
-            let audioURL = AppState.audioStorageDirectory().appendingPathComponent(fileName)
+            let audioURL = appState.storageLayout.audioDirectory.appendingPathComponent(fileName)
             try! Data([0]).write(to: audioURL)
             defer { try? FileManager.default.removeItem(at: audioURL) }
             let item = retryHistoryItem(audioFileName: fileName)
@@ -2607,7 +2607,7 @@ struct AppStateTranscriptionConfigurationTests {
                 .apiStandard(modelID: "whisper-large-v3")
             )
             let fileName = "retry-ready-\(UUID().uuidString).wav"
-            let audioURL = AppState.audioStorageDirectory().appendingPathComponent(fileName)
+            let audioURL = appState.storageLayout.audioDirectory.appendingPathComponent(fileName)
             try! Data([0]).write(to: audioURL)
             defer { try? FileManager.default.removeItem(at: audioURL) }
             let item = retryHistoryItem(audioFileName: fileName)
@@ -2620,10 +2620,20 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testRetryPreservesMeetingSummaryMetadata() async throws {
         resetDefaults()
         let store = PipelineHistoryStore(inMemory: true)
+        let rootDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "quill-retry-summary-metadata-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        defer { try? FileManager.default.removeItem(at: rootDirectory) }
+        let storageLayout = AppStateStorageLayout(rootDirectory: rootDirectory)
+        try FileManager.default.createDirectory(
+            at: storageLayout.audioDirectory,
+            withIntermediateDirectories: true
+        )
         let fileName = "retry-summary-metadata-\(UUID().uuidString).wav"
-        let audioURL = AppState.audioStorageDirectory().appendingPathComponent(fileName)
+        let audioURL = storageLayout.audioDirectory.appendingPathComponent(fileName)
         try Data([0]).write(to: audioURL)
-        defer { try? FileManager.default.removeItem(at: audioURL) }
 
         let attempt = MeetingSummaryAttempt(
             occurredAt: Date(timeIntervalSince1970: 2_100),
@@ -2646,12 +2656,13 @@ struct AppStateTranscriptionConfigurationTests {
         )
         _ = try store.append(item, maxCount: 10)
 
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-        defer {
-            AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
+        var dependencies = AppStateDependencies.live
+        dependencies.storageLayout = storageLayout
+        dependencies.makePipelineHistoryStore = { _ in store }
+        let configuredDependencies = dependencies
+        let appState = await MainActor.run {
+            AppState(dependencies: configuredDependencies)
         }
-        AppState.pipelineHistoryStoreFactory = { store }
-        let appState = await MainActor.run { AppState() }
 
         await MainActor.run {
             appState.transcriptionAPIKey = "test-api-key"
@@ -2680,17 +2691,18 @@ struct AppStateTranscriptionConfigurationTests {
     }
 
     private static func testAudioImportTimeoutPreservesRawTranscriptAndFailedOutcome() async throws {
-        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try FileManager.default.createDirectory(
+                at: environment.storageLayout.audioDirectory,
+                withIntermediateDirectories: true
+            )
             resetDefaults()
             let rawTranscript = "가져온 원본 전사문"
             let replacementTranscript = "뒤늦게 설치된 다른 전사문"
-            let store = AppState.makeDefaultPipelineHistoryStore()
-            let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-            defer {
-                AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
-            }
-            AppState.pipelineHistoryStoreFactory = { store }
-            let sourceURL = rootDirectory.appendingPathComponent(
+            let store = PipelineHistoryStore(storeURL: environment.storageLayout.historyStoreURL)
+            var dependencies = environment.dependencies
+            dependencies.makePipelineHistoryStore = { _ in store }
+            let sourceURL = environment.rootDirectory.appendingPathComponent(
                 "import-timeout-\(UUID().uuidString).wav"
             )
             try writeTestWAV(at: sourceURL)
@@ -2710,7 +2722,10 @@ struct AppStateTranscriptionConfigurationTests {
                 throw URLError(.timedOut)
             }
 
-            let appState = await MainActor.run { AppState() }
+            let configuredDependencies = dependencies
+        let appState = await MainActor.run {
+            AppState(dependencies: configuredDependencies)
+        }
             await MainActor.run {
                 appState.apiKey = "post-processing-key"
                 appState.transcriptionAPIKey = "transcription-key"
@@ -2772,18 +2787,19 @@ struct AppStateTranscriptionConfigurationTests {
     }
 
     private static func testRetryTimeoutPreservesRawTranscriptAndFailedOutcome() async throws {
-        try await AppStateTestStorage.withIsolatedStorage { _ in
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try FileManager.default.createDirectory(
+                at: environment.storageLayout.audioDirectory,
+                withIntermediateDirectories: true
+            )
             resetDefaults()
             let rawTranscript = "재시도 원본 전사문"
             let replacementTranscript = "뒤늦게 설치된 재시도 전사문"
-            let store = AppState.makeDefaultPipelineHistoryStore()
-            let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-            defer {
-                AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
-            }
-            AppState.pipelineHistoryStoreFactory = { store }
+            let store = PipelineHistoryStore(storeURL: environment.storageLayout.historyStoreURL)
+            var dependencies = environment.dependencies
+            dependencies.makePipelineHistoryStore = { _ in store }
             let fileName = "retry-timeout-\(UUID().uuidString).wav"
-            let audioURL = AppState.audioStorageDirectory()
+            let audioURL = environment.storageLayout.audioDirectory
                 .appendingPathComponent(fileName)
             try writeTestWAV(at: audioURL)
             let originalItem = retryHistoryItem(
@@ -2807,7 +2823,10 @@ struct AppStateTranscriptionConfigurationTests {
                 throw URLError(.timedOut)
             }
 
-            let appState = await MainActor.run { AppState() }
+            let configuredDependencies = dependencies
+        let appState = await MainActor.run {
+            AppState(dependencies: configuredDependencies)
+        }
             await MainActor.run {
                 appState.apiKey = "post-processing-key"
                 appState.transcriptionAPIKey = "transcription-key"
@@ -2848,17 +2867,18 @@ struct AppStateTranscriptionConfigurationTests {
     }
 
     private static func testRetryTranscriptionFailurePreservesExistingAIOutcome() async throws {
-        try await AppStateTestStorage.withIsolatedStorage { _ in
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try FileManager.default.createDirectory(
+                at: environment.storageLayout.audioDirectory,
+                withIntermediateDirectories: true
+            )
             resetDefaults()
             let previousOutcome = "failed:previous-processing-error"
-            let store = AppState.makeDefaultPipelineHistoryStore()
-            let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-            defer {
-                AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
-            }
-            AppState.pipelineHistoryStoreFactory = { store }
+            let store = PipelineHistoryStore(storeURL: environment.storageLayout.historyStoreURL)
+            var dependencies = environment.dependencies
+            dependencies.makePipelineHistoryStore = { _ in store }
             let fileName = "retry-failure-\(UUID().uuidString).wav"
-            let audioURL = AppState.audioStorageDirectory()
+            let audioURL = environment.storageLayout.audioDirectory
                 .appendingPathComponent(fileName)
             try writeTestWAV(at: audioURL)
             let originalItem = retryHistoryItem(
@@ -2877,7 +2897,10 @@ struct AppStateTranscriptionConfigurationTests {
                 failingCloudDependencies()
             }
 
-            let appState = await MainActor.run { AppState() }
+            let configuredDependencies = dependencies
+            let appState = await MainActor.run {
+                AppState(dependencies: configuredDependencies)
+            }
             await MainActor.run {
                 appState.transcriptionAPIKey = "transcription-key"
                 appState.transcriptionAPIURL =
@@ -3026,21 +3049,22 @@ struct AppStateTranscriptionConfigurationTests {
     }
 
     private static func testResumedRetryPersistsAIProcessingOutcome() async throws {
-        try await AppStateTestStorage.withIsolatedStorage { rootDirectory in
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try FileManager.default.createDirectory(
+                at: environment.storageLayout.audioDirectory,
+                withIntermediateDirectories: true
+            )
             resetDefaults()
             let rawTranscript = "재실행 후 복구된 원본 전사문"
             let historyID = UUID()
             let fileName = "\(historyID.uuidString).wav"
-            let audioURL = AppState.audioStorageDirectory()
+            let audioURL = environment.storageLayout.audioDirectory
                 .appendingPathComponent(fileName)
             try writeTestWAV(at: audioURL)
 
-            let store = AppState.makeDefaultPipelineHistoryStore()
-            let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-            defer {
-                AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
-            }
-            AppState.pipelineHistoryStoreFactory = { store }
+            let store = PipelineHistoryStore(storeURL: environment.storageLayout.historyStoreURL)
+            var dependencies = environment.dependencies
+            dependencies.makePipelineHistoryStore = { _ in store }
             let originalItem = PipelineHistoryItem(
                 id: historyID,
                 timestamp: Date(timeIntervalSince1970: 1),
@@ -3064,12 +3088,8 @@ struct AppStateTranscriptionConfigurationTests {
             _ = try store.append(originalItem, maxCount: 10)
 
             let jobStore = CloudTranscriptionJobStore(
-                jobsDirectory: rootDirectory
-                    .appendingPathComponent(
-                        "cloud-transcription/jobs",
-                        isDirectory: true
-                    ),
-                temporaryRoot: rootDirectory
+                jobsDirectory: environment.storageLayout.cloudTranscriptionJobsDirectory,
+                temporaryRoot: environment.rootDirectory
                     .appendingPathComponent(
                         "cloud-transcription/tmp",
                         isDirectory: true
@@ -3127,7 +3147,10 @@ struct AppStateTranscriptionConfigurationTests {
                 throw URLError(.timedOut)
             }
 
-            let appState = await MainActor.run { AppState() }
+            let configuredDependencies = dependencies
+        let appState = await MainActor.run {
+            AppState(dependencies: configuredDependencies)
+        }
             await waitUntil(timeoutNanoseconds: 3_000_000_000) {
                 store.loadAllHistory().contains {
                     $0.id == historyID
@@ -3243,7 +3266,9 @@ struct AppStateTranscriptionConfigurationTests {
         for cleanup in [staleGuard, storeUpdate] {
             assert(cleanup.contains("snapshot.item.transcriptFileName == nil"))
             assert(cleanup.contains("let transcriptFileName = updatedItem.transcriptFileName"))
-            assert(cleanup.contains("Self.deleteTranscriptFile(transcriptFileName)"))
+            assert(cleanup.contains("Self.deleteTranscriptFile("))
+            assert(cleanup.contains("transcriptFileName,"))
+            assert(cleanup.contains("transcriptDirectory: transcriptDirectory"))
         }
     }
 

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -138,6 +138,7 @@ struct AppStateTranscriptionConfigurationTests {
         try await testRetryPreservesMeetingSummaryMetadata()
         try await testAudioImportTimeoutPreservesRawTranscriptAndFailedOutcome()
         try await testRetryTimeoutPreservesRawTranscriptAndFailedOutcome()
+        try await testCreatedAppStateKeepsItsRetryDependencySnapshot()
         try await testRetryTranscriptionFailurePreservesExistingAIOutcome()
         try testRetryUsesCurrentPostProcessingAndAudioOnlyMetadata()
         try testAudioOnlyRetryCreatesTranscriptFileAndPreservesMetadata()
@@ -2794,10 +2795,12 @@ struct AppStateTranscriptionConfigurationTests {
             )
             resetDefaults()
             let rawTranscript = "재시도 원본 전사문"
-            let replacementTranscript = "뒤늦게 설치된 재시도 전사문"
             let store = PipelineHistoryStore(storeURL: environment.storageLayout.historyStoreURL)
             var dependencies = environment.dependencies
             dependencies.makePipelineHistoryStore = { _ in store }
+            dependencies.makeRetryCloudTranscriptionDependencies = {
+                successfulCloudDependencies(transcript: rawTranscript)
+            }
             let fileName = "retry-timeout-\(UUID().uuidString).wav"
             let audioURL = environment.storageLayout.audioDirectory
                 .appendingPathComponent(fileName)
@@ -2808,25 +2811,18 @@ struct AppStateTranscriptionConfigurationTests {
             )
             _ = try store.append(originalItem, maxCount: 10)
 
-            let originalRetryDependencies =
-                AppState.retryCloudTranscriptionDependenciesFactory
             let originalTransport = AppState.postProcessingTransport
             defer {
-                AppState.retryCloudTranscriptionDependenciesFactory =
-                    originalRetryDependencies
                 AppState.postProcessingTransport = originalTransport
-            }
-            AppState.retryCloudTranscriptionDependenciesFactory = {
-                successfulCloudDependencies(transcript: rawTranscript)
             }
             AppState.postProcessingTransport = { _ in
                 throw URLError(.timedOut)
             }
 
             let configuredDependencies = dependencies
-        let appState = await MainActor.run {
-            AppState(dependencies: configuredDependencies)
-        }
+            let appState = await MainActor.run {
+                AppState(dependencies: configuredDependencies)
+            }
             await MainActor.run {
                 appState.apiKey = "post-processing-key"
                 appState.transcriptionAPIKey = "transcription-key"
@@ -2842,11 +2838,6 @@ struct AppStateTranscriptionConfigurationTests {
                         == .ready
                 )
                 appState.retryTranscription(item: originalItem)
-                AppState.retryCloudTranscriptionDependenciesFactory = {
-                    successfulCloudDependencies(
-                        transcript: replacementTranscript
-                    )
-                }
                 precondition(
                     appState.retryingItemIDs.contains(originalItem.id)
                 )
@@ -2866,6 +2857,67 @@ struct AppStateTranscriptionConfigurationTests {
         }
     }
 
+    private static func testCreatedAppStateKeepsItsRetryDependencySnapshot() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try FileManager.default.createDirectory(
+                at: environment.storageLayout.audioDirectory,
+                withIntermediateDirectories: true
+            )
+            resetDefaults()
+            let rawTranscript = "인스턴스가 보존한 재시도 전사문"
+            let replacementTranscript = "생성 후 교체된 재시도 전사문"
+            let store = PipelineHistoryStore(
+                storeURL: environment.storageLayout.historyStoreURL
+            )
+            var dependencies = environment.dependencies
+            dependencies.makePipelineHistoryStore = { _ in store }
+            dependencies.makeRetryCloudTranscriptionDependencies = {
+                successfulCloudDependencies(transcript: rawTranscript)
+            }
+            let fileName = "retry-dependency-snapshot-\(UUID().uuidString).wav"
+            let audioURL = environment.storageLayout.audioDirectory
+                .appendingPathComponent(fileName)
+            try writeTestWAV(at: audioURL)
+            let originalItem = retryHistoryItem(audioFileName: fileName)
+            _ = try store.append(originalItem, maxCount: 10)
+
+            let retainedDependencies = dependencies
+            let appState = await MainActor.run {
+                AppState(dependencies: retainedDependencies)
+            }
+            dependencies.makeRetryCloudTranscriptionDependencies = {
+                successfulCloudDependencies(transcript: replacementTranscript)
+            }
+
+            await MainActor.run {
+                appState.transcriptionAPIKey = "transcription-key"
+                appState.transcriptionAPIURL = "https://api.example.com/openai/v1"
+                appState.setNoteBrowserTranscriptionChoice(
+                    .apiStandard(modelID: "whisper-large-v3")
+                )
+                appState.disablePostProcessing = true
+                precondition(
+                    appState.noteBrowserRetryAvailability(for: originalItem)
+                        == .ready
+                )
+                appState.retryTranscription(item: originalItem)
+                precondition(
+                    appState.retryingItemIDs.contains(originalItem.id)
+                )
+            }
+
+            await waitUntil {
+                !appState.retryingItemIDs.contains(originalItem.id)
+            }
+            let persisted = try requireHistoryItem(
+                withID: originalItem.id,
+                in: store.loadAllHistory()
+            )
+            precondition(persisted.rawTranscript == rawTranscript)
+            precondition(persisted.rawTranscript != replacementTranscript)
+        }
+    }
+
     private static func testRetryTranscriptionFailurePreservesExistingAIOutcome() async throws {
         try await AppStateTestStorage.withIsolatedStorage { environment in
             try FileManager.default.createDirectory(
@@ -2877,6 +2929,9 @@ struct AppStateTranscriptionConfigurationTests {
             let store = PipelineHistoryStore(storeURL: environment.storageLayout.historyStoreURL)
             var dependencies = environment.dependencies
             dependencies.makePipelineHistoryStore = { _ in store }
+            dependencies.makeRetryCloudTranscriptionDependencies = {
+                failingCloudDependencies()
+            }
             let fileName = "retry-failure-\(UUID().uuidString).wav"
             let audioURL = environment.storageLayout.audioDirectory
                 .appendingPathComponent(fileName)
@@ -2886,16 +2941,6 @@ struct AppStateTranscriptionConfigurationTests {
                 aiProcessingOutcome: previousOutcome
             )
             _ = try store.append(originalItem, maxCount: 10)
-
-            let originalRetryDependencies =
-                AppState.retryCloudTranscriptionDependenciesFactory
-            defer {
-                AppState.retryCloudTranscriptionDependenciesFactory =
-                    originalRetryDependencies
-            }
-            AppState.retryCloudTranscriptionDependenciesFactory = {
-                failingCloudDependencies()
-            }
 
             let configuredDependencies = dependencies
             let appState = await MainActor.run {
@@ -3065,6 +3110,9 @@ struct AppStateTranscriptionConfigurationTests {
             let store = PipelineHistoryStore(storeURL: environment.storageLayout.historyStoreURL)
             var dependencies = environment.dependencies
             dependencies.makePipelineHistoryStore = { _ in store }
+            dependencies.makeRetryCloudTranscriptionDependencies = {
+                successfulCloudDependencies(transcript: rawTranscript)
+            }
             let originalItem = PipelineHistoryItem(
                 id: historyID,
                 timestamp: Date(timeIntervalSince1970: 1),
@@ -3132,25 +3180,18 @@ struct AppStateTranscriptionConfigurationTests {
                 account: "transcription_api_url"
             )
 
-            let originalRetryDependencies =
-                AppState.retryCloudTranscriptionDependenciesFactory
             let originalTransport = AppState.postProcessingTransport
             defer {
-                AppState.retryCloudTranscriptionDependenciesFactory =
-                    originalRetryDependencies
                 AppState.postProcessingTransport = originalTransport
-            }
-            AppState.retryCloudTranscriptionDependenciesFactory = {
-                successfulCloudDependencies(transcript: rawTranscript)
             }
             AppState.postProcessingTransport = { _ in
                 throw URLError(.timedOut)
             }
 
             let configuredDependencies = dependencies
-        let appState = await MainActor.run {
-            AppState(dependencies: configuredDependencies)
-        }
+            let appState = await MainActor.run {
+                AppState(dependencies: configuredDependencies)
+            }
             await waitUntil(timeoutNanoseconds: 3_000_000_000) {
                 store.loadAllHistory().contains {
                     $0.id == historyID

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -2858,64 +2858,101 @@ struct AppStateTranscriptionConfigurationTests {
     }
 
     private static func testCreatedAppStateKeepsItsRetryDependencySnapshot() async throws {
-        try await AppStateTestStorage.withIsolatedStorage { environment in
-            try FileManager.default.createDirectory(
-                at: environment.storageLayout.audioDirectory,
-                withIntermediateDirectories: true
-            )
-            resetDefaults()
-            let rawTranscript = "인스턴스가 보존한 재시도 전사문"
-            let replacementTranscript = "생성 후 교체된 재시도 전사문"
-            let store = PipelineHistoryStore(
-                storeURL: environment.storageLayout.historyStoreURL
-            )
-            var dependencies = environment.dependencies
-            dependencies.makePipelineHistoryStore = { _ in store }
-            dependencies.makeRetryCloudTranscriptionDependencies = {
-                successfulCloudDependencies(transcript: rawTranscript)
-            }
-            let fileName = "retry-dependency-snapshot-\(UUID().uuidString).wav"
-            let audioURL = environment.storageLayout.audioDirectory
-                .appendingPathComponent(fileName)
-            try writeTestWAV(at: audioURL)
-            let originalItem = retryHistoryItem(audioFileName: fileName)
-            _ = try store.append(originalItem, maxCount: 10)
-
-            let retainedDependencies = dependencies
-            let appState = await MainActor.run {
-                AppState(dependencies: retainedDependencies)
-            }
-            dependencies.makeRetryCloudTranscriptionDependencies = {
-                successfulCloudDependencies(transcript: replacementTranscript)
-            }
-
-            await MainActor.run {
-                appState.transcriptionAPIKey = "transcription-key"
-                appState.transcriptionAPIURL = "https://api.example.com/openai/v1"
-                appState.setNoteBrowserTranscriptionChoice(
-                    .apiStandard(modelID: "whisper-large-v3")
+        try await AppStateTestStorage.withIsolatedStorage { firstEnvironment in
+            try await AppStateTestStorage.withIsolatedStorage { secondEnvironment in
+                resetDefaults()
+                let firstTranscript = "첫 인스턴스의 재시도 전사문"
+                let secondTranscript = "두 번째 인스턴스의 재시도 전사문"
+                let firstStore = PipelineHistoryStore(
+                    storeURL: firstEnvironment.storageLayout.historyStoreURL
                 )
-                appState.disablePostProcessing = true
-                precondition(
-                    appState.noteBrowserRetryAvailability(for: originalItem)
-                        == .ready
+                let secondStore = PipelineHistoryStore(
+                    storeURL: secondEnvironment.storageLayout.historyStoreURL
                 )
-                appState.retryTranscription(item: originalItem)
-                precondition(
-                    appState.retryingItemIDs.contains(originalItem.id)
+                var dependencies = firstEnvironment.dependencies
+                dependencies.makePipelineHistoryStore = { _ in firstStore }
+                dependencies.makeRetryCloudTranscriptionDependencies = {
+                    successfulCloudDependencies(transcript: firstTranscript)
+                }
+                let firstItem = try retryHistoryItem(
+                    in: firstEnvironment.storageLayout,
+                    filePrefix: "first-retry-dependency"
                 )
-            }
+                _ = try firstStore.append(firstItem, maxCount: 10)
 
-            await waitUntil {
-                !appState.retryingItemIDs.contains(originalItem.id)
+                let firstDependencies = dependencies
+                let firstState = await MainActor.run {
+                    AppState(dependencies: firstDependencies)
+                }
+
+                dependencies.storageLayout = secondEnvironment.storageLayout
+                dependencies.makePipelineHistoryStore = { _ in secondStore }
+                dependencies.makeRetryCloudTranscriptionDependencies = {
+                    successfulCloudDependencies(transcript: secondTranscript)
+                }
+                let secondItem = try retryHistoryItem(
+                    in: secondEnvironment.storageLayout,
+                    filePrefix: "second-retry-dependency"
+                )
+                _ = try secondStore.append(secondItem, maxCount: 10)
+                let secondDependencies = dependencies
+                let secondState = await MainActor.run {
+                    AppState(dependencies: secondDependencies)
+                }
+
+                await MainActor.run {
+                    for (appState, item) in [
+                        (firstState, firstItem),
+                        (secondState, secondItem)
+                    ] {
+                        appState.transcriptionAPIKey = "transcription-key"
+                        appState.transcriptionAPIURL = "https://api.example.com/openai/v1"
+                        appState.setNoteBrowserTranscriptionChoice(
+                            .apiStandard(modelID: "whisper-large-v3")
+                        )
+                        appState.disablePostProcessing = true
+                        precondition(
+                            appState.noteBrowserRetryAvailability(for: item)
+                                == .ready
+                        )
+                        appState.retryTranscription(item: item)
+                        precondition(
+                            appState.retryingItemIDs.contains(item.id)
+                        )
+                    }
+                }
+
+                await waitUntil {
+                    !firstState.retryingItemIDs.contains(firstItem.id)
+                        && !secondState.retryingItemIDs.contains(secondItem.id)
+                }
+                let firstPersisted = try requireHistoryItem(
+                    withID: firstItem.id,
+                    in: firstStore.loadAllHistory()
+                )
+                let secondPersisted = try requireHistoryItem(
+                    withID: secondItem.id,
+                    in: secondStore.loadAllHistory()
+                )
+                precondition(firstPersisted.rawTranscript == firstTranscript)
+                precondition(secondPersisted.rawTranscript == secondTranscript)
             }
-            let persisted = try requireHistoryItem(
-                withID: originalItem.id,
-                in: store.loadAllHistory()
-            )
-            precondition(persisted.rawTranscript == rawTranscript)
-            precondition(persisted.rawTranscript != replacementTranscript)
         }
+    }
+
+    private static func retryHistoryItem(
+        in storageLayout: AppStateStorageLayout,
+        filePrefix: String
+    ) throws -> PipelineHistoryItem {
+        try FileManager.default.createDirectory(
+            at: storageLayout.audioDirectory,
+            withIntermediateDirectories: true
+        )
+        let fileName = "\(filePrefix)-\(UUID().uuidString).wav"
+        try writeTestWAV(
+            at: storageLayout.audioDirectory.appendingPathComponent(fileName)
+        )
+        return retryHistoryItem(audioFileName: fileName)
     }
 
     private static func testRetryTranscriptionFailurePreservesExistingAIOutcome() async throws {

--- a/Tests/AudioImportFileCopyTests.swift
+++ b/Tests/AudioImportFileCopyTests.swift
@@ -16,14 +16,25 @@ struct AudioImportFileCopyTests {
         let sourceURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("quill-audio-import-copy-source-\(ProcessInfo.processInfo.globallyUniqueString)")
             .appendingPathExtension("m4a")
+        let destinationDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-audio-import-copy-destination-\(ProcessInfo.processInfo.globallyUniqueString)")
         let contents = Data("audio import copy test".utf8)
         try contents.write(to: sourceURL)
-        defer { try? FileManager.default.removeItem(at: sourceURL) }
+        try FileManager.default.createDirectory(
+            at: destinationDirectory,
+            withIntermediateDirectories: true
+        )
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: destinationDirectory)
+        }
 
-        guard let saved = await AppState.saveSecurityScopedAudioFileOffMain(from: sourceURL) else {
+        guard let saved = await AppState.saveSecurityScopedAudioFileOffMain(
+            from: sourceURL,
+            audioDirectory: destinationDirectory
+        ) else {
             preconditionFailure("Expected off-main audio copy to succeed")
         }
-        defer { try? FileManager.default.removeItem(at: saved.fileURL) }
 
         precondition(saved.fileName.hasSuffix(".m4a"), "Expected copied file to preserve supported extension")
         let copied = try Data(contentsOf: saved.fileURL)
@@ -34,8 +45,13 @@ struct AudioImportFileCopyTests {
         let missingURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("quill-missing-audio-import-\(ProcessInfo.processInfo.globallyUniqueString)")
             .appendingPathExtension("mp3")
+        let destinationDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-missing-audio-destination-\(ProcessInfo.processInfo.globallyUniqueString)")
 
-        let saved = await AppState.saveSecurityScopedAudioFileOffMain(from: missingURL)
+        let saved = await AppState.saveSecurityScopedAudioFileOffMain(
+            from: missingURL,
+            audioDirectory: destinationDirectory
+        )
 
         precondition(saved == nil, "Expected missing source file to fail off-main copy")
     }
@@ -43,11 +59,17 @@ struct AudioImportFileCopyTests {
     private static func testImportAudioFileUsesOffMainSecurityScopedCopy() throws {
         let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
 
-        assertContains(source, "static func saveSecurityScopedAudioFileOffMain(from fileURL: URL) async -> SavedAudioFile?")
+        assertContains(
+            source,
+            "static func saveSecurityScopedAudioFileOffMain(\n        from fileURL: URL,\n        audioDirectory: URL\n    ) async -> SavedAudioFile?"
+        )
         assertContains(source, "await Task.detached(priority: .userInitiated)")
         assertContains(source, "let accessGranted = fileURL.startAccessingSecurityScopedResource()")
         assertContains(source, "fileURL.stopAccessingSecurityScopedResource()")
-        assertContains(source, "guard let savedAudioFile = await Self.saveSecurityScopedAudioFileOffMain(from: fileURL)")
+        assertContains(
+            source,
+            "guard let savedAudioFile = await Self.saveSecurityScopedAudioFileOffMain(\n                from: fileURL,\n                audioDirectory: audioDirectory"
+        )
         assertDoesNotContain(importAudioFileBody(in: source), "Self.saveAudioFile(from: fileURL)")
         assertDoesNotContain(importAudioFileBody(in: source), "startAccessingSecurityScopedResource()")
     }

--- a/Tests/FullSourceAppStateTestRunner.swift
+++ b/Tests/FullSourceAppStateTestRunner.swift
@@ -12,6 +12,7 @@ struct FullSourceAppStateTestRunner {
         }
 
         try await AppStateTestStorage.withIsolatedStorage { _ in
+            try AppStateDependenciesTests.main()
             try await AudioImportFileCopyTests.main()
             try LatestValueProgressCoalescerTests.main()
             try await AppStateStorageSafetyTests.main()

--- a/Tests/MeetingSummaryAppStateTests.swift
+++ b/Tests/MeetingSummaryAppStateTests.swift
@@ -56,7 +56,13 @@ struct MeetingSummaryAppStateTests {
 
     private static func testSuccessfulGenerationMarksPendingRevealConsumableOnce() async throws {
         let item = makeItem()
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in
                 MeetingSummaryGeneratorStub { _ in generationResult }
@@ -79,7 +85,13 @@ struct MeetingSummaryAppStateTests {
 
     private static func testFailedGenerationDoesNotMarkPendingReveal() async throws {
         let item = makeItem()
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in
                 MeetingSummaryGeneratorStub { _ in
@@ -114,7 +126,13 @@ struct MeetingSummaryAppStateTests {
         let item = makeItem()
             .withMeetingSummary(envelope(completed: false))
             .withMeetingSummaryAttempt(failedAttempt)
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
 
         try await MainActor.run {
             try appState.deleteMeetingSummary(noteID: item.id)
@@ -131,7 +149,13 @@ struct MeetingSummaryAppStateTests {
 
     private static func testDeleteMeetingSummaryRemovesFailedOnlyState() async throws {
         let item = makeItem()
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         let failedAttempt = await MainActor.run {
             MeetingSummaryAttempt(
                 occurredAt: Date(timeIntervalSince1970: 2_000),
@@ -171,7 +195,13 @@ struct MeetingSummaryAppStateTests {
 
     private static func testDeleteMeetingSummaryRejectsStaleFailedAttempt() async throws {
         let item = makeItem()
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         let staleAttempt = MeetingSummaryAttempt(
             occurredAt: Date(timeIntervalSince1970: 2_000),
             outcome: .failed,
@@ -342,7 +372,13 @@ struct MeetingSummaryAppStateTests {
 
     private static func testDeleteMeetingSummaryWithoutExistingSummaryThrows() async throws {
         let item = makeItem()
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
 
         do {
             try await MainActor.run {
@@ -356,7 +392,13 @@ struct MeetingSummaryAppStateTests {
 
     private static func testFailureAttemptUsesEffectiveFallbackModel() async throws {
         let item = makeItem()
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in
                 MeetingSummaryGeneratorStub { _ in
@@ -390,7 +432,13 @@ struct MeetingSummaryAppStateTests {
 
     private static func testGenerationPersistsOnlyAfterSuccess() async throws {
         let generator = MeetingSummaryControlledGenerator()
-        let appState = try await configuredAppState(item: makeItem())
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: makeItem(),
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in generator }
         }
@@ -421,7 +469,13 @@ struct MeetingSummaryAppStateTests {
 
     private static func testUnverifiedGenerationPersistsSummaryWarningState() async throws {
         let item = makeItem()
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         let unverifiedResult = MeetingSummaryGenerationResult(
             draft: generationResult.draft,
             promptVersion: generationResult.promptVersion,
@@ -508,7 +562,13 @@ struct MeetingSummaryAppStateTests {
     private static func testFailurePreservesExistingSummary() async throws {
         let existing = envelope(completed: true)
         let item = makeItem().withMeetingSummary(existing)
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in
                 MeetingSummaryGeneratorStub { _ in
@@ -532,7 +592,13 @@ struct MeetingSummaryAppStateTests {
     private static func testGroundingFailurePreservesExistingSummaryAndCompletion() async throws {
         let existing = envelope(completed: true)
         let item = makeItem().withMeetingSummary(existing)
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in
                 MeetingSummaryGeneratorStub { _ in
@@ -561,7 +627,13 @@ struct MeetingSummaryAppStateTests {
             spokenLanguageCode: "ko",
             spokenLanguageResolution: .engineDetected
         ).withMeetingSummary(existing)
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in
                 MeetingSummaryGeneratorStub { _ in
@@ -592,7 +664,13 @@ struct MeetingSummaryAppStateTests {
             rawTranscript: "회의에서 다음 주 화요일에 출시하기로 결정했습니다.",
             postProcessedTranscript: "회의에서 다음 주 화요일에 출시하기로 결정했습니다."
         )
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in
                 MeetingSummaryGeneratorStub { _ in generationResult }
@@ -806,7 +884,13 @@ struct MeetingSummaryAppStateTests {
             issue: QuillUserIssueRecord(code: .meetingSummaryUnavailable)
         )
         let item = makeItem().withMeetingSummaryAttempt(previousAttempt)
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in generator }
         }
@@ -837,7 +921,13 @@ struct MeetingSummaryAppStateTests {
     private static func testTranscriptChangeDiscardsInflightResult() async throws {
         let generator = MeetingSummaryControlledGenerator()
         let item = makeItem()
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in generator }
         }
@@ -873,7 +963,13 @@ struct MeetingSummaryAppStateTests {
     private static func testTranscriptChangeFailureDoesNotPersistAttempt() async throws {
         let generator = MeetingSummaryControlledGenerator()
         let item = makeItem()
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in generator }
         }
@@ -1141,7 +1237,13 @@ struct MeetingSummaryAppStateTests {
     private static func testDeleteDuringGenerationDoesNotRestoreSummary() async throws {
         let generator = MeetingSummaryControlledGenerator()
         let item = makeItem().withMeetingSummary(envelope(completed: false))
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in generator }
         }
@@ -1176,7 +1278,13 @@ struct MeetingSummaryAppStateTests {
     private static func testDeleteDuringGenerationFailureDoesNotPersistAttempt() async throws {
         let generator = MeetingSummaryControlledGenerator()
         let item = makeItem().withMeetingSummary(envelope(completed: false))
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in generator }
         }
@@ -1215,7 +1323,13 @@ struct MeetingSummaryAppStateTests {
             rawTranscript: "12345 ---",
             postProcessedTranscript: "12345 ---"
         )
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in
                 MeetingSummaryGeneratorStub { _ in generationResult }
@@ -1241,7 +1355,13 @@ struct MeetingSummaryAppStateTests {
             spokenLanguageCode: "en",
             spokenLanguageResolution: .engineDetected
         )
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
 
         await MainActor.run {
             appState.updateTranscript(
@@ -1257,7 +1377,13 @@ struct MeetingSummaryAppStateTests {
 
     private static func testActionCompletionPersists() async throws {
         let item = makeItem().withMeetingSummary(envelope(completed: false))
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         let actionID = item.meetingSummary!.content.actionItems[0].id
 
         try await MainActor.run {
@@ -1278,7 +1404,13 @@ struct MeetingSummaryAppStateTests {
 
     private static func testPostProcessingDisabledDoesNotBlockSummary() async throws {
         let item = makeItem()
-        let appState = try await configuredAppState(item: item)
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            storageLayout: fixture.storageLayout
+        )
         await MainActor.run {
             appState.disablePostProcessing = true
             precondition(
@@ -1337,9 +1469,7 @@ struct MeetingSummaryAppStateTests {
         }
     }
 
-    private static func configuredAppState(
-        item: PipelineHistoryItem
-    ) async throws -> AppState {
+    private static func configuredAppStateFixture() throws -> ConfiguredAppStateFixture {
         let rootDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent(
                 "quill-meeting-summary-tests-\(UUID().uuidString)",
@@ -1350,12 +1480,34 @@ struct MeetingSummaryAppStateTests {
             withIntermediateDirectories: true
         )
         let storageLayout = AppStateStorageLayout(rootDirectory: rootDirectory)
-        let store = PipelineHistoryStore(storeURL: storageLayout.historyStoreURL)
+        return ConfiguredAppStateFixture(
+            rootDirectory: rootDirectory,
+            storageLayout: storageLayout,
+            store: PipelineHistoryStore(storeURL: storageLayout.historyStoreURL)
+        )
+    }
+
+    private static func configuredAppState(
+        item: PipelineHistoryItem,
+        store: PipelineHistoryStore,
+        storageLayout: AppStateStorageLayout
+    ) async throws -> AppState {
         _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
         return await configuredPersistedAppState(
             store: store,
             storageLayout: storageLayout
         )
+    }
+
+    private struct ConfiguredAppStateFixture {
+        let rootDirectory: URL
+        let storageLayout: AppStateStorageLayout
+        let store: PipelineHistoryStore
+
+        func cleanup() {
+            try? store.detachForArchiveVerification()
+            try? FileManager.default.removeItem(at: rootDirectory)
+        }
     }
 
     @MainActor

--- a/Tests/MeetingSummaryAppStateTests.swift
+++ b/Tests/MeetingSummaryAppStateTests.swift
@@ -1027,34 +1027,14 @@ struct MeetingSummaryAppStateTests {
         let store = PipelineHistoryStore(storeURL: layout.historyStoreURL)
         let item = makeItem(audioFileName: audioFileName)
         _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
-        let originalRetryDependenciesFactory = AppState.retryCloudTranscriptionDependenciesFactory
-        defer {
-            AppState.retryCloudTranscriptionDependenciesFactory = originalRetryDependenciesFactory
-        }
-        AppState.retryCloudTranscriptionDependenciesFactory = {
-            CloudTranscriptionDependencies(
-                encodedUploadCeilingBytes: 10_000,
-                upload: { request, _ in
-                    let response = HTTPURLResponse(
-                        url: request.url!,
-                        statusCode: 200,
-                        httpVersion: "HTTP/1.1",
-                        headerFields: nil
-                    )!
-                    return (Data(#"{"text":"Retry source B."}"#.utf8), response)
-                },
-                checkpointStore: InMemoryCloudTranscriptionCheckpointStore(),
-                progress: { _ in },
-                temporaryRoot: FileManager.default.temporaryDirectory
-                    .appendingPathComponent(UUID().uuidString, isDirectory: true),
-                sleep: { _ in }
-            )
-        }
         let generator = MeetingSummaryControlledGenerator()
         let appState = await configuredPersistedAppState(
             store: store,
             generator: generator,
-            storageLayout: layout
+            storageLayout: layout,
+            retryDependencies: retryCloudDependencies(
+                transcript: "Retry source B."
+            )
         )
         await MainActor.run {
             appState.apiKey = "configured-key"
@@ -1126,18 +1106,14 @@ struct MeetingSummaryAppStateTests {
             spokenLanguageResolution: .engineDetected,
             audioFileName: audioFileName
         )
-        let originalRetryDependenciesFactory = AppState.retryCloudTranscriptionDependenciesFactory
-        defer {
-            AppState.retryCloudTranscriptionDependenciesFactory = originalRetryDependenciesFactory
-        }
-        AppState.retryCloudTranscriptionDependenciesFactory = retryCloudDependencies(
-            transcript: "Retry source B."
-        )
         let generator = MeetingSummaryControlledGenerator()
         let appState = await configuredPersistedAppState(
             store: store,
             generator: generator,
-            storageLayout: layout
+            storageLayout: layout,
+            retryDependencies: retryCloudDependencies(
+                transcript: "Retry source B."
+            )
         )
         await MainActor.run {
             appState.pipelineHistory = [item]
@@ -1482,12 +1458,16 @@ struct MeetingSummaryAppStateTests {
     private static func configuredPersistedAppState(
         store: PipelineHistoryStore,
         generator: (any MeetingSummaryGenerating)? = nil,
-        storageLayout: AppStateStorageLayout? = nil
+        storageLayout: AppStateStorageLayout? = nil,
+        retryDependencies: @escaping @Sendable () -> CloudTranscriptionDependencies = {
+            .live
+        }
     ) async -> AppState {
         let configuredDependencies = dependencies(
             store: store,
             generator: generator,
-            storageLayout: storageLayout
+            storageLayout: storageLayout,
+            retryDependencies: retryDependencies
         )
         return await MainActor.run {
             let appState = AppState(dependencies: configuredDependencies)
@@ -1559,7 +1539,7 @@ struct MeetingSummaryAppStateTests {
 
     private static func retryCloudDependencies(
         transcript: String
-    ) -> () -> CloudTranscriptionDependencies {
+    ) -> @Sendable () -> CloudTranscriptionDependencies {
         {
             CloudTranscriptionDependencies(
                 encodedUploadCeilingBytes: 10_000,

--- a/Tests/MeetingSummaryAppStateTests.swift
+++ b/Tests/MeetingSummaryAppStateTests.swift
@@ -8,7 +8,6 @@ struct MeetingSummaryAppStateTests {
         let originalFactory = await MainActor.run {
             AppState.meetingSummaryGeneratorFactory
         }
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
         do {
             try await testGenerationPersistsOnlyAfterSuccess()
             try await testUnverifiedGenerationPersistsSummaryWarningState()
@@ -47,13 +46,11 @@ struct MeetingSummaryAppStateTests {
             await MainActor.run {
                 AppState.meetingSummaryGeneratorFactory = originalFactory
             }
-            AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
             throw error
         }
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = originalFactory
         }
-        AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
         print("MeetingSummaryAppStateTests passed")
     }
 
@@ -154,10 +151,11 @@ struct MeetingSummaryAppStateTests {
             storeURL: directoryURL.appendingPathComponent("PipelineHistory.sqlite")
         )
         _ = try store.upsert(failedOnly, maxCount: 10, requiresDurableStore: true)
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-        defer { AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory }
-        AppState.pipelineHistoryStoreFactory = { store }
-        let persistedAppState = await configuredPersistedAppState()
+        let layout = AppStateStorageLayout(rootDirectory: directoryURL)
+        let persistedAppState = await configuredPersistedAppState(
+            store: store,
+            storageLayout: layout
+        )
 
         try await MainActor.run {
             try persistedAppState.deleteMeetingSummary(noteID: item.id)
@@ -215,10 +213,11 @@ struct MeetingSummaryAppStateTests {
         )
         let item = makeItem()
         _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-        defer { AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory }
-        AppState.pipelineHistoryStoreFactory = { store }
-        let appState = await configuredPersistedAppState()
+        let layout = AppStateStorageLayout(rootDirectory: directoryURL)
+        let appState = await configuredPersistedAppState(
+            store: store,
+            storageLayout: layout
+        )
         let failedAttempt = await MainActor.run {
             let attempt = MeetingSummaryAttempt(
                 occurredAt: Date(timeIntervalSince1970: 2_000),
@@ -286,10 +285,11 @@ struct MeetingSummaryAppStateTests {
         )
         let item = makeItem()
         _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-        defer { AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory }
-        AppState.pipelineHistoryStoreFactory = { store }
-        let appState = await configuredPersistedAppState()
+        let layout = AppStateStorageLayout(rootDirectory: directoryURL)
+        let appState = await configuredPersistedAppState(
+            store: store,
+            storageLayout: layout
+        )
         let failedAttempt = await MainActor.run {
             MeetingSummaryAttempt(
                 occurredAt: Date(timeIntervalSince1970: 2_000),
@@ -459,16 +459,13 @@ struct MeetingSummaryAppStateTests {
         )
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         let store = makeInMemoryFallbackStore(at: directoryURL)
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-        defer {
-            AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
-        }
-        AppState.pipelineHistoryStoreFactory = { store }
+        let layout = AppStateStorageLayout(rootDirectory: directoryURL)
 
         let item = makeItem()
-        let appState = await MainActor.run {
-            AppState()
-        }
+        let appState = await configuredPersistedAppState(
+            store: store,
+            storageLayout: layout
+        )
         await MainActor.run {
             appState.apiKey = "configured-key"
             appState.selectAIProcessingBackendChoice(
@@ -626,10 +623,11 @@ struct MeetingSummaryAppStateTests {
         )
         _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
 
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-        defer { AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory }
-        AppState.pipelineHistoryStoreFactory = { store }
-        let appState = await configuredPersistedAppState()
+        let layout = AppStateStorageLayout(rootDirectory: directoryURL)
+        let appState = await configuredPersistedAppState(
+            store: store,
+            storageLayout: layout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in
                 MeetingSummaryGeneratorStub { _ in generationResult }
@@ -662,10 +660,11 @@ struct MeetingSummaryAppStateTests {
         ).withMeetingSummary(existing)
         _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
 
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-        defer { AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory }
-        AppState.pipelineHistoryStoreFactory = { store }
-        let appState = await configuredPersistedAppState()
+        let layout = AppStateStorageLayout(rootDirectory: directoryURL)
+        let appState = await configuredPersistedAppState(
+            store: store,
+            storageLayout: layout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in
                 MeetingSummaryGeneratorStub { _ in
@@ -712,10 +711,11 @@ struct MeetingSummaryAppStateTests {
         ).withMeetingSummary(existing)
         _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
 
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-        defer { AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory }
-        AppState.pipelineHistoryStoreFactory = { store }
-        let appState = await configuredPersistedAppState()
+        let layout = AppStateStorageLayout(rootDirectory: directoryURL)
+        let appState = await configuredPersistedAppState(
+            store: store,
+            storageLayout: layout
+        )
         await MainActor.run {
             AppState.meetingSummaryGeneratorFactory = { _ in
                 MeetingSummaryGeneratorStub { _ in
@@ -770,12 +770,13 @@ struct MeetingSummaryAppStateTests {
             .withMeetingSummaryAttempt(attempt)
         let store = PipelineHistoryStore(inMemory: true)
         _ = try store.append(item, maxCount: 10)
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-        defer {
-            AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
-        }
-        AppState.pipelineHistoryStoreFactory = { store }
-        let appState = await MainActor.run { AppState() }
+        let directoryURL = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let layout = AppStateStorageLayout(rootDirectory: directoryURL)
+        let appState = await configuredPersistedAppState(
+            store: store,
+            storageLayout: layout
+        )
 
         await MainActor.run {
             appState.updateTranscript(id: item.id, text: "Edited transcript.")
@@ -900,24 +901,22 @@ struct MeetingSummaryAppStateTests {
 
     private static func testSuccessfulRetryInvalidatesInflightSummaryGeneration() async throws {
         let audioFileName = "retry-summary-invalidation-\(UUID().uuidString).mp3"
-        let audioURL = AppState.audioStorageDirectory().appendingPathComponent(audioFileName)
-        try Data([0]).write(to: audioURL)
-        defer { try? FileManager.default.removeItem(at: audioURL) }
-
         let directoryURL = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directoryURL) }
-        let store = PipelineHistoryStore(
-            storeURL: directoryURL.appendingPathComponent("PipelineHistory.sqlite")
+        let layout = AppStateStorageLayout(rootDirectory: directoryURL)
+        let audioURL = layout.audioDirectory.appendingPathComponent(audioFileName)
+        try FileManager.default.createDirectory(
+            at: layout.audioDirectory,
+            withIntermediateDirectories: true
         )
+        try Data([0]).write(to: audioURL)
+        let store = PipelineHistoryStore(storeURL: layout.historyStoreURL)
         let item = makeItem(audioFileName: audioFileName)
         _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
         let originalRetryDependenciesFactory = AppState.retryCloudTranscriptionDependenciesFactory
         defer {
-            AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
             AppState.retryCloudTranscriptionDependenciesFactory = originalRetryDependenciesFactory
         }
-        AppState.pipelineHistoryStoreFactory = { store }
         AppState.retryCloudTranscriptionDependenciesFactory = {
             CloudTranscriptionDependencies(
                 encodedUploadCeilingBytes: 10_000,
@@ -938,7 +937,10 @@ struct MeetingSummaryAppStateTests {
             )
         }
         let generator = MeetingSummaryControlledGenerator()
-        let appState = await MainActor.run { AppState() }
+        let appState = await configuredPersistedAppState(
+            store: store,
+            storageLayout: layout
+        )
         await MainActor.run {
             appState.apiKey = "configured-key"
             appState.transcriptionAPIKey = "test-api-key"
@@ -995,32 +997,33 @@ struct MeetingSummaryAppStateTests {
 
     private static func testRetryWithMissingHistoryEntryKeepsSummaryGenerationActive() async throws {
         let audioFileName = "retry-missing-history-\(UUID().uuidString).mp3"
-        let audioURL = AppState.audioStorageDirectory().appendingPathComponent(audioFileName)
-        try Data([0]).write(to: audioURL)
-        defer { try? FileManager.default.removeItem(at: audioURL) }
-
         let directoryURL = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directoryURL) }
-        let store = PipelineHistoryStore(
-            storeURL: directoryURL.appendingPathComponent("PipelineHistory.sqlite")
+        let layout = AppStateStorageLayout(rootDirectory: directoryURL)
+        let audioURL = layout.audioDirectory.appendingPathComponent(audioFileName)
+        try FileManager.default.createDirectory(
+            at: layout.audioDirectory,
+            withIntermediateDirectories: true
         )
+        try Data([0]).write(to: audioURL)
+        let store = PipelineHistoryStore(storeURL: layout.historyStoreURL)
         let item = makeItem(
             spokenLanguageCode: "en",
             spokenLanguageResolution: .engineDetected,
             audioFileName: audioFileName
         )
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
         let originalRetryDependenciesFactory = AppState.retryCloudTranscriptionDependenciesFactory
         defer {
-            AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory
             AppState.retryCloudTranscriptionDependenciesFactory = originalRetryDependenciesFactory
         }
-        AppState.pipelineHistoryStoreFactory = { store }
         AppState.retryCloudTranscriptionDependenciesFactory = retryCloudDependencies(
             transcript: "Retry source B."
         )
         let generator = MeetingSummaryControlledGenerator()
-        let appState = await MainActor.run { AppState() }
+        let appState = await configuredPersistedAppState(
+            store: store,
+            storageLayout: layout
+        )
         await MainActor.run {
             appState.pipelineHistory = [item]
             configureSummaryGeneration(appState, generator: generator)
@@ -1062,11 +1065,12 @@ struct MeetingSummaryAppStateTests {
             spokenLanguageCode: "en",
             spokenLanguageResolution: .engineDetected
         )
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-        defer { AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory }
-        AppState.pipelineHistoryStoreFactory = { store }
         let generator = MeetingSummaryControlledGenerator()
-        let appState = await MainActor.run { AppState() }
+        let layout = AppStateStorageLayout(rootDirectory: directoryURL)
+        let appState = await configuredPersistedAppState(
+            store: store,
+            storageLayout: layout
+        )
         await MainActor.run {
             appState.pipelineHistory = [item]
             configureSummaryGeneration(appState, generator: generator)
@@ -1107,11 +1111,12 @@ struct MeetingSummaryAppStateTests {
             spokenLanguageResolution: .engineDetected
         )
         _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
-        let originalHistoryStoreFactory = AppState.pipelineHistoryStoreFactory
-        defer { AppState.pipelineHistoryStoreFactory = originalHistoryStoreFactory }
-        AppState.pipelineHistoryStoreFactory = { store }
+        let layout = AppStateStorageLayout(rootDirectory: directoryURL)
         let generator = MeetingSummaryControlledGenerator()
-        let appState = await configuredPersistedAppState()
+        let appState = await configuredPersistedAppState(
+            store: store,
+            storageLayout: layout
+        )
         await MainActor.run {
             configureSummaryGeneration(appState, generator: generator)
         }
@@ -1312,9 +1317,16 @@ struct MeetingSummaryAppStateTests {
         return directoryURL
     }
 
-    private static func configuredPersistedAppState() async -> AppState {
-        await MainActor.run {
-            let appState = AppState()
+    private static func configuredPersistedAppState(
+        store: PipelineHistoryStore,
+        storageLayout: AppStateStorageLayout
+    ) async -> AppState {
+        var dependencies = AppStateDependencies.live
+        dependencies.storageLayout = storageLayout
+        dependencies.makePipelineHistoryStore = { _ in store }
+        let configuredDependencies = dependencies
+        return await MainActor.run {
+            let appState = AppState(dependencies: configuredDependencies)
             appState.apiKey = "configured-key"
             appState.selectAIProcessingBackendChoice(
                 .cloud(modelID: "summary/model"),
@@ -1328,22 +1340,22 @@ struct MeetingSummaryAppStateTests {
     private static func configuredAppState(
         item: PipelineHistoryItem
     ) async throws -> AppState {
-        let storeURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("quill-meeting-summary-tests-\(UUID().uuidString)")
-            .appendingPathExtension("sqlite")
-        let store = PipelineHistoryStore(storeURL: storeURL)
-        _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
-        AppState.pipelineHistoryStoreFactory = { store }
-        return await MainActor.run {
-            let appState = AppState()
-            appState.apiKey = "configured-key"
-            appState.selectAIProcessingBackendChoice(
-                .cloud(modelID: "summary/model"),
-                for: .meetingSummary
+        let rootDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "quill-meeting-summary-tests-\(UUID().uuidString)",
+                isDirectory: true
             )
-            appState.disableMeetingSummary = false
-            return appState
-        }
+        try FileManager.default.createDirectory(
+            at: rootDirectory,
+            withIntermediateDirectories: true
+        )
+        let storageLayout = AppStateStorageLayout(rootDirectory: rootDirectory)
+        let store = PipelineHistoryStore(storeURL: storageLayout.historyStoreURL)
+        _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
+        return await configuredPersistedAppState(
+            store: store,
+            storageLayout: storageLayout
+        )
     }
 
     @MainActor

--- a/Tests/MeetingSummaryAppStateTests.swift
+++ b/Tests/MeetingSummaryAppStateTests.swift
@@ -51,10 +51,10 @@ struct MeetingSummaryAppStateTests {
         let firstItem = makeItem()
         let secondItem = makeItem()
         let firstGenerator = MeetingSummaryGeneratorStub { _ in
-            generationResult(overview: "first generator")
+            makeGenerationResult(overview: "first generator")
         }
         let secondGenerator = MeetingSummaryGeneratorStub { _ in
-            generationResult(overview: "second generator")
+            makeGenerationResult(overview: "second generator")
         }
         let firstState = try await configuredAppState(
             item: firstItem,
@@ -85,49 +85,60 @@ struct MeetingSummaryAppStateTests {
     }
 
     private static func testCreatedAppStateKeepsItsSummaryDependencySnapshot() async throws {
-        let fixture = try configuredAppStateFixture()
-        defer { fixture.cleanup() }
-        let item = makeItem()
-        _ = try fixture.store.upsert(
-            item,
+        let firstFixture = try configuredAppStateFixture()
+        defer { firstFixture.cleanup() }
+        let secondFixture = try configuredAppStateFixture()
+        defer { secondFixture.cleanup() }
+        let firstItem = makeItem()
+        let secondItem = makeItem()
+        _ = try firstFixture.store.upsert(
+            firstItem,
+            maxCount: 10,
+            requiresDurableStore: true
+        )
+        _ = try secondFixture.store.upsert(
+            secondItem,
             maxCount: 10,
             requiresDurableStore: true
         )
         let firstGenerator = MeetingSummaryGeneratorStub { _ in
-            generationResult(overview: "first generator")
+            makeGenerationResult(overview: "first generator")
         }
         let secondGenerator = MeetingSummaryGeneratorStub { _ in
-            generationResult(overview: "second generator")
+            makeGenerationResult(overview: "second generator")
         }
         var dependencies = AppStateDependencies.live
-        dependencies.storageLayout = fixture.storageLayout
-        dependencies.makePipelineHistoryStore = { _ in fixture.store }
+        dependencies.storageLayout = firstFixture.storageLayout
+        dependencies.makePipelineHistoryStore = { _ in firstFixture.store }
         dependencies.makeMeetingSummaryGenerator = { _ in firstGenerator }
-        let configuredDependencies = dependencies
-        let appState = await MainActor.run {
-            AppState(dependencies: configuredDependencies)
+        let firstDependencies = dependencies
+        let firstState = await MainActor.run {
+            let appState = AppState(dependencies: firstDependencies)
+            configureSummaryGeneration(appState)
+            return appState
         }
+
+        dependencies.storageLayout = secondFixture.storageLayout
+        dependencies.makePipelineHistoryStore = { _ in secondFixture.store }
         dependencies.makeMeetingSummaryGenerator = { _ in secondGenerator }
-        await MainActor.run {
-            appState.apiKey = "configured-key"
-            appState.selectAIProcessingBackendChoice(
-                .cloud(modelID: "summary/model"),
-                for: .meetingSummary
-            )
-            appState.disableMeetingSummary = false
-            precondition(
-                appState.meetingSummaryAvailability(for: appState.pipelineHistory[0])
-                    == .available,
-                "test requires an available summary source"
-            )
+        let secondDependencies = dependencies
+        let secondState = await MainActor.run {
+            let appState = AppState(dependencies: secondDependencies)
+            configureSummaryGeneration(appState)
+            return appState
         }
 
-        try await appState.generateMeetingSummary(id: item.id)
+        try await firstState.generateMeetingSummary(id: firstItem.id)
+        try await secondState.generateMeetingSummary(id: secondItem.id)
 
         await MainActor.run {
             precondition(
-                appState.pipelineHistory[0].meetingSummary?.content.overview.text
+                firstState.pipelineHistory[0].meetingSummary?.content.overview.text
                     == "first generator"
+            )
+            precondition(
+                secondState.pipelineHistory[0].meetingSummary?.content.overview.text
+                    == "second generator"
             )
         }
     }
@@ -1670,7 +1681,7 @@ struct MeetingSummaryAppStateTests {
         backendKind: .cloud
     )
 
-    private static func generationResult(
+    private static func makeGenerationResult(
         overview: String
     ) -> MeetingSummaryGenerationResult {
         MeetingSummaryGenerationResult(

--- a/Tests/MeetingSummaryAppStateTests.swift
+++ b/Tests/MeetingSummaryAppStateTests.swift
@@ -5,53 +5,131 @@ import Foundation
 #endif
 struct MeetingSummaryAppStateTests {
     static func main() async throws {
-        let originalFactory = await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory
-        }
-        do {
-            try await testGenerationPersistsOnlyAfterSuccess()
-            try await testUnverifiedGenerationPersistsSummaryWarningState()
-            try await testNonDurableHistoryWarningPreventsSummaryPersistence()
-            try await testFailurePreservesExistingSummary()
-            try await testGroundingFailurePreservesExistingSummaryAndCompletion()
-            try await testLanguageMismatchPreservesSummaryAndRecordsAttempt()
-            try await testLegacyAutoNotePersistsInferredKoreanOnGeneration()
-            try await testSuccessfulAttemptSurvivesDurableReload()
-            try await testFailedAttemptSurvivesDurableReload()
-            try await testFailedAttemptPersistenceFailureRemainsTransient()
-            try await testSourceChangePreservesExistingFailedAttempt()
-            try await testTranscriptChangeDiscardsInflightResult()
-            try await testTranscriptChangeFailureDoesNotPersistAttempt()
-            try await testSuccessfulRetryInvalidatesInflightSummaryGeneration()
-            try await testRetryWithMissingHistoryEntryKeepsSummaryGenerationActive()
-            try await testDeleteWithMissingHistoryEntryKeepsSummaryGenerationActive()
-            try await testClearWithSaveFailureKeepsSummaryGenerationActive()
-            try await testDeleteDuringGenerationDoesNotRestoreSummary()
-            try await testDeleteDuringGenerationFailureDoesNotPersistAttempt()
-            try await testTranscriptReplacementReinfersDerivedSpokenLanguage()
-            try await testTranscriptReplacementPreservesEngineDetectedLanguage()
-            try await testTranscriptEditingPreservesSummaryMetadata()
-            try await testActionCompletionPersists()
-            try await testPostProcessingDisabledDoesNotBlockSummary()
-            try await testDeleteMeetingSummaryRemovesEntireSummaryState()
-            try await testDeleteMeetingSummaryRemovesFailedOnlyState()
-            try await testDeleteMeetingSummaryRejectsStaleFailedAttempt()
-            try await testDeleteFailedSummaryStatePersistsAndInvalidatesInflightGeneration()
-            try await testFailedSummaryDeletePreservesStateWhenDurableWriteFails()
-            try await testDeleteMeetingSummaryWithoutExistingSummaryThrows()
-            try await testFailureAttemptUsesEffectiveFallbackModel()
-            try await testSuccessfulGenerationMarksPendingRevealConsumableOnce()
-            try await testFailedGenerationDoesNotMarkPendingReveal()
-        } catch {
-            await MainActor.run {
-                AppState.meetingSummaryGeneratorFactory = originalFactory
-            }
-            throw error
-        }
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = originalFactory
-        }
+        try await testAppStateInstancesUseIndependentSummaryGenerators()
+        try await testCreatedAppStateKeepsItsSummaryDependencySnapshot()
+        try await testGenerationPersistsOnlyAfterSuccess()
+        try await testUnverifiedGenerationPersistsSummaryWarningState()
+        try await testNonDurableHistoryWarningPreventsSummaryPersistence()
+        try await testFailurePreservesExistingSummary()
+        try await testGroundingFailurePreservesExistingSummaryAndCompletion()
+        try await testLanguageMismatchPreservesSummaryAndRecordsAttempt()
+        try await testLegacyAutoNotePersistsInferredKoreanOnGeneration()
+        try await testSuccessfulAttemptSurvivesDurableReload()
+        try await testFailedAttemptSurvivesDurableReload()
+        try await testFailedAttemptPersistenceFailureRemainsTransient()
+        try await testSourceChangePreservesExistingFailedAttempt()
+        try await testTranscriptChangeDiscardsInflightResult()
+        try await testTranscriptChangeFailureDoesNotPersistAttempt()
+        try await testSuccessfulRetryInvalidatesInflightSummaryGeneration()
+        try await testRetryWithMissingHistoryEntryKeepsSummaryGenerationActive()
+        try await testDeleteWithMissingHistoryEntryKeepsSummaryGenerationActive()
+        try await testClearWithSaveFailureKeepsSummaryGenerationActive()
+        try await testDeleteDuringGenerationDoesNotRestoreSummary()
+        try await testDeleteDuringGenerationFailureDoesNotPersistAttempt()
+        try await testTranscriptReplacementReinfersDerivedSpokenLanguage()
+        try await testTranscriptReplacementPreservesEngineDetectedLanguage()
+        try await testTranscriptEditingPreservesSummaryMetadata()
+        try await testActionCompletionPersists()
+        try await testPostProcessingDisabledDoesNotBlockSummary()
+        try await testDeleteMeetingSummaryRemovesEntireSummaryState()
+        try await testDeleteMeetingSummaryRemovesFailedOnlyState()
+        try await testDeleteMeetingSummaryRejectsStaleFailedAttempt()
+        try await testDeleteFailedSummaryStatePersistsAndInvalidatesInflightGeneration()
+        try await testFailedSummaryDeletePreservesStateWhenDurableWriteFails()
+        try await testDeleteMeetingSummaryWithoutExistingSummaryThrows()
+        try await testFailureAttemptUsesEffectiveFallbackModel()
+        try await testSuccessfulGenerationMarksPendingRevealConsumableOnce()
+        try await testFailedGenerationDoesNotMarkPendingReveal()
         print("MeetingSummaryAppStateTests passed")
+    }
+
+    private static func testAppStateInstancesUseIndependentSummaryGenerators() async throws {
+        let firstFixture = try configuredAppStateFixture()
+        defer { firstFixture.cleanup() }
+        let secondFixture = try configuredAppStateFixture()
+        defer { secondFixture.cleanup() }
+        let firstItem = makeItem()
+        let secondItem = makeItem()
+        let firstGenerator = MeetingSummaryGeneratorStub { _ in
+            generationResult(overview: "first generator")
+        }
+        let secondGenerator = MeetingSummaryGeneratorStub { _ in
+            generationResult(overview: "second generator")
+        }
+        let firstState = try await configuredAppState(
+            item: firstItem,
+            store: firstFixture.store,
+            generator: firstGenerator,
+            storageLayout: firstFixture.storageLayout
+        )
+        let secondState = try await configuredAppState(
+            item: secondItem,
+            store: secondFixture.store,
+            generator: secondGenerator,
+            storageLayout: secondFixture.storageLayout
+        )
+
+        try await firstState.generateMeetingSummary(id: firstItem.id)
+        try await secondState.generateMeetingSummary(id: secondItem.id)
+
+        await MainActor.run {
+            precondition(
+                firstState.pipelineHistory[0].meetingSummary?.content.overview.text
+                    == "first generator"
+            )
+            precondition(
+                secondState.pipelineHistory[0].meetingSummary?.content.overview.text
+                    == "second generator"
+            )
+        }
+    }
+
+    private static func testCreatedAppStateKeepsItsSummaryDependencySnapshot() async throws {
+        let fixture = try configuredAppStateFixture()
+        defer { fixture.cleanup() }
+        let item = makeItem()
+        _ = try fixture.store.upsert(
+            item,
+            maxCount: 10,
+            requiresDurableStore: true
+        )
+        let firstGenerator = MeetingSummaryGeneratorStub { _ in
+            generationResult(overview: "first generator")
+        }
+        let secondGenerator = MeetingSummaryGeneratorStub { _ in
+            generationResult(overview: "second generator")
+        }
+        var dependencies = AppStateDependencies.live
+        dependencies.storageLayout = fixture.storageLayout
+        dependencies.makePipelineHistoryStore = { _ in fixture.store }
+        dependencies.makeMeetingSummaryGenerator = { _ in firstGenerator }
+        let configuredDependencies = dependencies
+        let appState = await MainActor.run {
+            AppState(dependencies: configuredDependencies)
+        }
+        dependencies.makeMeetingSummaryGenerator = { _ in secondGenerator }
+        await MainActor.run {
+            appState.apiKey = "configured-key"
+            appState.selectAIProcessingBackendChoice(
+                .cloud(modelID: "summary/model"),
+                for: .meetingSummary
+            )
+            appState.disableMeetingSummary = false
+            precondition(
+                appState.meetingSummaryAvailability(for: appState.pipelineHistory[0])
+                    == .available,
+                "test requires an available summary source"
+            )
+        }
+
+        try await appState.generateMeetingSummary(id: item.id)
+
+        await MainActor.run {
+            precondition(
+                appState.pipelineHistory[0].meetingSummary?.content.overview.text
+                    == "first generator"
+            )
+        }
     }
 
     private static func testSuccessfulGenerationMarksPendingRevealConsumableOnce() async throws {
@@ -61,13 +139,9 @@ struct MeetingSummaryAppStateTests {
         let appState = try await configuredAppState(
             item: item,
             store: fixture.store,
+            generator: MeetingSummaryGeneratorStub { _ in generationResult },
             storageLayout: fixture.storageLayout
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in
-                MeetingSummaryGeneratorStub { _ in generationResult }
-            }
-        }
 
         try await appState.generateMeetingSummary(id: item.id)
 
@@ -90,15 +164,11 @@ struct MeetingSummaryAppStateTests {
         let appState = try await configuredAppState(
             item: item,
             store: fixture.store,
+            generator: MeetingSummaryGeneratorStub { _ in
+                throw MeetingSummaryError.invalidResponse(.responseEnvelope)
+            },
             storageLayout: fixture.storageLayout
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in
-                MeetingSummaryGeneratorStub { _ in
-                    throw MeetingSummaryError.invalidResponse(.responseEnvelope)
-                }
-            }
-        }
 
         do {
             try await appState.generateMeetingSummary(id: item.id)
@@ -244,8 +314,10 @@ struct MeetingSummaryAppStateTests {
         let item = makeItem()
         _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
         let layout = AppStateStorageLayout(rootDirectory: directoryURL)
+        let generator = MeetingSummaryControlledGenerator()
         let appState = await configuredPersistedAppState(
             store: store,
+            generator: generator,
             storageLayout: layout
         )
         let failedAttempt = await MainActor.run {
@@ -267,10 +339,6 @@ struct MeetingSummaryAppStateTests {
             appState.pipelineHistory = store.loadAllHistory()
         }
 
-        let generator = MeetingSummaryControlledGenerator()
-        await MainActor.run {
-            configureSummaryGeneration(appState, generator: generator)
-        }
         let summaryTask = Task { @MainActor in
             try await appState.generateMeetingSummary(id: item.id)
         }
@@ -316,8 +384,10 @@ struct MeetingSummaryAppStateTests {
         let item = makeItem()
         _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
         let layout = AppStateStorageLayout(rootDirectory: directoryURL)
+        let generator = MeetingSummaryControlledGenerator()
         let appState = await configuredPersistedAppState(
             store: store,
+            generator: generator,
             storageLayout: layout
         )
         let failedAttempt = await MainActor.run {
@@ -336,10 +406,6 @@ struct MeetingSummaryAppStateTests {
         try store.update(failedOnly, requiresDurableStore: true)
         await MainActor.run {
             appState.pipelineHistory = store.loadAllHistory()
-        }
-        let generator = MeetingSummaryControlledGenerator()
-        await MainActor.run {
-            configureSummaryGeneration(appState, generator: generator)
         }
         let summaryTask = Task { @MainActor in
             try await appState.generateMeetingSummary(id: item.id)
@@ -397,18 +463,14 @@ struct MeetingSummaryAppStateTests {
         let appState = try await configuredAppState(
             item: item,
             store: fixture.store,
+            generator: MeetingSummaryGeneratorStub { _ in
+                throw MeetingSummaryError.rateLimited(
+                    model: "fallback/model",
+                    retryAfter: 1
+                )
+            },
             storageLayout: fixture.storageLayout
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in
-                MeetingSummaryGeneratorStub { _ in
-                    throw MeetingSummaryError.rateLimited(
-                        model: "fallback/model",
-                        retryAfter: 1
-                    )
-                }
-            }
-        }
 
         do {
             try await appState.generateMeetingSummary(id: item.id)
@@ -437,11 +499,9 @@ struct MeetingSummaryAppStateTests {
         let appState = try await configuredAppState(
             item: makeItem(),
             store: fixture.store,
+            generator: generator,
             storageLayout: fixture.storageLayout
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in generator }
-        }
 
         let task = Task { @MainActor in
             try await appState.generateMeetingSummary(
@@ -471,11 +531,6 @@ struct MeetingSummaryAppStateTests {
         let item = makeItem()
         let fixture = try configuredAppStateFixture()
         defer { fixture.cleanup() }
-        let appState = try await configuredAppState(
-            item: item,
-            store: fixture.store,
-            storageLayout: fixture.storageLayout
-        )
         let unverifiedResult = MeetingSummaryGenerationResult(
             draft: generationResult.draft,
             promptVersion: generationResult.promptVersion,
@@ -483,11 +538,12 @@ struct MeetingSummaryAppStateTests {
             backendKind: generationResult.backendKind,
             evidenceVerification: .unverified
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in
-                MeetingSummaryGeneratorStub { _ in unverifiedResult }
-            }
-        }
+        let appState = try await configuredAppState(
+            item: item,
+            store: fixture.store,
+            generator: MeetingSummaryGeneratorStub { _ in unverifiedResult },
+            storageLayout: fixture.storageLayout
+        )
 
         try await appState.generateMeetingSummary(id: item.id)
 
@@ -518,6 +574,7 @@ struct MeetingSummaryAppStateTests {
         let item = makeItem()
         let appState = await configuredPersistedAppState(
             store: store,
+            generator: MeetingSummaryGeneratorStub { _ in generationResult },
             storageLayout: layout
         )
         await MainActor.run {
@@ -533,11 +590,6 @@ struct MeetingSummaryAppStateTests {
                     == .historyPersistenceUnavailable,
                 "in-memory history warns for this session"
             )
-        }
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in
-                MeetingSummaryGeneratorStub { _ in generationResult }
-            }
         }
 
         do {
@@ -567,15 +619,11 @@ struct MeetingSummaryAppStateTests {
         let appState = try await configuredAppState(
             item: item,
             store: fixture.store,
+            generator: MeetingSummaryGeneratorStub { _ in
+                throw MeetingSummaryError.invalidResponse(.responseEnvelope)
+            },
             storageLayout: fixture.storageLayout
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in
-                MeetingSummaryGeneratorStub { _ in
-                    throw MeetingSummaryError.invalidResponse(.responseEnvelope)
-                }
-            }
-        }
 
         do {
             try await appState.generateMeetingSummary(id: item.id)
@@ -597,15 +645,11 @@ struct MeetingSummaryAppStateTests {
         let appState = try await configuredAppState(
             item: item,
             store: fixture.store,
+            generator: MeetingSummaryGeneratorStub { _ in
+                throw MeetingSummaryError.outputRejected(.sourceQuoteNotFound)
+            },
             storageLayout: fixture.storageLayout
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in
-                MeetingSummaryGeneratorStub { _ in
-                    throw MeetingSummaryError.outputRejected(.sourceQuoteNotFound)
-                }
-            }
-        }
 
         do {
             try await appState.generateMeetingSummary(id: item.id)
@@ -632,15 +676,11 @@ struct MeetingSummaryAppStateTests {
         let appState = try await configuredAppState(
             item: item,
             store: fixture.store,
+            generator: MeetingSummaryGeneratorStub { _ in
+                throw MeetingSummaryError.outputRejected(.languageMismatch)
+            },
             storageLayout: fixture.storageLayout
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in
-                MeetingSummaryGeneratorStub { _ in
-                    throw MeetingSummaryError.outputRejected(.languageMismatch)
-                }
-            }
-        }
 
         do {
             try await appState.generateMeetingSummary(id: item.id)
@@ -669,13 +709,9 @@ struct MeetingSummaryAppStateTests {
         let appState = try await configuredAppState(
             item: item,
             store: fixture.store,
+            generator: MeetingSummaryGeneratorStub { _ in generationResult },
             storageLayout: fixture.storageLayout
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in
-                MeetingSummaryGeneratorStub { _ in generationResult }
-            }
-        }
 
         try await appState.generateMeetingSummary(id: item.id)
 
@@ -704,13 +740,9 @@ struct MeetingSummaryAppStateTests {
         let layout = AppStateStorageLayout(rootDirectory: directoryURL)
         let appState = await configuredPersistedAppState(
             store: store,
+            generator: MeetingSummaryGeneratorStub { _ in generationResult },
             storageLayout: layout
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in
-                MeetingSummaryGeneratorStub { _ in generationResult }
-            }
-        }
 
         try await appState.generateMeetingSummary(id: item.id)
 
@@ -741,15 +773,11 @@ struct MeetingSummaryAppStateTests {
         let layout = AppStateStorageLayout(rootDirectory: directoryURL)
         let appState = await configuredPersistedAppState(
             store: store,
+            generator: MeetingSummaryGeneratorStub { _ in
+                throw MeetingSummaryError.outputRejected(.languageMismatch)
+            },
             storageLayout: layout
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in
-                MeetingSummaryGeneratorStub { _ in
-                    throw MeetingSummaryError.outputRejected(.languageMismatch)
-                }
-            }
-        }
 
         do {
             try await appState.generateMeetingSummary(id: item.id)
@@ -792,15 +820,11 @@ struct MeetingSummaryAppStateTests {
         let layout = AppStateStorageLayout(rootDirectory: directoryURL)
         let appState = await configuredPersistedAppState(
             store: store,
+            generator: MeetingSummaryGeneratorStub { _ in
+                throw MeetingSummaryError.outputRejected(.languageMismatch)
+            },
             storageLayout: layout
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in
-                MeetingSummaryGeneratorStub { _ in
-                    throw MeetingSummaryError.outputRejected(.languageMismatch)
-                }
-            }
-        }
         shouldFailUpdate = true
 
         do {
@@ -889,11 +913,9 @@ struct MeetingSummaryAppStateTests {
         let appState = try await configuredAppState(
             item: item,
             store: fixture.store,
+            generator: generator,
             storageLayout: fixture.storageLayout
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in generator }
-        }
 
         let task = Task { @MainActor in
             try await appState.generateMeetingSummary(id: item.id)
@@ -926,11 +948,9 @@ struct MeetingSummaryAppStateTests {
         let appState = try await configuredAppState(
             item: item,
             store: fixture.store,
+            generator: generator,
             storageLayout: fixture.storageLayout
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in generator }
-        }
 
         let task = Task { @MainActor in
             try await appState.generateMeetingSummary(id: item.id)
@@ -968,11 +988,9 @@ struct MeetingSummaryAppStateTests {
         let appState = try await configuredAppState(
             item: item,
             store: fixture.store,
+            generator: generator,
             storageLayout: fixture.storageLayout
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in generator }
-        }
 
         let task = Task { @MainActor in
             try await appState.generateMeetingSummary(id: item.id)
@@ -1035,6 +1053,7 @@ struct MeetingSummaryAppStateTests {
         let generator = MeetingSummaryControlledGenerator()
         let appState = await configuredPersistedAppState(
             store: store,
+            generator: generator,
             storageLayout: layout
         )
         await MainActor.run {
@@ -1050,7 +1069,6 @@ struct MeetingSummaryAppStateTests {
                 for: .meetingSummary
             )
             appState.disableMeetingSummary = false
-            AppState.meetingSummaryGeneratorFactory = { _ in generator }
             precondition(
                 appState.meetingSummaryAvailability(for: appState.pipelineHistory[0])
                     == .available,
@@ -1118,11 +1136,11 @@ struct MeetingSummaryAppStateTests {
         let generator = MeetingSummaryControlledGenerator()
         let appState = await configuredPersistedAppState(
             store: store,
+            generator: generator,
             storageLayout: layout
         )
         await MainActor.run {
             appState.pipelineHistory = [item]
-            configureSummaryGeneration(appState, generator: generator)
             appState.transcriptionAPIKey = "test-api-key"
             appState.transcriptionAPIURL = "https://provider.example/v1"
             appState.setNoteBrowserTranscriptionChoice(
@@ -1165,11 +1183,11 @@ struct MeetingSummaryAppStateTests {
         let layout = AppStateStorageLayout(rootDirectory: directoryURL)
         let appState = await configuredPersistedAppState(
             store: store,
+            generator: generator,
             storageLayout: layout
         )
         await MainActor.run {
             appState.pipelineHistory = [item]
-            configureSummaryGeneration(appState, generator: generator)
         }
 
         let summaryTask = Task { @MainActor in
@@ -1211,11 +1229,9 @@ struct MeetingSummaryAppStateTests {
         let generator = MeetingSummaryControlledGenerator()
         let appState = await configuredPersistedAppState(
             store: store,
+            generator: generator,
             storageLayout: layout
         )
-        await MainActor.run {
-            configureSummaryGeneration(appState, generator: generator)
-        }
 
         let summaryTask = Task { @MainActor in
             try await appState.generateMeetingSummary(id: item.id)
@@ -1242,11 +1258,9 @@ struct MeetingSummaryAppStateTests {
         let appState = try await configuredAppState(
             item: item,
             store: fixture.store,
+            generator: generator,
             storageLayout: fixture.storageLayout
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in generator }
-        }
 
         let task = Task { @MainActor in
             try await appState.generateMeetingSummary(id: item.id)
@@ -1283,11 +1297,9 @@ struct MeetingSummaryAppStateTests {
         let appState = try await configuredAppState(
             item: item,
             store: fixture.store,
+            generator: generator,
             storageLayout: fixture.storageLayout
         )
-        await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in generator }
-        }
 
         let task = Task { @MainActor in
             try await appState.generateMeetingSummary(id: item.id)
@@ -1328,12 +1340,10 @@ struct MeetingSummaryAppStateTests {
         let appState = try await configuredAppState(
             item: item,
             store: fixture.store,
+            generator: MeetingSummaryGeneratorStub { _ in generationResult },
             storageLayout: fixture.storageLayout
         )
         await MainActor.run {
-            AppState.meetingSummaryGeneratorFactory = { _ in
-                MeetingSummaryGeneratorStub { _ in generationResult }
-            }
             appState.updateTranscript(
                 id: item.id,
                 text: "회의에서 다음 주 화요일에 출시하기로 결정했습니다."
@@ -1449,22 +1459,39 @@ struct MeetingSummaryAppStateTests {
         return directoryURL
     }
 
+    private static func dependencies(
+        store: PipelineHistoryStore,
+        generator: (any MeetingSummaryGenerating)? = nil,
+        storageLayout: AppStateStorageLayout? = nil,
+        retryDependencies: @escaping @Sendable () -> CloudTranscriptionDependencies = {
+            .live
+        }
+    ) -> AppStateDependencies {
+        var dependencies = AppStateDependencies.live
+        if let storageLayout {
+            dependencies.storageLayout = storageLayout
+        }
+        dependencies.makePipelineHistoryStore = { _ in store }
+        if let generator {
+            dependencies.makeMeetingSummaryGenerator = { _ in generator }
+        }
+        dependencies.makeRetryCloudTranscriptionDependencies = retryDependencies
+        return dependencies
+    }
+
     private static func configuredPersistedAppState(
         store: PipelineHistoryStore,
-        storageLayout: AppStateStorageLayout
+        generator: (any MeetingSummaryGenerating)? = nil,
+        storageLayout: AppStateStorageLayout? = nil
     ) async -> AppState {
-        var dependencies = AppStateDependencies.live
-        dependencies.storageLayout = storageLayout
-        dependencies.makePipelineHistoryStore = { _ in store }
-        let configuredDependencies = dependencies
+        let configuredDependencies = dependencies(
+            store: store,
+            generator: generator,
+            storageLayout: storageLayout
+        )
         return await MainActor.run {
             let appState = AppState(dependencies: configuredDependencies)
-            appState.apiKey = "configured-key"
-            appState.selectAIProcessingBackendChoice(
-                .cloud(modelID: "summary/model"),
-                for: .meetingSummary
-            )
-            appState.disableMeetingSummary = false
+            configureSummaryGeneration(appState)
             return appState
         }
     }
@@ -1490,13 +1517,23 @@ struct MeetingSummaryAppStateTests {
     private static func configuredAppState(
         item: PipelineHistoryItem,
         store: PipelineHistoryStore,
-        storageLayout: AppStateStorageLayout
+        generator: (any MeetingSummaryGenerating)? = nil,
+        storageLayout: AppStateStorageLayout? = nil
     ) async throws -> AppState {
         _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
-        return await configuredPersistedAppState(
+        let appState = await configuredPersistedAppState(
             store: store,
+            generator: generator,
             storageLayout: storageLayout
         )
+        await MainActor.run {
+            precondition(
+                appState.meetingSummaryAvailability(for: appState.pipelineHistory[0])
+                    == .available,
+                "test requires an available summary source"
+            )
+        }
+        return appState
     }
 
     private struct ConfiguredAppStateFixture {
@@ -1511,22 +1548,13 @@ struct MeetingSummaryAppStateTests {
     }
 
     @MainActor
-    private static func configureSummaryGeneration(
-        _ appState: AppState,
-        generator: MeetingSummaryControlledGenerator
-    ) {
+    private static func configureSummaryGeneration(_ appState: AppState) {
         appState.apiKey = "configured-key"
         appState.selectAIProcessingBackendChoice(
             .cloud(modelID: "summary/model"),
             for: .meetingSummary
         )
         appState.disableMeetingSummary = false
-        AppState.meetingSummaryGeneratorFactory = { _ in generator }
-        precondition(
-            appState.meetingSummaryAvailability(for: appState.pipelineHistory[0])
-                == .available,
-            "test requires an available summary source"
-        )
     }
 
     private static func retryCloudDependencies(
@@ -1661,6 +1689,27 @@ struct MeetingSummaryAppStateTests {
         modelID: "summary/model",
         backendKind: .cloud
     )
+
+    private static func generationResult(
+        overview: String
+    ) -> MeetingSummaryGenerationResult {
+        MeetingSummaryGenerationResult(
+            draft: MeetingSummaryDraftContentV2(
+                overview: MeetingSummaryEvidenceText(
+                    text: overview,
+                    sourceQuotes: generationResult.draft.overview.sourceQuotes
+                ),
+                keyPoints: generationResult.draft.keyPoints,
+                decisions: generationResult.draft.decisions,
+                actionItems: generationResult.draft.actionItems,
+                openQuestions: generationResult.draft.openQuestions
+            ),
+            promptVersion: generationResult.promptVersion,
+            modelID: generationResult.modelID,
+            backendKind: generationResult.backendKind,
+            evidenceVerification: generationResult.evidenceVerification
+        )
+    }
 }
 
 private final class MeetingSummaryGeneratorStub:

--- a/docs/superpowers/specs/2026-08-12-app-state-history-summary-dependencies-design.md
+++ b/docs/superpowers/specs/2026-08-12-app-state-history-summary-dependencies-design.md
@@ -1,0 +1,431 @@
+# AppState History and Summary Dependencies Design
+
+**Date:** 2026-08-12
+**Status:** Approved for implementation planning
+**Stacked base:** `worktree-internal-logic-small-refactors` at `709bfa3`
+
+## Goal
+
+Replace the first high-value group of `AppState` global mutable test seams with instance-owned dependencies while preserving Quill’s storage layout, history recovery behavior, meeting-summary behavior, cloud retry behavior, and existing user-facing errors.
+
+This is the first large internal refactoring step, not a full decomposition of `AppState`. It establishes a stable instance dependency boundary that later workflow and storage refactors can build on.
+
+## Delivery Strategy
+
+This work uses two sequential pull requests.
+
+### PR A: Small internal refactors
+
+Branch: `worktree-internal-logic-small-refactors`
+
+PR A contains only:
+
+- linear oversized-token splitting,
+- centralized post-processing prompt-leak policy,
+- safe timestamp formatter reuse.
+
+It targets `main` and must merge first.
+
+### PR B: AppState history and summary dependencies
+
+Branch: `worktree-app-state-history-summary-dependencies`
+
+PR B is based on PR A’s current head while implementation proceeds. It is not opened until PR A is merged. After PR A merges, PR B’s own commits are rebased onto the latest `main` so its final diff contains only this dependency refactoring.
+
+If PR A is squash-merged, PR B must transplant only the commits after `709bfa3` onto the new `main`, rather than rebasing the entire stacked history naively.
+
+## Scope
+
+### Included
+
+- `AppStateStorageLayout`
+- `AppStateDependencies`
+- instance-owned storage layout and history-store construction
+- instance-owned meeting-summary generator construction
+- instance-owned cloud retry dependencies
+- archive and recovery store replacement through the instance factory
+- recording-journal and cloud-job paths derived from the instance layout
+- migration of History + Summary tests away from the selected global seams
+- minimum source-contract updates needed for the new instance path
+- full regression verification
+
+### Excluded
+
+- Local AI and Native Whisper installation dependencies
+- post-processing transport and audio-import cloud dependencies
+- Google Calendar dependencies
+- app termination and alert presentation dependencies
+- all remaining `AppState` static seams
+- general `AppState` file splitting
+- recording, import, retry, or summary workflow extraction
+- replacement of all source-string tests
+- credential storage changes
+- throwing storage APIs or new storage error types
+- file-format, path-name, retry-policy, or user-copy changes
+
+## Current Problem
+
+`AppState` currently owns mutable static closures for storage roots, history-store creation, meeting-summary generation, and cloud retry dependencies. Tests replace these values globally and restore them with `defer`.
+
+This creates several structural problems:
+
+- tests are order-dependent when restoration is missed or delayed,
+- tests that mutate the same seam cannot safely run in parallel,
+- multiple `AppState` instances cannot use different environments,
+- asynchronous work can observe a later test’s replacement closure,
+- future workflow extraction remains coupled to class-level service location,
+- tests contain extensive setup and restoration boilerplate.
+
+The production application creates one `AppState`, but the dependency model should not require global process state to express that fact.
+
+## Architecture
+
+### AppStateStorageLayout
+
+Create a focused value type:
+
+```swift
+struct AppStateStorageLayout: Sendable {
+    let rootDirectory: URL
+
+    var audioDirectory: URL { ... }
+    var transcriptDirectory: URL { ... }
+    var historyStoreURL: URL { ... }
+    var cloudTranscriptionJobsDirectory: URL { ... }
+    var cloudTranscriptionTemporaryDirectory: URL { ... }
+
+    static var live: AppStateStorageLayout { ... }
+}
+```
+
+The layout owns path relationships only. It does not become a general file service and does not change current directory-creation or error behavior.
+
+Required path compatibility:
+
+- root: `AppName.applicationSupportDirectory`
+- audio: `<root>/audio`
+- transcripts: `<root>/transcripts`
+- history: `<root>/PipelineHistory.sqlite`
+- cloud jobs: `<root>/cloud-transcription/jobs`
+- cloud temporary root: `<FileManager.default.temporaryDirectory>/<bundle-id>/cloud-transcription`
+
+The cloud temporary directory is included because the current cloud job store derives it alongside persistent job storage. The bundle identifier fallback remains `com.woosublee.quill`.
+
+The value is `Sendable` because immutable URLs are captured by detached storage work.
+
+### AppStateDependencies
+
+Create a value type:
+
+```swift
+struct AppStateDependencies {
+    var storageLayout: AppStateStorageLayout
+    var makePipelineHistoryStore: @Sendable (URL) -> PipelineHistoryStore
+    var makeMeetingSummaryGenerator:
+        @MainActor (AppState) -> any MeetingSummaryGenerating
+    var makeRetryCloudTranscriptionDependencies:
+        @Sendable () -> CloudTranscriptionDependencies
+
+    static var live: AppStateDependencies { ... }
+}
+```
+
+The properties are variables so tests can copy `.live` and replace only the seam they need. `AppStateDependencies.live` returns a fresh value and is not itself mutable global state.
+
+The live implementations preserve current behavior:
+
+- `makePipelineHistoryStore` calls `PipelineHistoryStore(storeURL:)`,
+- `makeMeetingSummaryGenerator` calls `appState.makeMeetingSummaryService()`,
+- retry cloud dependencies use `.live`,
+- storage uses `AppStateStorageLayout.live`.
+
+No generic dependency container, registry, protocol framework, or test-only reset mechanism is introduced.
+
+### AppState ownership
+
+`AppState` receives and retains dependencies:
+
+```swift
+private let dependencies: AppStateDependencies
+
+init(dependencies: AppStateDependencies = .live) {
+    self.dependencies = dependencies
+    ...
+}
+```
+
+The default keeps `AppDelegate` and all production call sites source-compatible:
+
+```swift
+let appState = AppState()
+```
+
+After initialization, an `AppState` never reads a selected class-level dependency seam. Its behavior is determined by the value supplied to that instance.
+
+## Removed Static Seams
+
+Remove these mutable static properties from `AppState`:
+
+- `meetingSummaryGeneratorFactory`
+- `storageRootProvider`
+- `pipelineHistoryStoreFactory`
+- `pipelineHistoryStoreAtURLFactory`
+- `retryCloudTranscriptionDependenciesFactory`
+
+Remove or replace `makeDefaultPipelineHistoryStore()` once no production or test caller needs the static helper.
+
+Do not add compatibility shims with the same mutable global behavior. A temporary static bridge would leave the concurrency and test-isolation problem intact.
+
+## Storage Data Flow
+
+### Initialization
+
+1. `AppState` stores the supplied dependencies.
+2. It obtains `storageLayout` from that value.
+3. Existing directory-creation behavior prepares the root, audio, and transcript paths.
+4. It creates the initial history store with:
+
+```swift
+let pipelineHistoryStore = dependencies.makePipelineHistoryStore(
+    storageLayout.historyStoreURL
+)
+```
+
+5. Recording journal and cloud transcription job stores use paths from the same layout.
+6. Startup history verification, recording-journal recovery, trim, sidecar reconciliation, and orphan cleanup continue in the existing order.
+
+No persistence operation is reordered merely to introduce dependencies.
+
+### Runtime file access
+
+All instance operations that save, load, inspect, or delete note assets derive their URLs from the retained layout. This includes:
+
+- transcript save/load/delete,
+- audio save/delete and size lookup,
+- Note Browser stored-audio lookup,
+- retry snapshot construction,
+- recording and cloud recovery paths,
+- MCP meeting-source access,
+- archive/recovery settings paths.
+
+Static helper functions that execute off the main actor accept the layout or an already-derived directory explicitly. They must not fall back to a process-wide root provider.
+
+### Archive and recovery
+
+Archive and recovery are the most sensitive history-store replacement paths.
+
+Before detached archive work begins, capture the instance factory and storage root:
+
+```swift
+let storageRoot = dependencies.storageLayout.rootDirectory
+let makeStore = dependencies.makePipelineHistoryStore
+```
+
+`HistoryArchiveTransition` receives that captured factory as today. Completion and recovery paths create the new active store through the same instance dependency:
+
+```swift
+let activeStore = dependencies.makePipelineHistoryStore(
+    dependencies.storageLayout.historyStoreURL
+)
+```
+
+After a verified fresh history store is installed, recording journal and cloud job stores are recreated from the same retained storage layout. Existing availability, durability, readability, transition guards, and UI state resets remain unchanged.
+
+## Meeting Summary Data Flow
+
+Meeting-summary generation uses the retained dependency:
+
+```swift
+let generator = dependencies.makeMeetingSummaryGenerator(self)
+let result = try await generator.generate(...)
+```
+
+The existing Main Actor isolation is preserved. Generator construction remains scoped to a generation attempt, matching current behavior.
+
+Different `AppState` instances may therefore use different summary generators without modifying global state. Existing source fingerprinting, in-flight invalidation, persistence, warning records, pending reveal state, and error propagation remain unchanged.
+
+## Cloud Retry Data Flow
+
+Manual and resumed cloud retry execution use:
+
+```swift
+let cloudDependencies =
+    dependencies.makeRetryCloudTranscriptionDependencies()
+```
+
+The factory is called when a retry execution is prepared, as in the current behavior. The difference is that the selected factory belongs to the `AppState` instance and cannot be changed by another test after construction.
+
+Audio-import cloud dependencies remain on their existing static seam in this PR because import behavior is outside the selected History + Summary boundary.
+
+## Test Migration
+
+### Test dependency construction
+
+Tests use copy-and-override setup:
+
+```swift
+var dependencies = AppStateDependencies.live
+dependencies.storageLayout = AppStateStorageLayout(
+    rootDirectory: temporaryRoot
+)
+dependencies.makePipelineHistoryStore = { _ in store }
+dependencies.makeMeetingSummaryGenerator = { _ in generator }
+
+let appState = AppState(dependencies: dependencies)
+```
+
+No test mutates the selected `AppState` static seams after this migration.
+
+### AppStateTestStorage
+
+Replace the current global storage overrides with an environment passed to the operation:
+
+```swift
+struct AppStateTestEnvironment {
+    let rootDirectory: URL
+    let storageLayout: AppStateStorageLayout
+    let dependencies: AppStateDependencies
+}
+```
+
+```swift
+@MainActor
+static func withIsolatedStorage<T>(
+    _ operation: (AppStateTestEnvironment) async throws -> T
+) async throws -> T
+```
+
+The helper:
+
+1. creates a unique temporary root,
+2. builds an `AppStateStorageLayout`,
+3. builds dependencies using that layout,
+4. temporarily redirects `AppSettingsStorage.storageDirectoryOverride`,
+5. passes the environment to the test,
+6. restores the settings override and deletes the temporary root.
+
+`AppSettingsStorage.storageDirectoryOverride` remains temporarily global because credential storage is explicitly outside this PR. It is the only storage test global retained by this helper.
+
+### MeetingSummaryAppStateTests
+
+Migrate generator and history-store setup to dependencies supplied during `AppState` creation.
+
+Tests that need a controlled generator create the generator before the `AppState`, then pass it through `makeMeetingSummaryGenerator`. Helpers such as `configuredAppState` and `configuredPersistedAppState` accept or construct dependencies rather than assigning class properties.
+
+The suite’s outer save/restore block for the selected static seams is removed.
+
+### AppStateStorageSafetyTests
+
+Pass unavailable, fallback, archived, and replacement stores through the dependencies for each `AppState` instance. Use environment storage-layout paths rather than `AppState.audioStorageDirectory()` and related class helpers.
+
+Archive tests verify that the instance factory creates and installs the replacement store.
+
+### AppStateTranscriptionConfigurationTests
+
+Only history/retry cases using the selected seams migrate in this PR. Tests using audio-import cloud dependencies or post-processing transport continue to use their existing seams.
+
+For migrated retry cases:
+
+- history store comes from instance dependencies,
+- retry cloud dependencies come from instance dependencies,
+- audio paths come from the test environment’s layout.
+
+### Source-contract tests
+
+Do not broadly replace source-string tests in this PR.
+
+Update `AppStateHistoryProtectionSourceTests` only where it asserts the removed store factory name. Its order and guard assertions continue to require that:
+
+- archive work captures the instance store factory,
+- replacement stores are created through `dependencies.makePipelineHistoryStore`,
+- snapshot-only recovery failure does not replace the active store.
+
+Behavior-test conversion of these source contracts remains a separate follow-up project.
+
+## Error Handling
+
+This refactoring does not create a new error model.
+
+Preserve:
+
+- directory preparation using existing `try?` behavior,
+- `PipelineHistoryStore` availability and durability states,
+- archive/recovery verification and fallback behavior,
+- current history-unavailable messages,
+- meeting-summary issue classification and persistence,
+- cloud retry issue classification and fallback,
+- current file cleanup semantics.
+
+The refactoring changes dependency ownership, not error interpretation.
+
+Throwing storage-layout preparation, typed credential failures, and `NoteAssetStore` belong to later PRs.
+
+## Concurrency and Lifetime
+
+- Each `AppState` stores an immutable dependency value.
+- Dependency factories captured by `Task.detached` must be `@Sendable`.
+- Tests configure dependencies before creating the `AppState`; they do not mutate captured shared variables unless their existing harness explicitly synchronizes access.
+- Meeting-summary generator creation remains Main Actor-isolated.
+- A factory must not capture an `AppState` strongly unless the current call path already requires it; the live summary factory receives the instance as an argument instead.
+- No process-global dependency reset is needed.
+
+## Verification
+
+### New behavior tests
+
+Add focused tests proving:
+
+1. two `AppState` instances with different layouts load different history stores,
+2. two instances use their own meeting-summary generators,
+3. retry dependencies are isolated per instance,
+4. archive replacement uses the originating instance’s history-store factory,
+5. default `AppState()` resolves the existing live storage layout,
+6. changing a test dependency value after one instance is created does not alter that instance.
+
+### Static seam removal checks
+
+The selected identifiers must no longer appear as mutable `AppState` properties:
+
+- `meetingSummaryGeneratorFactory`
+- `storageRootProvider`
+- `pipelineHistoryStoreFactory`
+- `pipelineHistoryStoreAtURLFactory`
+- `retryCloudTranscriptionDependenciesFactory`
+
+Tests must not save, assign, or restore those class properties.
+
+### Test suites
+
+Run at minimum:
+
+- `MeetingSummaryAppStateTests`
+- `AppStateStorageSafetyTests`
+- `AppStateTranscriptionConfigurationTests`
+- `AppStateHistoryProtectionSourceTests`
+- grouped app-state runner
+- `make check-test-wiring`
+- `make test`
+
+### Completion criteria
+
+The work is complete when:
+
+- all listed tests pass,
+- full `make test` passes,
+- production `AppState()` remains source-compatible,
+- persisted paths and file names remain identical,
+- archive/recovery ordering and guards remain intact,
+- the five selected static mutable seams are gone,
+- History + Summary tests no longer mutate those seams,
+- no unrelated static seam or workflow is refactored,
+- PR B contains only commits after the PR A base when finally opened.
+
+## Follow-up Sequence
+
+After PR B, proceed with separate projects rather than expanding this PR:
+
+1. convert source-string history tests to behavioral collaborators,
+2. introduce throwing storage and credential boundaries,
+3. migrate Local AI and model installer dependencies,
+4. extract history, retry, and summary workflows from `AppState`,
+5. split the remaining `AppState` file by stable responsibility.


### PR DESCRIPTION
## Summary
- introduce `AppStateStorageLayout` and `AppStateDependencies` as instance-owned values
- move history storage, note assets, archive/recovery replacement, and external consumers to the originating AppState layout
- inject meeting-summary generators and cloud retry dependencies per AppState instance
- replace process-global History + Summary test overrides with isolated dependency environments
- verify archive factory ownership and remove the selected static service-locator seams

## Compatibility
- keeps `AppState()` source-compatible
- preserves existing storage paths, file names, archive/recovery guards, retry behavior, summary persistence, and user-facing errors
- leaves unrelated Local AI, audio-import, post-processing transport, Calendar, and alert seams unchanged

## Validation
- selected seam and direct static storage-path scans: 0 matches
- `make check-test-wiring`
- `make test`
- `make all CODESIGN_IDENTITY=Quill`

This is PR B of the sequential rollout and is based on the merged PR #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 앱 저장소와 파일 경로 관리가 안정화되어 오디오·전사 파일을 보다 일관되게 저장하고 복구합니다.
  * 회의 요약 생성, 클라우드 전사 재시도, 기록 보관 및 복구 흐름의 안정성이 향상되었습니다.
  * Obsidian 내보내기와 테스트 케이스 내보내기가 올바른 저장 위치를 사용합니다.

* **테스트**
  * 저장소 격리, 파일 정리, 복구, 재시도 및 회의 요약 관련 검증을 강화했습니다.
  * 앱 상태 의존성과 저장소 경로에 대한 자동 검증을 추가했습니다.

* **문서**
  * 앱 상태 저장소 및 의존성 관리 설계 문서를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->