### PR TITLE
Replace history source-contract tests with behavior tests

### DIFF
--- a/Tests/AppStateHistoryProtectionSourceTests.swift
+++ b/Tests/AppStateHistoryProtectionSourceTests.swift
@@ -39,22 +39,22 @@ struct AppStateHistoryProtectionSourceTests {
             )
         }
 
-        // The remaining archive-guard conditions beyond `pendingAudioImportJobIDs`
-        // (already covered behaviorally by
-        // AppStateStorageSafetyTests.verifiesArchiveCompletionAllowsImmediateAssetSavesWithoutRestart's
-        // preconditions and by the isHistoryUnavailable precondition
-        // `archiveOldHistoryAndStartFresh` itself requires) can only occur while
-        // history is simultaneously unavailable, which is also the precondition
-        // for calling archive at all. Live recording, retry, and meeting-summary
-        // generation cannot be driven into that exact combined state through the
-        // public API without a real audio pipeline, so this remains a narrow
-        // existence check rather than a simulated race.
+        // Every archive-guard condition can only actually block anything while
+        // history is simultaneously unavailable, since `archiveOldHistoryAndStartFresh`
+        // itself requires `isHistoryUnavailable == true` as its own precondition
+        // — and `requireAvailableHistoryForMutation()` blocks the public entry
+        // points (`importAudioFile`, recording start, retry, meeting-summary
+        // generation) from ever running while history is unavailable. That
+        // combination cannot be constructed through the public API without a
+        // real audio/recording/summary pipeline, so these guards remain a
+        // narrow existence check rather than a simulated race.
         let archiveGuardRange = try source.range(
             from: "func archiveOldHistoryAndStartFresh(",
             to: "@MainActor\n    func clearPipelineHistory()"
         )
         let archiveGuardBody = String(source[archiveGuardRange])
         for requiredGuard in [
+            "pendingAudioImportJobIDs.isEmpty",
             "!cloudTranscriptionHistoryCoordinator.hasActiveWork",
             "meetingSummaryGeneratingNoteIDs.isEmpty",
             "pendingRecordingJournalFinalizationCount == 0",
@@ -65,6 +65,11 @@ struct AppStateHistoryProtectionSourceTests {
                 "archive continues to wait for \(requiredGuard) before moving history files"
             )
         }
+        try expect(
+            source.contains("pendingAudioImportJobIDs.insert(jobID)")
+                && source.contains("pendingAudioImportJobIDs.remove(jobID)"),
+            "audio import is tracked before its detached audio copy can touch history storage"
+        )
 
         // Recording start and microphone-permission resumption recheck history
         // availability after every asynchronous suspension point as defense in
@@ -78,6 +83,12 @@ struct AppStateHistoryProtectionSourceTests {
         )
         let recordingStart = String(source[recordingStartRange])
         try expect(
+            source.contains("private var pendingRecordingStartCount = 0")
+                && recordingStart.contains("pendingRecordingStartCount += 1")
+                && recordingStart.contains("defer { self.pendingRecordingStartCount -= 1 }"),
+            "an awaited recording start tracks itself as pending via defer, so an early throw or return still decrements the count"
+        )
+        try expect(
             recordingStart.components(separatedBy: "requireAvailableHistoryForMutation()").count >= 3,
             "an awaited recording start rechecks archive protection before creating writers"
         )
@@ -86,6 +97,13 @@ struct AppStateHistoryProtectionSourceTests {
             to: "private func applyAudioInterruptionIfNeeded()"
         )
         let microphonePermission = String(source[microphonePermissionRange])
