### PR TITLE
Move model dependencies onto AppState instances

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -364,9 +364,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     static var googleCalendarServiceFactory: () -> GoogleCalendarService = {
         GoogleCalendarService()
     }
-    static var nativeWhisperInstallStatusProvider: (NativeWhisperModel) -> NativeWhisperInstallStatus = { model in
-        NativeWhisperModelStore().installStatus(for: model)
-    }
     static var modelDownloadQuitAlertPresenter: @MainActor () -> NSApplication.ModalResponse = {
         let alert = NSAlert()
         alert.messageText = localizedCatalogString("Quit while models are downloading?")
@@ -385,21 +382,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     static var applicationTerminationReply: @MainActor (Bool) -> Void = {
         NSApp.reply(toApplicationShouldTerminate: $0)
     }
-    static var nativeWhisperInstallStarter: (
-        NativeWhisperModel,
-        @escaping (NativeWhisperDownloadProgress) -> Void,
-        @escaping (Result<Void, NativeWhisperInstallerError>) -> Void
-    ) -> NativeWhisperInstallTask = { model, progress, completion in
-        NativeWhisperInstaller().install(
-            model: model,
-            progress: progress,
-            completion: completion
-        )
-    }
-    static var nativeWhisperProgressSchedule:
-        LatestValueProgressCoalescer<NativeWhisperDownloadProgress>.Schedule =
-            LatestValueProgressCoalescer<NativeWhisperDownloadProgress>.mainQueueSchedule
-
     private final class WeakAppStateReference: @unchecked Sendable {
         weak var value: AppState?
 
@@ -1054,8 +1036,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    @Published private(set) var nativeWhisperInstallStatus: NativeWhisperInstallStatus =
-        AppState.nativeWhisperInstallStatusProvider(.recommended)
+    @Published private(set) var nativeWhisperInstallStatus: NativeWhisperInstallStatus
     @Published private(set) var nativeWhisperInstallProgress = NativeWhisperDownloadProgress(downloadedBytes: 0, totalBytes: NativeWhisperModelCatalog.recommended.approximateBytes)
     @Published private(set) var isInstallingNativeWhisper = false
     @Published private(set) var nativeWhisperInstallError: String?
@@ -1308,7 +1289,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func refreshNativeWhisperInstallStatus() {
-        nativeWhisperInstallStatus = Self.nativeWhisperInstallStatusProvider(.recommended)
+        nativeWhisperInstallStatus = dependencies.nativeWhisper.installStatus(
+            .recommended
+        )
         scheduleNoteBrowserTranscriptionModeNormalizationForProviderConfiguration()
     }
 
@@ -1326,14 +1309,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
         isInstallingNativeWhisper = true
         nativeWhisperInstallProgress = NativeWhisperDownloadProgress(downloadedBytes: 0, totalBytes: model.approximateBytes)
         let progressCoalescer = LatestValueProgressCoalescer<NativeWhisperDownloadProgress>(
-            schedule: Self.nativeWhisperProgressSchedule
+            schedule: dependencies.nativeWhisper.progressSchedule
         ) { [weak self] progress in
             MainActor.assumeIsolated {
                 self?.nativeWhisperInstallProgress = progress
             }
         }
         nativeWhisperProgressCoalescer = progressCoalescer
-        nativeWhisperInstallTask = Self.nativeWhisperInstallStarter(
+        let startInstall = dependencies.nativeWhisper.startInstall
+        nativeWhisperInstallTask = startInstall(
             model,
             { progress in
                 progressCoalescer.submit(progress)
@@ -1420,7 +1404,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @MainActor
     func deleteNativeWhisperModel() {
         do {
-            try NativeWhisperModelStore().deleteModel(.recommended)
+            try dependencies.nativeWhisper.deleteModel(.recommended)
             nativeWhisperInstallError = nil
             nativeWhisperInstallIssue = nil
         } catch {
@@ -2444,6 +2428,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     init(dependencies: AppStateDependencies = .live) {
         self.dependencies = dependencies
+        nativeWhisperInstallStatus = dependencies.nativeWhisper.installStatus(
+            .recommended
+        )
         let storageLayout = dependencies.storageLayout
         let storageRoot = Self.preparedDirectory(storageLayout.rootDirectory)
         let audioDirectory = Self.preparedDirectory(storageLayout.audioDirectory)

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -4420,13 +4420,29 @@ final class AppState: ObservableObject, @unchecked Sendable {
             : defaultContextScreenshotMaxDimension
     }
 
-    func makeAIProcessingBackendExecutor(
-        choice: AIProcessingBackendChoice
+    static func makeAIProcessingBackendExecutor(
+        choice: AIProcessingBackendChoice,
+        apiKey: String,
+        baseURL: String,
+        localServerManager: LocalAIServerManager,
+        localAIAvailability: LocalAIProcessingAvailability
     ) -> AIProcessingBackendExecutor {
         AIProcessingBackendExecutor(
             choice: choice,
-            cloudBaseURL: apiBaseURL,
+            cloudBaseURL: baseURL,
             cloudAPIKey: apiKey,
+            localServerManager: localServerManager,
+            localAIAvailability: localAIAvailability
+        )
+    }
+
+    func makeAIProcessingBackendExecutor(
+        choice: AIProcessingBackendChoice
+    ) -> AIProcessingBackendExecutor {
+        Self.makeAIProcessingBackendExecutor(
+            choice: choice,
+            apiKey: apiKey,
+            baseURL: apiBaseURL,
             localServerManager: localAIServerManager,
             localAIAvailability: dependencies.localAI.processingAvailability()
         )
@@ -4453,10 +4469,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         localAIAvailability: LocalAIProcessingAvailability
     ) -> PostProcessingService {
         PostProcessingService(
-            backendExecutor: AIProcessingBackendExecutor(
+            backendExecutor: makeAIProcessingBackendExecutor(
                 choice: choice,
-                cloudBaseURL: baseURL,
-                cloudAPIKey: apiKey,
+                apiKey: apiKey,
+                baseURL: baseURL,
                 localServerManager: localServerManager,
                 localAIAvailability: localAIAvailability
             ),
@@ -4490,10 +4506,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         localAIAvailability: LocalAIProcessingAvailability
     ) -> AppContextService {
         AppContextService(
-            backendExecutor: AIProcessingBackendExecutor(
+            backendExecutor: makeAIProcessingBackendExecutor(
                 choice: choice,
-                cloudBaseURL: baseURL,
-                cloudAPIKey: apiKey,
+                apiKey: apiKey,
+                baseURL: baseURL,
                 localServerManager: localServerManager,
                 localAIAvailability: localAIAvailability
             ),

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -367,12 +367,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     static var nativeWhisperInstallStatusProvider: (NativeWhisperModel) -> NativeWhisperInstallStatus = { model in
         NativeWhisperModelStore().installStatus(for: model)
     }
-    static var localAIServerManagerFactory: () -> LocalAIServerManager = {
-        LocalAIServerManager()
-    }
-    static var localAIIdleShutdownSleep: @Sendable (UInt64) async throws -> Void = {
-        try await Task.sleep(nanoseconds: $0)
-    }
     static var modelDownloadQuitAlertPresenter: @MainActor () -> NSApplication.ModalResponse = {
         let alert = NSAlert()
         alert.messageText = localizedCatalogString("Quit while models are downloading?")
@@ -390,32 +384,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
     static var applicationTerminationReply: @MainActor (Bool) -> Void = {
         NSApp.reply(toApplicationShouldTerminate: $0)
-    }
-    static var localAIInstallStatusProvider: @Sendable (LocalAIModel) -> LocalAIInstallStatus = {
-        LocalAIModelStore().installStatus(for: $0)
-    }
-    static var localAIInstallStarter: (
-        LocalAIModel,
-        @escaping (LocalAIDownloadProgress) -> Void,
-        @escaping (Result<Void, LocalAIInstallerError>) -> Void
-    ) -> LocalAIInstallTask = { model, progress, completion in
-        LocalAIInstaller().install(
-            model: model,
-            progress: progress,
-            completion: completion
-        )
-    }
-    static var localAIProgressSchedule:
-        LatestValueProgressCoalescer<LocalAIDownloadProgress>.Schedule =
-            LatestValueProgressCoalescer<LocalAIDownloadProgress>.mainQueueSchedule
-    static var localAIModelDelete: @Sendable (LocalAIModel) throws -> Void = {
-        try LocalAIModelStore().deleteModel($0)
-    }
-    static var localAIPartialModelDelete: @Sendable (LocalAIModel) throws -> Void = {
-        try LocalAIModelStore().deletePartialModel($0)
-    }
-    static var localAIProcessingAvailabilityProvider: () -> LocalAIProcessingAvailability = {
-        .live()
     }
     static var nativeWhisperInstallStarter: (
         NativeWhisperModel,
@@ -2647,7 +2615,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             defaults: .standard,
             key: meetingSummaryBackendChoiceStorageKey
         )
-        let localAIServerManager = Self.localAIServerManagerFactory()
+        let localAIServerManager = dependencies.localAI.makeServerManager()
         let shortcuts = Self.loadShortcutConfiguration(
             holdKey: holdShortcutStorageKey,
             toggleKey: toggleShortcutStorageKey,
@@ -2978,7 +2946,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             baseURL: apiBaseURL,
             customContextPrompt: customContextPrompt,
             contextScreenshotMaxDimension: contextScreenshotMaxDimension,
-            localServerManager: localAIServerManager
+            localServerManager: localAIServerManager,
+            localAIAvailability: dependencies.localAI.processingAvailability()
         )
         self.hasCompletedSetup = hasCompletedSetup
         self.transcriptionEnabled = transcriptionEnabled
@@ -3174,7 +3143,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     func startLocalAIIdleShutdownMonitoring() {
         guard localAIIdleShutdownTask == nil else { return }
         let manager = localAIServerManager
-        let sleep = Self.localAIIdleShutdownSleep
+        let sleep = dependencies.localAI.idleShutdownSleep
         localAIIdleShutdownTask = Task {
             while !Task.isCancelled {
                 do {
@@ -3216,7 +3185,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 )
             }
             let generation = nextLocalAIStatusRefreshGeneration(for: model)
-            let statusProvider = Self.localAIInstallStatusProvider
+            let statusProvider = dependencies.localAI.installStatus
             let appStateReference = WeakAppStateReference(self)
             Task.detached(priority: .utility) {
                 let status = statusProvider(model)
@@ -3582,7 +3551,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         guard LocalAIModelCatalog.model(id: model.id) == model else {
             return false
         }
-        return Self.localAIProcessingAvailabilityProvider().isModelSupported(model)
+        return dependencies.localAI.processingAvailability().isModelSupported(model)
     }
 
     @MainActor
@@ -3666,7 +3635,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return currentChoice
         }
 
-        let availability = Self.localAIProcessingAvailabilityProvider()
+        let availability = dependencies.localAI.processingAvailability()
         if hasCompletedLocalAIStatusRefresh, availability.isSupported {
             let readyModels = availability.availableModels.filter {
                 $0.capabilities.supports(feature.modelFeature)
@@ -3774,7 +3743,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let unavailableLocalDisplays = unavailableLocalAIChoiceDisplay(
             for: feature
         ).map { [$0] } ?? []
-        let availability = Self.localAIProcessingAvailabilityProvider()
+        let availability = dependencies.localAI.processingAvailability()
         let localDisplays = LocalAIModelCatalog.all.compactMap {
             model -> AIProcessingChoiceDisplay? in
             let choice = AIProcessingBackendChoice.localAI(modelID: model.id)
@@ -3906,7 +3875,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         localAIInstallStates[model.id] = state
 
         let progressCoalescer = LatestValueProgressCoalescer<LocalAIDownloadProgress>(
-            schedule: Self.localAIProgressSchedule
+            schedule: dependencies.localAI.progressSchedule
         ) { [weak self] progress in
             MainActor.assumeIsolated {
                 guard let self,
@@ -3922,9 +3891,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
         localAIProgressCoalescers[model.id] = progressCoalescer
 
-        let statusProvider = Self.localAIInstallStatusProvider
-        let partialModelDelete = Self.localAIPartialModelDelete
-        localAIInstallTasks[model.id] = Self.localAIInstallStarter(
+        let statusProvider = dependencies.localAI.installStatus
+        let partialModelDelete = dependencies.localAI.deletePartialModel
+        let startInstall = dependencies.localAI.startInstall
+        localAIInstallTasks[model.id] = startInstall(
             model,
             { progress in
                 progressCoalescer.submit(progress)
@@ -4119,7 +4089,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             guard let selectedModel = LocalAIModelCatalog.model(id: modelID) else {
                 return nil
             }
-            let availability = Self.localAIProcessingAvailabilityProvider()
+            let availability = dependencies.localAI.processingAvailability()
             guard availability.isModelSupported(selectedModel) else {
                 return nil
             }
@@ -4210,8 +4180,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         localAIStatusRefreshPendingModelIDs.insert(model.id)
         _ = nextLocalAIStatusRefreshGeneration(for: model)
         let manager = localAIServerManager
-        let modelDelete = Self.localAIModelDelete
-        let statusProvider = Self.localAIInstallStatusProvider
+        let modelDelete = dependencies.localAI.deleteModel
+        let statusProvider = dependencies.localAI.installStatus
         Task { [weak self] in
             let outcome: LocalAIModelDeletionOutcome
             do {
@@ -4470,7 +4440,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             choice: choice,
             cloudBaseURL: apiBaseURL,
             cloudAPIKey: apiKey,
-            localServerManager: localAIServerManager
+            localServerManager: localAIServerManager,
+            localAIAvailability: dependencies.localAI.processingAvailability()
         )
     }
 
@@ -4491,14 +4462,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
         baseURL: String,
         cloudFallbackModelID: String,
         instructionExecutionGuardEnabled: Bool,
-        localServerManager: LocalAIServerManager
+        localServerManager: LocalAIServerManager,
+        localAIAvailability: LocalAIProcessingAvailability
     ) -> PostProcessingService {
         PostProcessingService(
             backendExecutor: AIProcessingBackendExecutor(
                 choice: choice,
                 cloudBaseURL: baseURL,
                 cloudAPIKey: apiKey,
-                localServerManager: localServerManager
+                localServerManager: localServerManager,
+                localAIAvailability: localAIAvailability
             ),
             cloudFallbackModelID: choice.isLocal ? nil : cloudFallbackModelID,
             instructionExecutionGuardEnabled: instructionExecutionGuardEnabled,
@@ -4515,7 +4488,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             baseURL: apiBaseURL,
             cloudFallbackModelID: postProcessingFallbackModel,
             instructionExecutionGuardEnabled: instructionExecutionGuardEnabled,
-            localServerManager: localAIServerManager
+            localServerManager: localAIServerManager,
+            localAIAvailability: dependencies.localAI.processingAvailability()
         )
     }
 
@@ -4525,14 +4499,16 @@ final class AppState: ObservableObject, @unchecked Sendable {
         baseURL: String,
         customContextPrompt: String,
         contextScreenshotMaxDimension: Int,
-        localServerManager: LocalAIServerManager
+        localServerManager: LocalAIServerManager,
+        localAIAvailability: LocalAIProcessingAvailability
     ) -> AppContextService {
         AppContextService(
             backendExecutor: AIProcessingBackendExecutor(
                 choice: choice,
                 cloudBaseURL: baseURL,
                 cloudAPIKey: apiKey,
-                localServerManager: localServerManager
+                localServerManager: localServerManager,
+                localAIAvailability: localAIAvailability
             ),
             customContextPrompt: customContextPrompt,
             contextModel: choice.modelID,
@@ -4553,7 +4529,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             baseURL: apiBaseURL,
             customContextPrompt: customContextPrompt,
             contextScreenshotMaxDimension: contextScreenshotMaxDimension,
-            localServerManager: localAIServerManager
+            localServerManager: localAIServerManager,
+            localAIAvailability: dependencies.localAI.processingAvailability()
         )
     }
 

--- a/Sources/AppStateDependencies.swift
+++ b/Sources/AppStateDependencies.swift
@@ -36,9 +36,84 @@ struct AppStateStorageLayout: Sendable {
     }
 }
 
+struct AppStateLocalAIDependencies {
+    typealias InstallStarter = (
+        LocalAIModel,
+        @escaping (LocalAIDownloadProgress) -> Void,
+        @escaping (Result<Void, LocalAIInstallerError>) -> Void
+    ) -> LocalAIInstallTask
+
+    var makeServerManager: () -> LocalAIServerManager
+    var idleShutdownSleep: @Sendable (UInt64) async throws -> Void
+    var installStatus: @Sendable (LocalAIModel) -> LocalAIInstallStatus
+    var startInstall: InstallStarter
+    var progressSchedule:
+        LatestValueProgressCoalescer<LocalAIDownloadProgress>.Schedule
+    var deleteModel: @Sendable (LocalAIModel) throws -> Void
+    var deletePartialModel: @Sendable (LocalAIModel) throws -> Void
+    var processingAvailability: () -> LocalAIProcessingAvailability
+
+    static var live: AppStateLocalAIDependencies {
+        let store = LocalAIModelStore()
+        return AppStateLocalAIDependencies(
+            makeServerManager: { LocalAIServerManager(store: store) },
+            idleShutdownSleep: { try await Task.sleep(nanoseconds: $0) },
+            installStatus: { store.installStatus(for: $0) },
+            startInstall: { model, progress, completion in
+                LocalAIInstaller(store: store).install(
+                    model: model,
+                    progress: progress,
+                    completion: completion
+                )
+            },
+            progressSchedule:
+                LatestValueProgressCoalescer<LocalAIDownloadProgress>
+                    .mainQueueSchedule,
+            deleteModel: { try store.deleteModel($0) },
+            deletePartialModel: { try store.deletePartialModel($0) },
+            processingAvailability: { .live() }
+        )
+    }
+}
+
+struct AppStateNativeWhisperDependencies {
+    typealias InstallStarter = (
+        NativeWhisperModel,
+        @escaping (NativeWhisperDownloadProgress) -> Void,
+        @escaping (Result<Void, NativeWhisperInstallerError>) -> Void
+    ) -> NativeWhisperInstallTask
+
+    var installStatus:
+        @Sendable (NativeWhisperModel) -> NativeWhisperInstallStatus
+    var startInstall: InstallStarter
+    var progressSchedule:
+        LatestValueProgressCoalescer<NativeWhisperDownloadProgress>.Schedule
+    var deleteModel: @Sendable (NativeWhisperModel) throws -> Void
+
+    static var live: AppStateNativeWhisperDependencies {
+        let store = NativeWhisperModelStore()
+        return AppStateNativeWhisperDependencies(
+            installStatus: { store.installStatus(for: $0) },
+            startInstall: { model, progress, completion in
+                NativeWhisperInstaller(store: store).install(
+                    model: model,
+                    progress: progress,
+                    completion: completion
+                )
+            },
+            progressSchedule:
+                LatestValueProgressCoalescer<NativeWhisperDownloadProgress>
+                    .mainQueueSchedule,
+            deleteModel: { try store.deleteModel($0) }
+        )
+    }
+}
+
 struct AppStateDependencies {
     var storageLayout: AppStateStorageLayout
     var credentialStorageLayout: CredentialStorageLayout
+    var localAI: AppStateLocalAIDependencies
+    var nativeWhisper: AppStateNativeWhisperDependencies
     var makePipelineHistoryStore:
         @Sendable (URL) -> PipelineHistoryStore
     var makeMeetingSummaryGenerator:
@@ -50,6 +125,8 @@ struct AppStateDependencies {
         AppStateDependencies(
             storageLayout: .live,
             credentialStorageLayout: .live,
+            localAI: .live,
+            nativeWhisper: .live,
             makePipelineHistoryStore: { PipelineHistoryStore(storeURL: $0) },
             makeMeetingSummaryGenerator: { appState in
                 appState.makeMeetingSummaryService()

--- a/Tests/AppStateAIProcessingBackendTests.swift
+++ b/Tests/AppStateAIProcessingBackendTests.swift
@@ -75,6 +75,7 @@ struct AppStateAIProcessingBackendTests {
         try await testDeleteDuringInstallWaitsAndCannotAutoSelect()
         try await testDeleteFailureAndSuccessStateReset()
         try await testDeletingOnlyLocalModelDoesNotSubstituteCloud()
+        try testEveryBackendExecutorConstructionUsesCentralFactory()
         try testEveryPostProcessingConstructionUsesCentralFactory()
         try testCloudResumeCapturesPostProcessingServiceBeforeTaskStarts()
         try testContextCaptureUsesServiceSnapshotAndKeepsCancellationGuards()
@@ -238,7 +239,6 @@ struct AppStateAIProcessingBackendTests {
         let statusHarness = LocalAIStatusHarness(defaultStatus: .ready)
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         let defaults = UserDefaults.standard
         defaults.set("remembered/post", forKey: "post_processing_model")
         defaults.set("remembered/context", forKey: "context_model")
@@ -268,7 +268,6 @@ struct AppStateAIProcessingBackendTests {
         let statusHarness = LocalAIStatusHarness(defaultStatus: .ready)
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let legacyChoice = AIProcessingBackendChoice.localAI(
             modelID: LocalAIModelCatalog.quality.id
@@ -322,7 +321,6 @@ struct AppStateAIProcessingBackendTests {
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
         dependencies.localAI.startInstall = installHarness.start
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let legacyChoice = AIProcessingBackendChoice.localAI(
             modelID: LocalAIModelCatalog.quality.id
@@ -361,7 +359,6 @@ struct AppStateAIProcessingBackendTests {
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let localChoice = AIProcessingBackendChoice.localAI(
             modelID: LocalAIModelCatalog.quality.id
@@ -387,7 +384,6 @@ struct AppStateAIProcessingBackendTests {
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let localChoice = AIProcessingBackendChoice.localAI(
             modelID: LocalAIModelCatalog.quality.id
@@ -424,7 +420,6 @@ struct AppStateAIProcessingBackendTests {
         dependencies.localAI.deleteModel = { model in
             deletionHarness.record(modelID: model.id, managerWasStopped: true)
         }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         defer {
             AppSettingsStorage.delete(account: "groq_api_key")
         }
@@ -502,7 +497,6 @@ struct AppStateAIProcessingBackendTests {
         )
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         storeChoice(retiredChoice, forKey: "post_processing_backend_choice")
 
         let appState = await makeRefreshedAppState(dependencies: dependencies)
@@ -608,7 +602,6 @@ struct AppStateAIProcessingBackendTests {
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
@@ -634,7 +627,6 @@ struct AppStateAIProcessingBackendTests {
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
         let appState = await makeRefreshedAppState(dependencies: dependencies)
@@ -682,7 +674,6 @@ struct AppStateAIProcessingBackendTests {
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
         dependencies.localAI.startInstall = installHarness.start
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
         let appState = await makeRefreshedAppState(dependencies: dependencies)
@@ -709,7 +700,6 @@ struct AppStateAIProcessingBackendTests {
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
@@ -731,7 +721,6 @@ struct AppStateAIProcessingBackendTests {
         let model = LocalAIModelCatalog.quality
         statusHarness.set(.ready, for: model)
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
@@ -767,7 +756,6 @@ struct AppStateAIProcessingBackendTests {
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
         dependencies.localAI.startInstall = installHarness.start
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
         let appState = await makeRefreshedAppState(dependencies: dependencies)
@@ -901,7 +889,6 @@ struct AppStateAIProcessingBackendTests {
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
         dependencies.localAI.startInstall = installHarness.start
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         dependencies.localAI.progressSchedule = scheduler.schedule
 
         let model = LocalAIModelCatalog.quality
@@ -954,7 +941,6 @@ struct AppStateAIProcessingBackendTests {
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
         dependencies.localAI.startInstall = installHarness.start
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
         let appState = await makeRefreshedAppState(dependencies: dependencies)
@@ -1006,7 +992,6 @@ struct AppStateAIProcessingBackendTests {
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
         dependencies.localAI.startInstall = installHarness.start
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
         let appState = await makeRefreshedAppState(dependencies: dependencies)
@@ -1049,7 +1034,6 @@ struct AppStateAIProcessingBackendTests {
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
         dependencies.localAI.startInstall = installHarness.start
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
         let appState = await makeRefreshedAppState(dependencies: dependencies)
@@ -1105,7 +1089,6 @@ struct AppStateAIProcessingBackendTests {
                 managerWasStopped: false
             )
         }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
         let appState = await makeRefreshedAppState(dependencies: dependencies)
@@ -1241,7 +1224,6 @@ struct AppStateAIProcessingBackendTests {
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
         dependencies.localAI.startInstall = installHarness.start
         dependencies.localAI.deletePartialModel = { _ in }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
         let appState = await makeRefreshedAppState(dependencies: dependencies)
@@ -1291,7 +1273,6 @@ struct AppStateAIProcessingBackendTests {
                 managerWasStopped: !process.isRunning
             )
         }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         dependencies.localAI.makeServerManager = { manager }
         AppState.modelDownloadQuitAlertPresenter = { .alertFirstButtonReturn }
         AppState.applicationTerminationReply = replyHarness.reply
@@ -1421,7 +1402,6 @@ struct AppStateAIProcessingBackendTests {
                 managerWasStopped: !process.isRunning
             )
         }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         dependencies.nativeWhisper.installStatus = {
             nativeStatusHarness.installStatus(for: $0)
         }
@@ -1486,7 +1466,6 @@ struct AppStateAIProcessingBackendTests {
         dependencies.localAI.installStatus = { localStatusHarness.status(for: $0) }
         dependencies.localAI.startInstall = localInstallHarness.start
         dependencies.localAI.deletePartialModel = { _ in }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         dependencies.nativeWhisper.installStatus = {
             nativeStatusHarness.installStatus(for: $0)
         }
@@ -1537,7 +1516,6 @@ struct AppStateAIProcessingBackendTests {
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
         dependencies.localAI.startInstall = installHarness.start
         dependencies.localAI.deletePartialModel = { _ in }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         AppState.modelDownloadQuitAlertPresenter = { .alertSecondButtonReturn }
         AppState.applicationTerminationReply = replyHarness.reply
 
@@ -1574,7 +1552,6 @@ struct AppStateAIProcessingBackendTests {
         dependencies.localAI.deletePartialModel = { _ in
             throw TestLocalAILifecycleError.partialCleanupFailed
         }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
         let appState = await makeRefreshedAppState(dependencies: dependencies)
@@ -1608,7 +1585,6 @@ struct AppStateAIProcessingBackendTests {
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
         dependencies.localAI.startInstall = installHarness.start
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
         let appState = await makeRefreshedAppState(dependencies: dependencies)
@@ -1682,7 +1658,6 @@ struct AppStateAIProcessingBackendTests {
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
         dependencies.localAI.startInstall = installHarness.start
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
         let appState = await makeRefreshedAppState(dependencies: dependencies)
@@ -1788,7 +1763,6 @@ struct AppStateAIProcessingBackendTests {
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
         dependencies.localAI.startInstall = installHarness.start
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let canonical = LocalAIModelCatalog.quality
         let forged = LocalAIModel(
@@ -1823,7 +1797,6 @@ struct AppStateAIProcessingBackendTests {
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
@@ -2043,7 +2016,6 @@ struct AppStateAIProcessingBackendTests {
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
         dependencies.localAI.startInstall = installHarness.start
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         defer {
             statusHarness.releaseBlockedCall()
         }
@@ -2083,7 +2055,6 @@ struct AppStateAIProcessingBackendTests {
         )
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         defer {
             statusHarness.releaseBlockedCall()
         }
@@ -2190,7 +2161,6 @@ struct AppStateAIProcessingBackendTests {
             deletionHarness.record(modelID: model.id, managerWasStopped: true)
             statusHarness.set(.notInstalled, for: model)
         }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         dependencies.localAI.makeServerManager = { manager }
 
         let model = LocalAIModelCatalog.quality
@@ -2263,7 +2233,6 @@ struct AppStateAIProcessingBackendTests {
             deletionHarness.record(modelID: model.id, managerWasStopped: true)
             throw TestLocalAILifecycleError.fullDeleteFailed
         }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         dependencies.localAI.makeServerManager = { manager }
 
         let model = LocalAIModelCatalog.quality
@@ -2303,7 +2272,6 @@ struct AppStateAIProcessingBackendTests {
         let deletionHarness = LocalAIDeletionHarness()
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         dependencies.localAI.deleteModel = { model in
             deletionHarness.record(modelID: model.id, managerWasStopped: true)
             statusHarness.set(.notInstalled, for: model)
@@ -2415,6 +2383,21 @@ struct AppStateAIProcessingBackendTests {
                 physicalMemory: 8 * 1024 * 1024 * 1024
             )
         }
+    }
+
+    private static func testEveryBackendExecutorConstructionUsesCentralFactory() throws {
+        let source = try appStateSource()
+        let factoryBody = sourceBlock(
+            in: source,
+            from: "static func makeAIProcessingBackendExecutor(",
+            to: "func makeAIProcessingBackendExecutor("
+        )
+        assert(backendExecutorConstructorCount(in: factoryBody) == 1)
+        assert(
+            backendExecutorConstructorCount(
+                in: source.replacingOccurrences(of: factoryBody, with: "")
+            ) == 0
+        )
     }
 
     private static func testEveryPostProcessingConstructionUsesCentralFactory() throws {
@@ -2621,8 +2604,17 @@ struct AppStateAIProcessingBackendTests {
         try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
     }
 
+    private static func backendExecutorConstructorCount(in source: String) -> Int {
+        constructorCount(named: "AIProcessingBackendExecutor", in: source)
+    }
+
     private static func constructorCount(in source: String) -> Int {
-        let pattern = #"(?<![A-Za-z0-9_])PostProcessingService\("#
+        constructorCount(named: "PostProcessingService", in: source)
+    }
+
+    private static func constructorCount(named typeName: String, in source: String) -> Int {
+        let escapedTypeName = NSRegularExpression.escapedPattern(for: typeName)
+        let pattern = "(?<![A-Za-z0-9_])\(escapedTypeName)\\("
         let regex = try! NSRegularExpression(pattern: pattern)
         let range = NSRange(source.startIndex..<source.endIndex, in: source)
         return regex.numberOfMatches(in: source, range: range)

--- a/Tests/AppStateAIProcessingBackendTests.swift
+++ b/Tests/AppStateAIProcessingBackendTests.swift
@@ -834,17 +834,17 @@ struct AppStateAIProcessingBackendTests {
         let installHarness = ControlledNativeWhisperInstallHarness()
         let scheduler = ProgressScheduleHarness()
         var dependencies = modelTestDependencies()
-        AppState.nativeWhisperInstallStatusProvider = {
+        dependencies.nativeWhisper.installStatus = {
             statusHarness.installStatus(for: $0)
         }
-        AppState.nativeWhisperInstallStarter = { model, progress, completion in
+        dependencies.nativeWhisper.startInstall = { model, progress, completion in
             installHarness.start(
                 model: model,
                 progress: progress,
                 completion: completion
             )
         }
-        AppState.nativeWhisperProgressSchedule = scheduler.schedule
+        dependencies.nativeWhisper.progressSchedule = scheduler.schedule
 
         let appState = await MainActor.run { AppState(dependencies: dependencies) }
         await MainActor.run {
@@ -1266,6 +1266,8 @@ struct AppStateAIProcessingBackendTests {
     }
 
     private static func testTerminationWaitsForLocalAIQuiescenceAndSuppressesDuplicates() async throws {
+        let effects = ModelTerminationEffectSnapshot()
+        defer { effects.restore() }
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
@@ -1336,6 +1338,8 @@ struct AppStateAIProcessingBackendTests {
     }
 
     private static func testNativeWhisperTerminationWaitsForWorkerQuiescence() async throws {
+        let effects = ModelTerminationEffectSnapshot()
+        defer { effects.restore() }
         resetAIProcessingDefaults()
         let nativeStatusHarness = NativeWhisperStatusHarness(status: .notInstalled)
         let nativeInstallHarness = ControlledNativeWhisperInstallHarness()
@@ -1350,10 +1354,10 @@ struct AppStateAIProcessingBackendTests {
             waitForProcessExit: { _, _ in true }
         )
         var dependencies = modelTestDependencies()
-        AppState.nativeWhisperInstallStatusProvider = {
+        dependencies.nativeWhisper.installStatus = {
             nativeStatusHarness.installStatus(for: $0)
         }
-        AppState.nativeWhisperInstallStarter = { model, progress, completion in
+        dependencies.nativeWhisper.startInstall = { model, progress, completion in
             nativeInstallHarness.start(
                 model: model,
                 progress: progress,
@@ -1390,6 +1394,8 @@ struct AppStateAIProcessingBackendTests {
     }
 
     private static func testCombinedNativeAndLocalTerminationWaitsForBothWorkers() async throws {
+        let effects = ModelTerminationEffectSnapshot()
+        defer { effects.restore() }
         resetAIProcessingDefaults()
         let localStatusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let localInstallHarness = LocalAIInstallHarness()
@@ -1416,10 +1422,10 @@ struct AppStateAIProcessingBackendTests {
             )
         }
         dependencies.localAI.processingAvailability = supportedLocalAIAvailability
-        AppState.nativeWhisperInstallStatusProvider = {
+        dependencies.nativeWhisper.installStatus = {
             nativeStatusHarness.installStatus(for: $0)
         }
-        AppState.nativeWhisperInstallStarter = { model, progress, completion in
+        dependencies.nativeWhisper.startInstall = { model, progress, completion in
             nativeInstallHarness.start(
                 model: model,
                 progress: progress,
@@ -1468,6 +1474,8 @@ struct AppStateAIProcessingBackendTests {
     }
 
     private static func testTerminationCleanupBlocksNewModelInstalls() async {
+        let effects = ModelTerminationEffectSnapshot()
+        defer { effects.restore() }
         resetAIProcessingDefaults()
         let localStatusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let localInstallHarness = LocalAIInstallHarness()
@@ -1479,10 +1487,10 @@ struct AppStateAIProcessingBackendTests {
         dependencies.localAI.startInstall = localInstallHarness.start
         dependencies.localAI.deletePartialModel = { _ in }
         dependencies.localAI.processingAvailability = supportedLocalAIAvailability
-        AppState.nativeWhisperInstallStatusProvider = {
+        dependencies.nativeWhisper.installStatus = {
             nativeStatusHarness.installStatus(for: $0)
         }
-        AppState.nativeWhisperInstallStarter = { model, progress, completion in
+        dependencies.nativeWhisper.startInstall = { model, progress, completion in
             nativeInstallHarness.start(
                 model: model,
                 progress: progress,
@@ -1519,6 +1527,8 @@ struct AppStateAIProcessingBackendTests {
     }
 
     private static func testPendingRecordingTerminationCancelRepliesFalseOnce() async {
+        let effects = ModelTerminationEffectSnapshot()
+        defer { effects.restore() }
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
@@ -2680,17 +2690,11 @@ struct AppStateAIProcessingBackendTests {
     }
 }
 
-private struct LocalAISeamSnapshot {
-    let nativeWhisperInstallStatusProvider = AppState.nativeWhisperInstallStatusProvider
-    let nativeWhisperInstallStarter = AppState.nativeWhisperInstallStarter
-    let nativeWhisperProgressSchedule = AppState.nativeWhisperProgressSchedule
+private struct ModelTerminationEffectSnapshot {
     let modelDownloadQuitAlertPresenter = AppState.modelDownloadQuitAlertPresenter
     let applicationTerminationReply = AppState.applicationTerminationReply
 
     func restore() {
-        AppState.nativeWhisperInstallStatusProvider = nativeWhisperInstallStatusProvider
-        AppState.nativeWhisperInstallStarter = nativeWhisperInstallStarter
-        AppState.nativeWhisperProgressSchedule = nativeWhisperProgressSchedule
         AppState.modelDownloadQuitAlertPresenter = modelDownloadQuitAlertPresenter
         AppState.applicationTerminationReply = applicationTerminationReply
     }

--- a/Tests/AppStateAIProcessingBackendTests.swift
+++ b/Tests/AppStateAIProcessingBackendTests.swift
@@ -9,14 +9,6 @@ struct AppStateAIProcessingBackendTests {
     static func main() async throws {
         let defaultsSnapshot = UserDefaultsSnapshot()
         let originalSettingsDirectory = AppSettingsStorage.storageDirectoryOverride
-        let originalLocalAIInstallStatusProvider =
-            AppState.localAIInstallStatusProvider
-        let suiteStatusHarness = LocalAIStatusHarness(
-            defaultStatus: .notInstalled
-        )
-        AppState.localAIInstallStatusProvider = {
-            suiteStatusHarness.status(for: $0)
-        }
         let isolatedSettingsDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent(
                 "quill-app-state-ai-processing-tests-\(ProcessInfo.processInfo.globallyUniqueString)",
@@ -26,8 +18,6 @@ struct AppStateAIProcessingBackendTests {
         defer {
             defaultsSnapshot.restore()
             AppSettingsStorage.storageDirectoryOverride = originalSettingsDirectory
-            AppState.localAIInstallStatusProvider =
-                originalLocalAIInstallStatusProvider
             try? FileManager.default.removeItem(at: isolatedSettingsDirectory)
         }
 
@@ -80,6 +70,8 @@ struct AppStateAIProcessingBackendTests {
         await testCloudSelectionPublishesContextChoiceOnce()
         await testSelectionWaitsForInitialStatusRefresh()
         await testBackgroundStatusRefreshIgnoresStaleGeneration()
+        await testAppStateInstancesKeepIndependentLocalAIEnvironments()
+        await testExecutorUsesOriginatingLocalAIAvailability()
         try await testDeleteDuringInstallWaitsAndCannotAutoSelect()
         try await testDeleteFailureAndSuccessStateReset()
         try await testDeletingOnlyLocalModelDoesNotSubstituteCloud()
@@ -244,10 +236,9 @@ struct AppStateAIProcessingBackendTests {
     private static func testStoredLocalChoicesPreserveRememberedCloudModels() async {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .ready)
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         let defaults = UserDefaults.standard
         defaults.set("remembered/post", forKey: "post_processing_model")
         defaults.set("remembered/context", forKey: "context_model")
@@ -260,7 +251,7 @@ struct AppStateAIProcessingBackendTests {
         storeChoice(postChoice, forKey: "post_processing_backend_choice")
         storeChoice(contextChoice, forKey: "context_backend_choice")
 
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
 
         await MainActor.run {
             assert(appState.postProcessingBackendChoice == postChoice)
@@ -275,10 +266,9 @@ struct AppStateAIProcessingBackendTests {
     private static func testIncompatibleLegacyContextSelectionIsPreservedAndDisabled() async {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .ready)
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let legacyChoice = AIProcessingBackendChoice.localAI(
             modelID: LocalAIModelCatalog.quality.id
@@ -286,7 +276,7 @@ struct AppStateAIProcessingBackendTests {
         storeChoice(legacyChoice, forKey: "context_backend_choice")
         UserDefaults.standard.set(false, forKey: "disable_context_capture")
 
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             precondition(
                 appState.disableContextCapture,
@@ -329,17 +319,16 @@ struct AppStateAIProcessingBackendTests {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let legacyChoice = AIProcessingBackendChoice.localAI(
             modelID: LocalAIModelCatalog.quality.id
         )
         storeChoice(legacyChoice, forKey: "context_backend_choice")
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             precondition(appState.disableContextCapture)
             precondition(appState.contextBackendChoice == legacyChoice)
@@ -370,10 +359,9 @@ struct AppStateAIProcessingBackendTests {
     private static func testStartupPreservesUnavailableCompatibleLocalChoiceWithoutCloudFallback() async {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let localChoice = AIProcessingBackendChoice.localAI(
             modelID: LocalAIModelCatalog.quality.id
@@ -381,7 +369,7 @@ struct AppStateAIProcessingBackendTests {
         storeChoice(localChoice, forKey: "post_processing_backend_choice")
         AppSettingsStorage.save("configured-key", account: "groq_api_key")
 
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             precondition(
                 appState.postProcessingBackendChoice == localChoice,
@@ -397,15 +385,14 @@ struct AppStateAIProcessingBackendTests {
     private static func testSettingsDismissalPreservesUnavailableLocalChoiceWithoutCloudFallback() async {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let localChoice = AIProcessingBackendChoice.localAI(
             modelID: LocalAIModelCatalog.quality.id
         )
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             appState.apiKey = "configured-key"
             appState.postProcessingBackendChoice = localChoice
@@ -431,15 +418,14 @@ struct AppStateAIProcessingBackendTests {
         )
         let installHarness = LocalAIInstallHarness()
         let deletionHarness = LocalAIDeletionHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIModelDelete = { model in
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.deleteModel = { model in
             deletionHarness.record(modelID: model.id, managerWasStopped: true)
         }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         defer {
-            seams.restore()
             AppSettingsStorage.delete(account: "groq_api_key")
         }
 
@@ -449,7 +435,7 @@ struct AppStateAIProcessingBackendTests {
         storeChoice(retiredChoice, forKey: "context_backend_choice")
         AppSettingsStorage.save("configured-cloud-key", account: "groq_api_key")
 
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             precondition(appState.postProcessingBackendChoice == retiredChoice)
             precondition(appState.contextBackendChoice == retiredChoice)
@@ -514,13 +500,12 @@ struct AppStateAIProcessingBackendTests {
             statuses: [LocalAIModelCatalog.quality.id: .ready],
             defaultStatus: .notInstalled
         )
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         storeChoice(retiredChoice, forKey: "post_processing_backend_choice")
 
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             precondition(appState.postProcessingBackendChoice == retiredChoice)
             precondition(appState.disablePostProcessing)
@@ -621,12 +606,11 @@ struct AppStateAIProcessingBackendTests {
     private static func testMeetingSummaryDraftFallsBackOrTurnsOffOnDismissal() async {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             appState.apiKey = ""
             appState.disableMeetingSummary = false
@@ -648,13 +632,12 @@ struct AppStateAIProcessingBackendTests {
     private static func testDiscardUndownloadedSelectionsRestoresActiveChoices() async {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             appState.apiKey = "configured-key"
             appState.disablePostProcessing = false
@@ -696,14 +679,13 @@ struct AppStateAIProcessingBackendTests {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             appState.selectAIProcessingBackendChoice(
                 .localAI(modelID: model.id),
@@ -725,12 +707,11 @@ struct AppStateAIProcessingBackendTests {
     private static func testSettingsDismissalDisablesAIWithoutReadyModels() async {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             appState.apiKey = ""
             appState.disablePostProcessing = false
@@ -746,14 +727,13 @@ struct AppStateAIProcessingBackendTests {
     private static func testSettingsDismissalFallsBackToReadyLocalAIModel() async {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
-        let seams = LocalAISeamSnapshot()
+        var dependencies = modelTestDependencies()
         let model = LocalAIModelCatalog.quality
         statusHarness.set(.ready, for: model)
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             appState.apiKey = ""
             appState.postProcessingBackendChoice = .cloud(
@@ -784,14 +764,13 @@ struct AppStateAIProcessingBackendTests {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             let originalPostChoice = appState.postProcessingBackendChoice
             let originalContextChoice = appState.contextBackendChoice
@@ -854,7 +833,7 @@ struct AppStateAIProcessingBackendTests {
         let statusHarness = NativeWhisperStatusHarness(status: .notInstalled)
         let installHarness = ControlledNativeWhisperInstallHarness()
         let scheduler = ProgressScheduleHarness()
-        let seams = LocalAISeamSnapshot()
+        var dependencies = modelTestDependencies()
         AppState.nativeWhisperInstallStatusProvider = {
             statusHarness.installStatus(for: $0)
         }
@@ -866,9 +845,8 @@ struct AppStateAIProcessingBackendTests {
             )
         }
         AppState.nativeWhisperProgressSchedule = scheduler.schedule
-        defer { seams.restore() }
 
-        let appState = await MainActor.run { AppState() }
+        let appState = await MainActor.run { AppState(dependencies: dependencies) }
         await MainActor.run {
             appState.installNativeWhisperModel()
         }
@@ -920,15 +898,14 @@ struct AppStateAIProcessingBackendTests {
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
         let scheduler = ProgressScheduleHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        AppState.localAIProgressSchedule = scheduler.schedule
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
+        dependencies.localAI.progressSchedule = scheduler.schedule
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             appState.installLocalAIModel(model)
         }
@@ -974,14 +951,13 @@ struct AppStateAIProcessingBackendTests {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             appState.selectAIProcessingBackendChoice(
                 .localAI(modelID: model.id),
@@ -1027,14 +1003,13 @@ struct AppStateAIProcessingBackendTests {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         let originalPostChoice = await MainActor.run {
             let originalPostChoice = appState.postProcessingBackendChoice
             appState.selectAIProcessingBackendChoice(
@@ -1071,14 +1046,13 @@ struct AppStateAIProcessingBackendTests {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             appState.selectAIProcessingBackendChoice(
                 .localAI(modelID: model.id),
@@ -1122,20 +1096,19 @@ struct AppStateAIProcessingBackendTests {
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
         let partialDeletionHarness = LocalAIDeletionHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIPartialModelDelete = { model in
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.deletePartialModel = { model in
             partialDeletionHarness.record(
                 modelID: model.id,
                 managerWasStopped: false
             )
         }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         let originalChoices = await MainActor.run { () -> (AIProcessingBackendChoice, AIProcessingBackendChoice) in
             let choices = (
                 appState.postProcessingBackendChoice,
@@ -1231,16 +1204,15 @@ struct AppStateAIProcessingBackendTests {
             terminationGracePeriod: 0,
             waitForProcessExit: { _, _ in true }
         )
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIServerManagerFactory = { manager }
-        AppState.localAIIdleShutdownSleep = { nanoseconds in
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.makeServerManager = { manager }
+        dependencies.localAI.idleShutdownSleep = { nanoseconds in
             try await sleepHarness.sleep(nanoseconds: nanoseconds)
         }
-        defer { seams.restore() }
 
         _ = try await manager.withBaseURL(for: LocalAIModelCatalog.quality) { $0 }
         precondition(process.isRunning)
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
 
         await MainActor.run {
             appState.startLocalAIIdleShutdownMonitoring()
@@ -1265,15 +1237,14 @@ struct AppStateAIProcessingBackendTests {
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
         let completion = LockedBox(false)
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIPartialModelDelete = { _ in }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.deletePartialModel = { _ in }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             appState.installLocalAIModel(model)
         }
@@ -1309,23 +1280,22 @@ struct AppStateAIProcessingBackendTests {
             terminationGracePeriod: 0,
             waitForProcessExit: { _, _ in true }
         )
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIPartialModelDelete = { model in
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.deletePartialModel = { model in
             partialDeletionHarness.record(
                 modelID: model.id,
                 managerWasStopped: !process.isRunning
             )
         }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        AppState.localAIServerManagerFactory = { manager }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
+        dependencies.localAI.makeServerManager = { manager }
         AppState.modelDownloadQuitAlertPresenter = { .alertFirstButtonReturn }
         AppState.applicationTerminationReply = replyHarness.reply
-        defer { seams.restore() }
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         _ = try await manager.withBaseURL(for: LocalAIModelCatalog.quality) { $0 }
         await MainActor.run {
             appState.selectAIProcessingBackendChoice(
@@ -1379,7 +1349,7 @@ struct AppStateAIProcessingBackendTests {
             terminationGracePeriod: 0,
             waitForProcessExit: { _, _ in true }
         )
-        let seams = LocalAISeamSnapshot()
+        var dependencies = modelTestDependencies()
         AppState.nativeWhisperInstallStatusProvider = {
             nativeStatusHarness.installStatus(for: $0)
         }
@@ -1390,12 +1360,11 @@ struct AppStateAIProcessingBackendTests {
                 completion: completion
             )
         }
-        AppState.localAIServerManagerFactory = { manager }
+        dependencies.localAI.makeServerManager = { manager }
         AppState.modelDownloadQuitAlertPresenter = { .alertFirstButtonReturn }
         AppState.applicationTerminationReply = replyHarness.reply
-        defer { seams.restore() }
 
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         _ = try await manager.withBaseURL(for: LocalAIModelCatalog.quality) { $0 }
         await MainActor.run {
             appState.installNativeWhisperModel(autoSelectWhenReady: true)
@@ -1437,16 +1406,16 @@ struct AppStateAIProcessingBackendTests {
             terminationGracePeriod: 0,
             waitForProcessExit: { _, _ in true }
         )
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { localStatusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = localInstallHarness.start
-        AppState.localAIPartialModelDelete = { model in
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { localStatusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = localInstallHarness.start
+        dependencies.localAI.deletePartialModel = { model in
             partialDeletionHarness.record(
                 modelID: model.id,
                 managerWasStopped: !process.isRunning
             )
         }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         AppState.nativeWhisperInstallStatusProvider = {
             nativeStatusHarness.installStatus(for: $0)
         }
@@ -1457,13 +1426,12 @@ struct AppStateAIProcessingBackendTests {
                 completion: completion
             )
         }
-        AppState.localAIServerManagerFactory = { manager }
+        dependencies.localAI.makeServerManager = { manager }
         AppState.modelDownloadQuitAlertPresenter = { .alertFirstButtonReturn }
         AppState.applicationTerminationReply = replyHarness.reply
-        defer { seams.restore() }
 
         let localModel = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         _ = try await manager.withBaseURL(for: LocalAIModelCatalog.quality) { $0 }
         await MainActor.run {
             appState.installNativeWhisperModel(autoSelectWhenReady: false)
@@ -1506,11 +1474,11 @@ struct AppStateAIProcessingBackendTests {
         let nativeStatusHarness = NativeWhisperStatusHarness(status: .notInstalled)
         let nativeInstallHarness = ControlledNativeWhisperInstallHarness()
         let replyHarness = TerminationReplyHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { localStatusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = localInstallHarness.start
-        AppState.localAIPartialModelDelete = { _ in }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { localStatusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = localInstallHarness.start
+        dependencies.localAI.deletePartialModel = { _ in }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         AppState.nativeWhisperInstallStatusProvider = {
             nativeStatusHarness.installStatus(for: $0)
         }
@@ -1523,11 +1491,10 @@ struct AppStateAIProcessingBackendTests {
         }
         AppState.modelDownloadQuitAlertPresenter = { .alertFirstButtonReturn }
         AppState.applicationTerminationReply = replyHarness.reply
-        defer { seams.restore() }
 
         let activeModel = LocalAIModelCatalog.quality
         let blockedModel = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             appState.installLocalAIModel(activeModel)
             precondition(
@@ -1556,17 +1523,16 @@ struct AppStateAIProcessingBackendTests {
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
         let replyHarness = TerminationReplyHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIPartialModelDelete = { _ in }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.deletePartialModel = { _ in }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         AppState.modelDownloadQuitAlertPresenter = { .alertSecondButtonReturn }
         AppState.applicationTerminationReply = replyHarness.reply
-        defer { seams.restore() }
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             appState.installLocalAIModel(model)
             let reply = appState.requestTerminationAfterModelCleanup(
@@ -1592,17 +1558,16 @@ struct AppStateAIProcessingBackendTests {
             expectedBytes: LocalAIModelCatalog.quality.approximateBytes
         ))
         let installHarness = LocalAIInstallHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIPartialModelDelete = { _ in
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.deletePartialModel = { _ in
             throw TestLocalAILifecycleError.partialCleanupFailed
         }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             appState.installLocalAIModel(model)
             appState.cancelLocalAIInstall(model)
@@ -1630,14 +1595,13 @@ struct AppStateAIProcessingBackendTests {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         let originalChoice = await MainActor.run { () -> AIProcessingBackendChoice in
             let originalChoice = appState.postProcessingBackendChoice
             appState.selectAIProcessingBackendChoice(
@@ -1668,14 +1632,13 @@ struct AppStateAIProcessingBackendTests {
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
         let availability = LockedBox(supportedLocalAIAvailability())
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIProcessingAvailabilityProvider = { availability.value }
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.processingAvailability = { availability.value }
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         let originalChoice = await MainActor.run { () -> AIProcessingBackendChoice in
             let originalChoice = appState.contextBackendChoice
             appState.selectAIProcessingBackendChoice(
@@ -1706,14 +1669,13 @@ struct AppStateAIProcessingBackendTests {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             appState.selectAIProcessingBackendChoice(
                 .localAI(modelID: model.id),
@@ -1741,14 +1703,13 @@ struct AppStateAIProcessingBackendTests {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .ready)
         let installHarness = LocalAIInstallHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIProcessingAvailabilityProvider = unsupportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.processingAvailability = unsupportedLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             let originalChoice = appState.postProcessingBackendChoice
             appState.selectAIProcessingBackendChoice(
@@ -1777,17 +1738,16 @@ struct AppStateAIProcessingBackendTests {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .ready)
         let installHarness = LocalAIInstallHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIProcessingAvailabilityProvider = lowMemoryLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.processingAvailability = lowMemoryLocalAIAvailability
 
         let model = LocalAIModelCatalog.quality
         let storedChoice = AIProcessingBackendChoice.localAI(modelID: model.id)
         storeChoice(storedChoice, forKey: "post_processing_backend_choice")
         UserDefaults.standard.set(false, forKey: "disable_post_processing")
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
 
         await MainActor.run {
             precondition(appState.postProcessingBackendChoice == storedChoice)
@@ -1815,11 +1775,10 @@ struct AppStateAIProcessingBackendTests {
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
         let deletionHarness = LocalAIDeletionHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
         let canonical = LocalAIModelCatalog.quality
         let forged = LocalAIModel(
@@ -1829,8 +1788,8 @@ struct AppStateAIProcessingBackendTests {
             artifacts: canonical.artifacts,
             approximateResidentRAMBytes: canonical.approximateResidentRAMBytes
         )
-        let appState = await makeRefreshedAppState()
-        AppState.localAIModelDelete = { model in
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
+        dependencies.localAI.deleteModel = { model in
             deletionHarness.record(modelID: model.id, managerWasStopped: true)
         }
         await MainActor.run {
@@ -1852,12 +1811,11 @@ struct AppStateAIProcessingBackendTests {
     private static func testAIProcessingChoiceDisplayMetadata() async {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        defer { seams.restore() }
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
 
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             let displays = appState.aiProcessingChoiceDisplays(for: .postProcessing)
             let cloud = displays.first { display in
@@ -2072,16 +2030,15 @@ struct AppStateAIProcessingBackendTests {
             subsequentResult: .ready
         )
         let installHarness = LocalAIInstallHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         defer {
             statusHarness.releaseBlockedCall()
-            seams.restore()
         }
 
-        let appState = await MainActor.run { AppState() }
+        let appState = await MainActor.run { AppState(dependencies: dependencies) }
         statusHarness.waitUntilBlockedCallEntered()
         await MainActor.run {
             appState.selectAIProcessingBackendChoice(
@@ -2114,15 +2071,14 @@ struct AppStateAIProcessingBackendTests {
             blockedResult: .ready,
             subsequentResult: .notInstalled
         )
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
         defer {
             statusHarness.releaseBlockedCall()
-            seams.restore()
         }
 
-        let appState = await MainActor.run { AppState() }
+        let appState = await MainActor.run { AppState(dependencies: dependencies) }
         statusHarness.waitUntilBlockedCallEntered()
         await MainActor.run {
             appState.refreshAllLocalAIInstallStates()
@@ -2144,34 +2100,91 @@ struct AppStateAIProcessingBackendTests {
         precondition(statusHarness.mainThreadCallCount == 0)
     }
 
+    private static func testAppStateInstancesKeepIndependentLocalAIEnvironments() async {
+        resetAIProcessingDefaults()
+        let firstStatus = LocalAIStatusHarness(defaultStatus: .ready)
+        let secondStatus = LocalAIStatusHarness(defaultStatus: .notInstalled)
+        let firstManager = LocalAIServerManager()
+        let secondManager = LocalAIServerManager()
+        var firstDependencies = AppStateDependencies.live
+        firstDependencies.localAI.installStatus = firstStatus.status
+        firstDependencies.localAI.processingAvailability = supportedLocalAIAvailability
+        firstDependencies.localAI.makeServerManager = { firstManager }
+        var secondDependencies = AppStateDependencies.live
+        secondDependencies.localAI.installStatus = secondStatus.status
+        secondDependencies.localAI.processingAvailability = unsupportedLocalAIAvailability
+        secondDependencies.localAI.makeServerManager = { secondManager }
+
+        let instances = await MainActor.run {
+            (
+                AppState(dependencies: firstDependencies),
+                AppState(dependencies: secondDependencies)
+            )
+        }
+        await instances.0.waitForLocalAIInstallStateRefresh()
+        await instances.1.waitForLocalAIInstallStateRefresh()
+
+        await MainActor.run {
+            precondition(
+                instances.0.localAIInstallState(for: LocalAIModelCatalog.quality).status
+                    == .ready
+            )
+            precondition(
+                instances.1.localAIInstallState(for: LocalAIModelCatalog.quality).status
+                    == .notInstalled
+            )
+            precondition(instances.0.isLocalAIModelAvailable(LocalAIModelCatalog.quality))
+            precondition(!instances.1.isLocalAIModelAvailable(LocalAIModelCatalog.quality))
+            precondition(instances.0.localAIServerManager === firstManager)
+            precondition(instances.1.localAIServerManager === secondManager)
+        }
+    }
+
+    private static func testExecutorUsesOriginatingLocalAIAvailability() async {
+        resetAIProcessingDefaults()
+        var dependencies = AppStateDependencies.live
+        dependencies.localAI.installStatus = { _ in .ready }
+        dependencies.localAI.processingAvailability = unsupportedLocalAIAvailability
+        let appState = await MainActor.run {
+            AppState(dependencies: dependencies)
+        }
+        await appState.waitForLocalAIInstallStateRefresh()
+
+        await MainActor.run {
+            let executor = appState.makeAIProcessingBackendExecutor(
+                choice: .localAI(modelID: LocalAIModelCatalog.quality.id)
+            )
+            precondition(!executor.isConfigured)
+        }
+    }
+
     private static func testDeleteDuringInstallWaitsAndCannotAutoSelect() async throws {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
         let partialDeletionHarness = LocalAIDeletionHarness()
         let deletionHarness = LocalAIDeletionHarness()
-        let seams = LocalAISeamSnapshot()
+        var dependencies = modelTestDependencies()
         let manager = LocalAIServerManager(
             launchProcess: { _, _, port, _ in (TestLocalAIServerProcess(), port) },
             pollHealth: { _ in true },
             readinessProbe: successfulReadinessProbe,
             validateModel: { _ in .ready }
         )
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIInstallStarter = installHarness.start
-        AppState.localAIPartialModelDelete = { model in
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.startInstall = installHarness.start
+        dependencies.localAI.deletePartialModel = { model in
             partialDeletionHarness.record(modelID: model.id, managerWasStopped: false)
         }
-        AppState.localAIModelDelete = { model in
+        dependencies.localAI.deleteModel = { model in
             deletionHarness.record(modelID: model.id, managerWasStopped: true)
             statusHarness.set(.notInstalled, for: model)
         }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        AppState.localAIServerManagerFactory = { manager }
-        defer { seams.restore() }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
+        dependencies.localAI.makeServerManager = { manager }
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         let originalChoices = await MainActor.run { () -> (AIProcessingBackendChoice, AIProcessingBackendChoice) in
             let choices = (
                 appState.postProcessingBackendChoice,
@@ -2228,24 +2241,23 @@ struct AppStateAIProcessingBackendTests {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .ready)
         let deletionHarness = LocalAIDeletionHarness()
-        let seams = LocalAISeamSnapshot()
+        var dependencies = modelTestDependencies()
         let manager = LocalAIServerManager(
             launchProcess: { _, _, port, _ in (TestLocalAIServerProcess(), port) },
             pollHealth: { _ in true },
             readinessProbe: successfulReadinessProbe,
             validateModel: { _ in .ready }
         )
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIModelDelete = { model in
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.deleteModel = { model in
             deletionHarness.record(modelID: model.id, managerWasStopped: true)
             throw TestLocalAILifecycleError.fullDeleteFailed
         }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        AppState.localAIServerManagerFactory = { manager }
-        defer { seams.restore() }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
+        dependencies.localAI.makeServerManager = { manager }
 
         let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         await MainActor.run {
             appState.postProcessingBackendChoice = .localAI(modelID: model.id)
             appState.deleteLocalAIModel(model)
@@ -2279,16 +2291,15 @@ struct AppStateAIProcessingBackendTests {
             defaultStatus: .notInstalled
         )
         let deletionHarness = LocalAIDeletionHarness()
-        let seams = LocalAISeamSnapshot()
-        AppState.localAIInstallStatusProvider = { statusHarness.status(for: $0) }
-        AppState.localAIProcessingAvailabilityProvider = supportedLocalAIAvailability
-        AppState.localAIModelDelete = { model in
+        var dependencies = modelTestDependencies()
+        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
+        dependencies.localAI.deleteModel = { model in
             deletionHarness.record(modelID: model.id, managerWasStopped: true)
             statusHarness.set(.notInstalled, for: model)
         }
-        defer { seams.restore() }
 
-        let appState = await makeRefreshedAppState()
+        let appState = await makeRefreshedAppState(dependencies: dependencies)
         let retainedChoice = AIProcessingBackendChoice.localAI(
             modelID: LocalAIModelCatalog.quality.id
         )
@@ -2327,8 +2338,24 @@ struct AppStateAIProcessingBackendTests {
         precondition(deletionHarness.deletedModelIDs == [LocalAIModelCatalog.quality.id])
     }
 
+    private static func modelTestDependencies() -> AppStateDependencies {
+        var dependencies = AppStateDependencies.live
+        dependencies.localAI.installStatus = { _ in .notInstalled }
+        dependencies.localAI.processingAvailability = supportedLocalAIAvailability
+        dependencies.nativeWhisper.installStatus = { _ in .notInstalled }
+        return dependencies
+    }
+
     private static func makeRefreshedAppState() async -> AppState {
-        let appState = await MainActor.run { AppState() }
+        await makeRefreshedAppState(dependencies: modelTestDependencies())
+    }
+
+    private static func makeRefreshedAppState(
+        dependencies: AppStateDependencies
+    ) async -> AppState {
+        let appState = await MainActor.run {
+            AppState(dependencies: dependencies)
+        }
         await appState.waitForLocalAIInstallStateRefresh()
         return appState
     }
@@ -2657,14 +2684,6 @@ private struct LocalAISeamSnapshot {
     let nativeWhisperInstallStatusProvider = AppState.nativeWhisperInstallStatusProvider
     let nativeWhisperInstallStarter = AppState.nativeWhisperInstallStarter
     let nativeWhisperProgressSchedule = AppState.nativeWhisperProgressSchedule
-    let installStatusProvider = AppState.localAIInstallStatusProvider
-    let installStarter = AppState.localAIInstallStarter
-    let localAIProgressSchedule = AppState.localAIProgressSchedule
-    let modelDelete = AppState.localAIModelDelete
-    let partialModelDelete = AppState.localAIPartialModelDelete
-    let availabilityProvider = AppState.localAIProcessingAvailabilityProvider
-    let serverManagerFactory = AppState.localAIServerManagerFactory
-    let idleShutdownSleep = AppState.localAIIdleShutdownSleep
     let modelDownloadQuitAlertPresenter = AppState.modelDownloadQuitAlertPresenter
     let applicationTerminationReply = AppState.applicationTerminationReply
 
@@ -2672,14 +2691,6 @@ private struct LocalAISeamSnapshot {
         AppState.nativeWhisperInstallStatusProvider = nativeWhisperInstallStatusProvider
         AppState.nativeWhisperInstallStarter = nativeWhisperInstallStarter
         AppState.nativeWhisperProgressSchedule = nativeWhisperProgressSchedule
-        AppState.localAIInstallStatusProvider = installStatusProvider
-        AppState.localAIInstallStarter = installStarter
-        AppState.localAIProgressSchedule = localAIProgressSchedule
-        AppState.localAIModelDelete = modelDelete
-        AppState.localAIPartialModelDelete = partialModelDelete
-        AppState.localAIProcessingAvailabilityProvider = availabilityProvider
-        AppState.localAIServerManagerFactory = serverManagerFactory
-        AppState.localAIIdleShutdownSleep = idleShutdownSleep
         AppState.modelDownloadQuitAlertPresenter = modelDownloadQuitAlertPresenter
         AppState.applicationTerminationReply = applicationTerminationReply
     }

--- a/Tests/AppStateDependenciesTests.swift
+++ b/Tests/AppStateDependenciesTests.swift
@@ -7,6 +7,8 @@ struct AppStateDependenciesTests {
     static func main() throws {
         try verifiesStorageLayoutPreservesCanonicalPaths()
         try verifiesLiveDependenciesReturnFreshValues()
+        try verifiesLocalAIDependenciesAreIndependentValues()
+        try verifiesNativeWhisperDependenciesAreIndependentValues()
         print("AppStateDependenciesTests passed")
     }
 
@@ -40,6 +42,45 @@ struct AppStateDependenciesTests {
 
         try expect(second.storageLayout.rootDirectory == AppName.applicationSupportDirectory,
                    "mutating one dependency value does not alter a later live value")
+    }
+
+    private static func verifiesLocalAIDependenciesAreIndependentValues() throws {
+        var first = AppStateDependencies.live
+        let second = AppStateDependencies.live
+        first.localAI.installStatus = { _ in .ready }
+        first.localAI.processingAvailability = {
+            LocalAIProcessingAvailability(
+                isAppleSilicon: false,
+                runnerIsExecutable: false,
+                physicalMemory: 0
+            )
+        }
+
+        try expect(
+            first.localAI.installStatus(LocalAIModelCatalog.quality) == .ready,
+            "the overridden Local AI value is used by the first dependency copy"
+        )
+        try expect(
+            second.localAI.processingAvailability()
+                != first.localAI.processingAvailability(),
+            "mutating one Local AI dependency value does not alter another"
+        )
+    }
+
+    private static func verifiesNativeWhisperDependenciesAreIndependentValues() throws {
+        var first = AppStateDependencies.live
+        let second = AppStateDependencies.live
+        let originalSecondStatus = second.nativeWhisper.installStatus(.recommended)
+        first.nativeWhisper.installStatus = { _ in .ready }
+
+        try expect(
+            first.nativeWhisper.installStatus(.recommended) == .ready,
+            "the overridden Native Whisper value is used by the first dependency copy"
+        )
+        try expect(
+            second.nativeWhisper.installStatus(.recommended) == originalSecondStatus,
+            "mutating one Native Whisper dependency value does not alter another"
+        )
     }
 
     private static func expect(

--- a/Tests/AppStateHistoryProtectionSourceTests.swift
+++ b/Tests/AppStateHistoryProtectionSourceTests.swift
@@ -17,7 +17,7 @@ struct AppStateHistoryProtectionSourceTests {
     static func main() throws {
         let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
         let repositorySwiftSource = try combinedSwiftSource(in: ["Sources", "Tests"])
-        let removedSeams = [
+        let removedHistorySeams: [String] = [
             ["meeting", "Summary", "Generator", "Factory"].joined(),
             ["storage", "Root", "Provider"].joined(),
             ["pipeline", "History", "Store", "Factory"].joined(),
@@ -25,6 +25,20 @@ struct AppStateHistoryProtectionSourceTests {
             ["retry", "Cloud", "Transcription", "Dependencies", "Factory"].joined(),
             ["make", "Default", "Pipeline", "History", "Store"].joined()
         ]
+        let removedModelSeams: [String] = [
+            ["native", "Whisper", "Install", "Status", "Provider"].joined(),
+            ["native", "Whisper", "Install", "Starter"].joined(),
+            ["native", "Whisper", "Progress", "Schedule"].joined(),
+            ["local", "AI", "Server", "Manager", "Factory"].joined(),
+            ["local", "AI", "Idle", "Shutdown", "Sleep"].joined(),
+            ["local", "AI", "Install", "Status", "Provider"].joined(),
+            ["local", "AI", "Install", "Starter"].joined(),
+            ["local", "AI", "Progress", "Schedule"].joined(),
+            ["local", "AI", "Model", "Delete"].joined(),
+            ["local", "AI", "Partial", "Model", "Delete"].joined(),
+            ["local", "AI", "Processing", "Availability", "Provider"].joined()
+        ]
+        let removedSeams = removedHistorySeams + removedModelSeams
         let removedStaticReferences = [
             ["App", "State", ".", "app", "Storage", "Root", "Directory"].joined(),
             ["App", "State", ".", "audio", "Storage", "Directory"].joined(),

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -7,14 +7,6 @@ import Foundation
 #endif
 struct AppStateTranscriptionConfigurationTests {
     static func main() async throws {
-        let originalNativeWhisperInstallStatusProvider =
-            AppState.nativeWhisperInstallStatusProvider
-        AppState.nativeWhisperInstallStatusProvider = { _ in .notInstalled }
-        defer {
-            AppState.nativeWhisperInstallStatusProvider =
-                originalNativeWhisperInstallStatusProvider
-        }
-
         try testMakeTranscriptionServiceUsesLocalConfiguration()
         try testMakeTranscriptionServiceMapsEmptyLocalWhisperPathToNil()
         try testMakeTranscriptionServiceDefaultsLegacyMlxWhisperOff()
@@ -91,6 +83,8 @@ struct AppStateTranscriptionConfigurationTests {
         await testNativeWhisperInstallAutoSelectsOnSuccess()
         await testExplicitBackendChoiceCancelsAutoSelectionOnly()
         await testNativeWhisperCancellationClearsAutoSelection()
+        await testAppStateInstancesKeepIndependentNativeWhisperEnvironments()
+        await testNativeWhisperDeletionUsesOriginatingDependency()
         await testSetupProcessingPresetsPreserveProviderConfiguration()
         try testSetupProcessingPresetUsesExistingChoiceSetter()
         try testNormalizationGuardsStayInsideMainActorIsolation()
@@ -151,9 +145,30 @@ struct AppStateTranscriptionConfigurationTests {
         print("AppStateTranscriptionConfigurationTests passed")
     }
 
+    private static func transcriptionTestDependencies(
+        from base: AppStateDependencies = .live,
+        status: @escaping @Sendable (NativeWhisperModel) -> NativeWhisperInstallStatus = {
+            _ in .notInstalled
+        }
+    ) -> AppStateDependencies {
+        var dependencies = base
+        dependencies.nativeWhisper.installStatus = status
+        return dependencies
+    }
+
+    private static func makeAppState() -> AppState {
+        makeAppState(dependencies: transcriptionTestDependencies())
+    }
+
+    private static func makeAppState(
+        dependencies: AppStateDependencies
+    ) -> AppState {
+        AppState(dependencies: dependencies)
+    }
+
     private static func testMakeTranscriptionServiceUsesLocalConfiguration() throws {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
         appState.useLocalTranscription = true
         appState.localTranscriptionModel = .find(id: "apple-speech")
         appState.transcriptionLanguage = .find(code: "en")
@@ -170,7 +185,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testMakeTranscriptionServiceMapsEmptyLocalWhisperPathToNil() throws {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
         appState.useLocalTranscription = true
         appState.localWhisperPath = ""
 
@@ -182,7 +197,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testMakeTranscriptionServiceDefaultsLegacyMlxWhisperOff() throws {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
         appState.useLocalTranscription = true
         appState.localTranscriptionModel = .find(id: "mlx-community/whisper-large-v3-turbo")
 
@@ -194,7 +209,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testMakeTranscriptionServicePassesLegacyMlxWhisperToggle() throws {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
         appState.isRecording = true
         appState.useLocalTranscription = true
         appState.useLegacyMlxWhisper = true
@@ -311,7 +326,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testContextModelDefaultsToQwen36() {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
 
         assert(AppState.defaultContextModel == "qwen/qwen3.6-27b")
         assert(appState.contextModel == "qwen/qwen3.6-27b")
@@ -322,7 +337,7 @@ struct AppStateTranscriptionConfigurationTests {
         let defaults = UserDefaults.standard
         defaults.set("meta-llama/llama-4-scout-17b-16e-instruct", forKey: "context_model")
 
-        let appState = AppState()
+        let appState = makeAppState()
 
         assert(appState.contextModel == "qwen/qwen3.6-27b")
         assert(defaults.string(forKey: "context_model") == "qwen/qwen3.6-27b")
@@ -333,7 +348,7 @@ struct AppStateTranscriptionConfigurationTests {
         let defaults = UserDefaults.standard
         defaults.set("custom/context-model", forKey: "context_model")
 
-        let appState = AppState()
+        let appState = makeAppState()
 
         assert(appState.contextModel == "custom/context-model")
     }
@@ -367,18 +382,18 @@ struct AppStateTranscriptionConfigurationTests {
         let defaults = UserDefaults.standard
 
         assert(defaults.object(forKey: "note_browser_enabled") == nil)
-        assert(AppState().noteBrowserEnabled)
+        assert(makeAppState().noteBrowserEnabled)
     }
 
     private static func testNoteBrowserPreservesExplicitOptOut() {
         resetDefaults()
         let defaults = UserDefaults.standard
-        let appState = AppState()
+        let appState = makeAppState()
 
         appState.noteBrowserEnabled = false
 
         assert(defaults.object(forKey: "note_browser_enabled") as? Bool == false)
-        assert(!AppState().noteBrowserEnabled)
+        assert(!makeAppState().noteBrowserEnabled)
     }
 
     private static func testExistingInstallMigratesMissingTranscriptionPreferenceOn() async {
@@ -387,7 +402,7 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.set(true, forKey: "hasCompletedSetup")
         defaults.removeObject(forKey: "transcription_enabled")
 
-        let appState = await MainActor.run { AppState() }
+        let appState = await MainActor.run { makeAppState() }
 
         await MainActor.run {
             precondition(appState.transcriptionEnabled)
@@ -402,7 +417,7 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.set(true, forKey: "hasCompletedSetup")
         defaults.set(false, forKey: "transcription_enabled")
 
-        let appState = await MainActor.run { AppState() }
+        let appState = await MainActor.run { makeAppState() }
 
         await MainActor.run {
             precondition(!appState.transcriptionEnabled)
@@ -413,7 +428,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testRecordOnlyDoesNotRequireAccessibility() async {
         resetDefaults()
-        let appState = await MainActor.run { AppState() }
+        let appState = await MainActor.run { makeAppState() }
         await MainActor.run {
             appState.disableAutoPaste = false
             appState.isCommandModeEnabled = true
@@ -427,7 +442,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testTranscriptionOffPreservesRememberedBackend() async {
         resetDefaults()
-        let appState = await MainActor.run { AppState() }
+        let appState = await MainActor.run { makeAppState() }
 
         await MainActor.run {
             appState.apiKey = "global-key"
@@ -442,7 +457,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testTranscriptionOnPreservesRememberedBackendReadiness() async {
         resetDefaults()
-        let appState = await MainActor.run { AppState() }
+        let appState = await MainActor.run { makeAppState() }
 
         await MainActor.run {
             appState.apiKey = "global-key"
@@ -462,7 +477,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testNoteBrowserSelectionControlsTranscriptionWithoutForgettingModel() async {
         resetDefaults()
-        let appState = await MainActor.run { AppState() }
+        let appState = await MainActor.run { makeAppState() }
 
         await MainActor.run {
             appState.apiKey = "configured-key"
@@ -481,7 +496,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testNoteBrowserSelectionRejectsUnreadyChoice() async {
         resetDefaults()
-        let appState = await MainActor.run { AppState() }
+        let appState = await MainActor.run { makeAppState() }
 
         await MainActor.run {
             appState.transcriptionEnabled = false
@@ -498,7 +513,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testSettingsTranscriptionToggleRequiresReadyRememberedChoice() async {
         resetDefaults()
-        let appState = await MainActor.run { AppState() }
+        let appState = await MainActor.run { makeAppState() }
 
         await MainActor.run {
             appState.selectedMicrophoneID =
@@ -527,10 +542,8 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testSettingsDraftPreservesPreviousReadyTranscriptionChoice() async {
         resetDefaults()
-        let originalProvider = AppState.nativeWhisperInstallStatusProvider
-        AppState.nativeWhisperInstallStatusProvider = { _ in .ready }
-        defer { AppState.nativeWhisperInstallStatusProvider = originalProvider }
-        let appState = await MainActor.run { AppState() }
+        var dependencies = transcriptionTestDependencies(status: { _ in .ready })
+        let appState = await MainActor.run { makeAppState(dependencies: dependencies) }
 
         await MainActor.run {
             let previousChoice = TranscriptionBackendChoice.nativeWhisper(
@@ -557,7 +570,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testSettingsDismissalTurnsOffTranscriptionWithoutReadyModel() async {
         resetDefaults()
-        let appState = await MainActor.run { AppState() }
+        let appState = await MainActor.run { makeAppState() }
 
         await MainActor.run {
             appState.selectedMicrophoneID =
@@ -579,10 +592,8 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testSettingsDismissalFallsBackToReadyTranscriptionModel() async {
         resetDefaults()
-        let originalProvider = AppState.nativeWhisperInstallStatusProvider
-        AppState.nativeWhisperInstallStatusProvider = { _ in .ready }
-        defer { AppState.nativeWhisperInstallStatusProvider = originalProvider }
-        let appState = await MainActor.run { AppState() }
+        var dependencies = transcriptionTestDependencies(status: { _ in .ready })
+        let appState = await MainActor.run { makeAppState(dependencies: dependencies) }
 
         await MainActor.run {
             appState.selectedMicrophoneID =
@@ -610,7 +621,7 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.set(false, forKey: "hasCompletedSetup")
         defaults.removeObject(forKey: "first_install_defaults_version")
 
-        _ = await MainActor.run { AppState() }
+        _ = await MainActor.run { makeAppState() }
 
         precondition(defaults.bool(forKey: "disable_auto_paste"))
         precondition(defaults.string(forKey: "transcription_language") == "auto")
@@ -626,7 +637,7 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.set(true, forKey: "hasCompletedSetup")
         defaults.removeObject(forKey: "first_install_defaults_version")
 
-        let appState = await MainActor.run { AppState() }
+        let appState = await MainActor.run { makeAppState() }
 
         await MainActor.run {
             precondition(!appState.disableAutoPaste)
@@ -648,7 +659,7 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.set("timeOnly", forKey: "overlay_waveform_display_mode")
         defaults.set(true, forKey: "press_enter_voice_command_enabled")
 
-        let appState = await MainActor.run { AppState() }
+        let appState = await MainActor.run { makeAppState() }
 
         await MainActor.run {
             precondition(!appState.disableAutoPaste)
@@ -678,7 +689,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testLegacyMlxWhisperOptionsDefaultToOff() {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
 
         assert(appState.showLegacyMlxWhisperOptions == false)
         assert(appState.useLegacyMlxWhisper == false)
@@ -690,7 +701,7 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.set(true, forKey: "show_legacy_mlx_whisper_options")
         defaults.set(false, forKey: "use_legacy_mlx_whisper")
 
-        let appState = AppState()
+        let appState = makeAppState()
 
         assert(appState.showLegacyMlxWhisperOptions == true)
         assert(appState.useLegacyMlxWhisper == false)
@@ -705,7 +716,7 @@ struct AppStateTranscriptionConfigurationTests {
         let defaults = UserDefaults.standard
         defaults.set(true, forKey: "use_legacy_mlx_whisper")
 
-        let appState = AppState()
+        let appState = makeAppState()
 
         assert(appState.useLegacyMlxWhisper == true)
         assert(appState.showLegacyMlxWhisperOptions == true)
@@ -714,7 +725,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testLegacyMlxWhisperOptionsStayVisibleWhenEngineIsTurnedOff() {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
         appState.showLegacyMlxWhisperOptions = true
         appState.useLegacyMlxWhisper = true
 
@@ -726,7 +737,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testPermissionStatusUpdateSkipsUnchangedValues() {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
         appState.updatePermissionStatus(accessibility: true, screenRecording: true)
 
         var changeCount = 0
@@ -746,7 +757,7 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.removeObject(forKey: "recording_overlay_layout")
         defaults.removeObject(forKey: "use_compact_overlay")
 
-        let appState = AppState()
+        let appState = makeAppState()
         appState.recordingOverlayLayout = .notchSides
 
         assert(defaults.string(forKey: "recording_overlay_layout") == "notchSides")
@@ -757,18 +768,18 @@ struct AppStateTranscriptionConfigurationTests {
         resetDefaults()
         UserDefaults.standard.removeObject(forKey: "recording_cancel_shortcut")
 
-        let appState = AppState()
+        let appState = makeAppState()
 
         assert(appState.recordingCancelShortcut == .defaultRecordingCancel)
     }
 
     private static func testRecordingCancelShortcutPersistsDisabled() {
         resetDefaults()
-        var appState = AppState()
+        var appState = makeAppState()
         let validation = appState.setRecordingCancelShortcut(.disabled)
         assert(validation == nil)
 
-        appState = AppState()
+        appState = makeAppState()
 
         assert(appState.recordingCancelShortcut == .disabled)
     }
@@ -783,11 +794,11 @@ struct AppStateTranscriptionConfigurationTests {
             preset: nil,
             exactModifierKeyCodes: [55]
         )
-        var appState = AppState()
+        var appState = makeAppState()
         let validation = appState.setRecordingCancelShortcut(custom)
         assert(validation == nil)
 
-        appState = AppState()
+        appState = makeAppState()
 
         assert(appState.recordingCancelShortcut == custom)
         assert(appState.savedRecordingCancelCustomShortcut == custom)
@@ -800,7 +811,7 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.set(try! JSONEncoder().encode(escHold), forKey: "hold_shortcut")
         defaults.removeObject(forKey: "recording_cancel_shortcut")
 
-        let appState = AppState()
+        let appState = makeAppState()
         let storedCancel = try! JSONDecoder().decode(
             ShortcutBinding.self,
             from: defaults.data(forKey: "recording_cancel_shortcut")!
@@ -813,7 +824,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testRecordingCancelShortcutRejectsHoldConflict() {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
 
         let validation = appState.setRecordingCancelShortcut(appState.holdShortcut)
 
@@ -823,7 +834,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testRecordingCancelShortcutRejectsPasteAgainConflict() {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
         let f5 = ShortcutPreset.f5.binding
 
         assert(appState.setShortcut(f5, for: .copyAgain) == nil)
@@ -835,7 +846,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testPasteAgainShortcutRejectsRecordingCancelConflict() {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
 
         let validation = appState.setShortcut(.defaultRecordingCancel, for: .copyAgain)
 
@@ -845,7 +856,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testPasteAgainShortcutReportsManualModifierCollision() {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
         _ = appState.setCommandModeEnabled(true)
         _ = appState.setCommandModeStyle(.manual)
         _ = appState.setCommandModeManualModifier(.option)
@@ -858,7 +869,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testHoldShortcutRejectsCancelConflict() {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
 
         let validation = appState.setShortcut(.defaultRecordingCancel, for: .hold)
 
@@ -868,7 +879,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testHoldShortcutRejectsMoreSpecificCancelOverlap() {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
         let commandEsc = ShortcutBinding(
             keyCode: 53,
             keyDisplay: "Esc",
@@ -886,7 +897,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testRecordingCancelShortcutRejectsModifierOnlyOverlapWithKeyCombo() {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
         let commandOnly = ShortcutBinding(
             keyCode: 55,
             keyDisplay: "Command",
@@ -915,7 +926,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testRecordingCancelShortcutRejectsMoreSpecificHoldOverlap() {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
         let commandEsc = ShortcutBinding(
             keyCode: 53,
             keyDisplay: "Esc",
@@ -935,7 +946,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testRecordingCancelShortcutRejectsManualModifierRuntimeOverlap() {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
         _ = appState.setCommandModeEnabled(true)
         _ = appState.setCommandModeStyle(.manual)
         _ = appState.setCommandModeManualModifier(.option)
@@ -967,7 +978,7 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testCommandModeManualModifierReportsCancelOverlap() {
         resetDefaults()
-        let appState = AppState()
+        let appState = makeAppState()
         let commandEsc = ShortcutBinding(
             keyCode: 53,
             keyDisplay: "Esc",
@@ -1199,7 +1210,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testAudioImportConfigurationUsesChoiceDerivedBackend() async {
         resetDefaults()
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             let legacyModel = TranscriptionModel.find(id: "mlx-community/whisper-medium-mlx")
 
             let nativeConfiguration = appState.audioImportConfiguration(for: .nativeWhisper(modelID: NativeWhisperModelCatalog.recommended.id))
@@ -1325,7 +1336,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testNoteBrowserTranscriptionChoiceDisplayIncludesResolvedModels() async {
         resetDefaults()
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             appState.transcriptionModel = "whisper-large-v3-turbo"
             appState.realtimeStreamingModel = ""
 
@@ -1391,6 +1402,37 @@ struct AppStateTranscriptionConfigurationTests {
         precondition(legacyBranch.contains("update(\\AppState.showLegacyMlxWhisperOptions, to: true)"))
     }
 
+    private final class NativeWhisperModelDependencyHarness: @unchecked Sendable {
+        private let lock = NSLock()
+        private var status: NativeWhisperInstallStatus
+        private var deleted: [NativeWhisperModel] = []
+
+        init(status: NativeWhisperInstallStatus) {
+            self.status = status
+        }
+
+        var deletedModels: [NativeWhisperModel] {
+            lock.withLock { deleted }
+        }
+
+        func installStatus(
+            for model: NativeWhisperModel
+        ) -> NativeWhisperInstallStatus {
+            lock.withLock { status }
+        }
+
+        func setStatus(_ status: NativeWhisperInstallStatus) {
+            lock.withLock { self.status = status }
+        }
+
+        func deleteModel(_ model: NativeWhisperModel) throws {
+            lock.withLock {
+                deleted.append(model)
+                status = .notInstalled
+            }
+        }
+    }
+
     private final class NativeWhisperInstallHarness: @unchecked Sendable {
         var progress: ((NativeWhisperDownloadProgress) -> Void)?
         var completion: ((Result<Void, NativeWhisperInstallerError>) -> Void)?
@@ -1410,17 +1452,16 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testNativeWhisperInstallLeavesAppleActiveUntilCompletion() async {
         resetDefaults()
         let harness = NativeWhisperInstallHarness()
-        let originalStarter = AppState.nativeWhisperInstallStarter
-        let originalStatus = AppState.nativeWhisperInstallStatusProvider
-        AppState.nativeWhisperInstallStarter = harness.start
-        AppState.nativeWhisperInstallStatusProvider = { _ in .notInstalled }
-        defer {
-            AppState.nativeWhisperInstallStarter = originalStarter
-            AppState.nativeWhisperInstallStatusProvider = originalStatus
-        }
+        let statusHarness = NativeWhisperModelDependencyHarness(
+            status: .notInstalled
+        )
+        var dependencies = transcriptionTestDependencies(
+            status: statusHarness.installStatus
+        )
+        dependencies.nativeWhisper.startInstall = harness.start
 
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState(dependencies: dependencies)
             appState.setNoteBrowserTranscriptionChoice(.appleLive)
             appState.installNativeWhisperModel(autoSelectWhenReady: true)
 
@@ -1433,17 +1474,16 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testInstallCallWhileAlreadyInstallingStillArmsAutoSelection() async {
         resetDefaults()
         let harness = NativeWhisperInstallHarness()
-        let originalStarter = AppState.nativeWhisperInstallStarter
-        let originalStatus = AppState.nativeWhisperInstallStatusProvider
-        AppState.nativeWhisperInstallStarter = harness.start
-        AppState.nativeWhisperInstallStatusProvider = { _ in .notInstalled }
-        defer {
-            AppState.nativeWhisperInstallStarter = originalStarter
-            AppState.nativeWhisperInstallStatusProvider = originalStatus
-        }
+        let statusHarness = NativeWhisperModelDependencyHarness(
+            status: .notInstalled
+        )
+        var dependencies = transcriptionTestDependencies(
+            status: statusHarness.installStatus
+        )
+        dependencies.nativeWhisper.startInstall = harness.start
 
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState(dependencies: dependencies)
             appState.setNoteBrowserTranscriptionChoice(.appleLive)
             appState.installNativeWhisperModel(autoSelectWhenReady: false)
             appState.cancelNativeWhisperAutoSelection()
@@ -1460,23 +1500,22 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testNativeWhisperInstallAutoSelectsOnSuccess() async {
         resetDefaults()
         let harness = NativeWhisperInstallHarness()
-        let originalStarter = AppState.nativeWhisperInstallStarter
-        let originalStatus = AppState.nativeWhisperInstallStatusProvider
-        AppState.nativeWhisperInstallStarter = harness.start
-        AppState.nativeWhisperInstallStatusProvider = { _ in .notInstalled }
-        defer {
-            AppState.nativeWhisperInstallStarter = originalStarter
-            AppState.nativeWhisperInstallStatusProvider = originalStatus
-        }
+        let statusHarness = NativeWhisperModelDependencyHarness(
+            status: .notInstalled
+        )
+        var dependencies = transcriptionTestDependencies(
+            status: statusHarness.installStatus
+        )
+        dependencies.nativeWhisper.startInstall = harness.start
 
         let appState = await MainActor.run { () -> AppState in
-            let appState = AppState()
+            let appState = makeAppState(dependencies: dependencies)
             appState.setNoteBrowserTranscriptionChoice(.appleLive)
             appState.installNativeWhisperModel(autoSelectWhenReady: true)
             return appState
         }
 
-        AppState.nativeWhisperInstallStatusProvider = { _ in .ready }
+        statusHarness.setStatus(.ready)
         harness.completion?(.success(()))
         await waitUntil { !appState.isInstallingNativeWhisper }
 
@@ -1492,17 +1531,16 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testExplicitBackendChoiceCancelsAutoSelectionOnly() async {
         resetDefaults()
         let harness = NativeWhisperInstallHarness()
-        let originalStarter = AppState.nativeWhisperInstallStarter
-        let originalStatus = AppState.nativeWhisperInstallStatusProvider
-        AppState.nativeWhisperInstallStarter = harness.start
-        AppState.nativeWhisperInstallStatusProvider = { _ in .notInstalled }
-        defer {
-            AppState.nativeWhisperInstallStarter = originalStarter
-            AppState.nativeWhisperInstallStatusProvider = originalStatus
-        }
+        let statusHarness = NativeWhisperModelDependencyHarness(
+            status: .notInstalled
+        )
+        var dependencies = transcriptionTestDependencies(
+            status: statusHarness.installStatus
+        )
+        dependencies.nativeWhisper.startInstall = harness.start
 
         let appState = await MainActor.run { () -> AppState in
-            let appState = AppState()
+            let appState = makeAppState(dependencies: dependencies)
             appState.apiKey = "test-api-key"
             appState.setNoteBrowserTranscriptionChoice(.appleLive)
             appState.installNativeWhisperModel(autoSelectWhenReady: true)
@@ -1514,7 +1552,7 @@ struct AppStateTranscriptionConfigurationTests {
             return appState
         }
 
-        AppState.nativeWhisperInstallStatusProvider = { _ in .ready }
+        statusHarness.setStatus(.ready)
         harness.completion?(.success(()))
         await waitUntil { !appState.isInstallingNativeWhisper }
 
@@ -1530,17 +1568,16 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testNativeWhisperCancellationClearsAutoSelection() async {
         resetDefaults()
         let harness = NativeWhisperInstallHarness()
-        let originalStarter = AppState.nativeWhisperInstallStarter
-        let originalStatus = AppState.nativeWhisperInstallStatusProvider
-        AppState.nativeWhisperInstallStarter = harness.start
-        AppState.nativeWhisperInstallStatusProvider = { _ in .notInstalled }
-        defer {
-            AppState.nativeWhisperInstallStarter = originalStarter
-            AppState.nativeWhisperInstallStatusProvider = originalStatus
-        }
+        let statusHarness = NativeWhisperModelDependencyHarness(
+            status: .notInstalled
+        )
+        var dependencies = transcriptionTestDependencies(
+            status: statusHarness.installStatus
+        )
+        dependencies.nativeWhisper.startInstall = harness.start
 
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState(dependencies: dependencies)
             appState.setNoteBrowserTranscriptionChoice(.appleLive)
             appState.installNativeWhisperModel(autoSelectWhenReady: true)
             precondition(appState.willAutoSelectNativeWhisperWhenReady)
@@ -1552,14 +1589,50 @@ struct AppStateTranscriptionConfigurationTests {
         }
     }
 
-    private static func testSetupProcessingPresetsPreserveProviderConfiguration() async {
+    private static func testAppStateInstancesKeepIndependentNativeWhisperEnvironments() async {
         resetDefaults()
-        let originalProvider = AppState.nativeWhisperInstallStatusProvider
-        AppState.nativeWhisperInstallStatusProvider = { _ in .ready }
-        defer { AppState.nativeWhisperInstallStatusProvider = originalProvider }
+        var readyDependencies = AppStateDependencies.live
+        readyDependencies.nativeWhisper.installStatus = { _ in .ready }
+        var missingDependencies = AppStateDependencies.live
+        missingDependencies.nativeWhisper.installStatus = { _ in .notInstalled }
+
+        let instances = await MainActor.run {
+            (
+                AppState(dependencies: readyDependencies),
+                AppState(dependencies: missingDependencies)
+            )
+        }
 
         await MainActor.run {
-            let appState = AppState()
+            precondition(instances.0.hasNativeLocalWhisperModel)
+            precondition(!instances.1.hasNativeLocalWhisperModel)
+        }
+    }
+
+    private static func testNativeWhisperDeletionUsesOriginatingDependency() async {
+        resetDefaults()
+        let harness = NativeWhisperModelDependencyHarness(status: .ready)
+        var dependencies = AppStateDependencies.live
+        dependencies.nativeWhisper.installStatus = harness.installStatus
+        dependencies.nativeWhisper.deleteModel = harness.deleteModel
+
+        let appState = await MainActor.run {
+            AppState(dependencies: dependencies)
+        }
+        await MainActor.run {
+            precondition(appState.hasNativeLocalWhisperModel)
+            appState.deleteNativeWhisperModel()
+            precondition(!appState.hasNativeLocalWhisperModel)
+        }
+        precondition(harness.deletedModels == [.recommended])
+    }
+
+    private static func testSetupProcessingPresetsPreserveProviderConfiguration() async {
+        resetDefaults()
+        var dependencies = transcriptionTestDependencies(status: { _ in .ready })
+
+        await MainActor.run {
+            let appState = makeAppState(dependencies: dependencies)
             appState.apiKey = "shared-api-key"
             appState.apiBaseURL = "https://provider.example.com/openai/v1"
             appState.transcriptionAPIKey = "transcription-override"
@@ -1691,7 +1764,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testAPITranscriptionModesRemainSelectableWithoutResolvedAPIKey() async {
         resetDefaults()
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
 
             precondition(appState.isNoteBrowserTranscriptionModeAvailable(.apiStandard))
             precondition(appState.isNoteBrowserTranscriptionModeAvailable(.apiRealtime))
@@ -1804,7 +1877,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testTranscriptionAPIKeyEnablesAPIModesWithoutGlobalAPIKey() async {
         resetDefaults()
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             appState.transcriptionAPIKey = "transcription-key"
 
             precondition(appState.isNoteBrowserTranscriptionModeAvailable(.apiStandard))
@@ -1823,7 +1896,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testEmptyTranscriptionAPIKeyFallsBackToGlobalAPIKey() async {
         resetDefaults()
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             appState.apiKey = "global-key"
             appState.transcriptionAPIKey = "  "
 
@@ -1840,7 +1913,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testRemovingAPIKeyPreservesSelectedAPIMode() async {
         resetDefaults()
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             appState.apiKey = "global-key"
             appState.setNoteBrowserTranscriptionMode(.apiStandard)
             precondition(appState.currentNoteBrowserTranscriptionMode == .apiStandard)
@@ -1865,7 +1938,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testRemovingAPIKeyPreservesSelectedAPIModeWhileRecording() async {
         resetDefaults()
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             appState.apiKey = "global-key"
             appState.setNoteBrowserTranscriptionMode(.apiRealtime)
             precondition(appState.currentNoteBrowserTranscriptionMode == .apiRealtime)
@@ -1887,7 +1960,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testSystemDefaultAndSystemAudioConvertsAPIRealtimeToStandard() async {
         resetDefaults()
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             appState.apiKey = "global-key"
             appState.setNoteBrowserTranscriptionMode(.apiRealtime)
             precondition(appState.currentNoteBrowserTranscriptionMode == .apiRealtime)
@@ -1903,7 +1976,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testSystemDefaultAndSystemAudioTurnsOffWithoutReadyFallback() async {
         resetDefaults()
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             appState.setNoteBrowserTranscriptionMode(.localAppleLive)
             appState.transcriptionEnabled = true
             precondition(appState.currentNoteBrowserTranscriptionMode == .localAppleLive)
@@ -1919,7 +1992,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testSystemDefaultAndSystemAudioRejectsLiveModeSelections() async {
         resetDefaults()
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             appState.apiKey = "global-key"
             appState.selectedMicrophoneID = AudioInputDevice.systemDefaultAndSystemAudioID
             precondition(!appState.isNoteBrowserTranscriptionModeAvailable(.apiRealtime))
@@ -1951,7 +2024,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testCombinedSourceDisabledWhenQueuedLiveOnlyChoiceNotRecording() async {
         resetDefaults()
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             appState.apiKey = "global-key"
             appState.setNoteBrowserTranscriptionMode(.apiRealtime)
             appState.transcriptionEnabled = true
@@ -1978,7 +2051,7 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.set("legacy-device-uid", forKey: "selected_microphone_id")
 
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             precondition(appState.selectedMicrophoneDeviceID == "legacy-device-uid")
             precondition(appState.selectedMicrophoneID == "legacy-device-uid")
             precondition(appState.selectedAudioSourceID == AudioInputDevice.defaultMicrophoneID)
@@ -1993,7 +2066,7 @@ struct AppStateTranscriptionConfigurationTests {
         resetDefaults()
 
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             appState.transcriptionEnabled = false
             appState.selectMicrophoneDevice("external-device-uid")
             precondition(appState.selectedMicrophoneDeviceID == "external-device-uid")
@@ -2029,7 +2102,7 @@ struct AppStateTranscriptionConfigurationTests {
         AppSettingsStorage.save("global-key", account: "groq_api_key")
 
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
 
             precondition(appState.currentNoteBrowserTranscriptionMode == .apiStandard)
             precondition(!appState.useLocalTranscription)
@@ -2045,7 +2118,7 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.set(true, forKey: "realtime_streaming_enabled")
 
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
 
             precondition(!appState.transcriptionEnabled)
             precondition(appState.currentNoteBrowserTranscriptionMode == .apiRealtime)
@@ -2062,7 +2135,7 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.set("apple-speech", forKey: "local_transcription_model")
 
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
 
             precondition(!appState.transcriptionEnabled)
             precondition(appState.currentNoteBrowserTranscriptionMode == .localAppleLive)
@@ -2078,12 +2151,10 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.set("apple-speech", forKey: "local_transcription_model")
         defaults.set(false, forKey: "use_legacy_mlx_whisper")
 
-        let originalProvider = AppState.nativeWhisperInstallStatusProvider
-        defer { AppState.nativeWhisperInstallStatusProvider = originalProvider }
-        AppState.nativeWhisperInstallStatusProvider = { _ in .ready }
+        var dependencies = transcriptionTestDependencies(status: { _ in .ready })
 
         let finalState = await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState(dependencies: dependencies)
             let expectedChoice = TranscriptionBackendChoice.nativeWhisper(
                 modelID: NativeWhisperModelCatalog.recommended.id
             )
@@ -2104,12 +2175,10 @@ struct AppStateTranscriptionConfigurationTests {
 
     private static func testRepeatedNativeWhisperSelectionRemainsStable() async {
         resetDefaults()
-        let originalProvider = AppState.nativeWhisperInstallStatusProvider
-        defer { AppState.nativeWhisperInstallStatusProvider = originalProvider }
-        AppState.nativeWhisperInstallStatusProvider = { _ in .ready }
+        var dependencies = transcriptionTestDependencies(status: { _ in .ready })
 
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState(dependencies: dependencies)
             let nativeChoice = TranscriptionBackendChoice.nativeWhisper(
                 modelID: NativeWhisperModelCatalog.recommended.id
             )
@@ -2141,12 +2210,10 @@ struct AppStateTranscriptionConfigurationTests {
             try? FileManager.default.removeItem(at: cacheRoot)
         }
 
-        let originalProvider = AppState.nativeWhisperInstallStatusProvider
-        defer { AppState.nativeWhisperInstallStatusProvider = originalProvider }
-        AppState.nativeWhisperInstallStatusProvider = { _ in .ready }
+        var dependencies = transcriptionTestDependencies(status: { _ in .ready })
 
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState(dependencies: dependencies)
             let legacyChoice = TranscriptionBackendChoice.legacyMlxWhisper(model: legacyModel)
             let nativeChoice = TranscriptionBackendChoice.nativeWhisper(
                 modelID: NativeWhisperModelCatalog.recommended.id
@@ -2185,7 +2252,7 @@ struct AppStateTranscriptionConfigurationTests {
         }
 
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             appState.useLocalTranscription = true
             appState.localTranscriptionModel = legacyModel
             appState.useLegacyMlxWhisper = true
@@ -2222,12 +2289,10 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.set(legacyModel.id, forKey: "local_transcription_model")
         defaults.set(true, forKey: "use_legacy_mlx_whisper")
 
-        let originalProvider = AppState.nativeWhisperInstallStatusProvider
-        defer { AppState.nativeWhisperInstallStatusProvider = originalProvider }
-        AppState.nativeWhisperInstallStatusProvider = { _ in .notInstalled }
+        var dependencies = transcriptionTestDependencies(status: { _ in .notInstalled })
 
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState(dependencies: dependencies)
 
             precondition(appState.currentNoteBrowserTranscriptionChoice == .legacyMlxWhisper(model: legacyModel))
             precondition(appState.useLocalTranscription)
@@ -2243,7 +2308,7 @@ struct AppStateTranscriptionConfigurationTests {
         let metadata = GoogleCalendarConnectionMetadata(accountEmail: "user@example.com")
         UserDefaults.standard.set(try JSONEncoder().encode(metadata), forKey: GoogleCalendarConnectionMetadata.storageKey)
 
-        let appState = AppState()
+        let appState = makeAppState()
 
         assert(appState.googleCalendarConnection.isConnected)
         assert(appState.googleCalendarConnection.accountEmail == "user@example.com")
@@ -2256,7 +2321,7 @@ struct AppStateTranscriptionConfigurationTests {
         resetDefaults()
         UserDefaults.standard.set(Data("not-json".utf8), forKey: GoogleCalendarConnectionMetadata.storageKey)
 
-        let appState = AppState()
+        let appState = makeAppState()
 
         assert(!appState.googleCalendarConnection.isConnected)
         assert(UserDefaults.standard.data(forKey: GoogleCalendarConnectionMetadata.storageKey) == nil)
@@ -2268,7 +2333,7 @@ struct AppStateTranscriptionConfigurationTests {
         defaults.set(30, forKey: "calendar_recording_reminder_lead_minutes")
         defaults.removeObject(forKey: "calendar_recording_reminder_lead_minutes_list")
 
-        let appState = AppState()
+        let appState = makeAppState()
 
         assert(appState.calendarRecordingReminderLeadMinutes == [30])
         assert(defaults.array(forKey: "calendar_recording_reminder_lead_minutes_list") as? [Int] == [30])
@@ -2279,7 +2344,7 @@ struct AppStateTranscriptionConfigurationTests {
         let defaults = UserDefaults.standard
         defaults.set([120, 14, 14], forKey: "calendar_recording_reminder_lead_minutes_list")
 
-        let appState = AppState()
+        let appState = makeAppState()
 
         assert(appState.calendarRecordingReminderLeadMinutes == [15, 60])
         assert(defaults.array(forKey: "calendar_recording_reminder_lead_minutes_list") as? [Int] == [15, 60])
@@ -2290,7 +2355,7 @@ struct AppStateTranscriptionConfigurationTests {
         let defaults = UserDefaults.standard
         defaults.set([], forKey: "calendar_recording_reminder_lead_minutes_list")
 
-        let appState = AppState()
+        let appState = makeAppState()
 
         assert(appState.calendarRecordingReminderLeadMinutes == [CalendarRecordingReminderScheduler.defaultLeadMinutes])
         assert(defaults.array(forKey: "calendar_recording_reminder_lead_minutes_list") as? [Int] == [CalendarRecordingReminderScheduler.defaultLeadMinutes])
@@ -2299,7 +2364,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testCalendarRecordingReminderLeadMinutesPersistNormalizedSelection() {
         resetDefaults()
         let defaults = UserDefaults.standard
-        let appState = AppState()
+        let appState = makeAppState()
 
         appState.calendarRecordingReminderLeadMinutes = [60, 5, 5, -1, 14, 500]
 
@@ -2318,7 +2383,7 @@ struct AppStateTranscriptionConfigurationTests {
         UserDefaults.standard.set(customClientID, forKey: "google_calendar_client_id")
 
         let configuration = await MainActor.run {
-            AppState().googleCalendarOAuthConfiguration
+            makeAppState().googleCalendarOAuthConfiguration
         }
 
         assert(!configuration.usesCustomCredentials)
@@ -2339,7 +2404,7 @@ struct AppStateTranscriptionConfigurationTests {
         }
         AppState.googleCalendarTokenLoader = { _ in nil }
 
-        let appState = AppState()
+        let appState = makeAppState()
         await appState.loadGoogleCalendars(force: true)
 
         assert(appState.googleCalendarConnection.isConnected)
@@ -2364,7 +2429,7 @@ struct AppStateTranscriptionConfigurationTests {
             GoogleCalendarOAuthToken(accessToken: "expired-token", refreshToken: nil, expiresAt: Date(timeIntervalSince1970: 0), accountEmail: "user@example.com")
         }
 
-        let appState = AppState()
+        let appState = makeAppState()
         await appState.loadGoogleCalendars(force: true)
 
         assert(appState.googleCalendarConnection.isConnected)
@@ -2384,7 +2449,7 @@ struct AppStateTranscriptionConfigurationTests {
             try! JSONEncoder().encode(GoogleCalendarConnectionMetadata(accountEmail: "user@example.com")),
             forKey: GoogleCalendarConnectionMetadata.storageKey
         )
-        let appState = AppState()
+        let appState = makeAppState()
         await MainActor.run {
             appState.markGoogleCalendarTemporarilyUnavailable(
                 feature: .recordingReminders,
@@ -2410,7 +2475,7 @@ struct AppStateTranscriptionConfigurationTests {
         }
         AppState.googleCalendarTokenLoader = { _ in nil }
 
-        let appState = AppState()
+        let appState = makeAppState()
         await appState.startGoogleCalendarHealthCheck()
         await waitUntil { appState.googleCalendarConnection.health.status == .needsReconnect }
 
@@ -2437,7 +2502,7 @@ struct AppStateTranscriptionConfigurationTests {
             GoogleCalendarService { _ in throw CalendarListFailure() }
         }
 
-        let appState = AppState()
+        let appState = makeAppState()
         await appState.loadGoogleCalendars(force: true)
 
         assert(appState.googleCalendarConnection.isConnected)
@@ -2470,7 +2535,7 @@ struct AppStateTranscriptionConfigurationTests {
             }
         }
 
-        let appState = AppState()
+        let appState = makeAppState()
         await appState.loadGoogleCalendars(force: true)
 
         assert(appState.googleCalendarConnection.isConnected)
@@ -2531,7 +2596,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testRetryAvailabilityRequiresStoredAudio() async {
         resetDefaults()
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             let item = retryHistoryItem(audioFileName: nil)
             precondition(appState.noteBrowserStoredAudioURL(for: item) == nil)
             precondition(appState.noteBrowserRetryAvailability(for: item) == .noAudio)
@@ -2541,7 +2606,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testRetryAvailabilityOffersSelectableCloudAlternative() async {
         resetDefaults()
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             let fileName = "retry-model-setup-\(UUID().uuidString).wav"
             let audioURL = appState.storageLayout.audioDirectory.appendingPathComponent(fileName)
             try! Data([0]).write(to: audioURL)
@@ -2565,7 +2630,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testRetryAvailabilityRequiresModelSelection() async {
         resetDefaults()
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             appState.apiKey = "test-api-key"
             appState.setNoteBrowserTranscriptionChoice(.appleLive)
             let fileName = "retry-model-selection-\(UUID().uuidString).wav"
@@ -2582,7 +2647,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testRetryAvailabilityRequiresProviderConfiguration() async {
         resetDefaults()
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             appState.setNoteBrowserTranscriptionChoice(
                 .apiStandard(modelID: "whisper-large-v3")
             )
@@ -2602,7 +2667,7 @@ struct AppStateTranscriptionConfigurationTests {
     private static func testRetryAvailabilityAcceptsConfiguredAPIStandard() async {
         resetDefaults()
         await MainActor.run {
-            let appState = AppState()
+            let appState = makeAppState()
             appState.apiKey = "test-api-key"
             appState.setNoteBrowserTranscriptionChoice(
                 .apiStandard(modelID: "whisper-large-v3")

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -1449,143 +1449,132 @@ struct AppStateTranscriptionConfigurationTests {
         }
     }
 
-    private static func testNativeWhisperInstallLeavesAppleActiveUntilCompletion() async {
-        resetDefaults()
-        let harness = NativeWhisperInstallHarness()
-        let statusHarness = NativeWhisperModelDependencyHarness(
+    private struct NativeWhisperInstallFixture {
+        let installer: NativeWhisperInstallHarness
+        let status: NativeWhisperModelDependencyHarness
+        let appState: AppState
+    }
+
+    private static func makeNativeWhisperInstallFixture()
+        -> NativeWhisperInstallFixture {
+        let installer = NativeWhisperInstallHarness()
+        let status = NativeWhisperModelDependencyHarness(
             status: .notInstalled
         )
         var dependencies = transcriptionTestDependencies(
-            status: statusHarness.installStatus
+            status: { status.installStatus(for: $0) }
         )
-        dependencies.nativeWhisper.startInstall = harness.start
+        dependencies.nativeWhisper.startInstall = {
+            installer.start(
+                model: $0,
+                progress: $1,
+                completion: $2
+            )
+        }
+        return NativeWhisperInstallFixture(
+            installer: installer,
+            status: status,
+            appState: makeAppState(dependencies: dependencies)
+        )
+    }
+
+    private static func testNativeWhisperInstallLeavesAppleActiveUntilCompletion() async {
+        resetDefaults()
+        let fixture = makeNativeWhisperInstallFixture()
 
         await MainActor.run {
-            let appState = makeAppState(dependencies: dependencies)
-            appState.setNoteBrowserTranscriptionChoice(.appleLive)
-            appState.installNativeWhisperModel(autoSelectWhenReady: true)
+            fixture.appState.setNoteBrowserTranscriptionChoice(.appleLive)
+            fixture.appState.installNativeWhisperModel(autoSelectWhenReady: true)
 
-            precondition(appState.currentNoteBrowserTranscriptionChoice == .appleLive)
-            precondition(appState.willAutoSelectNativeWhisperWhenReady)
-            precondition(appState.isInstallingNativeWhisper)
+            precondition(fixture.appState.currentNoteBrowserTranscriptionChoice == .appleLive)
+            precondition(fixture.appState.willAutoSelectNativeWhisperWhenReady)
+            precondition(fixture.appState.isInstallingNativeWhisper)
         }
     }
 
     private static func testInstallCallWhileAlreadyInstallingStillArmsAutoSelection() async {
         resetDefaults()
-        let harness = NativeWhisperInstallHarness()
-        let statusHarness = NativeWhisperModelDependencyHarness(
-            status: .notInstalled
-        )
-        var dependencies = transcriptionTestDependencies(
-            status: statusHarness.installStatus
-        )
-        dependencies.nativeWhisper.startInstall = harness.start
+        let fixture = makeNativeWhisperInstallFixture()
 
         await MainActor.run {
-            let appState = makeAppState(dependencies: dependencies)
-            appState.setNoteBrowserTranscriptionChoice(.appleLive)
-            appState.installNativeWhisperModel(autoSelectWhenReady: false)
-            appState.cancelNativeWhisperAutoSelection()
-            precondition(appState.isInstallingNativeWhisper)
-            precondition(!appState.willAutoSelectNativeWhisperWhenReady)
+            fixture.appState.setNoteBrowserTranscriptionChoice(.appleLive)
+            fixture.appState.installNativeWhisperModel(autoSelectWhenReady: false)
+            fixture.appState.cancelNativeWhisperAutoSelection()
+            precondition(fixture.appState.isInstallingNativeWhisper)
+            precondition(!fixture.appState.willAutoSelectNativeWhisperWhenReady)
 
-            appState.installNativeWhisperModel(autoSelectWhenReady: true)
+            fixture.appState.installNativeWhisperModel(autoSelectWhenReady: true)
 
-            precondition(appState.isInstallingNativeWhisper)
-            precondition(appState.willAutoSelectNativeWhisperWhenReady)
+            precondition(fixture.appState.isInstallingNativeWhisper)
+            precondition(fixture.appState.willAutoSelectNativeWhisperWhenReady)
         }
     }
 
     private static func testNativeWhisperInstallAutoSelectsOnSuccess() async {
         resetDefaults()
-        let harness = NativeWhisperInstallHarness()
-        let statusHarness = NativeWhisperModelDependencyHarness(
-            status: .notInstalled
-        )
-        var dependencies = transcriptionTestDependencies(
-            status: statusHarness.installStatus
-        )
-        dependencies.nativeWhisper.startInstall = harness.start
+        let fixture = makeNativeWhisperInstallFixture()
 
-        let appState = await MainActor.run { () -> AppState in
-            let appState = makeAppState(dependencies: dependencies)
-            appState.setNoteBrowserTranscriptionChoice(.appleLive)
-            appState.installNativeWhisperModel(autoSelectWhenReady: true)
-            return appState
+        await MainActor.run {
+            fixture.appState.setNoteBrowserTranscriptionChoice(.appleLive)
+            fixture.appState.installNativeWhisperModel(autoSelectWhenReady: true)
         }
 
-        statusHarness.setStatus(.ready)
-        harness.completion?(.success(()))
-        await waitUntil { !appState.isInstallingNativeWhisper }
+        fixture.status.setStatus(.ready)
+        fixture.installer.completion?(.success(()))
+        await waitUntil { !fixture.appState.isInstallingNativeWhisper }
 
         await MainActor.run {
             precondition(
-                appState.currentNoteBrowserTranscriptionChoice
+                fixture.appState.currentNoteBrowserTranscriptionChoice
                     == .nativeWhisper(modelID: NativeWhisperModelCatalog.recommended.id)
             )
-            precondition(!appState.willAutoSelectNativeWhisperWhenReady)
+            precondition(!fixture.appState.willAutoSelectNativeWhisperWhenReady)
         }
     }
 
     private static func testExplicitBackendChoiceCancelsAutoSelectionOnly() async {
         resetDefaults()
-        let harness = NativeWhisperInstallHarness()
-        let statusHarness = NativeWhisperModelDependencyHarness(
-            status: .notInstalled
-        )
-        var dependencies = transcriptionTestDependencies(
-            status: statusHarness.installStatus
-        )
-        dependencies.nativeWhisper.startInstall = harness.start
+        let fixture = makeNativeWhisperInstallFixture()
 
-        let appState = await MainActor.run { () -> AppState in
-            let appState = makeAppState(dependencies: dependencies)
-            appState.apiKey = "test-api-key"
-            appState.setNoteBrowserTranscriptionChoice(.appleLive)
-            appState.installNativeWhisperModel(autoSelectWhenReady: true)
-            appState.cancelNativeWhisperAutoSelection()
-            appState.setNoteBrowserTranscriptionChoice(.apiStandard(modelID: "custom-model"))
+        await MainActor.run {
+            fixture.appState.apiKey = "test-api-key"
+            fixture.appState.setNoteBrowserTranscriptionChoice(.appleLive)
+            fixture.appState.installNativeWhisperModel(autoSelectWhenReady: true)
+            fixture.appState.cancelNativeWhisperAutoSelection()
+            fixture.appState.setNoteBrowserTranscriptionChoice(
+                .apiStandard(modelID: "custom-model")
+            )
 
-            precondition(appState.isInstallingNativeWhisper)
-            precondition(!appState.willAutoSelectNativeWhisperWhenReady)
-            return appState
+            precondition(fixture.appState.isInstallingNativeWhisper)
+            precondition(!fixture.appState.willAutoSelectNativeWhisperWhenReady)
         }
 
-        statusHarness.setStatus(.ready)
-        harness.completion?(.success(()))
-        await waitUntil { !appState.isInstallingNativeWhisper }
+        fixture.status.setStatus(.ready)
+        fixture.installer.completion?(.success(()))
+        await waitUntil { !fixture.appState.isInstallingNativeWhisper }
 
         await MainActor.run {
             precondition(
-                appState.currentNoteBrowserTranscriptionChoice
+                fixture.appState.currentNoteBrowserTranscriptionChoice
                     == .apiStandard(modelID: "custom-model")
             )
-            precondition(!appState.willAutoSelectNativeWhisperWhenReady)
+            precondition(!fixture.appState.willAutoSelectNativeWhisperWhenReady)
         }
     }
 
     private static func testNativeWhisperCancellationClearsAutoSelection() async {
         resetDefaults()
-        let harness = NativeWhisperInstallHarness()
-        let statusHarness = NativeWhisperModelDependencyHarness(
-            status: .notInstalled
-        )
-        var dependencies = transcriptionTestDependencies(
-            status: statusHarness.installStatus
-        )
-        dependencies.nativeWhisper.startInstall = harness.start
+        let fixture = makeNativeWhisperInstallFixture()
 
         await MainActor.run {
-            let appState = makeAppState(dependencies: dependencies)
-            appState.setNoteBrowserTranscriptionChoice(.appleLive)
-            appState.installNativeWhisperModel(autoSelectWhenReady: true)
-            precondition(appState.willAutoSelectNativeWhisperWhenReady)
+            fixture.appState.setNoteBrowserTranscriptionChoice(.appleLive)
+            fixture.appState.installNativeWhisperModel(autoSelectWhenReady: true)
+            precondition(fixture.appState.willAutoSelectNativeWhisperWhenReady)
 
-            appState.cancelNativeWhisperInstall()
+            fixture.appState.cancelNativeWhisperInstall()
 
-            precondition(!appState.willAutoSelectNativeWhisperWhenReady)
-            precondition(appState.nativeWhisperInstallProgress.isCancelled)
+            precondition(!fixture.appState.willAutoSelectNativeWhisperWhenReady)
+            precondition(fixture.appState.nativeWhisperInstallProgress.isCancelled)
         }
     }
 

--- a/docs/superpowers/specs/2026-08-13-app-state-local-ai-model-dependencies-design.md
+++ b/docs/superpowers/specs/2026-08-13-app-state-local-ai-model-dependencies-design.md
@@ -1,0 +1,442 @@
+# AppState Local AI and Model Dependencies Design
+
+**Date:** 2026-08-13
+**Status:** Approved for implementation planning
+**Issue:** #316
+**Base:** `origin/main` at `06db4e6`
+
+## Goal
+
+Move Local AI and Native Whisper model-management dependencies from mutable `AppState` static properties to instance-owned values while preserving current model paths, installation behavior, server lifecycle, UI behavior, errors, and the source compatibility of `AppState()`.
+
+This work extends the `AppStateDependencies` pattern established by #312 and refined by #314–#315. It changes dependency ownership, not the Local AI or Native Whisper product model.
+
+## Scope
+
+### Included
+
+- focused Local AI and Native Whisper dependency values in `AppStateDependencies`
+- instance-owned Local AI install status, installer start, progress scheduling, final and partial deletion, server-manager creation, idle-shutdown timing, and processing availability
+- instance-owned Native Whisper install status, installer start, progress scheduling, and model deletion
+- removal of the selected mutable `AppState` static seams
+- initialization of Native Whisper state from the supplied instance dependencies
+- explicit propagation of the originating instance’s Local AI availability into `AIProcessingBackendExecutor`
+- preservation of asynchronous dependency snapshots for status refresh, installation, cancellation cleanup, deletion, idle shutdown, and termination cleanup
+- migration of Local AI and Native Whisper `AppState` tests from static save/assign/restore setup to dependency copy-and-override setup
+- behavior tests proving that two `AppState` instances retain independent model environments
+- a narrow source scan preventing reintroduction of the removed static seams
+- a follow-up issue for the Native Whisper transcription execution path
+
+### Excluded
+
+- Native Whisper’s actual transcription execution path in `TranscriptionService`
+- model catalog, URLs, checksums, package formats, recommended models, and hardware requirements
+- Local AI or Native Whisper installer internals
+- the process-wide installer in-flight lock and key registry
+- model-download quit-alert presentation and application termination reply seams
+- Calendar, post-processing, cloud import, storage, credential, and unrelated `AppState` static seams
+- Local AI or Native Whisper workflow extraction
+- general `AppState.swift` splitting
+- new UI, user-facing text, error types, or retry policy
+
+## Current Problem
+
+`AppState` currently owns mutable static closures for Local AI and Native Whisper status, installation, progress scheduling, deletion, server creation, idle timing, and availability. Tests replace and restore these closures globally.
+
+This causes several problems:
+
+- model tests are order-dependent if restoration is delayed or missed,
+- tests that use the same seams cannot safely run concurrently,
+- multiple `AppState` instances cannot express different model environments,
+- asynchronous work can observe a dependency installed by a later test,
+- status, installation, deletion, server validation, and execution availability can resolve from different live environments,
+- the static registry obscures which instance owns active installer and server behavior.
+
+Two related correctness inconsistencies also need correction within this boundary:
+
+1. Native Whisper deletion constructs a live `NativeWhisperModelStore` directly instead of using the same environment as status and installation.
+2. `AppState` selection logic can use an overridden Local AI availability, while the actual `AIProcessingBackendExecutor` independently falls back to `LocalAIProcessingAvailability.live()`.
+
+## Architecture
+
+### Focused dependency values
+
+Extend `AppStateDependencies` with two focused value bundles rather than introducing a generic registry or service container.
+
+```swift
+struct AppStateLocalAIDependencies {
+    var makeServerManager: @MainActor () -> LocalAIServerManager
+    var idleShutdownSleep: @Sendable (Duration) async throws -> Void
+    var installStatus: @Sendable (LocalAIModel) -> LocalAIModelInstallStatus
+    var startInstall: @MainActor (
+        LocalAIModel,
+        @escaping @Sendable (Double) -> Void,
+        @escaping @Sendable (Result<Void, Error>) -> Void
+    ) -> any ModelInstallation
+    var progressSchedule: @MainActor (
+        @escaping @MainActor () -> Void
+    ) -> LocalAIProgressScheduling
+    var deleteModel: @Sendable (LocalAIModel) throws -> Void
+    var deletePartialModel: @Sendable (LocalAIModel) throws -> Void
+    var processingAvailability: @Sendable () -> LocalAIProcessingAvailability
+}
+```
+
+```swift
+struct AppStateNativeWhisperDependencies {
+    var installStatus: @Sendable (
+        NativeWhisperModel
+    ) -> NativeWhisperModelInstallStatus
+    var startInstall: @MainActor (
+        NativeWhisperModel,
+        @escaping @Sendable (Double) -> Void,
+        @escaping @Sendable (Result<Void, Error>) -> Void
+    ) -> any ModelInstallation
+    var progressSchedule: @MainActor (
+        @escaping @MainActor () -> Void
+    ) -> LocalAIProgressScheduling
+    var deleteModel: @Sendable (NativeWhisperModel) throws -> Void
+}
+```
+
+The exact type aliases and closure formatting may follow existing source conventions, but the ownership and included responsibilities are fixed by this design.
+
+`AppStateDependencies` gains two properties:
+
+```swift
+var localAI: AppStateLocalAIDependencies
+var nativeWhisper: AppStateNativeWhisperDependencies
+```
+
+These properties remain variables so tests can copy `.live` and override only the seam they need. The `AppState` retains the resulting dependency value after initialization.
+
+### Live dependency construction
+
+Each `.live` bundle creates one explicit model store and captures it across the whole model lifecycle.
+
+Local AI live construction:
+
+1. create one `LocalAIModelStore`,
+2. use it for install-status lookup,
+3. construct `LocalAIInstaller(store:)` for installation,
+4. construct `LocalAIServerManager(store:)` for server validation,
+5. use it for final and partial deletion,
+6. preserve the current progress scheduler, sleep implementation, and hardware availability provider.
+
+Native Whisper live construction:
+
+1. create one `NativeWhisperModelStore`,
+2. use it for install-status lookup,
+3. construct `NativeWhisperInstaller(store:)` for installation,
+4. use it for model deletion,
+5. preserve the current progress scheduler.
+
+The store is an implementation detail of the bundle. It is not exposed as a new public `AppState` API.
+
+### Removed mutable static seams
+
+Remove these model-related mutable static properties from `AppState`:
+
+- `nativeWhisperInstallStatusProvider`
+- `nativeWhisperInstallStarter`
+- `nativeWhisperProgressSchedule`
+- `localAIServerManagerFactory`
+- `localAIIdleShutdownSleep`
+- `localAIInstallStatusProvider`
+- `localAIInstallStarter`
+- `localAIProgressSchedule`
+- `localAIModelDelete`
+- `localAIPartialModelDelete`
+- `localAIProcessingAvailabilityProvider`
+
+Do not leave compatibility properties that forward to mutable global state. Tests and production code must use the originating `AppState` dependency value.
+
+The following adjacent seams remain unchanged because they are external effects outside model ownership:
+
+- `modelDownloadQuitAlertPresenter`
+- `applicationTerminationReply`
+
+## AppState Ownership and Initialization
+
+`AppState` continues to retain a single `AppStateDependencies` value supplied through:
+
+```swift
+init(dependencies: AppStateDependencies = .live)
+```
+
+Production construction remains source-compatible:
+
+```swift
+let appState = AppState()
+```
+
+### Native Whisper initial state
+
+The current stored-property initializer reads a mutable static provider before initializer dependencies are available. Replace it with explicit initialization inside `AppState.init(dependencies:)` using the supplied Native Whisper dependency value.
+
+The initial status must continue to represent `.recommended`, and all downstream initial selection and readiness behavior must remain unchanged.
+
+### Local AI server manager
+
+Create the manager with the supplied instance dependency during initialization and retain it as the existing `AppState` instance property. The manager itself is already an actor with instance state; only its factory ownership changes.
+
+## Runtime Data Flow
+
+### Status refresh
+
+Status refreshes read `dependencies.localAI.installStatus` or `dependencies.nativeWhisper.installStatus` from the originating instance.
+
+Before starting detached or asynchronous work, copy the closure into a local constant. This preserves the existing snapshot behavior and prevents active work from observing another instance or test environment.
+
+Generation checks, stale refresh suppression, state normalization, and UI publication remain unchanged.
+
+### Installation and progress
+
+Installation keeps the current lifecycle:
+
+1. reject duplicate or invalid starts as today,
+2. establish the existing generation and in-flight state,
+3. create the progress coalescer from the instance dependency,
+4. capture install status, install starter, and partial cleanup closures from the instance dependency,
+5. start the existing installer,
+6. publish progress and completion through the existing callbacks,
+7. reconcile final status before marking success,
+8. preserve cancellation, retry, and error behavior.
+
+The dependency change must not reorder completion relative to the final coalesced progress update.
+
+### Cancellation cleanup
+
+When installation cancellation triggers partial-model cleanup, capture the originating instance’s partial-delete and status closures before starting detached cleanup work.
+
+A later change to another test dependency must not alter cleanup or final status reconciliation for the active install.
+
+### Deletion
+
+Local AI deletion continues to run through `LocalAIServerManager.withExclusiveMaintenance`, ensuring that active inference is excluded and the resident server is stopped before model files are deleted. The delete and status closures come from the same Local AI dependency bundle as the manager.
+
+Native Whisper deletion uses the Native Whisper bundle’s delete closure instead of constructing `NativeWhisperModelStore()` directly.
+
+Current success, failure, state-transition, and user-message behavior remains unchanged.
+
+### Idle shutdown and termination
+
+Idle shutdown captures the originating instance’s manager and sleep closure before creating its task. Existing idempotence and cancellation behavior remain intact.
+
+Unified termination cleanup continues to:
+
+1. cancel Native Whisper and Local AI installations,
+2. wait for both installer families to become quiescent,
+3. stop the originating instance’s Local AI server manager,
+4. invoke the existing external alert and termination-reply seams.
+
+No public method names or source-contract markers for this flow are intentionally changed.
+
+### Local AI availability consistency
+
+All Local AI selection and UI choice logic reads the originating instance’s availability dependency.
+
+When `AppState` constructs `AIProcessingBackendExecutor`, it explicitly supplies the same availability value rather than allowing the executor to fall back to `.live()`. The UI decision and actual execution gate must therefore agree for a given `AppState` instance.
+
+This does not change the executor’s availability model or hardware rules; it only supplies the correct instance snapshot.
+
+## Native Whisper Execution Boundary
+
+`TranscriptionService` currently constructs a live `NativeWhisperModelStore` and `NativeWhisperRuntime` when performing actual Native Whisper transcription.
+
+This design intentionally does not migrate that execution path. Doing so would require a separate transcription execution dependency or immutable execution snapshot, propagation through service construction, and replacement of an exact-source contract that protects preflight ordering.
+
+No compatibility shim is added in #316. A follow-up issue will track:
+
+- an originating-instance Native Whisper model path/runtime snapshot,
+- propagation into actual transcription execution,
+- preservation of preflight-before-audio-conversion behavior,
+- behavior-based replacement or adjustment of the relevant source contract.
+
+## Installer Process-Wide Coordination
+
+`LocalAIInstaller` and `NativeWhisperInstaller` maintain process-wide lock-protected in-flight key sets. These are not `AppState` service locators; they prevent concurrent modification of the same filesystem model artifact.
+
+They remain process-wide in this work. Moving them into `AppStateDependencies` would allow two instances targeting the same model path to download or replace the file concurrently and would weaken safety.
+
+Any future effort to make this coordination explicit must preserve its process-wide filesystem semantics and belongs to a separate design.
+
+## Error Handling
+
+This refactoring introduces no new error model or user-facing copy.
+
+Preserve:
+
+- current installer errors,
+- current cancellation behavior,
+- current partial cleanup error handling,
+- current success verification through final install status,
+- current delete errors and state transitions,
+- current Local AI availability reasons,
+- current server stop and maintenance behavior,
+- current Native Whisper and Local AI user messages.
+
+A dependency closure failure follows the same `AppState` completion and error path as the corresponding live implementation today. The refactoring changes where the operation comes from, not how its result is interpreted.
+
+## Concurrency and Lifetime
+
+- Each `AppState` retains its own dependency value.
+- Closures used by `Task` or `Task.detached` are captured from that value before the work starts.
+- Relevant closures are `@Sendable` where they cross concurrency boundaries.
+- Main Actor-only manager construction, progress scheduling, and callback publication remain Main Actor-isolated.
+- Test harnesses synchronize mutable state captured by `@Sendable` closures.
+- Tests configure dependencies before `AppState` creation instead of mutating model globals afterward.
+- The live bundles may capture reference-type stores because those stores are immutable path environments for these operations.
+- No process-global dependency reset is introduced.
+
+## Test Migration
+
+### Copy-and-override setup
+
+Tests use the existing pattern:
+
+```swift
+var dependencies = AppStateDependencies.live
+dependencies.localAI.installStatus = { model in
+    harness.status(for: model)
+}
+dependencies.nativeWhisper.installStatus = { model in
+    harness.status(for: model)
+}
+
+let appState = AppState(dependencies: dependencies)
+```
+
+A test that needs a controlled installer, scheduler, deletion, availability, or server manager overrides that field on its dependency copy.
+
+### `AppStateAIProcessingBackendTests`
+
+Remove model-related static setup and `LocalAISeamSnapshot` save/restore behavior. Migrate status, installation, progress, deletion, availability, idle-shutdown, and server-manager tests to explicit dependencies.
+
+Quit-alert and termination-reply seams may retain a small, separate restoration helper because they are outside #316 and still process-global.
+
+Retain behavior coverage for:
+
+- duplicate install coalescing,
+- progress coalescing and completion precedence,
+- install cancellation and retry,
+- cancellation partial cleanup,
+- final ready-status verification,
+- status-refresh generation handling,
+- unsupported and low-memory availability,
+- Local AI deletion during server lifecycle,
+- delete success and failure,
+- server reuse and idle shutdown,
+- unified termination quiescence.
+
+### `AppStateTranscriptionConfigurationTests`
+
+Remove Native Whisper model static setup and migrate status/install/progress tests to dependencies supplied during `AppState` construction.
+
+Retain behavior coverage for:
+
+- keeping a ready Native Whisper choice,
+- maintaining Apple Live while installation is active,
+- automatic Native Whisper selection after success,
+- explicit user selection canceling pending auto-selection,
+- cancellation clearing pending selection,
+- combined-source fallback and legacy/native transition stability.
+
+The exact-source test for Native Whisper runtime preflight remains unchanged in this issue because the execution path is deferred.
+
+### Instance-isolation tests
+
+Add focused behavior tests proving that two `AppState` instances can retain different:
+
+- Local AI and Native Whisper initial statuses,
+- Local AI processing availability,
+- installer callbacks and progress environments,
+- Local AI server managers,
+- deletion results.
+
+At minimum, mutate or exercise one instance and verify the other instance’s observed status and harness state remain unchanged.
+
+Also verify that changing a local dependency value after creating the first `AppState` affects only a later instance and not the existing one.
+
+### Asynchronous snapshot tests
+
+Add or strengthen tests proving that:
+
+- a detached status refresh uses the originating instance provider,
+- cancellation cleanup uses the installer’s originating partial-delete and status closures,
+- idle shutdown uses the originating manager and sleep implementation,
+- executor availability matches the originating `AppState` availability.
+
+### Static seam removal scan
+
+Extend the narrow source audit used for removed process-global seams. The selected identifiers must no longer appear as mutable `AppState` properties, and tests must not save, assign, or restore them.
+
+The scan is a structural guard only. Lifecycle behavior remains protected by behavior tests rather than exact implementation text.
+
+## Expected Files
+
+Required source changes:
+
+- `Sources/AppStateDependencies.swift`
+- `Sources/AppState.swift`
+
+Required test migrations:
+
+- `Tests/AppStateDependenciesTests.swift`
+- `Tests/AppStateAIProcessingBackendTests.swift`
+- `Tests/AppStateTranscriptionConfigurationTests.swift`
+- `Tests/AppStateHistoryProtectionSourceTests.swift`
+
+Possible targeted additions depending on the most coherent test location:
+
+- `Tests/AppStateStorageSafetyTests.swift`
+
+No new production source file is required unless the focused dependency value definitions become clearer outside `AppStateDependencies.swift`. If a new test file is introduced, update the Makefile test list and the grouped full-source AppState runner.
+
+## Verification
+
+Run focused tests covering:
+
+- `AppStateDependenciesTests`
+- `AppStateAIProcessingBackendTests`
+- `AppStateTranscriptionConfigurationTests`
+- `AppStateHistoryProtectionSourceTests`
+- Local AI installer/model store/server manager tests
+- Native Whisper installer/model/runtime tests
+- AI processing backend tests
+
+Then run:
+
+- `make check-test-wiring`
+- `make test`
+- `make all CODESIGN_IDENTITY=Quill`
+
+If the known iCloud-synchronized build-directory codesign detritus causes `errSecInternalComponent`, clear extended attributes with `xattr -cr build` and rerun the same production build command.
+
+Before opening or merging the PR:
+
+- run `/code-review medium`,
+- resolve verified findings,
+- rerun affected tests and full verification,
+- confirm CI and CodeRabbit findings are resolved.
+
+## Completion Criteria
+
+The work is complete when:
+
+1. the selected eleven mutable model-related `AppState` static seams are removed,
+2. Local AI and Native Whisper model-management operations use originating-instance dependencies,
+3. Local AI status, install, delete, manager, and availability share one live store environment per dependency value,
+4. Native Whisper status, install, and delete share one live store environment per dependency value,
+5. actual Local AI executor availability agrees with the originating `AppState`,
+6. two `AppState` instances can use different model environments without cross-contamination,
+7. asynchronous work cannot observe a later test’s replacement model dependency,
+8. related tests no longer save, assign, or restore the removed static seams,
+9. installer process-wide filesystem coordination remains intact,
+10. existing model paths, UI, lifecycle, errors, and `AppState()` construction remain unchanged,
+11. focused tests, `make check-test-wiring`, `make test`, and the production build pass,
+12. Native Whisper actual transcription execution migration is tracked separately rather than silently omitted.
+
+## Follow-Up
+
+Create a separate issue for making Native Whisper actual transcription execution use an originating-instance immutable model path/runtime snapshot. Link it from #316 and roadmap #321 without blocking the model-management dependency migration described here.


### PR DESCRIPTION
## Summary

- add focused `AppStateLocalAIDependencies` and `AppStateNativeWhisperDependencies` values whose live implementations share one model store across each lifecycle
- move Local AI status, installation, progress, deletion, server management, idle timing, and availability onto the originating `AppState` instance
- move Native Whisper status, installation, progress, and deletion onto the originating `AppState` instance
- pass the instance Local AI availability snapshot into every `AppState`-created backend executor
- migrate Local AI and Native Whisper lifecycle tests from mutable class-level seams to dependency copy-and-override setup
- add two-instance isolation coverage and prevent the eleven removed static seam identifiers from returning

## Scope

This is a behavior-preserving internal refactor. It does not change model catalogs, download formats, checksums, hardware requirements, UI, user-facing copy, or installer process-wide filesystem coordination.

Native Whisper's actual transcription worker still constructs its model store/runtime directly. That intentionally deferred execution boundary is tracked in #327 and does not block this model-management migration.

Closes #316

## Verification

- `make check-test-wiring`
- `make test`
- `make all CODESIGN_IDENTITY=Quill`
- `/code-review medium` — no confirmed findings
