### PR TITLE
Introduce an instance-owned credential storage boundary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ FULL_SOURCE_APP_STATE_TESTS = \
 	Tests/AppStateTestStorage.swift \
 	Tests/AppStateDependenciesTests.swift \
 	Tests/NoteAssetStoreTests.swift \
+	Tests/CredentialStoreTests.swift \
 	Tests/AppStateStorageSafetyTests.swift \
 	Tests/AppStateHistoryProtectionSourceTests.swift \
 	Tests/AppStateTranscriptionConfigurationTests.swift \

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -8447,6 +8447,54 @@
         }
       }
     },
+    "Unable to save API key": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to save API key"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 키를 저장할 수 없음"
+          }
+        }
+      }
+    },
+    "Unable to save API base URL": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to save API base URL"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 기본 URL을 저장할 수 없음"
+          }
+        }
+      }
+    },
+    "Unable to save the provider value": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to save the provider value"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제공자 값을 저장할 수 없음"
+          }
+        }
+      }
+    },
     "Failed to save note title": {
       "localizations": {
         "en": {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2435,6 +2435,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let dependencies: AppStateDependencies
     var storageLayout: AppStateStorageLayout { dependencies.storageLayout }
     var noteAssetStore: NoteAssetStore { NoteAssetStore(storageLayout: storageLayout) }
+    var credentialStore: CredentialStore {
+        CredentialStore(layout: dependencies.credentialStorageLayout)
+    }
     private var pipelineHistoryStore: PipelineHistoryStore
     private var recordingJournalStore: RecordingJournalStore
     private var cloudTranscriptionJobStore: CloudTranscriptionJobStore
@@ -2512,11 +2515,26 @@ final class AppState: ObservableObject, @unchecked Sendable {
         if hasCompletedSetup && !hasStoredTranscriptionEnabled {
             UserDefaults.standard.set(true, forKey: transcriptionEnabledStorageKey)
         }
-        let apiKey = Self.loadStoredAPIKey(account: apiKeyStorageKey)
-        let apiBaseURL = Self.loadStoredAPIBaseURL(account: "api_base_url")
+        let initialCredentialStore = CredentialStore(
+            layout: dependencies.credentialStorageLayout
+        )
+        let apiKey = Self.loadStoredAPIKey(
+            account: apiKeyStorageKey,
+            credentialStore: initialCredentialStore
+        )
+        let apiBaseURL = Self.loadStoredAPIBaseURL(
+            account: "api_base_url",
+            credentialStore: initialCredentialStore
+        )
         let transcriptionModel = UserDefaults.standard.string(forKey: transcriptionModelStorageKey) ?? Self.defaultTranscriptionModel
-        let transcriptionAPIURL = Self.loadOptionalStoredAPIValue(account: transcriptionAPIURLStorageKey)
-        let transcriptionAPIKey = Self.loadStoredAPIKey(account: transcriptionAPIKeyStorageKey)
+        let transcriptionAPIURL = Self.loadOptionalStoredAPIValue(
+            account: transcriptionAPIURLStorageKey,
+            credentialStore: initialCredentialStore
+        )
+        let transcriptionAPIKey = Self.loadStoredAPIKey(
+            account: transcriptionAPIKeyStorageKey,
+            credentialStore: initialCredentialStore
+        )
         let meetingSummarySettingsInitialized = UserDefaults.standard.bool(
             forKey: meetingSummarySettingsInitializedStorageKey
         )
@@ -4266,8 +4284,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         defaultInputDeviceListenerAddress = nil
     }
 
-    private static func loadStoredAPIKey(account: String) -> String {
-        if let storedKey = AppSettingsStorage.load(account: account), !storedKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+    private static func loadStoredAPIKey(
+        account: String,
+        credentialStore: CredentialStore
+    ) -> String {
+        if let storedKey = credentialStore.load(account: account), !storedKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return storedKey
         }
         return ""
@@ -4276,9 +4297,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func persistAPIKey(_ value: String) {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {
-            AppSettingsStorage.delete(account: apiKeyStorageKey)
+            try? credentialStore.delete(account: apiKeyStorageKey)
         } else {
-            AppSettingsStorage.save(trimmed, account: apiKeyStorageKey)
+            try? credentialStore.save(trimmed, account: apiKeyStorageKey)
         }
     }
 
@@ -4304,8 +4325,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let didNormalize: Bool
     }
 
-    private static func loadStoredAPIBaseURL(account: String) -> String {
-        if let stored = AppSettingsStorage.load(account: account), !stored.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+    private static func loadStoredAPIBaseURL(
+        account: String,
+        credentialStore: CredentialStore
+    ) -> String {
+        if let stored = credentialStore.load(account: account), !stored.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return stored
         }
         return defaultAPIBaseURL
@@ -4524,23 +4548,26 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func persistAPIBaseURL(_ value: String) {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty || trimmed == Self.defaultAPIBaseURL {
-            AppSettingsStorage.delete(account: apiBaseURLStorageKey)
+            try? credentialStore.delete(account: apiBaseURLStorageKey)
         } else {
-            AppSettingsStorage.save(trimmed, account: apiBaseURLStorageKey)
+            try? credentialStore.save(trimmed, account: apiBaseURLStorageKey)
         }
     }
 
     private func persistOptionalAPIValue(_ value: String, account: String) {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {
-            AppSettingsStorage.delete(account: account)
+            try? credentialStore.delete(account: account)
         } else {
-            AppSettingsStorage.save(trimmed, account: account)
+            try? credentialStore.save(trimmed, account: account)
         }
     }
 
-    private static func loadOptionalStoredAPIValue(account: String) -> String {
-        let stored = AppSettingsStorage.load(account: account) ?? ""
+    private static func loadOptionalStoredAPIValue(
+        account: String,
+        credentialStore: CredentialStore
+    ) -> String {
+        let stored = credentialStore.load(account: account) ?? ""
         return stored.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -4296,10 +4296,26 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func persistAPIKey(_ value: String) {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            try? credentialStore.delete(account: apiKeyStorageKey)
-        } else {
-            try? credentialStore.save(trimmed, account: apiKeyStorageKey)
+        persistCredential(prefix: "Unable to save API key") {
+            if trimmed.isEmpty {
+                try credentialStore.delete(account: apiKeyStorageKey)
+            } else {
+                try credentialStore.save(trimmed, account: apiKeyStorageKey)
+            }
+        }
+    }
+
+    private func persistCredential(
+        prefix: String,
+        _ operation: () throws -> Void
+    ) {
+        do {
+            try operation()
+        } catch {
+            errorMessage = LocalizedUserMessage.providerFailure(
+                prefix: localizedCatalogString(prefix),
+                providerDetail: error.localizedDescription
+            )
         }
     }
 
@@ -4547,19 +4563,23 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private func persistAPIBaseURL(_ value: String) {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty || trimmed == Self.defaultAPIBaseURL {
-            try? credentialStore.delete(account: apiBaseURLStorageKey)
-        } else {
-            try? credentialStore.save(trimmed, account: apiBaseURLStorageKey)
+        persistCredential(prefix: "Unable to save API base URL") {
+            if trimmed.isEmpty || trimmed == Self.defaultAPIBaseURL {
+                try credentialStore.delete(account: apiBaseURLStorageKey)
+            } else {
+                try credentialStore.save(trimmed, account: apiBaseURLStorageKey)
+            }
         }
     }
 
     private func persistOptionalAPIValue(_ value: String, account: String) {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            try? credentialStore.delete(account: account)
-        } else {
-            try? credentialStore.save(trimmed, account: account)
+        persistCredential(prefix: "Unable to save the provider value") {
+            if trimmed.isEmpty {
+                try credentialStore.delete(account: account)
+            } else {
+                try credentialStore.save(trimmed, account: account)
+            }
         }
     }
 

--- a/Sources/AppStateDependencies.swift
+++ b/Sources/AppStateDependencies.swift
@@ -38,6 +38,7 @@ struct AppStateStorageLayout: Sendable {
 
 struct AppStateDependencies {
     var storageLayout: AppStateStorageLayout
+    var credentialStorageLayout: CredentialStorageLayout
     var makePipelineHistoryStore:
         @Sendable (URL) -> PipelineHistoryStore
     var makeMeetingSummaryGenerator:
@@ -48,6 +49,7 @@ struct AppStateDependencies {
     static var live: AppStateDependencies {
         AppStateDependencies(
             storageLayout: .live,
+            credentialStorageLayout: .live,
             makePipelineHistoryStore: { PipelineHistoryStore(storeURL: $0) },
             makeMeetingSummaryGenerator: { appState in
                 appState.makeMeetingSummaryService()

--- a/Sources/CredentialStore.swift
+++ b/Sources/CredentialStore.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+enum CredentialStoreError: Error {
+    case writeFailed(underlying: Error)
+}
+
+/// A focused, instance-owned boundary over the on-disk credential/settings
+/// file `AppSettingsStorage` also reads and writes.
+///
+/// `AppSettingsStorage.storageDirectoryOverride` remains in place as a
+/// transitional bridge: `CredentialStorageLayout.live` still consults it so
+/// the many existing tests in `AppStateTranscriptionConfigurationTests` and
+/// `AppStateAIProcessingBackendTests` that redirect it before constructing a
+/// bare `AppState()` keep working unchanged. Those two suites construct
+/// `AppState()` at roughly 150 call sites relying on that global today;
+/// migrating all of them to inject `credentialStorageLayout` explicitly is a
+/// materially larger, separate effort tracked as a follow-up rather than
+/// folded into this PR. Production code (`AppState`) no longer reads
+/// `AppSettingsStorage` directly — it goes through this type.
+struct CredentialStorageLayout: Sendable {
+    let directory: URL
+
+    static var live: CredentialStorageLayout {
+        CredentialStorageLayout(
+            directory: AppSettingsStorage.storageDirectoryOverride
+                ?? AppSettingsStorage.defaultStorageDirectory
+        )
+    }
+}
+
+struct CredentialStore: Sendable {
+    let layout: CredentialStorageLayout
+
+    private var settingsFileURL: URL {
+        layout.directory.appendingPathComponent(".settings")
+    }
+
+    func load(account: String) -> String? {
+        loadSettings()[account]
+    }
+
+    func save(_ value: String, account: String) throws {
+        var dict = loadSettings()
+        dict[account] = value
+        try writeSettings(dict)
+    }
+
+    func delete(account: String) throws {
+        var dict = loadSettings()
+        dict.removeValue(forKey: account)
+        try writeSettings(dict)
+    }
+
+    private func prepareDirectory() {
+        let directory = layout.directory
+        if !FileManager.default.fileExists(atPath: directory.path) {
+            try? FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+        }
+    }
+
+    private func loadSettings() -> [String: String] {
+        let url = settingsFileURL
+        guard FileManager.default.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url),
+              let dict = try? JSONDecoder().decode([String: String].self, from: data) else {
+            return [:]
+        }
+        return dict
+    }
+
+    private func writeSettings(_ dict: [String: String]) throws {
+        prepareDirectory()
+        let url = settingsFileURL
+        do {
+            let data = try JSONEncoder().encode(dict)
+            try data.write(to: url, options: [.atomic])
+        } catch {
+            throw CredentialStoreError.writeFailed(underlying: error)
+        }
+        // Restrict to owner-only read/write (0600). Best-effort: the value
+        // is already durably written above, so a permission-hardening
+        // failure here must not be reported as a write failure.
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: url.path
+        )
+    }
+}

--- a/Sources/CredentialStore.swift
+++ b/Sources/CredentialStore.swift
@@ -1,7 +1,14 @@
 import Foundation
 
-enum CredentialStoreError: Error {
+enum CredentialStoreError: LocalizedError {
     case writeFailed(underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .writeFailed(let underlying):
+            underlying.localizedDescription
+        }
+    }
 }
 
 /// A focused, instance-owned boundary over the on-disk credential/settings

--- a/Sources/KeychainStorage.swift
+++ b/Sources/KeychainStorage.swift
@@ -1,76 +1,28 @@
 import Foundation
 
+/// Legacy static entry point, kept only so the ~150 existing call sites in
+/// `AppStateTranscriptionConfigurationTests` and `AppStateAIProcessingBackendTests`
+/// that redirect `storageDirectoryOverride` before constructing a bare
+/// `AppState()` keep working unchanged (see `CredentialStorageLayout.live`'s
+/// doc comment in `CredentialStore.swift`). All file I/O now lives in
+/// `CredentialStore`; this type only owns the override and delegates to it.
 enum AppSettingsStorage {
-    private static let bundleID = Bundle.main.bundleIdentifier ?? "com.woosublee.quill"
     static var storageDirectoryOverride: URL?
 
-    private static var defaultStorageDirectory: URL {
+    static var defaultStorageDirectory: URL {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         return appSupport.appendingPathComponent(AppName.displayName, isDirectory: true)
     }
 
-    private static var storageDirectory: URL {
-        let dir = storageDirectoryOverride ?? defaultStorageDirectory
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir
-    }
-
-    private static var settingsFileURL: URL {
-        storageDirectory.appendingPathComponent(".settings")
-    }
-
-    // MARK: - Public API
-
     static func load(account: String) -> String? {
-        migrateFromKeychainIfNeeded(account: account)
-        let dict = loadSettings()
-        return dict[account]
+        CredentialStore(layout: .live).load(account: account)
     }
 
     static func save(_ value: String, account: String) {
-        var dict = loadSettings()
-        dict[account] = value
-        writeSettings(dict)
+        try? CredentialStore(layout: .live).save(value, account: account)
     }
 
     static func delete(account: String) {
-        var dict = loadSettings()
-        dict.removeValue(forKey: account)
-        writeSettings(dict)
+        try? CredentialStore(layout: .live).delete(account: account)
     }
-
-    // MARK: - File I/O
-
-    private static func loadSettings() -> [String: String] {
-        let url = settingsFileURL
-        guard FileManager.default.fileExists(atPath: url.path),
-              let data = try? Data(contentsOf: url),
-              let dict = try? JSONDecoder().decode([String: String].self, from: data) else {
-            return [:]
-        }
-        return dict
-    }
-
-    private static func writeSettings(_ dict: [String: String]) {
-        guard let data = try? JSONEncoder().encode(dict) else { return }
-        let url = settingsFileURL
-        try? data.write(to: url, options: [.atomic])
-        // Restrict to owner-only read/write (0600)
-        try? FileManager.default.setAttributes(
-            [.posixPermissions: 0o600],
-            ofItemAtPath: url.path
-        )
-    }
-
-    // MARK: - One-time migration from Keychain
-
-    private static let migrationDoneKey = "keychain_migration_done"
-
-    private static func migrateFromKeychainIfNeeded(account: String) {
-        var dict = loadSettings()
-        if dict[migrationDoneKey] != nil { return }
-        dict[migrationDoneKey] = "true"
-        writeSettings(dict)
-    }
-
 }

--- a/Tests/AppStateStorageSafetyTests.swift
+++ b/Tests/AppStateStorageSafetyTests.swift
@@ -5,6 +5,7 @@ struct AppStateStorageSafetyTests {
     static func main() async throws {
         try verifiesDefaultAppStateUsesLiveStorageLayout()
         try await verifiesAppStateInstancesKeepIndependentHistoryLayouts()
+        try await verifiesAppStateInstancesKeepIndependentCredentialStores()
         try await verifiesArchiveUsesOriginatingHistoryStoreFactory()
         try await verifiesHistoryCreatedAfterAssetsDoesNotSweep()
         try await verifiesHistoryRowsLostAfterSnapshotDoesNotSweep()
@@ -115,6 +116,65 @@ struct AppStateStorageSafetyTests {
                    "first AppState loads only its history layout")
         try expect(secondState.pipelineHistory.map(\.id) == [secondItem.id],
                    "second AppState loads only its history layout")
+    }
+
+    private static func verifiesAppStateInstancesKeepIndependentCredentialStores() async throws {
+        let parent = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quill-instance-credentials-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let firstStorageLayout = AppStateStorageLayout(
+            rootDirectory: parent.appendingPathComponent("first-storage", isDirectory: true)
+        )
+        let secondStorageLayout = AppStateStorageLayout(
+            rootDirectory: parent.appendingPathComponent("second-storage", isDirectory: true)
+        )
+        let firstCredentialLayout = CredentialStorageLayout(
+            directory: parent.appendingPathComponent("first-credentials", isDirectory: true)
+        )
+        let secondCredentialLayout = CredentialStorageLayout(
+            directory: parent.appendingPathComponent("second-credentials", isDirectory: true)
+        )
+        try CredentialStore(layout: firstCredentialLayout).save(
+            "first-instance-key",
+            account: "groq_api_key"
+        )
+        try CredentialStore(layout: secondCredentialLayout).save(
+            "second-instance-key",
+            account: "groq_api_key"
+        )
+
+        var firstDependencies = AppStateDependencies.live
+        firstDependencies.storageLayout = firstStorageLayout
+        firstDependencies.credentialStorageLayout = firstCredentialLayout
+        var secondDependencies = AppStateDependencies.live
+        secondDependencies.storageLayout = secondStorageLayout
+        secondDependencies.credentialStorageLayout = secondCredentialLayout
+        let configuredFirstDependencies = firstDependencies
+        let configuredSecondDependencies = secondDependencies
+        let firstState = await MainActor.run {
+            AppState(dependencies: configuredFirstDependencies)
+        }
+        let secondState = await MainActor.run {
+            AppState(dependencies: configuredSecondDependencies)
+        }
+
+        try expect(
+            firstState.apiKey == "first-instance-key",
+            "the first AppState loads its own stored API key"
+        )
+        try expect(
+            secondState.apiKey == "second-instance-key",
+            "the second AppState loads its own stored API key"
+        )
+
+        await MainActor.run {
+            firstState.apiKey = "first-instance-updated-key"
+        }
+        try expect(
+            CredentialStore(layout: secondCredentialLayout)
+                .load(account: "groq_api_key") == "second-instance-key",
+            "updating the first AppState's API key does not affect the second instance's stored credential"
+        )
     }
 
     private static func verifiesArchiveUsesOriginatingHistoryStoreFactory() async throws {

--- a/Tests/AppStateStorageSafetyTests.swift
+++ b/Tests/AppStateStorageSafetyTests.swift
@@ -171,6 +171,11 @@ struct AppStateStorageSafetyTests {
             firstState.apiKey = "first-instance-updated-key"
         }
         try expect(
+            CredentialStore(layout: firstCredentialLayout)
+                .load(account: "groq_api_key") == "first-instance-updated-key",
+            "updating the first AppState's API key persists to its own credential layout"
+        )
+        try expect(
             CredentialStore(layout: secondCredentialLayout)
                 .load(account: "groq_api_key") == "second-instance-key",
             "updating the first AppState's API key does not affect the second instance's stored credential"

--- a/Tests/AppStateTestStorage.swift
+++ b/Tests/AppStateTestStorage.swift
@@ -22,10 +22,11 @@ enum AppStateTestStorage {
             withIntermediateDirectories: true
         )
         let storageLayout = AppStateStorageLayout(rootDirectory: rootDirectory)
+        let settingsDirectory = rootDirectory.appendingPathComponent("settings", isDirectory: true)
         var dependencies = AppStateDependencies.live
         dependencies.storageLayout = storageLayout
-        AppSettingsStorage.storageDirectoryOverride = rootDirectory
-            .appendingPathComponent("settings", isDirectory: true)
+        dependencies.credentialStorageLayout = CredentialStorageLayout(directory: settingsDirectory)
+        AppSettingsStorage.storageDirectoryOverride = settingsDirectory
         defer {
             AppSettingsStorage.storageDirectoryOverride = originalSettingsDirectory
             try? FileManager.default.removeItem(at: rootDirectory)

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -3200,19 +3200,27 @@ struct AppStateTranscriptionConfigurationTests {
                 defaults: defaults,
                 key: "post_processing_backend_choice"
             )
-            AppSettingsStorage.save(
+            // AppState will be constructed with `environment.dependencies`, so
+            // fixture credentials must be written through the same
+            // credentialStorageLayout it will actually read from, not the
+            // process-global AppSettingsStorage override resetDefaults()
+            // points elsewhere.
+            let credentialStore = CredentialStore(
+                layout: environment.dependencies.credentialStorageLayout
+            )
+            try credentialStore.save(
                 "post-processing-key",
                 account: "groq_api_key"
             )
-            AppSettingsStorage.save(
+            try credentialStore.save(
                 "transcription-key",
                 account: "transcription_api_key"
             )
-            AppSettingsStorage.save(
+            try credentialStore.save(
                 "http://127.0.0.1:1",
                 account: "api_base_url"
             )
-            AppSettingsStorage.save(
+            try credentialStore.save(
                 "http://127.0.0.1:1",
                 account: "transcription_api_url"
             )

--- a/Tests/CredentialStoreTests.swift
+++ b/Tests/CredentialStoreTests.swift
@@ -1,0 +1,181 @@
+import Foundation
+
+#if !QUILL_GROUPED_TEST_RUNNER
+@main
+#endif
+struct CredentialStoreTests {
+    static func main() throws {
+        try testSaveAndLoadRoundTrips()
+        try testLoadReturnsNilForMissingAccount()
+        try testDeleteIsIdempotentForMissingAccount()
+        try testDeleteRemovesAnExistingValue()
+        try testSaveOverwritesAnExistingValue()
+        try testTwoStoresWithIndependentLayoutsDoNotShareValues()
+        try testSaveThrowsWhenDirectoryIsUnavailable()
+        try testDeleteThrowsWhenDirectoryIsUnavailable()
+        try testSettingsFileHasOwnerOnlyPermissions()
+        print("CredentialStoreTests passed")
+    }
+
+    private static func testSaveAndLoadRoundTrips() throws {
+        try withTemporaryStore { store in
+            try store.save("secret-value", account: "test_account")
+            let loaded = store.load(account: "test_account")
+            try expect(loaded == "secret-value", "loaded value matches the saved value")
+        }
+    }
+
+    private static func testLoadReturnsNilForMissingAccount() throws {
+        try withTemporaryStore { store in
+            try expect(
+                store.load(account: "missing-\(UUID().uuidString)") == nil,
+                "loading an account that was never saved returns nil"
+            )
+        }
+    }
+
+    private static func testDeleteIsIdempotentForMissingAccount() throws {
+        try withTemporaryStore { store in
+            try store.delete(account: "missing-\(UUID().uuidString)")
+        }
+    }
+
+    private static func testDeleteRemovesAnExistingValue() throws {
+        try withTemporaryStore { store in
+            try store.save("to-delete", account: "deletable_account")
+            try store.delete(account: "deletable_account")
+            try expect(
+                store.load(account: "deletable_account") == nil,
+                "a deleted account is no longer readable"
+            )
+        }
+    }
+
+    private static func testSaveOverwritesAnExistingValue() throws {
+        try withTemporaryStore { store in
+            try store.save("first-value", account: "overwritable_account")
+            try store.save("second-value", account: "overwritable_account")
+            try expect(
+                store.load(account: "overwritable_account") == "second-value",
+                "saving again overwrites the previous value"
+            )
+        }
+    }
+
+    private static func testTwoStoresWithIndependentLayoutsDoNotShareValues() throws {
+        let parent = FileManager.default.temporaryDirectory
+            .appendingPathComponent("credential-store-independent-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let firstStore = CredentialStore(
+            layout: CredentialStorageLayout(
+                directory: parent.appendingPathComponent("first", isDirectory: true)
+            )
+        )
+        let secondStore = CredentialStore(
+            layout: CredentialStorageLayout(
+                directory: parent.appendingPathComponent("second", isDirectory: true)
+            )
+        )
+
+        try firstStore.save("first-store-value", account: "shared_account_name")
+        try secondStore.save("second-store-value", account: "shared_account_name")
+
+        try expect(
+            firstStore.load(account: "shared_account_name") == "first-store-value",
+            "the first store keeps its own value"
+        )
+        try expect(
+            secondStore.load(account: "shared_account_name") == "second-store-value",
+            "the second store keeps its own value independent of the first"
+        )
+    }
+
+    private static func testSaveThrowsWhenDirectoryIsUnavailable() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("credential-store-blocked-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let directory = root.appendingPathComponent("settings-dir", isDirectory: true)
+        // Create a plain file where the settings directory should be, so
+        // FileManager cannot create it and any write into it fails.
+        try Data().write(to: directory)
+        let store = CredentialStore(layout: CredentialStorageLayout(directory: directory))
+
+        do {
+            try store.save("unwritable", account: "blocked_account")
+            throw TestFailure("expected save to throw when its directory cannot be created")
+        } catch is CredentialStoreError {
+            // expected
+        }
+    }
+
+    private static func testDeleteThrowsWhenDirectoryIsUnavailable() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("credential-store-blocked-delete-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let directory = root.appendingPathComponent("settings-dir", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let store = CredentialStore(layout: CredentialStorageLayout(directory: directory))
+        try store.save("value", account: "account_to_block")
+
+        // Replace the writable directory with a read-only one so the
+        // subsequent rewrite (delete is implemented as a rewrite of the
+        // settings dictionary) fails.
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o555],
+            ofItemAtPath: directory.path
+        )
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: directory.path
+            )
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        do {
+            try store.delete(account: "account_to_block")
+            throw TestFailure("expected delete to throw when its directory cannot be written")
+        } catch is CredentialStoreError {
+            // expected
+        }
+    }
+
+    private static func testSettingsFileHasOwnerOnlyPermissions() throws {
+        try withTemporaryStore { store in
+            try store.save("permission-checked-value", account: "permission_account")
+            let url = store.layout.directory.appendingPathComponent(".settings")
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+            let permissions = (attributes[.posixPermissions] as? NSNumber)?.intValue
+            try expect(
+                permissions == 0o600,
+                "the settings file is restricted to owner-only read/write"
+            )
+        }
+    }
+
+    private static func withTemporaryStore(
+        _ operation: (CredentialStore) throws -> Void
+    ) throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("credential-store-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = CredentialStore(layout: CredentialStorageLayout(directory: root))
+        try operation(store)
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ label: String
+    ) throws {
+        guard condition() else { throw TestFailure(label) }
+    }
+}
+
+private struct TestFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/Tests/CredentialStoreTests.swift
+++ b/Tests/CredentialStoreTests.swift
@@ -14,6 +14,7 @@ struct CredentialStoreTests {
         try testSaveThrowsWhenDirectoryIsUnavailable()
         try testDeleteThrowsWhenDirectoryIsUnavailable()
         try testSettingsFileHasOwnerOnlyPermissions()
+        try testErrorDescriptionSurfacesTheUnderlyingFailure()
         print("CredentialStoreTests passed")
     }
 
@@ -106,6 +107,27 @@ struct CredentialStoreTests {
             throw TestFailure("expected save to throw when its directory cannot be created")
         } catch is CredentialStoreError {
             // expected
+        }
+    }
+
+    private static func testErrorDescriptionSurfacesTheUnderlyingFailure() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("credential-store-error-description-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let directory = root.appendingPathComponent("settings-dir", isDirectory: true)
+        try Data().write(to: directory)
+        let store = CredentialStore(layout: CredentialStorageLayout(directory: directory))
+
+        do {
+            try store.save("unwritable", account: "blocked_account")
+            throw TestFailure("expected save to throw when its directory cannot be created")
+        } catch let error as CredentialStoreError {
+            let description = error.localizedDescription
+            try expect(
+                !description.contains("CredentialStoreError"),
+                "the error description surfaces the underlying failure, not the generic enum-case fallback"
+            )
         }
     }
 

--- a/Tests/FullSourceAppStateTestRunner.swift
+++ b/Tests/FullSourceAppStateTestRunner.swift
@@ -14,6 +14,7 @@ struct FullSourceAppStateTestRunner {
         try await AppStateTestStorage.withIsolatedStorage { _ in
             try AppStateDependenciesTests.main()
             try await NoteAssetStoreTests.main()
+            try CredentialStoreTests.main()
             try await AudioImportFileCopyTests.main()
             try LatestValueProgressCoalescerTests.main()
             try await AppStateStorageSafetyTests.main()


### PR DESCRIPTION
## Summary

- add `CredentialStore`, an instance-owned, throwing boundary over the on-disk credential/settings file, and wire it into `AppStateDependencies` as `credentialStorageLayout`
- migrate all 9 `AppState.swift` call sites that previously called `AppSettingsStorage`'s static `load`/`save`/`delete` directly
- `AppSettingsStorage` now delegates to `CredentialStore(layout: .live)` instead of duplicating file I/O, and its dead keychain-migration bookkeeping (which no longer touches a real Keychain) is removed entirely rather than copied into the new type
- add `Tests/CredentialStoreTests.swift` (round-trip, missing-value, delete, independent layouts, directory/permission failures) and a behavioral test proving two `AppState` instances keep independent credential stores

## Scope note (read before reviewing)

While implementing this, I found that ~150 combined call sites in `Tests/AppStateTranscriptionConfigurationTests.swift` and `Tests/AppStateAIProcessingBackendTests.swift` construct a bare `AppState()` after redirecting the process-global `AppSettingsStorage.storageDirectoryOverride`. Migrating all of them to inject `credentialStorageLayout` explicitly per test is a materially larger, separate effort (the code between the override redirect and the `AppState()` construction varies per test, so it isn't a single mechanical transform), so it's scoped out of this PR and tracked as a follow-up.

`AppSettingsStorage.storageDirectoryOverride` intentionally remains as a transitional bridge: `CredentialStorageLayout.live` still consults it, so those ~150 call sites keep working unchanged. Production code (`AppState`) no longer reads `AppSettingsStorage` directly — it goes through `CredentialStore`.

One existing test, `testResumedRetryPersistsAIProcessingOutcome`, wrote fixture credentials via the global override while constructing `AppState` from `environment.dependencies` — a real mismatch this migration surfaced (the override and the environment's `credentialStorageLayout` point at different directories). Fixed by routing its fixture writes through `environment.dependencies.credentialStorageLayout` instead.

## Validation

- `make check-test-wiring`
- `make test`
- `make all CODESIGN_IDENTITY=Quill`
- local `/code-review` (medium), three passes: initial pass found the mismatched-directory test bug above plus 6 cleanup findings (duplicated file I/O between `AppSettingsStorage` and `CredentialStore`, dead migration bookkeeping, a chmod failure incorrectly reported as a save failure); a follow-up pass after fixing them found no further issues

This is part of the standalone internal-refactoring track (#321), independent of the product roadmap.

Closes #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 자격 증명 저장 및 관리를 독립적인 저장소로 분리해 앱 상태 간 데이터 간섭을 방지했습니다.
  * API 키와 관련 설정을 안전하게 저장하고 삭제할 수 있으며, 저장 파일은 소유자 전용 권한으로 보호됩니다.

* **버그 수정**
  * 저장소별 자격 증명이 서로 덮어쓰이지 않도록 개선했습니다.
  * 손상되었거나 읽을 수 없는 설정 파일을 안정적으로 처리합니다.

* **테스트**
  * 자격 증명 저장·조회·삭제, 덮어쓰기, 저장소 독립성 및 파일 권한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->