+        try expect(
+            microphonePermission.contains("pendingRecordingStartCount += 1")
+                && microphonePermission.contains(
+                    "defer { strongSelf.pendingRecordingStartCount -= 1 }"
+                ),
+            "microphone permission resumption tracks itself as pending via defer, so an early throw or return still decrements the count"
+        )
         try expect(
             microphonePermission.components(
                 separatedBy: "strongSelf.requireAvailableHistoryForMutation()"

--- a/Tests/AppStateHistoryProtectionSourceTests.swift
+++ b/Tests/AppStateHistoryProtectionSourceTests.swift
@@ -1,5 +1,18 @@
 import Foundation
 
+/// Most history-safety guarantees this suite once checked via exact source text
+/// now have behavioral coverage in `AppStateStorageSafetyTests` (startup gating,
+/// archive/recovery ordering, mutation guards, and snapshot-only failure
+/// isolation). What remains here is limited to:
+///
+/// 1. a static scan proving removed process-global dependency seams do not
+///    reappear, and
+/// 2. a small number of defense-in-depth invariants that cannot be exercised
+///    through the public `AppState` API without simulating disk failures,
+///    permission-callback races, or wall-clock timing that would make the
+///    test itself the primary source of flakiness. Each is documented with
+///    the specific reason it remains a source check rather than a behavior
+///    test.
 struct AppStateHistoryProtectionSourceTests {
     static func main() throws {
         let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
@@ -26,157 +39,47 @@ struct AppStateHistoryProtectionSourceTests {
             )
         }
 
-        try expect(
-            source.contains("if initialHistoryArchiveSafety == .normal,")
-                && source.contains("pipelineHistoryStore.availability == .ready"),
-            "startup work is gated by history availability and archive safety"
-        )
-        let startupRange = try source.range(
-            from: "var savedHistory: [PipelineHistoryItem] = []",
-            to: "let storedInputID = AudioInputDevice.normalized("
-        )
-        let startup = String(source[startupRange])
-        try expectOrdered(
-            [
-                "if pipelineHistoryStore.availability == .ready {",
-                "pipelineHistoryStore.verifyHistoryReadable()",
-                "if initialHistoryArchiveSafety == .normal,",
-                "pipelineHistoryStore.availability == .ready {",
-                "recoverRecordingJournalsBeforeHistoryLoad(",
-                "cloudTranscriptionJobStore.reconcile(",
-                "sweepOrphanStoredFiles(",
-                "} else {\n            print(\"Skipping history startup work because persistent history is unavailable.\")"
-            ],
-            in: startup,
-            label: "ready startup work remains grouped behind availability and archive-safety gates"
-        )
-        let initialHistoryRead = try startup.range(
-            of: "pipelineHistoryStore.verifyHistoryReadable()"
-        ).unwrap("history readability probe")
-        let journalRecovery = try startup.range(
-            of: "recoverRecordingJournalsBeforeHistoryLoad("
-        ).unwrap("journal recovery")
-        try expect(
-            initialHistoryRead.lowerBound < journalRecovery.lowerBound,
-            "history readability is verified before startup recovery work"
-        )
-
-        try expect(
-            source.contains("@Published private(set) var isHistoryUnavailable = false")
-                && source.contains("private func synchronizeHistoryPersistenceState()")
-                && source.contains("let unavailable = pipelineHistoryStore.availability == .unavailable")
-                && source.contains("isHistoryUnavailable = unavailable")
-                && source.contains("historyArchiveSafety == .unresolvedArchive")
-                && source.contains("historyPersistenceWarning = warning"),
-            "history transitions publish protection and archived-history UI state"
-        )
-        try expect(
-            source.contains("private func loadPipelineHistory() -> [PipelineHistoryItem]")
-                && source.contains("synchronizeHistoryPersistenceState()"),
-            "runtime history reads synchronize the published protection state"
-        )
-        try expect(
-            source.contains("@Published private(set) var historyRecoverySnapshots")
-                && source.contains("@Published private(set) var isHistoryRecoveryOperationInProgress")
-                && source.contains("guard !isHistoryRecoveryOperationInProgress else")
-                && source.contains("func importHistoryRecoverySnapshot(id: UUID) -> Bool"),
-            "recovery import publishes state and blocks concurrent history mutations"
-        )
-        try expect(
-            source.contains("@Published private(set) var historyRecoveryInspectionSnapshotID")
-                && source.contains("func beginHistoryRecoveryInspection()")
-                && source.contains("func retryHistoryRecoveryInspection(id: UUID) -> Bool")
-                && source.contains("historyRecoveryInspectionRevision")
-                && !source.contains(
-                    "isHistoryRecoveryOperationInProgress = true\n        historyRecoveryOperationMessage = localizedCatalogString(\"Checking recovery contents…\")"
-                ),
-            "read-only recovery inspection has a separate lifecycle from active-history recovery writes"
-        )
-        let archivedStartupRange = try source.range(
-            from: "} else if initialHistoryArchiveSafety == .unresolvedArchive,",
-            to: "        } else {\n            print(\"Skipping history startup work because persistent history is unavailable.\")"
-        )
-        let archivedStartup = String(source[archivedStartupRange])
-        try expect(
-            archivedStartup.contains("recoverRecordingJournalsBeforeHistoryLoad(")
-                && archivedStartup.contains("markInterruptedRecoveryPlaceholders(")
-                && archivedStartup.contains("LegacyNoteTitleMigration.migrate(")
-                && archivedStartup.contains("cloudTranscriptionJobStore.reconcile(")
-                && !archivedStartup.contains("pipelineHistoryStore.trim(")
-                && !archivedStartup.contains("bootstrapAssetReferenceSnapshot(")
-                && !archivedStartup.contains("sweepOrphanStoredFiles("),
-            "published archives recover only the active generation while preserving old-data cleanup safeguards"
-        )
-        try expect(
-            source.contains("func archiveOldHistoryAndStartFresh(")
-                && source.contains("postAction: HistoryArchivePostAction = .startFresh")
-                && source.contains("try pipelineHistoryStore.detachForHistoryArchive()")
-                && source.contains("HistoryArchiveTransition(")
-                && source.contains("Task.detached(priority: .userInitiated)")
-                && source.contains("completeHistoryArchiveTransition(")
-                && source.contains("let activeStore = dependencies.makePipelineHistoryStore(")
-                && source.contains("historyArchiveSafety = HistoryArchiveTransition.inspect("),
-            "explicit archive transitions in the background and installs only a verified fresh history store"
-        )
-        let archiveRange = try source.range(
+        // The remaining archive-guard conditions beyond `pendingAudioImportJobIDs`
+        // (already covered behaviorally by
+        // AppStateStorageSafetyTests.verifiesArchiveCompletionAllowsImmediateAssetSavesWithoutRestart's
+        // preconditions and by the isHistoryUnavailable precondition
+        // `archiveOldHistoryAndStartFresh` itself requires) can only occur while
+        // history is simultaneously unavailable, which is also the precondition
+        // for calling archive at all. Live recording, retry, and meeting-summary
+        // generation cannot be driven into that exact combined state through the
+        // public API without a real audio pipeline, so this remains a narrow
+        // existence check rather than a simulated race.
+        let archiveGuardRange = try source.range(
             from: "func archiveOldHistoryAndStartFresh(",
             to: "@MainActor\n    func clearPipelineHistory()"
         )
-        let archiveBody = String(source[archiveRange])
-        try expect(
-            archiveBody.contains("let storageRoot = dependencies.storageLayout.rootDirectory")
-                && archiveBody.contains("let makeStore = dependencies.makePipelineHistoryStore"),
-            "archive captures the originating storage layout and history-store factory"
-        )
-        let archiveCompletionRange = try source.range(
-            from: "private func completeHistoryArchiveTransition(",
-            to: "private func completeHistoryRecoveryInspection("
-        )
-        let archiveCompletion = String(source[archiveCompletionRange])
-        try expectOrdered(
-            [
-                "pipelineHistoryStore = activeStore",
-                "let storageLayout = dependencies.storageLayout",
-                "_ = Self.preparedDirectory(storageLayout.rootDirectory)",
-                "let audioDirectory = Self.preparedDirectory(storageLayout.audioDirectory)",
-                "_ = Self.preparedDirectory(storageLayout.transcriptDirectory)",
-                "recordingJournalStore = RecordingJournalStore(",
-                "audioDirectory: audioDirectory",
-                "cloudTranscriptionJobStore = CloudTranscriptionJobStore("
-            ],
-            in: archiveCompletion,
-            label: "verified archive completion recreates active asset directories before runtime stores"
-        )
+        let archiveGuardBody = String(source[archiveGuardRange])
         for requiredGuard in [
-            "historyArchiveSafety == .normal",
-            "pendingAudioImportJobIDs.isEmpty",
             "!cloudTranscriptionHistoryCoordinator.hasActiveWork",
             "meetingSummaryGeneratingNoteIDs.isEmpty",
             "pendingRecordingJournalFinalizationCount == 0",
             "pendingRecordingStartCount == 0"
         ] {
             try expect(
-                archiveBody.contains(requiredGuard),
-                "archive waits for \(requiredGuard) before moving history files"
+                archiveGuardBody.contains(requiredGuard),
+                "archive continues to wait for \(requiredGuard) before moving history files"
             )
         }
-        try expect(
-            source.contains("pendingAudioImportJobIDs.insert(jobID)")
-                && source.contains("pendingAudioImportJobIDs.remove(jobID)"),
-            "audio import is tracked before its detached audio copy can touch history storage"
-        )
+
+        // Recording start and microphone-permission resumption recheck history
+        // availability after every asynchronous suspension point as defense in
+        // depth against history becoming unavailable while a start is in
+        // flight. Simulating that exact race (flip availability mid-permission
+        // callback) is disproportionate to this suite; the occurrence count is
+        // the cheapest faithful proxy for "the recheck was not deleted."
         let recordingStartRange = try source.range(
             from: "private func startRecording(triggerMode: RecordingTriggerMode",
             to: "/// Whether the configured recording flow will actually exercise Accessibility."
         )
         let recordingStart = String(source[recordingStartRange])
         try expect(
-            source.contains("private var pendingRecordingStartCount = 0")
-                && recordingStart.contains("pendingRecordingStartCount += 1")
-                && recordingStart.contains("defer { self.pendingRecordingStartCount -= 1 }")
-                && recordingStart.components(separatedBy: "requireAvailableHistoryForMutation()").count >= 3
-                && recordingStart.contains("beginRecording("),
-            "an awaited recording start remains pending and rechecks archive protection before creating writers"
+            recordingStart.components(separatedBy: "requireAvailableHistoryForMutation()").count >= 3,
+            "an awaited recording start rechecks archive protection before creating writers"
         )
         let microphonePermissionRange = try source.range(
             from: "private func ensureMicrophoneAccess() -> Bool",
@@ -184,15 +87,18 @@ struct AppStateHistoryProtectionSourceTests {
         )
         let microphonePermission = String(source[microphonePermissionRange])
         try expect(
-            microphonePermission.contains("pendingRecordingStartCount += 1")
-                && microphonePermission.contains("defer { strongSelf.pendingRecordingStartCount -= 1 }")
-                && microphonePermission.components(
-                    separatedBy: "strongSelf.requireAvailableHistoryForMutation()"
-                ).count >= 3
-                && microphonePermission.contains("strongSelf.beginRecording("),
-            "microphone permission resumption remains pending and rechecks archive protection before creating writers"
+            microphonePermission.components(
+                separatedBy: "strongSelf.requireAvailableHistoryForMutation()"
+            ).count >= 3,
+            "microphone permission resumption rechecks archive protection before creating writers"
         )
 
+        // A failed history update must not delete assets it never touched, and
+        // recovery import must remain the sole writer to active history while
+        // it runs. Forcing a genuine mid-write Core Data failure to observe
+        // this behaviorally would require corrupting the store at an exact
+        // instant inside a transaction, which is not reproducible through the
+        // public API.
         let persistenceRange = try source.range(
             from: "private func recordPipelineHistoryEntry(",
             to: "private func startRealtimeStreamingIfEnabled()"
@@ -204,6 +110,11 @@ struct AppStateHistoryProtectionSourceTests {
             "a failed update preserves assets and cannot write during recovery import"
         )
 
+        // Deferred orphan cleanup must use the reference snapshot's startup
+        // timestamp, not the time it happens to run, so a file created after
+        // startup is never mistaken for an old orphan. Verifying this
+        // behaviorally requires controlling the wall clock inside a detached
+        // Task, which the harness does not support.
         let orphanSweepRange = try source.range(
             from: "if referenceTrust.permitsStartupReferenceCleanup {\n                    let sweepReferenceTrust",
             to: "            } else {\n                print(\"Skipping history startup work because persistent history is unavailable.\")"
@@ -215,26 +126,11 @@ struct AppStateHistoryProtectionSourceTests {
             "delayed orphan cleanup uses the startup reference snapshot time"
         )
 
-        for functionMarker in [
-            "func clearPipelineHistory()",
-            "func deleteHistoryEntry(id: UUID)",
-            "func updateHistoryItemTitle(id: UUID, title: String)",
-            "func retryTranscription(item: PipelineHistoryItem)",
-            "func importAudioFile(_ fileURL: URL, choice: TranscriptionBackendChoice)",
-            "func startRecordingFromMCP() -> Bool",
-            "private func startRecording(triggerMode: RecordingTriggerMode",
-            "func setMeetingSummaryActionCompleted(",
-            "func deleteMeetingSummary(noteID: UUID)",
-            "func updateTranscript(id: UUID, text: String)"
-        ] {
-            let range = try source.range(of: functionMarker).unwrap(functionMarker)
-            let suffix = String(source[range.lowerBound...])
-            try expect(
-                suffix.prefix(360).contains("requireAvailableHistoryForMutation()"),
-                "\(functionMarker) checks protected history before side effects"
-            )
-        }
-
+        // Recovery inspection invalidation must clear stale scheduling state
+        // before any rescheduling can occur, and must only reschedule while
+        // Settings is actually showing the recovery tab. Reproducing this
+        // through the public API requires driving Settings tab navigation
+        // alongside recovery timing, which is out of scope for this suite.
         let invalidationRange = try source.range(
             from: "func invalidateHistoryRecoveryInspectionResults()",
             to: "func importHistoryRecoverySnapshot(id: UUID) -> Bool"
@@ -251,6 +147,11 @@ struct AppStateHistoryProtectionSourceTests {
             label: "recovery inspection invalidation clears stale scheduling state before it can return"
         )
 
+        // A new recovery import must clear any prior partial-result feedback
+        // before it starts, so a stale result from an earlier import cannot be
+        // shown alongside a new one. This requires observing state exactly at
+        // the instant between synchronous clearing and the detached import
+        // task starting, which is not reliably observable from outside.
         let importRange = try source.range(
             from: "func importHistoryRecoverySnapshot(id: UUID) -> Bool",
             to: "func cancelHistoryRecoveryScheduledDeletion(id: UUID) -> Bool"
@@ -263,27 +164,6 @@ struct AppStateHistoryProtectionSourceTests {
             ],
             in: recoveryImport,
             label: "a new recovery import clears prior partial feedback before detaching history"
-        )
-
-        let snapshotOperationRange = try source.range(
-            from: "private func runHistoryRecoverySnapshotOperation(",
-            to: "private func completeHistoryRecoverySnapshotOperation(at storageRoot: URL)"
-        )
-        let snapshotOperation = String(source[snapshotOperationRange])
-        try expect(
-            snapshotOperation.contains("completeHistoryRecoverySnapshotOperationFailure(")
-                && !snapshotOperation.contains("completeHistoryRecoveryOperationFailure("),
-            "snapshot-only recovery failures do not reuse active-store replacement"
-        )
-        let snapshotFailureRange = try source.range(
-            from: "private func completeHistoryRecoverySnapshotOperationFailure(at storageRoot: URL)",
-            to: "@discardableResult\n    private static func preparedDirectory("
-        )
-        let snapshotFailure = String(source[snapshotFailureRange])
-        try expect(
-            !snapshotFailure.contains("dependencies.makePipelineHistoryStore")
-                && !snapshotFailure.contains("pipelineHistoryStore ="),
-            "snapshot-only recovery failure keeps the active Core Data store attached"
         )
 
         print("AppStateHistoryProtectionSourceTests passed")

--- a/Tests/AppStateStorageSafetyTests.swift
+++ b/Tests/AppStateStorageSafetyTests.swift
@@ -18,6 +18,7 @@ struct AppStateStorageSafetyTests {
         try await verifiesTrustedHistorySweepsOrphans()
         try await verifiesArchiveCompletionAllowsImmediateAssetSavesWithoutRestart()
         try await verifiesSnapshotOnlyRecoveryFailureLeavesActiveStoreUntouched()
+        try await verifiesRecoveryOperationInProgressBlocksMutation()
         try await AppStateTestStorage.withIsolatedStorage { environment in
             try prepareStorageDirectories(for: environment.storageLayout)
             let fallbackAudioURL = try await verifiesFallbackHistoryDoesNotSweepStoredAudio(
@@ -239,6 +240,31 @@ struct AppStateStorageSafetyTests {
                     : PipelineHistoryStore(storeURL: url)
             }
 
+            let actionID = UUID()
+            let summary = MeetingSummaryEnvelope(
+                schemaVersion: MeetingSummaryEnvelope.currentSchemaVersion,
+                promptVersion: 1,
+                generatedAt: Date(),
+                sourceFingerprint: String(repeating: "a", count: 64),
+                modelID: "summary/model",
+                backendKind: .cloud,
+                content: MeetingSummaryContent(
+                    overview: MeetingSummaryEvidenceText(text: "Overview", sourceQuotes: []),
+                    keyPoints: [],
+                    decisions: [],
+                    actionItems: [
+                        MeetingSummaryActionItem(
+                            id: actionID,
+                            task: "Follow up",
+                            owner: nil,
+                            dueDate: nil,
+                            sourceQuote: nil,
+                            isCompleted: false
+                        )
+                    ],
+                    openQuestions: []
+                )
+            )
             let item = PipelineHistoryItem(
                 timestamp: Date(),
                 rawTranscript: "original transcript",
@@ -252,14 +278,14 @@ struct AppStateStorageSafetyTests {
                 customVocabulary: "",
                 audioFileName: audioURL.lastPathComponent,
                 transcriptFileName: transcriptURL.lastPathComponent
-            )
+            ).withMeetingSummary(summary)
             let configuredDependencies = dependencies
             let appState = await MainActor.run {
                 AppState(dependencies: configuredDependencies)
             }
             var setActionCompletedThrew = false
             var deleteMeetingSummaryThrew = false
-            await MainActor.run {
+            let mcpRecordingStarted = await MainActor.run { () -> Bool in
                 appState.pipelineHistory = [item]
                 appState.clearPipelineHistory()
                 appState.updateTranscript(id: item.id, text: "replacement transcript")
@@ -272,11 +298,14 @@ struct AppStateStorageSafetyTests {
                     URL(fileURLWithPath: "/nonexistent/protected-import.wav"),
                     choice: .apiStandard(modelID: "whisper-large-v3")
                 )
-                _ = appState.startRecordingFromMCP()
+                let recordingStarted = appState.startRecordingFromMCP()
                 do {
+                    // The item carries a real meeting summary with a matching
+                    // action so a thrown error here is caused by history
+                    // protection, not by the note lacking a summary to edit.
                     try appState.setMeetingSummaryActionCompleted(
                         noteID: item.id,
-                        actionID: UUID(),
+                        actionID: actionID,
                         isCompleted: true
                     )
                 } catch {
@@ -287,9 +316,14 @@ struct AppStateStorageSafetyTests {
                 } catch {
                     deleteMeetingSummaryThrew = true
                 }
+                return recordingStarted
             }
 
             try expect(appState.isHistoryUnavailable, "history load failure enters protection mode")
+            try expect(
+                !mcpRecordingStarted,
+                "protected history rejects an MCP-triggered recording start"
+            )
             try expect(
                 appState.pipelineHistory.map(\.id) == [item.id],
                 "protected history mutations do not alter in-memory note ownership"
@@ -306,6 +340,10 @@ struct AppStateStorageSafetyTests {
             try expect(!appState.isRecording, "protected history cannot start recording")
             try expect(setActionCompletedThrew, "protected history rejects meeting summary action updates")
             try expect(deleteMeetingSummaryThrew, "protected history rejects meeting summary deletion")
+            try expect(
+                appState.pipelineHistory.first?.meetingSummary?.content.actionItems.first?.isCompleted == false,
+                "protected history keeps the existing meeting summary action state unchanged"
+            )
         }
     }
 
@@ -683,6 +721,13 @@ struct AppStateStorageSafetyTests {
                 appState.historyPersistenceWarning?.code == .historyPersistenceUnavailable,
                 "unresolved archive transaction shows the protected-history warning"
             )
+            let archiveAccepted = await MainActor.run {
+                appState.archiveOldHistoryAndStartFresh()
+            }
+            try expect(
+                !archiveAccepted,
+                "an unresolved interrupted transaction rejects the archive-and-start-fresh recovery action"
+            )
         }
     }
 
@@ -844,6 +889,119 @@ struct AppStateStorageSafetyTests {
             try expect(
                 FileManager.default.fileExists(atPath: importedAudioURL.path),
                 "archive completion recreates the active audio directory so imports succeed immediately"
+            )
+
+            let transcriptFileName = "restart-free-transcript-\(UUID().uuidString).txt"
+            await MainActor.run {
+                guard let originalItem = appState.pipelineHistory.first else { return }
+                let noteItem = originalItem.replacingAssetFileNames(
+                    audioFileName: originalItem.audioFileName,
+                    transcriptFileName: transcriptFileName
+                )
+                appState.pipelineHistory = [noteItem]
+                appState.updateTranscript(id: noteItem.id, text: "restart-free transcript")
+            }
+            let importedTranscriptURL = environment.storageLayout.transcriptDirectory
+                .appendingPathComponent(transcriptFileName)
+            let writtenTranscript = try String(contentsOf: importedTranscriptURL, encoding: .utf8)
+            try expect(
+                writtenTranscript == "restart-free transcript",
+                "archive completion recreates the active transcript directory so transcript writes succeed immediately"
+            )
+        }
+    }
+
+    private static func verifiesRecoveryOperationInProgressBlocksMutation() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try prepareStorageDirectories(for: environment.storageLayout)
+            let storeURL = environment.storageLayout.historyStoreURL
+            let sourceItem = PipelineHistoryItem(
+                id: UUID(uuidString: "9B1D9E3E-1C40-4B62-9B62-9C0E7E9C2F20")!,
+                timestamp: Date(timeIntervalSince1970: 1_754_010_203),
+                rawTranscript: "recovery-in-progress source",
+                postProcessedTranscript: "recovery-in-progress source",
+                postProcessingPrompt: nil,
+                contextSummary: "",
+                contextScreenshotDataURL: nil,
+                contextScreenshotStatus: "No screenshot",
+                postProcessingStatus: "succeeded",
+                debugStatus: "",
+                customVocabulary: ""
+            )
+            let sourceStore = PipelineHistoryStore(storeURL: storeURL)
+            _ = try sourceStore.upsert(
+                sourceItem,
+                maxCount: Int.max,
+                requiresDurableStore: true
+            )
+            try sourceStore.detachForArchiveVerification()
+            let unavailableStore = PipelineHistoryStore(
+                storeURL: storeURL,
+                persistentStoreLoader: { _ in
+                    TestFailure("Injected unavailable history for recovery-in-progress fixture")
+                }
+            )
+            var dependencies = environment.dependencies
+            dependencies.makePipelineHistoryStore = makeUnavailableStartupStoreFactory(
+                unavailableStore,
+                startupURL: environment.storageLayout.historyStoreURL
+            )
+
+            let configuredDependencies = dependencies
+            let appState = await MainActor.run {
+                AppState(dependencies: configuredDependencies)
+            }
+            let archiveAccepted = await MainActor.run {
+                appState.archiveOldHistoryAndStartFresh()
+            }
+            try expect(
+                archiveAccepted,
+                "recovery-in-progress fixture enters the archive recovery route"
+            )
+            try await waitForArchiveCompletion(appState)
+
+            let snapshotID = try await MainActor.run { () -> UUID in
+                guard let snapshotID = appState.historyRecoverySnapshots.first?.id else {
+                    throw TestFailure(
+                        "archive did not publish a recovery snapshot for the recovery-in-progress fixture"
+                    )
+                }
+                return snapshotID
+            }
+
+            let freshItem = PipelineHistoryItem(
+                timestamp: Date(),
+                rawTranscript: "active generation note",
+                postProcessedTranscript: "active generation note",
+                postProcessingPrompt: nil,
+                contextSummary: "",
+                contextScreenshotDataURL: nil,
+                contextScreenshotStatus: "No screenshot",
+                postProcessingStatus: "succeeded",
+                debugStatus: "",
+                customVocabulary: ""
+            )
+            let (deletionAccepted, historyUnchangedWhileRecovering) = await MainActor.run { () -> (Bool, Bool) in
+                appState.pipelineHistory = [freshItem]
+                // Starting the recovery-snapshot delete flips
+                // isHistoryRecoveryOperationInProgress synchronously, before its
+                // detached work runs. A mutation attempted in this same
+                // synchronous window must observe the in-progress guard.
+                let deletionAccepted = appState.deleteHistoryRecoverySnapshot(id: snapshotID)
+                appState.clearPipelineHistory()
+                let historyUnchanged = appState.pipelineHistory.map(\.id) == [freshItem.id]
+                return (deletionAccepted, historyUnchanged)
+            }
+            try expect(deletionAccepted, "a real recovery-snapshot deletion is accepted")
+            try expect(
+                historyUnchangedWhileRecovering,
+                "a mutation attempted while a recovery operation is in progress is rejected"
+            )
+
+            try await waitForHistoryRecoveryCompletion(appState)
+            try expect(
+                appState.historyRecoverySnapshots.isEmpty,
+                "the recovery operation completes normally once it is allowed to run"
             )
         }
     }
@@ -1028,52 +1186,9 @@ struct AppStateStorageSafetyTests {
         }
     }
 
-    private static func waitForArchiveCompletion(_ appState: AppState) async throws {
-        let deadline = Date(timeIntervalSinceNow: 6)
-        while await MainActor.run(body: { appState.isHistoryArchiveTransitioning }), Date() < deadline {
-            try await Task.sleep(nanoseconds: 25_000_000)
-        }
-        let isStillTransitioning = await MainActor.run {
-            appState.isHistoryArchiveTransitioning
-        }
-        try expect(
-            !isStillTransitioning,
-            "archive transition completes within the test timeout"
-        )
-    }
-
-    private static func waitForHistoryRecoveryCompletion(_ appState: AppState) async throws {
-        let deadline = Date(timeIntervalSinceNow: 6)
-        while await MainActor.run(body: { appState.isHistoryRecoveryOperationInProgress }), Date() < deadline {
-            try await Task.sleep(nanoseconds: 25_000_000)
-        }
-        let isStillRecovering = await MainActor.run {
-            appState.isHistoryRecoveryOperationInProgress
-        }
-        try expect(
-            !isStillRecovering,
-            "history recovery operation completes within the test timeout"
-        )
-    }
-
-    private static func waitForHistoryRecoveryInspection(
-        _ appState: AppState,
-        snapshotID: UUID
-    ) async throws {
-        let deadline = Date(timeIntervalSinceNow: 6)
-        while Date() < deadline {
-            let isComplete = await MainActor.run {
-                appState.historyRecoveryInspectionSnapshotID == nil
-                    && appState.historyRecoveryInspections[snapshotID] != nil
-            }
-            if isComplete { return }
-            try await Task.sleep(nanoseconds: 25_000_000)
-        }
-        throw TestFailure("automatic recovery inspection did not complete within the test timeout")
-    }
-
     private static func waitUntil(
         timeoutSeconds: Double = 6,
+        failureMessage: @autoclosure () -> String = "condition did not become true within the test timeout",
         _ condition: @escaping @Sendable () async -> Bool
     ) async throws {
         let deadline = Date(timeIntervalSinceNow: timeoutSeconds)
@@ -1081,13 +1196,44 @@ struct AppStateStorageSafetyTests {
             if await condition() { return }
             try await Task.sleep(nanoseconds: 25_000_000)
         }
-        throw TestFailure("condition did not become true within the test timeout")
+        throw TestFailure(failureMessage())
+    }
+
+    private static func waitForArchiveCompletion(_ appState: AppState) async throws {
+        try await waitUntil(
+            failureMessage: "archive transition completes within the test timeout"
+        ) {
+            await MainActor.run { !appState.isHistoryArchiveTransitioning }
+        }
+    }
+
+    private static func waitForHistoryRecoveryCompletion(_ appState: AppState) async throws {
+        try await waitUntil(
+            failureMessage: "history recovery operation completes within the test timeout"
+        ) {
+            await MainActor.run { !appState.isHistoryRecoveryOperationInProgress }
+        }
+    }
+
+    private static func waitForHistoryRecoveryInspection(
+        _ appState: AppState,
+        snapshotID: UUID
+    ) async throws {
+        try await waitUntil(
+            failureMessage: "automatic recovery inspection did not complete within the test timeout"
+        ) {
+            await MainActor.run {
+                appState.historyRecoveryInspectionSnapshotID == nil
+                    && appState.historyRecoveryInspections[snapshotID] != nil
+            }
+        }
     }
 
     private static func waitForFileRemoval(at fileURL: URL) async throws {
-        let deadline = Date(timeIntervalSinceNow: 6)
-        while FileManager.default.fileExists(atPath: fileURL.path), Date() < deadline {
-            try await Task.sleep(nanoseconds: 100_000_000)
+        try await waitUntil(
+            failureMessage: "\(fileURL.lastPathComponent) was not removed within the test timeout"
+        ) {
+            !FileManager.default.fileExists(atPath: fileURL.path)
         }
     }
 

--- a/Tests/AppStateStorageSafetyTests.swift
+++ b/Tests/AppStateStorageSafetyTests.swift
@@ -16,6 +16,8 @@ struct AppStateStorageSafetyTests {
         try await verifiesMissingSnapshotWithUnreferencedAudioDoesNotSweep()
         try await verifiesMatchingHistorySnapshotSweepsOrphansAtStartup()
         try await verifiesTrustedHistorySweepsOrphans()
+        try await verifiesArchiveCompletionAllowsImmediateAssetSavesWithoutRestart()
+        try await verifiesSnapshotOnlyRecoveryFailureLeavesActiveStoreUntouched()
         try await AppStateTestStorage.withIsolatedStorage { environment in
             try prepareStorageDirectories(for: environment.storageLayout)
             let fallbackAudioURL = try await verifiesFallbackHistoryDoesNotSweepStoredAudio(
@@ -255,17 +257,42 @@ struct AppStateStorageSafetyTests {
             let appState = await MainActor.run {
                 AppState(dependencies: configuredDependencies)
             }
+            var setActionCompletedThrew = false
+            var deleteMeetingSummaryThrew = false
             await MainActor.run {
                 appState.pipelineHistory = [item]
                 appState.clearPipelineHistory()
                 appState.updateTranscript(id: item.id, text: "replacement transcript")
                 appState.toggleRecording()
+                appState.deleteHistoryEntry(id: item.id)
+                appState.updateHistoryItemTitle(id: item.id, title: "replacement title")
+                appState.retryTranscription(item: item)
+                appState.transcriptionAPIKey = "protected-transcription-key"
+                appState.importAudioFile(
+                    URL(fileURLWithPath: "/nonexistent/protected-import.wav"),
+                    choice: .apiStandard(modelID: "whisper-large-v3")
+                )
+                _ = appState.startRecordingFromMCP()
+                do {
+                    try appState.setMeetingSummaryActionCompleted(
+                        noteID: item.id,
+                        actionID: UUID(),
+                        isCompleted: true
+                    )
+                } catch {
+                    setActionCompletedThrew = true
+                }
+                do {
+                    try appState.deleteMeetingSummary(noteID: item.id)
+                } catch {
+                    deleteMeetingSummaryThrew = true
+                }
             }
 
             try expect(appState.isHistoryUnavailable, "history load failure enters protection mode")
             try expect(
                 appState.pipelineHistory.map(\.id) == [item.id],
-                "protected history clear does not alter in-memory note ownership"
+                "protected history mutations do not alter in-memory note ownership"
             )
             try expect(
                 FileManager.default.fileExists(atPath: audioURL.path),
@@ -277,6 +304,8 @@ struct AppStateStorageSafetyTests {
                 "protected history transcript edit does not write a sidecar"
             )
             try expect(!appState.isRecording, "protected history cannot start recording")
+            try expect(setActionCompletedThrew, "protected history rejects meeting summary action updates")
+            try expect(deleteMeetingSummaryThrew, "protected history rejects meeting summary deletion")
         }
     }
 
@@ -403,6 +432,31 @@ struct AppStateStorageSafetyTests {
             try expect(
                 relaunchedAppState.pipelineHistory.map(\.id) == [freshItem.id],
                 "published archive still loads the new active generation on restart"
+            )
+
+            let relaunchedAudioBytes = try Data(
+                contentsOf: payload.appendingPathComponent("audio/archived.wav")
+            )
+            let relaunchedTranscriptBytes = try Data(
+                contentsOf: payload.appendingPathComponent("transcripts/archived.txt")
+            )
+            let relaunchedCloudJobBytes = try Data(
+                contentsOf: payload.appendingPathComponent("cloud-transcription/jobs/archived.json")
+            )
+            try expect(
+                relaunchedAudioBytes == archivedAudioBytes
+                    && relaunchedTranscriptBytes == archivedTranscriptBytes
+                    && relaunchedCloudJobBytes == archivedCloudJobBytes,
+                "restarting while a published archive is unresolved does not sweep or trim the archived generation"
+            )
+            let activeAudioFileCount = try FileManager.default.contentsOfDirectory(
+                at: environment.storageLayout.audioDirectory,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            ).count
+            try expect(
+                activeAudioFileCount == 0,
+                "restarting while a published archive is unresolved does not sweep the fresh active generation, which holds no audio yet"
             )
         }
     }
@@ -736,6 +790,166 @@ struct AppStateStorageSafetyTests {
         }
     }
 
+    private static func verifiesArchiveCompletionAllowsImmediateAssetSavesWithoutRestart() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try prepareStorageDirectories(for: environment.storageLayout)
+            let storeURL = environment.storageLayout.historyStoreURL
+            try Data("unreadable original SQLite".utf8).write(to: storeURL)
+            let unavailableStore = PipelineHistoryStore(
+                storeURL: storeURL,
+                persistentStoreLoader: { _ in
+                    TestFailure("Injected unavailable history for restart-free save")
+                }
+            )
+            var dependencies = environment.dependencies
+            dependencies.makePipelineHistoryStore = makeUnavailableStartupStoreFactory(
+                unavailableStore,
+                startupURL: environment.storageLayout.historyStoreURL
+            )
+
+            let configuredDependencies = dependencies
+            let appState = await MainActor.run {
+                AppState(dependencies: configuredDependencies)
+            }
+            let archiveAccepted = await MainActor.run {
+                appState.archiveOldHistoryAndStartFresh()
+            }
+            try expect(archiveAccepted, "archive from protection mode is accepted")
+            try await waitForArchiveCompletion(appState)
+            try expect(
+                !appState.isHistoryUnavailable,
+                "verified fresh history leaves protection mode"
+            )
+
+            let sourceURL = environment.rootDirectory.appendingPathComponent("restart-free-import.wav")
+            try Data("fixture audio".utf8).write(to: sourceURL)
+            await MainActor.run {
+                appState.transcriptionAPIKey = "restart-free-key"
+                appState.importAudioFile(sourceURL, choice: .apiStandard(modelID: "whisper-large-v3"))
+            }
+
+            try await waitUntil {
+                await MainActor.run { !appState.pipelineHistory.isEmpty }
+            }
+            let importedAudioFileName = try await MainActor.run { () -> String in
+                guard let fileName = appState.pipelineHistory.first?.audioFileName else {
+                    throw TestFailure(
+                        "archive completion did not accept a new audio import without a restart"
+                    )
+                }
+                return fileName
+            }
+            let importedAudioURL = environment.storageLayout.audioDirectory
+                .appendingPathComponent(importedAudioFileName)
+            try expect(
+                FileManager.default.fileExists(atPath: importedAudioURL.path),
+                "archive completion recreates the active audio directory so imports succeed immediately"
+            )
+        }
+    }
+
+    private static func verifiesSnapshotOnlyRecoveryFailureLeavesActiveStoreUntouched() async throws {
+        try await AppStateTestStorage.withIsolatedStorage { environment in
+            try prepareStorageDirectories(for: environment.storageLayout)
+            let storeURL = environment.storageLayout.historyStoreURL
+            let sourceItem = PipelineHistoryItem(
+                id: UUID(uuidString: "6D1E9E3E-9C40-4B62-9B62-9C0E7E9C2F10")!,
+                timestamp: Date(timeIntervalSince1970: 1_754_010_203),
+                rawTranscript: "snapshot-only failure source",
+                postProcessedTranscript: "snapshot-only failure source",
+                postProcessingPrompt: nil,
+                contextSummary: "",
+                contextScreenshotDataURL: nil,
+                contextScreenshotStatus: "No screenshot",
+                postProcessingStatus: "succeeded",
+                debugStatus: "",
+                customVocabulary: ""
+            )
+            let sourceStore = PipelineHistoryStore(storeURL: storeURL)
+            _ = try sourceStore.upsert(
+                sourceItem,
+                maxCount: Int.max,
+                requiresDurableStore: true
+            )
+            try sourceStore.detachForArchiveVerification()
+            let unavailableStore = PipelineHistoryStore(
+                storeURL: storeURL,
+                persistentStoreLoader: { _ in
+                    TestFailure("Injected unavailable history for snapshot-only failure")
+                }
+            )
+            var dependencies = environment.dependencies
+            dependencies.makePipelineHistoryStore = makeUnavailableStartupStoreFactory(
+                unavailableStore,
+                startupURL: environment.storageLayout.historyStoreURL
+            )
+
+            let configuredDependencies = dependencies
+            let appState = await MainActor.run {
+                AppState(dependencies: configuredDependencies)
+            }
+            let archiveAccepted = await MainActor.run {
+                appState.archiveOldHistoryAndStartFresh()
+            }
+            try expect(archiveAccepted, "snapshot-only fixture enters the archive recovery route")
+            try await waitForArchiveCompletion(appState)
+
+            let snapshotID = try await MainActor.run { () -> UUID in
+                guard let snapshotID = appState.historyRecoverySnapshots.first?.id else {
+                    throw TestFailure(
+                        "archive did not publish a recovery snapshot for the snapshot-only fixture"
+                    )
+                }
+                return snapshotID
+            }
+            let recoveryDirectory = environment.rootDirectory
+                .appendingPathComponent("Recovery", isDirectory: true)
+            let snapshotDirectories = try FileManager.default.contentsOfDirectory(
+                at: recoveryDirectory,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            ).filter { $0.lastPathComponent.hasPrefix("history-") }
+            guard let snapshotDirectory = snapshotDirectories.first else {
+                throw TestFailure("snapshot-only fixture is missing its on-disk directory")
+            }
+            try FileManager.default.removeItem(at: snapshotDirectory)
+
+            let deletionAccepted = await MainActor.run {
+                appState.deleteHistoryRecoverySnapshot(id: snapshotID)
+            }
+            try expect(
+                deletionAccepted,
+                "AppState still accepts the request using its cached snapshot catalog"
+            )
+            try await waitForHistoryRecoveryCompletion(appState)
+
+            try expect(
+                appState.errorMessage == "Recovery snapshot operation could not be completed.",
+                "a snapshot-only failure surfaces its own error rather than a silent success"
+            )
+            try expect(
+                !appState.isHistoryUnavailable,
+                "a snapshot-only failure does not put the active history into protection mode"
+            )
+            try expect(
+                appState.historyRecoverySnapshots.isEmpty,
+                "a snapshot-only failure still refreshes the catalog from disk"
+            )
+
+            let relaunchedAppState = await MainActor.run {
+                AppState(dependencies: environment.dependencies)
+            }
+            try expect(
+                !relaunchedAppState.isHistoryUnavailable,
+                "a snapshot-only failure does not corrupt or replace the active Core Data store"
+            )
+            try expect(
+                relaunchedAppState.pipelineHistory.isEmpty,
+                "a snapshot-only failure does not resurrect the archived generation in the active store"
+            )
+        }
+    }
+
     private static func verifiesFallbackHistoryDoesNotSweepStoredAudio(
         environment: AppStateTestEnvironment
     ) async throws -> URL {
@@ -856,6 +1070,18 @@ struct AppStateStorageSafetyTests {
             try await Task.sleep(nanoseconds: 25_000_000)
         }
         throw TestFailure("automatic recovery inspection did not complete within the test timeout")
+    }
+
+    private static func waitUntil(
+        timeoutSeconds: Double = 6,
+        _ condition: @escaping @Sendable () async -> Bool
+    ) async throws {
+        let deadline = Date(timeIntervalSinceNow: timeoutSeconds)
+        while Date() < deadline {
+            if await condition() { return }
+            try await Task.sleep(nanoseconds: 25_000_000)
+        }
+        throw TestFailure("condition did not become true within the test timeout")
     }
 
     private static func waitForFileRemoval(at fileURL: URL) async throws {


### PR DESCRIPTION
## Summary

- replace most of `AppStateHistoryProtectionSourceTests`' exact-source-text assertions with behavioral tests in `AppStateStorageSafetyTests`
- add coverage for the regression this PR's design was originally written to protect: archive completion recreates active asset directories so a caller can save new audio/transcripts immediately, without an app restart
- add coverage proving a snapshot-only recovery failure (e.g. deleting a Recovery snapshot) never replaces or corrupts the active Core Data store
- add coverage proving a restart while a published archive is unresolved does not sweep or trim the archived generation
- extend history-protection coverage to block the full set of mutating entry points (`deleteHistoryEntry`, `updateHistoryItemTitle`, `retryTranscription`, `importAudioFile`, `startRecordingFromMCP`, `setMeetingSummaryActionCompleted`, `deleteMeetingSummary`) rather than a subset

## What stays as a source check, and why

A small number of invariants remain as documented source-text checks because they cannot be driven through the public `AppState` API without disproportionate simulation:

- the remaining `archiveOldHistoryAndStartFresh` guard conditions beyond `pendingAudioImportJobIDs` — these can only matter while history is *also* unavailable, which is already `archiveOldHistoryAndStartFresh`'s own precondition, and live recording/retry/summary generation cannot be driven into that combined state through the public API without a real audio pipeline
- the recheck-after-async-suspension pattern in recording start and microphone-permission resumption — defense in depth against history becoming unavailable mid-flow; simulating the exact race is disproportionate to this suite
- a failed history update preserving assets, and the recovery-write guard — reproducing a genuine mid-write Core Data failure requires corrupting the store at an exact instant inside a transaction
- deferred orphan cleanup using the startup snapshot's timestamp rather than execution time — requires controlling the wall clock inside a detached `Task`
- recovery-inspection invalidation ordering and recovery-import's clear-before-detach ordering — tied to Settings tab navigation and exact async timing that aren't reliably observable from outside

Each of these keeps a short rationale comment in the source file explaining why it wasn't converted.

## Validation

- `make check-test-wiring`
- `make test`
- `make all CODESIGN_IDENTITY=Quill`

This is part of the standalone internal-refactoring track (#321), independent of the product roadmap.

Closes #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
