### PR TITLE
Introduce a note asset storage boundary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ FULL_SOURCE_APP_STATE_TESTS = \
 	Tests/LatestValueProgressCoalescerTests.swift \
 	Tests/AppStateTestStorage.swift \
 	Tests/AppStateDependenciesTests.swift \
+	Tests/NoteAssetStoreTests.swift \
 	Tests/AppStateStorageSafetyTests.swift \
 	Tests/AppStateHistoryProtectionSourceTests.swift \
 	Tests/AppStateTranscriptionConfigurationTests.swift \

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2434,6 +2434,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var needsMicrophoneRefreshAfterRecording = false
     private let dependencies: AppStateDependencies
     var storageLayout: AppStateStorageLayout { dependencies.storageLayout }
+    var noteAssetStore: NoteAssetStore { NoteAssetStore(storageLayout: storageLayout) }
     private var pipelineHistoryStore: PipelineHistoryStore
     private var recordingJournalStore: RecordingJournalStore
     private var cloudTranscriptionJobStore: CloudTranscriptionJobStore
@@ -5306,8 +5307,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     func loadTranscript(from fileName: String) -> String? {
-        let fileURL = storageLayout.transcriptDirectory.appendingPathComponent(fileName)
-        return try? String(contentsOf: fileURL, encoding: .utf8)
+        try? noteAssetStore.loadTranscript(fileName: fileName)
     }
 
     static func fileSizeBytes(for fileURL: URL) -> Int64? {
@@ -7559,8 +7559,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     func storedAudioURL(for item: PipelineHistoryItem) -> URL? {
-        guard let fileName = item.audioFileName else { return nil }
-        return storageLayout.audioDirectory.appendingPathComponent(fileName)
+        noteAssetStore.storedAudioURL(for: item)
     }
 
     @MainActor

--- a/Sources/NoteAssetStore.swift
+++ b/Sources/NoteAssetStore.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 enum NoteAssetStoreError: Error {
-    case audioSaveFailed
-    case transcriptSaveFailed
+    case audioSaveFailed(underlying: Error)
+    case transcriptSaveFailed(underlying: Error)
     case transcriptLoadFailed(underlying: Error)
 }
 
@@ -24,6 +24,11 @@ enum NoteAssetStoreError: Error {
 struct NoteAssetStore: Sendable {
     let storageLayout: AppStateStorageLayout
 
+    /// Directory preparation intentionally stays best-effort, matching the
+    /// existing `AppState` directory-preparation contract established when
+    /// instance-owned storage layouts were introduced: callers proceed with
+    /// the directory URL regardless of creation success, and the subsequent
+    /// save/load operation is what surfaces a failure.
     @discardableResult
     func prepareDirectories() -> (audioDirectory: URL, transcriptDirectory: URL) {
         (
@@ -33,42 +38,50 @@ struct NoteAssetStore: Sendable {
     }
 
     func saveAudio(from tempURL: URL) throws -> AppState.SavedAudioFile {
-        guard let saved = AppState.saveAudioFile(
-            from: tempURL,
-            audioDirectory: storageLayout.audioDirectory
-        ) else {
-            throw NoteAssetStoreError.audioSaveFailed
+        let fileName = UUID().uuidString + "." + AudioImportOptions.storageExtension(
+            for: tempURL.lastPathComponent
+        )
+        let destURL = storageLayout.audioDirectory.appendingPathComponent(fileName)
+        do {
+            try? FileManager.default.removeItem(at: destURL)
+            try FileManager.default.copyItem(at: tempURL, to: destURL)
+            return AppState.SavedAudioFile(fileName: fileName, fileURL: destURL)
+        } catch {
+            throw NoteAssetStoreError.audioSaveFailed(underlying: error)
         }
-        return saved
     }
 
     func saveSecurityScopedAudio(from fileURL: URL) async throws -> AppState.SavedAudioFile {
-        guard let saved = await AppState.saveSecurityScopedAudioFileOffMain(
-            from: fileURL,
-            audioDirectory: storageLayout.audioDirectory
-        ) else {
-            throw NoteAssetStoreError.audioSaveFailed
-        }
-        return saved
+        try await Task.detached(priority: .userInitiated) {
+            let accessGranted = fileURL.startAccessingSecurityScopedResource()
+            defer {
+                if accessGranted {
+                    fileURL.stopAccessingSecurityScopedResource()
+                }
+            }
+            return try self.saveAudio(from: fileURL)
+        }.value
     }
 
-    func deleteAudio(fileName: String) {
-        let fileURL = storageLayout.audioDirectory.appendingPathComponent(fileName)
-        try? FileManager.default.removeItem(at: fileURL)
+    func deleteAudio(fileName: String) throws {
+        try Self.removeItemIfPresent(
+            at: storageLayout.audioDirectory.appendingPathComponent(fileName)
+        )
     }
 
     func saveTranscript(
         rawTranscript: String,
         postProcessedTranscript: String
     ) throws -> String {
-        guard let fileName = AppState.saveTranscriptFile(
-            rawTranscript: rawTranscript,
-            postProcessedTranscript: postProcessedTranscript,
-            transcriptDirectory: storageLayout.transcriptDirectory
-        ) else {
-            throw NoteAssetStoreError.transcriptSaveFailed
+        let fileName = UUID().uuidString + ".txt"
+        let fileURL = storageLayout.transcriptDirectory.appendingPathComponent(fileName)
+        let content = postProcessedTranscript.isEmpty ? rawTranscript : postProcessedTranscript
+        do {
+            try content.write(to: fileURL, atomically: true, encoding: .utf8)
+            return fileName
+        } catch {
+            throw NoteAssetStoreError.transcriptSaveFailed(underlying: error)
         }
-        return fileName
     }
 
     func loadTranscript(fileName: String) throws -> String {
@@ -80,20 +93,33 @@ struct NoteAssetStore: Sendable {
         }
     }
 
-    func deleteTranscript(fileName: String) {
-        AppState.deleteTranscriptFile(
-            fileName,
-            transcriptDirectory: storageLayout.transcriptDirectory
+    func deleteTranscript(fileName: String) throws {
+        try Self.removeItemIfPresent(
+            at: storageLayout.transcriptDirectory.appendingPathComponent(fileName)
         )
     }
 
-    func deleteAssets(audioFileName: String?, transcriptFileName: String?) {
+    /// Attempts both deletions independently — matching the existing
+    /// best-effort semantics of `AppState`'s asset cleanup — so a failure
+    /// deleting one asset never skips the other. If either deletion fails,
+    /// the first failure is thrown after both have been attempted.
+    func deleteAssets(audioFileName: String?, transcriptFileName: String?) throws {
+        var firstError: Error?
         if let audioFileName {
-            deleteAudio(fileName: audioFileName)
+            do {
+                try deleteAudio(fileName: audioFileName)
+            } catch {
+                firstError = error
+            }
         }
         if let transcriptFileName {
-            deleteTranscript(fileName: transcriptFileName)
+            do {
+                try deleteTranscript(fileName: transcriptFileName)
+            } catch {
+                if firstError == nil { firstError = error }
+            }
         }
+        if let firstError { throw firstError }
     }
 
     func storedAudioURL(for item: PipelineHistoryItem) -> URL? {
@@ -109,5 +135,23 @@ struct NoteAssetStore: Sendable {
             )
         }
         return directory
+    }
+
+    /// Deleting an already-missing file is treated as success (matching the
+    /// idempotent delete semantics used throughout `AppState`'s existing
+    /// asset cleanup). Any other failure — permissions, a read-only volume,
+    /// a directory that cannot be removed — propagates to the caller.
+    private static func removeItemIfPresent(at url: URL) throws {
+        do {
+            try FileManager.default.removeItem(at: url)
+        } catch let error as NSError {
+            if error.domain == NSCocoaErrorDomain, error.code == NSFileNoSuchFileError {
+                return
+            }
+            if error.domain == NSPOSIXErrorDomain, error.code == Int(ENOENT) {
+                return
+            }
+            throw error
+        }
     }
 }

--- a/Sources/NoteAssetStore.swift
+++ b/Sources/NoteAssetStore.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+enum NoteAssetStoreError: Error {
+    case audioSaveFailed
+    case transcriptSaveFailed
+    case transcriptLoadFailed(underlying: Error)
+}
+
+/// A focused, instance-owned boundary over `AppStateStorageLayout` for note
+/// audio and transcript files.
+///
+/// This does not yet own every audio/transcript call site in `AppState`.
+/// Several existing call sites (audio import, stopped-recording save/delete,
+/// cloud-transcription cleanup) are pinned by exact-source-text regression
+/// tests in other suites (`AudioImportFileCopyTests`,
+/// `CombinedRecordingNormalStopIntegrationTests`,
+/// `AppStateCloudTranscriptionCleanupSourceTests`,
+/// `AppStateRecordingJournalIntegrationSourceTests`). Migrating those call
+/// sites requires first converting those tests to behavioral coverage, which
+/// is out of scope here. This type provides the throwing API surface and
+/// migrates only the call sites those tests do not lock in place: the
+/// `loadTranscript(from:)` and `storedAudioURL(for:)` instance methods on
+/// `AppState`.
+struct NoteAssetStore: Sendable {
+    let storageLayout: AppStateStorageLayout
+
+    @discardableResult
+    func prepareDirectories() -> (audioDirectory: URL, transcriptDirectory: URL) {
+        (
+            Self.preparedDirectory(storageLayout.audioDirectory),
+            Self.preparedDirectory(storageLayout.transcriptDirectory)
+        )
+    }
+
+    func saveAudio(from tempURL: URL) throws -> AppState.SavedAudioFile {
+        guard let saved = AppState.saveAudioFile(
+            from: tempURL,
+            audioDirectory: storageLayout.audioDirectory
+        ) else {
+            throw NoteAssetStoreError.audioSaveFailed
+        }
+        return saved
+    }
+
+    func saveSecurityScopedAudio(from fileURL: URL) async throws -> AppState.SavedAudioFile {
+        guard let saved = await AppState.saveSecurityScopedAudioFileOffMain(
+            from: fileURL,
+            audioDirectory: storageLayout.audioDirectory
+        ) else {
+            throw NoteAssetStoreError.audioSaveFailed
+        }
+        return saved
+    }
+
+    func deleteAudio(fileName: String) {
+        let fileURL = storageLayout.audioDirectory.appendingPathComponent(fileName)
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+
+    func saveTranscript(
+        rawTranscript: String,
+        postProcessedTranscript: String
+    ) throws -> String {
+        guard let fileName = AppState.saveTranscriptFile(
+            rawTranscript: rawTranscript,
+            postProcessedTranscript: postProcessedTranscript,
+            transcriptDirectory: storageLayout.transcriptDirectory
+        ) else {
+            throw NoteAssetStoreError.transcriptSaveFailed
+        }
+        return fileName
+    }
+
+    func loadTranscript(fileName: String) throws -> String {
+        let fileURL = storageLayout.transcriptDirectory.appendingPathComponent(fileName)
+        do {
+            return try String(contentsOf: fileURL, encoding: .utf8)
+        } catch {
+            throw NoteAssetStoreError.transcriptLoadFailed(underlying: error)
+        }
+    }
+
+    func deleteTranscript(fileName: String) {
+        AppState.deleteTranscriptFile(
+            fileName,
+            transcriptDirectory: storageLayout.transcriptDirectory
+        )
+    }
+
+    func deleteAssets(audioFileName: String?, transcriptFileName: String?) {
+        if let audioFileName {
+            deleteAudio(fileName: audioFileName)
+        }
+        if let transcriptFileName {
+            deleteTranscript(fileName: transcriptFileName)
+        }
+    }
+
+    func storedAudioURL(for item: PipelineHistoryItem) -> URL? {
+        guard let fileName = item.audioFileName else { return nil }
+        return storageLayout.audioDirectory.appendingPathComponent(fileName)
+    }
+
+    private static func preparedDirectory(_ directory: URL) -> URL {
+        if !FileManager.default.fileExists(atPath: directory.path) {
+            try? FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+        }
+        return directory
+    }
+}

--- a/Tests/FullSourceAppStateTestRunner.swift
+++ b/Tests/FullSourceAppStateTestRunner.swift
@@ -13,6 +13,7 @@ struct FullSourceAppStateTestRunner {
 
         try await AppStateTestStorage.withIsolatedStorage { _ in
             try AppStateDependenciesTests.main()
+            try await NoteAssetStoreTests.main()
             try await AudioImportFileCopyTests.main()
             try LatestValueProgressCoalescerTests.main()
             try await AppStateStorageSafetyTests.main()

--- a/Tests/NoteAssetStoreTests.swift
+++ b/Tests/NoteAssetStoreTests.swift
@@ -14,6 +14,9 @@ struct NoteAssetStoreTests {
         try await testSaveSecurityScopedAudioThrowsWhenSourceFileIsMissing()
         try testDeleteAudioIsIdempotentForMissingFile()
         try testDeleteAssetsRemovesBothFiles()
+        try testDeleteTranscriptPropagatesNonMissingFileErrors()
+        try testDeleteAudioPropagatesNonMissingFileErrors()
+        try testDeleteAssetsStillDeletesTranscriptWhenAudioDeleteFails()
         try testStoredAudioURLResolvesFromItem()
         try testStoredAudioURLIsNilWithoutAudioFileName()
         try testPrepareDirectoriesCreatesAudioAndTranscriptDirectories()
@@ -61,7 +64,7 @@ struct NoteAssetStoreTests {
 
     private static func testDeleteTranscriptIsIdempotentForMissingFile() throws {
         try withTemporaryStore { store in
-            store.deleteTranscript(fileName: "missing-\(UUID().uuidString).txt")
+            try store.deleteTranscript(fileName: "missing-\(UUID().uuidString).txt")
         }
     }
 
@@ -110,7 +113,7 @@ struct NoteAssetStoreTests {
 
     private static func testDeleteAudioIsIdempotentForMissingFile() throws {
         try withTemporaryStore { store in
-            store.deleteAudio(fileName: "missing-\(UUID().uuidString).wav")
+            try store.deleteAudio(fileName: "missing-\(UUID().uuidString).wav")
         }
     }
 
@@ -126,7 +129,7 @@ struct NoteAssetStoreTests {
             defer { try? FileManager.default.removeItem(at: sourceURL) }
             let savedAudio = try store.saveAudio(from: sourceURL)
 
-            store.deleteAssets(
+            try store.deleteAssets(
                 audioFileName: savedAudio.fileName,
                 transcriptFileName: transcriptFileName
             )
@@ -140,6 +143,127 @@ struct NoteAssetStoreTests {
             try expect(
                 !FileManager.default.fileExists(atPath: transcriptURL.path),
                 "deleteAssets removes the saved transcript file"
+            )
+        }
+    }
+
+    private static func testDeleteTranscriptPropagatesNonMissingFileErrors() throws {
+        try withTemporaryStore { store in
+            let fileName = try store.saveTranscript(
+                rawTranscript: "blocked delete",
+                postProcessedTranscript: ""
+            )
+            let directory = store.storageLayout.transcriptDirectory
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o555],
+                ofItemAtPath: directory.path
+            )
+            defer {
+                try? FileManager.default.setAttributes(
+                    [.posixPermissions: 0o755],
+                    ofItemAtPath: directory.path
+                )
+            }
+
+            do {
+                try store.deleteTranscript(fileName: fileName)
+                throw TestFailure(
+                    "expected deleteTranscript to propagate a permission failure"
+                )
+            } catch let error as TestFailure {
+                throw error
+            } catch is NoteAssetStoreError {
+                throw TestFailure(
+                    "deleteTranscript should propagate the underlying FileManager error directly"
+                )
+            } catch {
+                // expected: the underlying FileManager error propagates directly
+            }
+        }
+    }
+
+    private static func testDeleteAudioPropagatesNonMissingFileErrors() throws {
+        try withTemporaryStore { store in
+            let sourceURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("note-asset-store-blocked-delete-\(UUID().uuidString).wav")
+            try Data("fixture".utf8).write(to: sourceURL)
+            defer { try? FileManager.default.removeItem(at: sourceURL) }
+            let saved = try store.saveAudio(from: sourceURL)
+
+            let directory = store.storageLayout.audioDirectory
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o555],
+                ofItemAtPath: directory.path
+            )
+            defer {
+                try? FileManager.default.setAttributes(
+                    [.posixPermissions: 0o755],
+                    ofItemAtPath: directory.path
+                )
+            }
+
+            do {
+                try store.deleteAudio(fileName: saved.fileName)
+                throw TestFailure(
+                    "expected deleteAudio to propagate a permission failure"
+                )
+            } catch let error as TestFailure {
+                throw error
+            } catch is NoteAssetStoreError {
+                throw TestFailure(
+                    "deleteAudio should propagate the underlying FileManager error directly"
+                )
+            } catch {
+                // expected: the underlying FileManager error propagates directly
+            }
+        }
+    }
+
+    private static func testDeleteAssetsStillDeletesTranscriptWhenAudioDeleteFails() throws {
+        try withTemporaryStore { store in
+            let transcriptFileName = try store.saveTranscript(
+                rawTranscript: "still deleted",
+                postProcessedTranscript: ""
+            )
+            let sourceURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("note-asset-store-partial-\(UUID().uuidString).wav")
+            try Data("fixture".utf8).write(to: sourceURL)
+            defer { try? FileManager.default.removeItem(at: sourceURL) }
+            let savedAudio = try store.saveAudio(from: sourceURL)
+
+            let audioDirectory = store.storageLayout.audioDirectory
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o555],
+                ofItemAtPath: audioDirectory.path
+            )
+            defer {
+                try? FileManager.default.setAttributes(
+                    [.posixPermissions: 0o755],
+                    ofItemAtPath: audioDirectory.path
+                )
+            }
+
+            do {
+                try store.deleteAssets(
+                    audioFileName: savedAudio.fileName,
+                    transcriptFileName: transcriptFileName
+                )
+                throw TestFailure("expected deleteAssets to propagate the audio deletion failure")
+            } catch let error as TestFailure {
+                throw error
+            } catch {
+                // expected: the blocked audio deletion still surfaces a failure
+            }
+
+            let transcriptURL = store.storageLayout.transcriptDirectory
+                .appendingPathComponent(transcriptFileName)
+            try expect(
+                !FileManager.default.fileExists(atPath: transcriptURL.path),
+                "deleteAssets still deletes the transcript even when the audio deletion fails"
+            )
+            try expect(
+                FileManager.default.fileExists(atPath: savedAudio.fileURL.path),
+                "the blocked audio file remains because its directory could not be modified"
             )
         }
     }

--- a/Tests/NoteAssetStoreTests.swift
+++ b/Tests/NoteAssetStoreTests.swift
@@ -1,0 +1,322 @@
+import Foundation
+
+#if !QUILL_GROUPED_TEST_RUNNER
+@main
+#endif
+struct NoteAssetStoreTests {
+    static func main() async throws {
+        try testSaveAndLoadTranscriptRoundTrips()
+        try testSaveTranscriptPrefersPostProcessedText()
+        try testLoadTranscriptThrowsForMissingFile()
+        try testDeleteTranscriptIsIdempotentForMissingFile()
+        try testSaveAudioCopiesFileAndPreservesExtension()
+        try testSaveAudioThrowsWhenSourceFileIsMissing()
+        try await testSaveSecurityScopedAudioThrowsWhenSourceFileIsMissing()
+        try testDeleteAudioIsIdempotentForMissingFile()
+        try testDeleteAssetsRemovesBothFiles()
+        try testStoredAudioURLResolvesFromItem()
+        try testStoredAudioURLIsNilWithoutAudioFileName()
+        try testPrepareDirectoriesCreatesAudioAndTranscriptDirectories()
+        try testTwoStoresWithIndependentLayoutsDoNotShareFiles()
+        try testSaveTranscriptThrowsWhenDirectoryIsUnavailable()
+        try testSaveAudioThrowsWhenDirectoryIsUnavailable()
+        print("NoteAssetStoreTests passed")
+    }
+
+    private static func testSaveAndLoadTranscriptRoundTrips() throws {
+        try withTemporaryStore { store in
+            let fileName = try store.saveTranscript(
+                rawTranscript: "raw",
+                postProcessedTranscript: "processed"
+            )
+            let loaded = try store.loadTranscript(fileName: fileName)
+            try expect(loaded == "processed", "loaded transcript matches the saved content")
+        }
+    }
+
+    private static func testSaveTranscriptPrefersPostProcessedText() throws {
+        try withTemporaryStore { store in
+            let fileName = try store.saveTranscript(
+                rawTranscript: "raw only",
+                postProcessedTranscript: ""
+            )
+            let loaded = try store.loadTranscript(fileName: fileName)
+            try expect(
+                loaded == "raw only",
+                "an empty post-processed transcript falls back to the raw transcript"
+            )
+        }
+    }
+
+    private static func testLoadTranscriptThrowsForMissingFile() throws {
+        try withTemporaryStore { store in
+            do {
+                _ = try store.loadTranscript(fileName: "missing-\(UUID().uuidString).txt")
+                throw TestFailure("expected loadTranscript to throw for a missing file")
+            } catch is NoteAssetStoreError {
+                // expected
+            }
+        }
+    }
+
+    private static func testDeleteTranscriptIsIdempotentForMissingFile() throws {
+        try withTemporaryStore { store in
+            store.deleteTranscript(fileName: "missing-\(UUID().uuidString).txt")
+        }
+    }
+
+    private static func testSaveAudioCopiesFileAndPreservesExtension() throws {
+        try withTemporaryStore { store in
+            let sourceURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("note-asset-store-source-\(UUID().uuidString).m4a")
+            let contents = Data("audio contents".utf8)
+            try contents.write(to: sourceURL)
+            defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+            let saved = try store.saveAudio(from: sourceURL)
+            try expect(saved.fileName.hasSuffix(".m4a"), "saved audio keeps the source extension")
+            let copied = try Data(contentsOf: saved.fileURL)
+            try expect(copied == contents, "saved audio contents match the source file")
+        }
+    }
+
+    private static func testSaveAudioThrowsWhenSourceFileIsMissing() throws {
+        try withTemporaryStore { store in
+            let missingURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("note-asset-store-missing-\(UUID().uuidString).wav")
+            do {
+                _ = try store.saveAudio(from: missingURL)
+                throw TestFailure("expected saveAudio to throw for a missing source file")
+            } catch is NoteAssetStoreError {
+                // expected
+            }
+        }
+    }
+
+    private static func testSaveSecurityScopedAudioThrowsWhenSourceFileIsMissing() async throws {
+        try await withTemporaryStoreAsync { store in
+            let missingURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("note-asset-store-missing-scoped-\(UUID().uuidString).wav")
+            do {
+                _ = try await store.saveSecurityScopedAudio(from: missingURL)
+                throw TestFailure(
+                    "expected saveSecurityScopedAudio to throw for a missing source file"
+                )
+            } catch is NoteAssetStoreError {
+                // expected
+            }
+        }
+    }
+
+    private static func testDeleteAudioIsIdempotentForMissingFile() throws {
+        try withTemporaryStore { store in
+            store.deleteAudio(fileName: "missing-\(UUID().uuidString).wav")
+        }
+    }
+
+    private static func testDeleteAssetsRemovesBothFiles() throws {
+        try withTemporaryStore { store in
+            let transcriptFileName = try store.saveTranscript(
+                rawTranscript: "to delete",
+                postProcessedTranscript: ""
+            )
+            let sourceURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("note-asset-store-to-delete-\(UUID().uuidString).wav")
+            try Data("fixture".utf8).write(to: sourceURL)
+            defer { try? FileManager.default.removeItem(at: sourceURL) }
+            let savedAudio = try store.saveAudio(from: sourceURL)
+
+            store.deleteAssets(
+                audioFileName: savedAudio.fileName,
+                transcriptFileName: transcriptFileName
+            )
+
+            try expect(
+                !FileManager.default.fileExists(atPath: savedAudio.fileURL.path),
+                "deleteAssets removes the saved audio file"
+            )
+            let transcriptURL = store.storageLayout.transcriptDirectory
+                .appendingPathComponent(transcriptFileName)
+            try expect(
+                !FileManager.default.fileExists(atPath: transcriptURL.path),
+                "deleteAssets removes the saved transcript file"
+            )
+        }
+    }
+
+    private static func testStoredAudioURLResolvesFromItem() throws {
+        try withTemporaryStore { store in
+            let item = makeItem(audioFileName: "resolved.wav")
+            let resolved = store.storedAudioURL(for: item)
+            try expect(
+                resolved == store.storageLayout.audioDirectory.appendingPathComponent("resolved.wav"),
+                "storedAudioURL resolves under the store's own audio directory"
+            )
+        }
+    }
+
+    private static func testStoredAudioURLIsNilWithoutAudioFileName() throws {
+        try withTemporaryStore { store in
+            let item = makeItem(audioFileName: nil)
+            try expect(
+                store.storedAudioURL(for: item) == nil,
+                "storedAudioURL is nil when the item has no audio file name"
+            )
+        }
+    }
+
+    private static func testPrepareDirectoriesCreatesAudioAndTranscriptDirectories() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("note-asset-store-prepare-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NoteAssetStore(storageLayout: AppStateStorageLayout(rootDirectory: root))
+
+        let (audioDirectory, transcriptDirectory) = store.prepareDirectories()
+
+        var isDirectory: ObjCBool = false
+        try expect(
+            FileManager.default.fileExists(atPath: audioDirectory.path, isDirectory: &isDirectory)
+                && isDirectory.boolValue,
+            "prepareDirectories creates the audio directory"
+        )
+        try expect(
+            FileManager.default.fileExists(atPath: transcriptDirectory.path, isDirectory: &isDirectory)
+                && isDirectory.boolValue,
+            "prepareDirectories creates the transcript directory"
+        )
+    }
+
+    private static func testTwoStoresWithIndependentLayoutsDoNotShareFiles() throws {
+        let parent = FileManager.default.temporaryDirectory
+            .appendingPathComponent("note-asset-store-independent-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let firstStore = NoteAssetStore(
+            storageLayout: AppStateStorageLayout(
+                rootDirectory: parent.appendingPathComponent("first", isDirectory: true)
+            )
+        )
+        let secondStore = NoteAssetStore(
+            storageLayout: AppStateStorageLayout(
+                rootDirectory: parent.appendingPathComponent("second", isDirectory: true)
+            )
+        )
+        firstStore.prepareDirectories()
+        secondStore.prepareDirectories()
+
+        let firstFileName = try firstStore.saveTranscript(
+            rawTranscript: "first store transcript",
+            postProcessedTranscript: ""
+        )
+        let secondFileName = try secondStore.saveTranscript(
+            rawTranscript: "second store transcript",
+            postProcessedTranscript: ""
+        )
+
+        try expect(
+            (try? secondStore.loadTranscript(fileName: firstFileName)) == nil,
+            "the second store cannot read a transcript saved only in the first store"
+        )
+        let firstLoaded = try firstStore.loadTranscript(fileName: firstFileName)
+        let secondLoaded = try secondStore.loadTranscript(fileName: secondFileName)
+        try expect(
+            firstLoaded == "first store transcript" && secondLoaded == "second store transcript",
+            "each store independently persists and loads its own transcript"
+        )
+    }
+
+    private static func testSaveTranscriptThrowsWhenDirectoryIsUnavailable() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("note-asset-store-blocked-transcript-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let storageLayout = AppStateStorageLayout(rootDirectory: root)
+        // Create a plain file where the transcript directory should be, so
+        // FileManager cannot create it and any write into it fails.
+        try Data().write(to: storageLayout.transcriptDirectory)
+        let store = NoteAssetStore(storageLayout: storageLayout)
+
+        do {
+            _ = try store.saveTranscript(rawTranscript: "unwritable", postProcessedTranscript: "")
+            throw TestFailure(
+                "expected saveTranscript to throw when its directory cannot be created"
+            )
+        } catch is NoteAssetStoreError {
+            // expected
+        }
+    }
+
+    private static func testSaveAudioThrowsWhenDirectoryIsUnavailable() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("note-asset-store-blocked-audio-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let storageLayout = AppStateStorageLayout(rootDirectory: root)
+        try Data().write(to: storageLayout.audioDirectory)
+        let store = NoteAssetStore(storageLayout: storageLayout)
+
+        let sourceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("note-asset-store-blocked-source-\(UUID().uuidString).wav")
+        try Data("fixture".utf8).write(to: sourceURL)
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        do {
+            _ = try store.saveAudio(from: sourceURL)
+            throw TestFailure("expected saveAudio to throw when its directory cannot be created")
+        } catch is NoteAssetStoreError {
+            // expected
+        }
+    }
+
+    private static func makeItem(audioFileName: String?) -> PipelineHistoryItem {
+        PipelineHistoryItem(
+            timestamp: Date(),
+            rawTranscript: "",
+            postProcessedTranscript: "",
+            postProcessingPrompt: nil,
+            contextSummary: "",
+            contextScreenshotDataURL: nil,
+            contextScreenshotStatus: "No screenshot",
+            postProcessingStatus: "succeeded",
+            debugStatus: "",
+            customVocabulary: "",
+            audioFileName: audioFileName
+        )
+    }
+
+    private static func withTemporaryStore(
+        _ operation: (NoteAssetStore) throws -> Void
+    ) throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("note-asset-store-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NoteAssetStore(storageLayout: AppStateStorageLayout(rootDirectory: root))
+        store.prepareDirectories()
+        try operation(store)
+    }
+
+    private static func withTemporaryStoreAsync(
+        _ operation: (NoteAssetStore) async throws -> Void
+    ) async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("note-asset-store-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = NoteAssetStore(storageLayout: AppStateStorageLayout(rootDirectory: root))
+        store.prepareDirectories()
+        try await operation(store)
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ label: String
+    ) throws {
+        guard condition() else { throw TestFailure(label) }
+    }
+}
+
+private struct TestFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}


### PR DESCRIPTION
## Summary

- add `NoteAssetStore`, an instance-owned, throwing boundary over `AppStateStorageLayout` for note audio and transcript files
- migrate the two `AppState` call sites that are not pinned by exact-source-text tests elsewhere (`loadTranscript(from:)`, `storedAudioURL(for:)`) to delegate to it
- add `Tests/NoteAssetStoreTests.swift` covering save/load/delete round trips, missing-file failures, directory-creation failure, and two independent storage layouts

## Scope note (read before reviewing)

While implementing this, I found that most of the remaining audio/transcript call sites (`importAudioFile`, stopped-recording save/delete, cloud-transcription cleanup) are pinned by **exact literal source-text assertions** in other, unrelated test suites:

- `Tests/AudioImportFileCopyTests.swift` — locks the exact signature of `saveSecurityScopedAudioFileOffMain` and the exact call-site text in `importAudioFile`
- `Tests/CombinedRecordingNormalStopIntegrationTests.swift` — locks the exact body of `savedAudioFileForStoppedRecording`
- `Tests/AppStateCloudTranscriptionCleanupSourceTests.swift` — locks `Self.deleteStoredFiles(...)` call-site text and the `private static func deleteAudioFile(` declaration as a block boundary
- `Tests/AppStateRecordingJournalIntegrationSourceTests.swift` — locks `savedAudioFileForStoppedRecording(...)` and `Self.deleteStoredFiles(...)`/`Self.deleteAudioFile(...)` text inside `persistAudioOnlyRecording`'s catch body

Migrating those call sites to `NoteAssetStore` would break all four suites for textual reasons, not behavioral ones — the same brittleness problem #313 addressed for history tests, just not yet done for these. Converting those suites to behavioral tests first is a materially larger, separate effort (touches recording-journal persistence-failure recovery, one of the most safety-sensitive paths in the app), so it's scoped out of this PR and tracked as follow-up rather than folded in here.

This PR intentionally delivers a smaller, safe slice: the boundary type exists, is fully tested, and owns the two call sites it safely can. `NoteAssetStore.saveAudio`, `saveSecurityScopedAudio`, `deleteAudio`, `deleteTranscript`, and `deleteAssets` are implemented and tested but not yet wired into the locked call sites.

## Validation

- `make check-test-wiring`
- `make test`
- `make all CODESIGN_IDENTITY=Quill`
- local `/code-review` (medium): no findings

This is part of the standalone internal-refactoring track (#321), independent of the product roadmap.

Closes #314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 오디오와 transcript 파일을 저장, 불러오기, 삭제할 수 있는 저장 기능을 추가했습니다.
  * 저장 레이아웃에 따라 자산을 안전하게 관리하고, 관련 오류를 명확하게 안내합니다.
  * 앱 상태에서 transcript와 오디오 자산 처리를 일관된 방식으로 지원합니다.

* **버그 수정**
  * 저장 실패 및 transcript 로드 실패가 적절한 오류로 처리됩니다.

* **테스트**
  * 저장·로드·삭제, 경로 처리, 확장자 보존 및 저장소 격리를 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->