### PR TITLE
Extract AppState history archive and recovery workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ FULL_SOURCE_APP_STATE_TESTS = \
 	Tests/AppStateDependenciesTests.swift \
 	Tests/NoteAssetStoreTests.swift \
 	Tests/CredentialStoreTests.swift \
+	Tests/HistoryArchiveRecoveryWorkflowTests.swift \
 	Tests/AppStateStorageSafetyTests.swift \
 	Tests/AppStateHistoryProtectionSourceTests.swift \
 	Tests/AppStateTranscriptionConfigurationTests.swift \

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -4933,6 +4933,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         historyRecoverySnapshots = state.snapshots
         historyRecoveryInspections = state.inspections
         historyRecoveryInspectionSnapshotID = state.inspectionSnapshotID
+        isHistoryRecoveryOperationInProgress =
+            state.recoveryOperation != .idle
+        historyRecoveryOperationMessage = recoveryOperationMessage(
+            for: state.recoveryOperation
+        )
+        historyRecoveryImportResult = state.importResult
         isHistoryUnavailable = state.isHistoryUnavailable
         historyPersistenceWarning = state.showsPersistenceWarning
             ? QuillUserIssueRecord(code: .historyPersistenceUnavailable)
@@ -5069,154 +5075,34 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @MainActor
     @discardableResult
     func importHistoryRecoverySnapshot(id: UUID) -> Bool {
-        guard requireAvailableHistoryForMutation(),
-              !isHistoryRecoveryOperationInProgress,
-              !isRecording,
-              !isTranscribing,
-              retryingItemIDs.isEmpty,
-              activeTranscriptionJobs.isEmpty,
-              pendingAudioImportJobIDs.isEmpty,
-              !cloudTranscriptionHistoryCoordinator.hasActiveWork,
-              meetingSummaryGeneratingNoteIDs.isEmpty,
-              activeRecordingID == nil,
-              activeSegmentedJournalController == nil,
-              pendingRecordingJournalFinalizationCount == 0,
-              pendingRecordingStartCount == 0,
-              pendingAudioOnlyStopIDs.isEmpty,
-              historyRecoverySnapshots.contains(where: {
-                  $0.id == id && $0.integrity == .ready
-              }) else {
-            return false
-        }
-        historyRecoveryImportResult = nil
-        do {
-            try pipelineHistoryStore.detachForArchiveVerification()
-        } catch {
-            errorMessage = historyUnavailableMessage
-            return false
-        }
-
-        let storageRoot = dependencies.storageLayout.rootDirectory
-        let storeURL = dependencies.storageLayout.historyStoreURL
-        let audioDirectory = dependencies.storageLayout.audioDirectory
-        let transcriptDirectory = dependencies.storageLayout.transcriptDirectory
-        let makeStore = dependencies.makePipelineHistoryStore
-        let appStateReference = WeakAppStateReference(self)
-        isHistoryRecoveryOperationInProgress = true
-        historyRecoveryOperationMessage = localizedCatalogString("Recovering history…")
-        Task.detached(priority: .userInitiated) {
-            let activeStore = makeStore(storeURL)
-            do {
-                guard activeStore.availability == .ready,
-                      activeStore.durability == .durable,
-                      activeStore.verifyHistoryReadable() else {
-                    throw HistoryRecoveryServiceError.snapshotNotReady
-                }
-                let result = try HistoryRecoveryService(storageRoot: storageRoot).importSnapshot(
-                    id: id,
-                    into: activeStore,
-                    audioDirectory: audioDirectory,
-                    transcriptDirectory: transcriptDirectory
-                )
-                try activeStore.detachForArchiveVerification()
-                await MainActor.run {
-                    appStateReference.value?.completeHistoryRecoveryImport(
-                        result,
-                        storageRoot: storageRoot
-                    )
-                }
-            } catch {
-                try? activeStore.detachForArchiveVerification()
-                await MainActor.run {
-                    appStateReference.value?.completeHistoryRecoveryOperationFailure(
-                        at: storageRoot
-                    )
-                }
-            }
-        }
-        return true
+        guard requireAvailableHistoryForMutation() else { return false }
+        return historyWorkflow.requestImport(
+            snapshotID: id,
+            context: historyWorkflowAdmissionContext(),
+            currentStore: pipelineHistoryStore,
+            activeHistory: pipelineHistory,
+            shouldRescheduleInspection: selectedSettingsTab == .recovery
+        ) == .accepted
     }
 
     @MainActor
     @discardableResult
     func cancelHistoryRecoveryScheduledDeletion(id: UUID) -> Bool {
-        guard !isHistoryRecoveryOperationInProgress,
-              historyRecoveryInspectionSnapshotID == nil,
-              historyRecoverySnapshots.contains(where: {
-                  $0.id == id && $0.integrity == .ready && $0.status == .completed
-              }) else {
-            return false
-        }
-        runHistoryRecoverySnapshotOperation(
-            message: localizedCatalogString("Cancelling scheduled deletion…")
-        ) { service in
-            try service.cancelScheduledDeletion(for: id)
-        }
-        return true
+        historyWorkflow.requestCancelScheduledDeletion(
+            snapshotID: id,
+            activeHistory: pipelineHistory,
+            shouldRescheduleInspection: selectedSettingsTab == .recovery
+        ) == .accepted
     }
 
     @MainActor
     @discardableResult
     func deleteHistoryRecoverySnapshot(id: UUID) -> Bool {
-        guard !isHistoryRecoveryOperationInProgress,
-              historyRecoveryInspectionSnapshotID == nil,
-              historyRecoverySnapshots.contains(where: { $0.id == id }) else {
-            return false
-        }
-        runHistoryRecoverySnapshotOperation(
-            message: localizedCatalogString("Deleting recovery snapshot…")
-        ) { service in
-            try service.deleteSnapshot(id: id)
-        }
-        return true
-    }
-
-    @MainActor
-    private func runHistoryRecoverySnapshotOperation(
-        message: String,
-        operation: @escaping @Sendable (HistoryRecoveryService) throws -> Void
-    ) {
-        let storageRoot = dependencies.storageLayout.rootDirectory
-        let appStateReference = WeakAppStateReference(self)
-        historyRecoveryImportResult = nil
-        isHistoryRecoveryOperationInProgress = true
-        historyRecoveryOperationMessage = message
-        Task.detached(priority: .userInitiated) {
-            do {
-                try operation(HistoryRecoveryService(storageRoot: storageRoot))
-                await MainActor.run {
-                    appStateReference.value?.completeHistoryRecoverySnapshotOperation(
-                        at: storageRoot
-                    )
-                }
-            } catch {
-                await MainActor.run {
-                    appStateReference.value?.completeHistoryRecoverySnapshotOperationFailure(
-                        at: storageRoot
-                    )
-                }
-            }
-        }
-    }
-
-    @MainActor
-    private func completeHistoryRecoverySnapshotOperation(at storageRoot: URL) {
-        historyArchiveSafety = HistoryArchiveTransition.inspect(at: storageRoot)
-        refreshHistoryRecoverySnapshots()
-        isHistoryRecoveryOperationInProgress = false
-        historyRecoveryOperationMessage = nil
-        synchronizeHistoryPersistenceState()
-    }
-
-    @MainActor
-    private func completeHistoryRecoverySnapshotOperationFailure(at storageRoot: URL) {
-        historyArchiveSafety = HistoryArchiveTransition.inspect(at: storageRoot)
-        refreshHistoryRecoverySnapshots()
-        isHistoryRecoveryOperationInProgress = false
-        historyRecoveryOperationMessage = nil
-        synchronizeHistoryPersistenceState()
-        invalidateHistoryRecoveryInspectionResults()
-        errorMessage = localizedCatalogString("Recovery snapshot operation could not be completed.")
+        historyWorkflow.requestDeleteSnapshot(
+            snapshotID: id,
+            activeHistory: pipelineHistory,
+            shouldRescheduleInspection: selectedSettingsTab == .recovery
+        ) == .accepted
     }
 
     @discardableResult
@@ -6515,20 +6401,24 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @discardableResult
     private func requireAvailableHistoryForMutation() -> Bool {
-        guard !isHistoryArchiveTransitioning else {
-            errorMessage = localizedCatalogString("Archiving recording history is still in progress.")
-            return false
-        }
-        guard !isHistoryRecoveryOperationInProgress else {
-            errorMessage = localizedCatalogString("History recovery is still in progress.")
-            return false
-        }
         synchronizeHistoryPersistenceState()
-        guard !isHistoryUnavailable else {
+        switch HistoryWorkflowAdmission.mutation(
+            state: historyWorkflow.state
+        ) {
+        case .accepted:
+            return true
+        case .rejected(.archiveTransitionInProgress):
+            errorMessage = localizedCatalogString(
+                "Archiving recording history is still in progress."
+            )
+        case .rejected(.recoveryOperationInProgress):
+            errorMessage = localizedCatalogString(
+                "History recovery is still in progress."
+            )
+        default:
             errorMessage = historyUnavailableMessage
-            return false
         }
-        return true
+        return false
     }
 
     @MainActor
@@ -6536,9 +6426,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     func archiveOldHistoryAndStartFresh(
         postAction: HistoryArchivePostAction = .startFresh
     ) -> Bool {
-        guard !isHistoryRecoveryOperationInProgress else {
-            return false
-        }
         synchronizeHistoryPersistenceState()
         let result = historyWorkflow.requestArchive(
             context: historyWorkflowAdmissionContext(),
@@ -6553,56 +6440,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
             errorMessage = historyUnavailableMessage
         }
         return result == .accepted
-    }
-
-    @MainActor
-    private func completeHistoryRecoveryImport(
-        _ result: HistoryRecoveryImportResult,
-        storageRoot: URL
-    ) {
-        let activeStore = dependencies.makePipelineHistoryStore(
-            dependencies.storageLayout.historyStoreURL
-        )
-        guard activeStore.availability == .ready,
-              activeStore.durability == .durable,
-              activeStore.verifyHistoryReadable() else {
-            completeHistoryRecoveryOperationFailure(at: storageRoot)
-            return
-        }
-        pipelineHistoryStore = activeStore
-        pipelineHistory = loadPipelineHistory()
-        historyArchiveSafety = HistoryArchiveTransition.inspect(at: storageRoot)
-        refreshHistoryRecoverySnapshots()
-        isHistoryRecoveryOperationInProgress = false
-        historyRecoveryOperationMessage = nil
-        if result.failedRecordCount > 0 || result.conflictRecordCount > 0 {
-            historyRecoveryImportResult = result
-        } else {
-            historyRecoveryImportResult = nil
-        }
-        synchronizeHistoryPersistenceState()
-        invalidateHistoryRecoveryInspectionResults()
-    }
-
-    @MainActor
-    private func completeHistoryRecoveryOperationFailure(at storageRoot: URL) {
-        let activeStore = dependencies.makePipelineHistoryStore(
-            dependencies.storageLayout.historyStoreURL
-        )
-        if activeStore.availability == .ready,
-           activeStore.durability == .durable,
-           activeStore.verifyHistoryReadable() {
-            pipelineHistoryStore = activeStore
-            pipelineHistory = loadPipelineHistory()
-        }
-        historyArchiveSafety = HistoryArchiveTransition.inspect(at: storageRoot)
-        refreshHistoryRecoverySnapshots()
-        isHistoryRecoveryOperationInProgress = false
-        historyRecoveryOperationMessage = nil
-        historyRecoveryImportResult = nil
-        synchronizeHistoryPersistenceState()
-        invalidateHistoryRecoveryInspectionResults()
-        errorMessage = localizedCatalogString("History recovery could not be completed.")
     }
 
     @MainActor

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -5105,17 +5105,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         ) == .accepted
     }
 
-    @discardableResult
-    private static func preparedDirectory(_ directory: URL) -> URL {
-        if !FileManager.default.fileExists(atPath: directory.path) {
-            try? FileManager.default.createDirectory(
-                at: directory,
-                withIntermediateDirectories: true
-            )
-        }
-        return directory
-    }
-
     private static func recoverRecordingJournalsBeforeHistoryLoad(
         recordingJournalStore: RecordingJournalStore,
         historyStore: PipelineHistoryStore,
@@ -6382,23 +6371,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
     }
 
+    @MainActor
     private func synchronizeHistoryPersistenceState() {
-        let state = historyWorkflow.synchronize(
-            activeStore: pipelineHistoryStore
+        applyHistoryWorkflowState(
+            historyWorkflow.synchronize(activeStore: pipelineHistoryStore)
         )
-        historyArchiveSafety = state.archiveSafety
-        isHistoryUnavailable = state.isHistoryUnavailable
-        historyPersistenceWarning = state.showsPersistenceWarning
-            ? QuillUserIssueRecord(code: .historyPersistenceUnavailable)
-            : nil
     }
 
-    private func loadPipelineHistory() -> [PipelineHistoryItem] {
-        let history = pipelineHistoryStore.loadAllHistory()
-        synchronizeHistoryPersistenceState()
-        return history
-    }
-
+    @MainActor
     @discardableResult
     private func requireAvailableHistoryForMutation() -> Bool {
         synchronizeHistoryPersistenceState()

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -11,11 +11,6 @@ import os.log
 private let recordingLog = OSLog(subsystem: "com.woosublee.quill", category: "Recording")
 private let calendarLog = OSLog(subsystem: "com.woosublee.quill", category: "Calendar")
 
-enum HistoryArchivePostAction: Sendable {
-    case startFresh
-    case openRecovery
-}
-
 extension AIProcessingFeature {
     var modelFeature: AIModelFeature {
         switch self {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -3095,6 +3095,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
             UserDefaults.standard.removeObject(forKey: pendingMutedAudioRestoreStorageKey)
         }
 
+        historyWorkflow.onEvent = { [weak self] event in
+            self?.applyHistoryWorkflowEvent(event)
+        }
+
         overlayManager.onStopButtonPressed = { [weak self] in
             DispatchQueue.main.async {
                 self?.handleOverlayStopButtonPressed()
@@ -4906,6 +4910,133 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
+    private func applyHistoryWorkflowEvent(
+        _ event: HistoryWorkflowEvent
+    ) {
+        switch event {
+        case .stateChanged(let state):
+            applyHistoryWorkflowState(state)
+        case .installRuntime(let replacement):
+            applyHistoryRuntimeReplacement(replacement)
+        case .failed(let failure):
+            applyHistoryWorkflowFailure(failure)
+        case .performPostAction(let postAction):
+            if postAction == .openRecovery {
+                openHistoryRecoverySettings()
+            }
+        }
+    }
+
+    @MainActor
+    private func applyHistoryWorkflowState(
+        _ state: HistoryWorkflowState
+    ) {
+        let completedArchive = isHistoryArchiveTransitioning
+            && state.archiveActivity == .idle
+        historyArchiveSafety = state.archiveSafety
+        isHistoryArchiveTransitioning = state.archiveActivity != .idle
+        if completedArchive {
+            historyRecoverySnapshots = state.snapshots
+            historyRecoveryInspections = state.inspections
+            historyRecoveryInspectionSnapshotID = state.inspectionSnapshotID
+            isHistoryRecoveryOperationInProgress =
+                state.recoveryOperation != .idle
+            historyRecoveryOperationMessage = recoveryOperationMessage(
+                for: state.recoveryOperation
+            )
+            historyRecoveryImportResult = state.importResult
+        }
+        isHistoryUnavailable = state.isHistoryUnavailable
+        historyPersistenceWarning = state.showsPersistenceWarning
+            ? QuillUserIssueRecord(code: .historyPersistenceUnavailable)
+            : nil
+    }
+
+    @MainActor
+    private func applyHistoryRuntimeReplacement(
+        _ replacement: HistoryRuntimeReplacement
+    ) {
+        switch replacement {
+        case .fresh(let runtime):
+            pipelineHistoryStore = runtime.historyStore
+            recordingJournalStore = runtime.recordingJournalStore
+            cloudTranscriptionJobStore = runtime.cloudTranscriptionJobStore
+            pipelineHistory = []
+            retryingItemIDs = []
+            pendingAudioImportJobIDs = []
+            cloudTranscriptionProgressByHistoryID = [:]
+            meetingSummaryGeneratingNoteIDs = []
+            meetingSummaryPendingRevealNoteIDs = []
+            forgetAllWarningBannerState()
+        case .recovered(let historyStore, let history):
+            pipelineHistoryStore = historyStore
+            pipelineHistory = history
+        }
+    }
+
+    @MainActor
+    private func recoveryOperationMessage(
+        for operation: HistoryRecoveryWorkflowOperation
+    ) -> String? {
+        switch operation {
+        case .idle:
+            return nil
+        case .importing:
+            return localizedCatalogString("Recovering history…")
+        case .cancellingScheduledDeletion:
+            return localizedCatalogString("Cancelling scheduled deletion…")
+        case .deletingSnapshot:
+            return localizedCatalogString("Deleting recovery snapshot…")
+        }
+    }
+
+    @MainActor
+    private func applyHistoryWorkflowFailure(
+        _ failure: HistoryWorkflowFailure
+    ) {
+        switch failure {
+        case .historyUnavailable,
+             .archiveTransitionFailed,
+             .freshStoreVerificationFailed:
+            errorMessage = historyUnavailableMessage
+        case .recoveryImportFailed,
+             .activeStoreReopenFailed:
+            errorMessage = localizedCatalogString(
+                "History recovery could not be completed."
+            )
+        case .snapshotOperationFailed:
+            errorMessage = localizedCatalogString(
+                "Recovery snapshot operation could not be completed."
+            )
+        case .inspectionFailed:
+            break
+        }
+    }
+
+    @MainActor
+    private func historyWorkflowAdmissionContext()
+        -> HistoryWorkflowAdmissionContext {
+        HistoryWorkflowAdmissionContext(
+            isRecording: isRecording,
+            isTranscribing: isTranscribing,
+            hasRetryWork: !retryingItemIDs.isEmpty,
+            hasActiveTranscriptionJobs: !activeTranscriptionJobs.isEmpty,
+            hasPendingAudioImports: !pendingAudioImportJobIDs.isEmpty,
+            hasCloudHistoryWork:
+                cloudTranscriptionHistoryCoordinator.hasActiveWork,
+            hasMeetingSummaryWork:
+                !meetingSummaryGeneratingNoteIDs.isEmpty,
+            hasActiveRecordingJournal:
+                activeRecordingID != nil
+                    || activeSegmentedJournalController != nil,
+            hasPendingRecordingFinalization:
+                pendingRecordingJournalFinalizationCount != 0,
+            hasPendingRecordingStart: pendingRecordingStartCount != 0,
+            hasPendingAudioOnlyStops: !pendingAudioOnlyStopIDs.isEmpty
+        )
+    }
+
+    @MainActor
     func openHistoryRecoverySettings() {
         refreshHistoryRecoverySnapshots()
         guard !historyRecoverySnapshots.isEmpty else { return }
@@ -6468,17 +6599,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private func synchronizeHistoryPersistenceState() {
-        let unavailable = pipelineHistoryStore.availability == .unavailable
-            || historyArchiveSafety == .unresolvedInterruptedTransaction
-        let warning: QuillUserIssueRecord?
-        if unavailable {
-            warning = QuillUserIssueRecord(code: .historyPersistenceUnavailable)
-        } else {
-            warning = nil
-        }
-        guard isHistoryUnavailable != unavailable || historyPersistenceWarning != warning else { return }
-        isHistoryUnavailable = unavailable
-        historyPersistenceWarning = warning
+        let state = historyWorkflow.synchronize(
+            activeStore: pipelineHistoryStore
+        )
+        historyArchiveSafety = state.archiveSafety
+        isHistoryUnavailable = state.isHistoryUnavailable
+        historyPersistenceWarning = state.showsPersistenceWarning
+            ? QuillUserIssueRecord(code: .historyPersistenceUnavailable)
+            : nil
     }
 
     private func loadPipelineHistory() -> [PipelineHistoryItem] {
@@ -6510,107 +6638,23 @@ final class AppState: ObservableObject, @unchecked Sendable {
     func archiveOldHistoryAndStartFresh(
         postAction: HistoryArchivePostAction = .startFresh
     ) -> Bool {
-        synchronizeHistoryPersistenceState()
-        guard isHistoryUnavailable,
-              (historyArchiveSafety == .normal || historyArchiveSafety == .unresolvedArchive),
-              !isHistoryArchiveTransitioning,
-              !isHistoryRecoveryOperationInProgress else {
+        guard !isHistoryRecoveryOperationInProgress else {
             return false
         }
-        guard !isRecording,
-              !isTranscribing,
-              retryingItemIDs.isEmpty,
-              activeTranscriptionJobs.isEmpty,
-              pendingAudioImportJobIDs.isEmpty,
-              !cloudTranscriptionHistoryCoordinator.hasActiveWork,
-              meetingSummaryGeneratingNoteIDs.isEmpty,
-              activeRecordingID == nil,
-              activeSegmentedJournalController == nil,
-              pendingRecordingJournalFinalizationCount == 0,
-              pendingRecordingStartCount == 0,
-              pendingAudioOnlyStopIDs.isEmpty else {
+        synchronizeHistoryPersistenceState()
+        let result = historyWorkflow.requestArchive(
+            context: historyWorkflowAdmissionContext(),
+            currentStore: pipelineHistoryStore,
+            postAction: postAction
+        )
+        if result == .rejected(.applicationBusy) {
             errorMessage = localizedCatalogString(
                 "Finish the current recording or transcription before archiving history."
             )
-            return false
-        }
-
-        do {
-            try pipelineHistoryStore.detachForHistoryArchive()
-        } catch {
+        } else if result == .rejected(.historyUnavailable) {
             errorMessage = historyUnavailableMessage
-            return false
         }
-
-        let storageRoot = dependencies.storageLayout.rootDirectory
-        let makeStore = dependencies.makePipelineHistoryStore
-        let appStateReference = WeakAppStateReference(self)
-        isHistoryArchiveTransitioning = true
-        historyArchiveSafety = .transitioning
-        Task.detached(priority: .userInitiated) {
-            do {
-                let result = try HistoryArchiveTransition(
-                    makeStore: makeStore
-                ).archiveAndCreateFreshHistory(at: storageRoot)
-                await MainActor.run {
-                    appStateReference.value?.completeHistoryArchiveTransition(
-                        result,
-                        storageRoot: storageRoot,
-                        postAction: postAction
-                    )
-                }
-            } catch {
-                await MainActor.run {
-                    appStateReference.value?.completeHistoryArchiveTransitionFailure(
-                        at: storageRoot
-                    )
-                }
-            }
-        }
-        return true
-    }
-
-    @MainActor
-    private func completeHistoryArchiveTransition(
-        _ result: HistoryArchiveTransitionResult,
-        storageRoot: URL,
-        postAction: HistoryArchivePostAction
-    ) {
-        let activeStore = dependencies.makePipelineHistoryStore(
-            dependencies.storageLayout.historyStoreURL
-        )
-        guard activeStore.availability == .ready,
-              activeStore.durability == .durable,
-              activeStore.verifyHistoryReadable() else {
-            completeHistoryArchiveTransitionFailure(at: storageRoot)
-            return
-        }
-        pipelineHistoryStore = activeStore
-        let storageLayout = dependencies.storageLayout
-        _ = Self.preparedDirectory(storageLayout.rootDirectory)
-        let audioDirectory = Self.preparedDirectory(storageLayout.audioDirectory)
-        _ = Self.preparedDirectory(storageLayout.transcriptDirectory)
-        recordingJournalStore = RecordingJournalStore(
-            audioDirectory: audioDirectory
-        )
-        cloudTranscriptionJobStore = CloudTranscriptionJobStore(
-            jobsDirectory: storageLayout.cloudTranscriptionJobsDirectory,
-            temporaryRoot: storageLayout.cloudTranscriptionTemporaryDirectory
-        )
-        pipelineHistory = []
-        retryingItemIDs = []
-        pendingAudioImportJobIDs = []
-        cloudTranscriptionProgressByHistoryID = [:]
-        meetingSummaryGeneratingNoteIDs = []
-        meetingSummaryPendingRevealNoteIDs = []
-        forgetAllWarningBannerState()
-        historyArchiveSafety = HistoryArchiveTransition.inspect(at: storageRoot)
-        refreshHistoryRecoverySnapshots()
-        isHistoryArchiveTransitioning = false
-        synchronizeHistoryPersistenceState()
-        if postAction == .openRecovery {
-            openHistoryRecoverySettings()
-        }
+        return result == .accepted
     }
 
     @MainActor
@@ -6697,14 +6741,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         synchronizeHistoryPersistenceState()
         invalidateHistoryRecoveryInspectionResults()
         errorMessage = localizedCatalogString("History recovery could not be completed.")
-    }
-
-    @MainActor
-    private func completeHistoryArchiveTransitionFailure(at storageRoot: URL) {
-        historyArchiveSafety = HistoryArchiveTransition.inspect(at: storageRoot)
-        isHistoryArchiveTransitioning = false
-        synchronizeHistoryPersistenceState()
-        errorMessage = historyUnavailableMessage
     }
 
     @MainActor

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -5090,6 +5090,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     func cancelHistoryRecoveryScheduledDeletion(id: UUID) -> Bool {
         historyWorkflow.requestCancelScheduledDeletion(
             snapshotID: id,
+            activeStore: pipelineHistoryStore,
             activeHistory: pipelineHistory,
             shouldRescheduleInspection: selectedSettingsTab == .recovery
         ) == .accepted
@@ -5100,6 +5101,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     func deleteHistoryRecoverySnapshot(id: UUID) -> Bool {
         historyWorkflow.requestDeleteSnapshot(
             snapshotID: id,
+            activeStore: pipelineHistoryStore,
             activeHistory: pipelineHistory,
             shouldRescheduleInspection: selectedSettingsTab == .recovery
         ) == .accepted

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2389,6 +2389,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     var credentialStore: CredentialStore {
         CredentialStore(layout: dependencies.credentialStorageLayout)
     }
+    private let historyWorkflow: HistoryArchiveRecoveryWorkflow
     private var pipelineHistoryStore: PipelineHistoryStore
     private var recordingJournalStore: RecordingJournalStore
     private var cloudTranscriptionJobStore: CloudTranscriptionJobStore
@@ -2431,21 +2432,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
             .recommended
         )
         let storageLayout = dependencies.storageLayout
-        let storageRoot = Self.preparedDirectory(storageLayout.rootDirectory)
-        let audioDirectory = Self.preparedDirectory(storageLayout.audioDirectory)
-        _ = Self.preparedDirectory(storageLayout.transcriptDirectory)
-        let recoveredArchiveSafety = HistoryArchiveTransition
-            .rollbackInterruptedTransactions(at: storageRoot)
-        if recoveredArchiveSafety != .unresolvedInterruptedTransaction {
-            _ = try? HistoryRecoveryService(storageRoot: storageRoot)
-                .removeExpiredCompletedSnapshots()
-        }
-        let initialHistoryArchiveSafety = HistoryArchiveTransition.inspect(at: storageRoot)
-        pipelineHistoryStore = dependencies.makePipelineHistoryStore(
-            storageLayout.historyStoreURL
+        let historyWorkflow = HistoryArchiveRecoveryWorkflow(
+            storageLayout: storageLayout,
+            makeHistoryStore: dependencies.makePipelineHistoryStore
         )
-        let initialHistoryUnavailable = pipelineHistoryStore.availability == .unavailable
-            || initialHistoryArchiveSafety == .unresolvedInterruptedTransaction
+        let historyStartup = historyWorkflow.prepareStartup()
+        self.historyWorkflow = historyWorkflow
+        pipelineHistoryStore = historyStartup.activeStore
+        let audioDirectory = storageLayout.audioDirectory
         recordingJournalStore = RecordingJournalStore(
             audioDirectory: audioDirectory
         )
@@ -2754,11 +2748,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         var savedHistory: [PipelineHistoryItem] = []
         var cloudReconciliation: CloudTranscriptionReconciliation?
 
-        if pipelineHistoryStore.availability == .ready {
-            pipelineHistoryStore.verifyHistoryReadable()
-        }
-        if initialHistoryArchiveSafety == .normal,
-           pipelineHistoryStore.availability == .ready {
+        if historyStartup.permitsNormalHistoryStartup {
             Self.recoverRecordingJournalsBeforeHistoryLoad(
                 recordingJournalStore: recordingJournalStore,
                 historyStore: pipelineHistoryStore,
@@ -2917,8 +2907,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             } else {
                 print("Skipping history startup work because persistent history is unavailable.")
             }
-        } else if initialHistoryArchiveSafety == .unresolvedArchive,
-                  pipelineHistoryStore.availability == .ready {
+        } else if historyStartup.permitsUnresolvedArchiveStartup {
             Self.recoverRecordingJournalsBeforeHistoryLoad(
                 recordingJournalStore: recordingJournalStore,
                 historyStore: pipelineHistoryStore,
@@ -3042,23 +3031,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.soundVolume = soundVolume
         self.voiceMacros = initialMacros
         self.pipelineHistory = savedHistory
-        self.isHistoryUnavailable = initialHistoryUnavailable
-        self.historyArchiveSafety = initialHistoryArchiveSafety
-        self.historyRecoverySnapshots = HistoryRecoveryService(storageRoot: storageRoot).listSnapshots()
-        if initialHistoryUnavailable {
-            self.historyPersistenceWarning = QuillUserIssueRecord(
-                code: .historyPersistenceUnavailable
-            )
-        } else {
-            switch pipelineHistoryStore.durability {
-            case .durable:
-                self.historyPersistenceWarning = nil
-            case .inMemory:
-                self.historyPersistenceWarning = QuillUserIssueRecord(
-                    code: .historyPersistenceUnavailable
-                )
-            }
-        }
+        self.isHistoryUnavailable = historyStartup.state.isHistoryUnavailable
+        self.historyArchiveSafety = historyStartup.state.archiveSafety
+        self.historyRecoverySnapshots = historyStartup.state.snapshots
+        self.historyPersistenceWarning = historyStartup.state.showsPersistenceWarning
+            ? QuillUserIssueRecord(code: .historyPersistenceUnavailable)
+            : nil
         self.hasAccessibility = initialAccessibility
         self.hasScreenRecordingPermission = initialScreenCapturePermission
         self.launchAtLogin = SMAppService.mainApp.status == .enabled

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2029,9 +2029,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published private(set) var historyRecoverySnapshots: [HistoryRecoverySnapshotDescriptor] = []
     @Published private(set) var historyRecoveryInspections: [UUID: HistoryRecoveryInspection] = [:]
     @Published private(set) var historyRecoveryInspectionSnapshotID: UUID?
-    private var historyRecoveryInspectionQueue: [UUID] = []
-    private var historyRecoveryInspectionAttemptedIDs = Set<UUID>()
-    private var historyRecoveryInspectionRevision = 0
     @Published private(set) var isHistoryRecoveryOperationInProgress = false
     @Published private(set) var historyRecoveryOperationMessage: String?
     @Published private(set) var historyRecoveryImportResult: HistoryRecoveryImportResult?
@@ -4931,21 +4928,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func applyHistoryWorkflowState(
         _ state: HistoryWorkflowState
     ) {
-        let completedArchive = isHistoryArchiveTransitioning
-            && state.archiveActivity == .idle
         historyArchiveSafety = state.archiveSafety
         isHistoryArchiveTransitioning = state.archiveActivity != .idle
-        if completedArchive {
-            historyRecoverySnapshots = state.snapshots
-            historyRecoveryInspections = state.inspections
-            historyRecoveryInspectionSnapshotID = state.inspectionSnapshotID
-            isHistoryRecoveryOperationInProgress =
-                state.recoveryOperation != .idle
-            historyRecoveryOperationMessage = recoveryOperationMessage(
-                for: state.recoveryOperation
-            )
-            historyRecoveryImportResult = state.importResult
-        }
+        historyRecoverySnapshots = state.snapshots
+        historyRecoveryInspections = state.inspections
+        historyRecoveryInspectionSnapshotID = state.inspectionSnapshotID
         isHistoryUnavailable = state.isHistoryUnavailable
         historyPersistenceWarning = state.showsPersistenceWarning
             ? QuillUserIssueRecord(code: .historyPersistenceUnavailable)
@@ -5047,124 +5034,36 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func refreshHistoryRecoverySnapshots() {
-        historyRecoverySnapshots = HistoryRecoveryService(
-            storageRoot: storageLayout.rootDirectory
-        ).listSnapshots()
-        let currentIDs = Set(historyRecoverySnapshots.map(\.id))
-        historyRecoveryInspections = historyRecoveryInspections.filter {
-            currentIDs.contains($0.key)
-        }
+        historyWorkflow.refreshSnapshots()
     }
 
     @MainActor
     func beginHistoryRecoveryInspection() {
-        guard !isHistoryRecoveryOperationInProgress,
-              historyRecoveryInspectionSnapshotID == nil else {
-            return
-        }
-        historyRecoveryInspectionAttemptedIDs = []
-        historyRecoveryInspectionQueue = historyRecoverySnapshots.compactMap { snapshot in
-            snapshot.integrity == .ready ? snapshot.id : nil
-        }
-        startNextHistoryRecoveryInspection()
+        historyWorkflow.beginInspection(activeHistory: pipelineHistory)
     }
 
     @MainActor
     func ensureHistoryRecoveryInspection() {
-        guard historyRecoveryInspectionSnapshotID == nil,
-              historyRecoveryInspectionQueue.isEmpty,
-              historyRecoveryInspectionAttemptedIDs.isEmpty,
-              historyRecoveryInspections.isEmpty else {
-            return
-        }
-        beginHistoryRecoveryInspection()
+        historyWorkflow.ensureInspection(activeHistory: pipelineHistory)
     }
 
     @MainActor
     @discardableResult
     func retryHistoryRecoveryInspection(id: UUID) -> Bool {
-        guard !isHistoryRecoveryOperationInProgress,
-              historyRecoverySnapshots.contains(where: {
-                  $0.id == id && $0.integrity == .ready
-              }) else {
-            return false
-        }
-        historyRecoveryInspectionAttemptedIDs.remove(id)
-        historyRecoveryInspectionQueue.removeAll { $0 == id }
-        historyRecoveryInspectionQueue.insert(id, at: 0)
-        startNextHistoryRecoveryInspection()
-        return true
-    }
-
-    @MainActor
-    private func startNextHistoryRecoveryInspection() {
-        guard !isHistoryRecoveryOperationInProgress,
-              historyRecoveryInspectionSnapshotID == nil else {
-            return
-        }
-        while !historyRecoveryInspectionQueue.isEmpty {
-            let snapshotID = historyRecoveryInspectionQueue.removeFirst()
-            guard !historyRecoveryInspectionAttemptedIDs.contains(snapshotID),
-                  historyRecoverySnapshots.contains(where: {
-                      $0.id == snapshotID && $0.integrity == .ready
-                  }) else {
-                continue
-            }
-            historyRecoveryInspectionAttemptedIDs.insert(snapshotID)
-            historyRecoveryInspectionSnapshotID = snapshotID
-            let inspectionRevision = historyRecoveryInspectionRevision
-            let storageRoot = dependencies.storageLayout.rootDirectory
-            let activeHistory = pipelineHistory
-            let appStateReference = WeakAppStateReference(self)
-            Task.detached(priority: .userInitiated) {
-                do {
-                    let inspection = try HistoryRecoveryService(storageRoot: storageRoot)
-                        .inspectSnapshot(id: snapshotID, against: activeHistory)
-                    await MainActor.run {
-                        appStateReference.value?.completeHistoryRecoveryInspection(
-                            inspection,
-                            snapshotID: snapshotID,
-                            inspectionRevision: inspectionRevision,
-                            storageRoot: storageRoot
-                        )
-                    }
-                } catch {
-                    await MainActor.run {
-                        appStateReference.value?.completeHistoryRecoveryInspectionFailure(
-                            snapshotID: snapshotID,
-                            inspectionRevision: inspectionRevision,
-                            storageRoot: storageRoot
-                        )
-                    }
-                }
-            }
-            return
-        }
+        historyWorkflow.retryInspection(
+            id: id,
+            activeHistory: pipelineHistory
+        ) == .accepted
     }
 
     @MainActor
     func invalidateHistoryRecoveryInspectionResults() {
-        historyRecoveryInspectionRevision &+= 1
-        historyRecoveryInspections = [:]
-        historyRecoveryInspectionQueue = []
-        historyRecoveryInspectionAttemptedIDs = []
-        guard selectedSettingsTab == .recovery,
-              !isHistoryRecoveryOperationInProgress else {
-            return
-        }
-        historyRecoveryInspectionQueue = historyRecoverySnapshots.compactMap { snapshot in
-            guard snapshot.integrity == .ready,
-                  snapshot.status != .inspectionFailed else {
-                return nil
-            }
-            return snapshot.id
-        }
-        historyRecoveryInspectionAttemptedIDs = Set(
-            historyRecoverySnapshots.compactMap { snapshot in
-                snapshot.status == .inspectionFailed ? snapshot.id : nil
-            }
+        historyWorkflow.invalidateInspection(
+            activeHistory: pipelineHistory,
+            shouldReschedule:
+                selectedSettingsTab == .recovery
+                    && !isHistoryRecoveryOperationInProgress
         )
-        startNextHistoryRecoveryInspection()
     }
 
     @MainActor
@@ -5307,7 +5206,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         isHistoryRecoveryOperationInProgress = false
         historyRecoveryOperationMessage = nil
         synchronizeHistoryPersistenceState()
-        startNextHistoryRecoveryInspection()
     }
 
     @MainActor
@@ -6655,42 +6553,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
             errorMessage = historyUnavailableMessage
         }
         return result == .accepted
-    }
-
-    @MainActor
-    private func completeHistoryRecoveryInspection(
-        _ inspection: HistoryRecoveryInspection,
-        snapshotID: UUID,
-        inspectionRevision: Int,
-        storageRoot: URL
-    ) {
-        guard historyRecoveryInspectionSnapshotID == snapshotID else { return }
-        historyRecoveryInspectionSnapshotID = nil
-        historyArchiveSafety = HistoryArchiveTransition.inspect(at: storageRoot)
-        refreshHistoryRecoverySnapshots()
-        if inspectionRevision == historyRecoveryInspectionRevision,
-           historyRecoverySnapshots.contains(where: { $0.id == inspection.snapshotID }) {
-            historyRecoveryInspections[inspection.snapshotID] = inspection
-        }
-        synchronizeHistoryPersistenceState()
-        startNextHistoryRecoveryInspection()
-    }
-
-    @MainActor
-    private func completeHistoryRecoveryInspectionFailure(
-        snapshotID: UUID,
-        inspectionRevision: Int,
-        storageRoot: URL
-    ) {
-        guard historyRecoveryInspectionSnapshotID == snapshotID else { return }
-        historyRecoveryInspectionSnapshotID = nil
-        historyArchiveSafety = HistoryArchiveTransition.inspect(at: storageRoot)
-        refreshHistoryRecoverySnapshots()
-        if inspectionRevision == historyRecoveryInspectionRevision {
-            historyRecoveryInspections.removeValue(forKey: snapshotID)
-        }
-        synchronizeHistoryPersistenceState()
-        startNextHistoryRecoveryInspection()
     }
 
     @MainActor

--- a/Sources/HistoryArchiveRecoveryWorkflow.swift
+++ b/Sources/HistoryArchiveRecoveryWorkflow.swift
@@ -128,8 +128,8 @@ enum HistoryWorkflowAdmission {
         context: HistoryWorkflowAdmissionContext
     ) -> HistoryWorkflowCommandResult {
         guard state.isHistoryUnavailable,
-              state.archiveSafety == .normal
-                || state.archiveSafety == .unresolvedArchive else {
+              (state.archiveSafety == .normal
+                || state.archiveSafety == .unresolvedArchive) else {
             return .rejected(.archiveNotRequired)
         }
         guard state.archiveActivity == .idle else {
@@ -365,6 +365,7 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
     private var inspectionAttemptedIDs = Set<UUID>()
     private var inspectionRevision = 0
     private var inspectionActiveHistory: [PipelineHistoryItem] = []
+    private var snapshotOperationActiveStore: PipelineHistoryStore?
 
     convenience init(
         storageLayout: AppStateStorageLayout,
@@ -591,11 +592,13 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
     @MainActor
     func requestCancelScheduledDeletion(
         snapshotID: UUID,
+        activeStore: PipelineHistoryStore,
         activeHistory: [PipelineHistoryItem],
         shouldRescheduleInspection: Bool
     ) -> HistoryWorkflowCommandResult {
         requestSnapshotOperation(
             .cancelScheduledDeletion(snapshotID),
+            activeStore: activeStore,
             activeHistory: activeHistory,
             shouldRescheduleInspection: shouldRescheduleInspection
         )
@@ -604,11 +607,13 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
     @MainActor
     func requestDeleteSnapshot(
         snapshotID: UUID,
+        activeStore: PipelineHistoryStore,
         activeHistory: [PipelineHistoryItem],
         shouldRescheduleInspection: Bool
     ) -> HistoryWorkflowCommandResult {
         requestSnapshotOperation(
             .delete(snapshotID),
+            activeStore: activeStore,
             activeHistory: activeHistory,
             shouldRescheduleInspection: shouldRescheduleInspection
         )
@@ -672,6 +677,7 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
     @MainActor
     private func requestSnapshotOperation(
         _ operation: HistorySnapshotOperation,
+        activeStore: PipelineHistoryStore,
         activeHistory: [PipelineHistoryItem],
         shouldRescheduleInspection: Bool
     ) -> HistoryWorkflowCommandResult {
@@ -681,6 +687,7 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
             requiresCompletedSnapshot: operation.requiresCompletedSnapshot
         )
         guard admission == .accepted else { return admission }
+        snapshotOperationActiveStore = activeStore
         state.importResult = nil
         state.recoveryOperation = operation.recoveryOperation
         emitState()
@@ -744,7 +751,7 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
                 || result.conflictRecordCount > 0
             ? result
             : nil
-        synchronizeStateForVerifiedStore(reopenedStore)
+        _ = synchronize(activeStore: reopenedStore)
         invalidateInspection(
             activeHistory: history,
             shouldReschedule: shouldRescheduleInspection
@@ -772,7 +779,7 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
                     historyStore: reopenedStore,
                     history: activeHistory
                 )))
-                synchronizeStateForVerifiedStore(reopenedStore)
+                _ = synchronize(activeStore: reopenedStore)
                 failure = requestedFailure
             } else {
                 state.isHistoryUnavailable = true
@@ -796,7 +803,12 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
 
     @MainActor
     private func completeSnapshotOperationSuccess() {
+        let activeStore = snapshotOperationActiveStore
+        snapshotOperationActiveStore = nil
         refreshSafetyAndSnapshots()
+        if let activeStore {
+            _ = synchronize(activeStore: activeStore)
+        }
         state.recoveryOperation = .idle
         emitState()
         startNextInspection()
@@ -807,7 +819,12 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
         activeHistory: [PipelineHistoryItem],
         shouldRescheduleInspection: Bool
     ) {
+        let activeStore = snapshotOperationActiveStore
+        snapshotOperationActiveStore = nil
         refreshSafetyAndSnapshots()
+        if let activeStore {
+            _ = synchronize(activeStore: activeStore)
+        }
         state.recoveryOperation = .idle
         state.importResult = nil
         invalidateInspection(
@@ -859,6 +876,7 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
             }
             return
         }
+        inspectionActiveHistory = []
     }
 
     @MainActor
@@ -929,7 +947,7 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
         emit(.installRuntime(.fresh(runtime)))
         refreshSafetyAndSnapshots()
         state.archiveActivity = .idle
-        synchronizeStateForVerifiedStore(activeStore)
+        _ = synchronize(activeStore: activeStore)
         emitState()
         emit(.performPostAction(postAction))
     }
@@ -938,9 +956,7 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
     private func completeArchiveFailure(
         _ failure: HistoryWorkflowFailure
     ) {
-        state.archiveSafety = dependencies.inspectArchiveSafety(
-            storageLayout.rootDirectory
-        )
+        refreshSafetyAndSnapshots()
         state.archiveActivity = .idle
         state.isHistoryUnavailable = true
         state.showsPersistenceWarning = true
@@ -964,17 +980,6 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
             state.isHistoryUnavailable = true
             state.showsPersistenceWarning = true
         }
-    }
-
-    @MainActor
-    private func synchronizeStateForVerifiedStore(
-        _ activeStore: PipelineHistoryStore
-    ) {
-        state.isHistoryUnavailable =
-            activeStore.availability == .unavailable
-                || state.archiveSafety == .unresolvedInterruptedTransaction
-        state.showsPersistenceWarning = state.isHistoryUnavailable
-            || activeStore.durability == .inMemory
     }
 
     @discardableResult

--- a/Sources/HistoryArchiveRecoveryWorkflow.swift
+++ b/Sources/HistoryArchiveRecoveryWorkflow.swift
@@ -436,19 +436,16 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
         return .accepted
     }
 
-    @MainActor
-    func synchronize(activeStore: PipelineHistoryStore) {
-        let unavailable = activeStore.availability == .unavailable
-            || state.archiveSafety == .unresolvedInterruptedTransaction
-        let showsWarning = unavailable
+    @discardableResult
+    func synchronize(
+        activeStore: PipelineHistoryStore
+    ) -> HistoryWorkflowState {
+        state.isHistoryUnavailable =
+            activeStore.availability == .unavailable
+                || state.archiveSafety == .unresolvedInterruptedTransaction
+        state.showsPersistenceWarning = state.isHistoryUnavailable
             || activeStore.durability == .inMemory
-        guard state.isHistoryUnavailable != unavailable
-                || state.showsPersistenceWarning != showsWarning else {
-            return
-        }
-        state.isHistoryUnavailable = unavailable
-        state.showsPersistenceWarning = showsWarning
-        emitState()
+        return state
     }
 
     @MainActor

--- a/Sources/HistoryArchiveRecoveryWorkflow.swift
+++ b/Sources/HistoryArchiveRecoveryWorkflow.swift
@@ -1,0 +1,348 @@
+import Foundation
+
+enum HistoryArchivePostAction: Equatable, Sendable {
+    case startFresh
+    case openRecovery
+}
+
+enum HistoryArchiveWorkflowActivity: Equatable, Sendable {
+    case idle
+    case transitioning(postAction: HistoryArchivePostAction)
+}
+
+enum HistoryRecoveryWorkflowOperation: Equatable, Sendable {
+    case idle
+    case importing(UUID)
+    case cancellingScheduledDeletion(UUID)
+    case deletingSnapshot(UUID)
+}
+
+struct HistoryWorkflowAdmissionContext: Equatable, Sendable {
+    let isRecording: Bool
+    let isTranscribing: Bool
+    let hasRetryWork: Bool
+    let hasActiveTranscriptionJobs: Bool
+    let hasPendingAudioImports: Bool
+    let hasCloudHistoryWork: Bool
+    let hasMeetingSummaryWork: Bool
+    let hasActiveRecordingJournal: Bool
+    let hasPendingRecordingFinalization: Bool
+    let hasPendingRecordingStart: Bool
+    let hasPendingAudioOnlyStops: Bool
+
+    init(
+        isRecording: Bool = false,
+        isTranscribing: Bool = false,
+        hasRetryWork: Bool = false,
+        hasActiveTranscriptionJobs: Bool = false,
+        hasPendingAudioImports: Bool = false,
+        hasCloudHistoryWork: Bool = false,
+        hasMeetingSummaryWork: Bool = false,
+        hasActiveRecordingJournal: Bool = false,
+        hasPendingRecordingFinalization: Bool = false,
+        hasPendingRecordingStart: Bool = false,
+        hasPendingAudioOnlyStops: Bool = false
+    ) {
+        self.isRecording = isRecording
+        self.isTranscribing = isTranscribing
+        self.hasRetryWork = hasRetryWork
+        self.hasActiveTranscriptionJobs = hasActiveTranscriptionJobs
+        self.hasPendingAudioImports = hasPendingAudioImports
+        self.hasCloudHistoryWork = hasCloudHistoryWork
+        self.hasMeetingSummaryWork = hasMeetingSummaryWork
+        self.hasActiveRecordingJournal = hasActiveRecordingJournal
+        self.hasPendingRecordingFinalization = hasPendingRecordingFinalization
+        self.hasPendingRecordingStart = hasPendingRecordingStart
+        self.hasPendingAudioOnlyStops = hasPendingAudioOnlyStops
+    }
+
+    var hasBlockingActivity: Bool {
+        isRecording
+            || isTranscribing
+            || hasRetryWork
+            || hasActiveTranscriptionJobs
+            || hasPendingAudioImports
+            || hasCloudHistoryWork
+            || hasMeetingSummaryWork
+            || hasActiveRecordingJournal
+            || hasPendingRecordingFinalization
+            || hasPendingRecordingStart
+            || hasPendingAudioOnlyStops
+    }
+}
+
+struct HistoryWorkflowState: Equatable, Sendable {
+    var archiveSafety: HistoryArchiveSafety
+    var archiveActivity: HistoryArchiveWorkflowActivity
+    var recoveryOperation: HistoryRecoveryWorkflowOperation
+    var snapshots: [HistoryRecoverySnapshotDescriptor]
+    var inspections: [UUID: HistoryRecoveryInspection]
+    var inspectionSnapshotID: UUID?
+    var importResult: HistoryRecoveryImportResult?
+    var isHistoryUnavailable: Bool
+    var showsPersistenceWarning: Bool
+
+    static var initial: HistoryWorkflowState {
+        HistoryWorkflowState(
+            archiveSafety: .normal,
+            archiveActivity: .idle,
+            recoveryOperation: .idle,
+            snapshots: [],
+            inspections: [:],
+            inspectionSnapshotID: nil,
+            importResult: nil,
+            isHistoryUnavailable: false,
+            showsPersistenceWarning: false
+        )
+    }
+}
+
+enum HistoryWorkflowRejection: Equatable, Sendable {
+    case archiveNotRequired
+    case historyUnavailable
+    case archiveTransitionInProgress
+    case recoveryOperationInProgress
+    case applicationBusy
+    case snapshotUnavailable
+    case inspectionInProgress
+}
+
+enum HistoryWorkflowCommandResult: Equatable, Sendable {
+    case accepted
+    case rejected(HistoryWorkflowRejection)
+}
+
+enum HistoryWorkflowFailure: Equatable, Sendable {
+    case historyUnavailable
+    case archiveTransitionFailed
+    case freshStoreVerificationFailed
+    case inspectionFailed(UUID)
+    case recoveryImportFailed
+    case activeStoreReopenFailed
+    case snapshotOperationFailed
+}
+
+enum HistoryWorkflowAdmission {
+    static func archive(
+        state: HistoryWorkflowState,
+        context: HistoryWorkflowAdmissionContext
+    ) -> HistoryWorkflowCommandResult {
+        guard state.isHistoryUnavailable,
+              state.archiveSafety == .normal
+                || state.archiveSafety == .unresolvedArchive else {
+            return .rejected(.archiveNotRequired)
+        }
+        guard state.archiveActivity == .idle else {
+            return .rejected(.archiveTransitionInProgress)
+        }
+        guard state.recoveryOperation == .idle else {
+            return .rejected(.recoveryOperationInProgress)
+        }
+        guard !context.hasBlockingActivity else {
+            return .rejected(.applicationBusy)
+        }
+        return .accepted
+    }
+
+    static func recoveryImport(
+        state: HistoryWorkflowState,
+        snapshotID: UUID,
+        context: HistoryWorkflowAdmissionContext
+    ) -> HistoryWorkflowCommandResult {
+        guard !state.isHistoryUnavailable else {
+            return .rejected(.historyUnavailable)
+        }
+        guard state.archiveActivity == .idle else {
+            return .rejected(.archiveTransitionInProgress)
+        }
+        guard state.recoveryOperation == .idle else {
+            return .rejected(.recoveryOperationInProgress)
+        }
+        guard !context.hasBlockingActivity else {
+            return .rejected(.applicationBusy)
+        }
+        guard state.snapshots.contains(where: {
+            $0.id == snapshotID && $0.integrity == .ready
+        }) else {
+            return .rejected(.snapshotUnavailable)
+        }
+        return .accepted
+    }
+
+    static func snapshotOperation(
+        state: HistoryWorkflowState,
+        snapshotID: UUID,
+        requiresCompletedSnapshot: Bool
+    ) -> HistoryWorkflowCommandResult {
+        guard state.recoveryOperation == .idle else {
+            return .rejected(.recoveryOperationInProgress)
+        }
+        guard state.inspectionSnapshotID == nil else {
+            return .rejected(.inspectionInProgress)
+        }
+        guard state.snapshots.contains(where: {
+            $0.id == snapshotID
+                && (!requiresCompletedSnapshot
+                    || ($0.integrity == .ready && $0.status == .completed))
+        }) else {
+            return .rejected(.snapshotUnavailable)
+        }
+        return .accepted
+    }
+
+    static func mutation(
+        state: HistoryWorkflowState
+    ) -> HistoryWorkflowCommandResult {
+        guard state.archiveActivity == .idle else {
+            return .rejected(.archiveTransitionInProgress)
+        }
+        guard state.recoveryOperation == .idle else {
+            return .rejected(.recoveryOperationInProgress)
+        }
+        guard !state.isHistoryUnavailable else {
+            return .rejected(.historyUnavailable)
+        }
+        return .accepted
+    }
+}
+
+struct HistoryFreshRuntime {
+    let historyStore: PipelineHistoryStore
+    let recordingJournalStore: RecordingJournalStore
+    let cloudTranscriptionJobStore: CloudTranscriptionJobStore
+}
+
+enum HistoryRuntimeReplacement {
+    case fresh(HistoryFreshRuntime)
+    case recovered(
+        historyStore: PipelineHistoryStore,
+        history: [PipelineHistoryItem]
+    )
+}
+
+enum HistoryWorkflowEvent {
+    case stateChanged(HistoryWorkflowState)
+    case installRuntime(HistoryRuntimeReplacement)
+    case failed(HistoryWorkflowFailure)
+    case performPostAction(HistoryArchivePostAction)
+}
+
+struct HistoryArchiveRecoveryWorkflowDependencies: Sendable {
+    typealias HistoryStoreFactory = @Sendable (URL) -> PipelineHistoryStore
+
+    var makeHistoryStore: HistoryStoreFactory
+    var rollbackInterruptedTransactions: @Sendable (URL) -> HistoryArchiveSafety
+    var inspectArchiveSafety: @Sendable (URL) -> HistoryArchiveSafety
+    var removeExpiredSnapshots: @Sendable (URL) throws -> [UUID]
+    var listSnapshots: @Sendable (URL) -> [HistoryRecoverySnapshotDescriptor]
+    var archiveAndCreateFreshHistory:
+        @Sendable (URL, @escaping HistoryStoreFactory) throws
+            -> HistoryArchiveTransitionResult
+    var inspectSnapshot:
+        @Sendable (URL, UUID, [PipelineHistoryItem]) throws
+            -> HistoryRecoveryInspection
+    var importSnapshot:
+        @Sendable (
+            URL,
+            UUID,
+            PipelineHistoryStore,
+            URL,
+            URL
+        ) throws -> HistoryRecoveryImportResult
+    var cancelScheduledDeletion: @Sendable (URL, UUID) throws -> Void
+    var deleteSnapshot: @Sendable (URL, UUID) throws -> Void
+    var makeRecordingJournalStore: @Sendable (URL) -> RecordingJournalStore
+    var makeCloudTranscriptionJobStore:
+        @Sendable (AppStateStorageLayout) -> CloudTranscriptionJobStore
+
+    static func live(
+        makeHistoryStore: @escaping HistoryStoreFactory
+    ) -> HistoryArchiveRecoveryWorkflowDependencies {
+        HistoryArchiveRecoveryWorkflowDependencies(
+            makeHistoryStore: makeHistoryStore,
+            rollbackInterruptedTransactions: {
+                HistoryArchiveTransition.rollbackInterruptedTransactions(at: $0)
+            },
+            inspectArchiveSafety: {
+                HistoryArchiveTransition.inspect(at: $0)
+            },
+            removeExpiredSnapshots: {
+                try HistoryRecoveryService(storageRoot: $0)
+                    .removeExpiredCompletedSnapshots()
+            },
+            listSnapshots: {
+                HistoryRecoveryService(storageRoot: $0).listSnapshots()
+            },
+            archiveAndCreateFreshHistory: { root, factory in
+                try HistoryArchiveTransition(makeStore: factory)
+                    .archiveAndCreateFreshHistory(at: root)
+            },
+            inspectSnapshot: { root, id, history in
+                try HistoryRecoveryService(storageRoot: root)
+                    .inspectSnapshot(id: id, against: history)
+            },
+            importSnapshot: { root, id, store, audio, transcripts in
+                try HistoryRecoveryService(storageRoot: root)
+                    .importSnapshot(
+                        id: id,
+                        into: store,
+                        audioDirectory: audio,
+                        transcriptDirectory: transcripts
+                    )
+            },
+            cancelScheduledDeletion: { root, id in
+                try HistoryRecoveryService(storageRoot: root)
+                    .cancelScheduledDeletion(for: id)
+            },
+            deleteSnapshot: { root, id in
+                try HistoryRecoveryService(storageRoot: root)
+                    .deleteSnapshot(id: id)
+            },
+            makeRecordingJournalStore: {
+                RecordingJournalStore(audioDirectory: $0)
+            },
+            makeCloudTranscriptionJobStore: {
+                CloudTranscriptionJobStore(
+                    jobsDirectory: $0.cloudTranscriptionJobsDirectory,
+                    temporaryRoot: $0.cloudTranscriptionTemporaryDirectory
+                )
+            }
+        )
+    }
+}
+
+final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
+    let storageLayout: AppStateStorageLayout
+    let dependencies: HistoryArchiveRecoveryWorkflowDependencies
+    private(set) var state = HistoryWorkflowState.initial
+    var onEvent: (@MainActor (HistoryWorkflowEvent) -> Void)?
+
+    convenience init(
+        storageLayout: AppStateStorageLayout,
+        makeHistoryStore: @escaping
+            HistoryArchiveRecoveryWorkflowDependencies.HistoryStoreFactory
+    ) {
+        self.init(
+            storageLayout: storageLayout,
+            dependencies: .live(makeHistoryStore: makeHistoryStore)
+        )
+    }
+
+    init(
+        storageLayout: AppStateStorageLayout,
+        dependencies: HistoryArchiveRecoveryWorkflowDependencies
+    ) {
+        self.storageLayout = storageLayout
+        self.dependencies = dependencies
+    }
+
+    @MainActor
+    private func emitState() {
+        emit(.stateChanged(state))
+    }
+
+    @MainActor
+    private func emit(_ event: HistoryWorkflowEvent) {
+        onEvent?(event)
+    }
+}

--- a/Sources/HistoryArchiveRecoveryWorkflow.swift
+++ b/Sources/HistoryArchiveRecoveryWorkflow.swift
@@ -394,6 +394,49 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
     }
 
     @MainActor
+    @discardableResult
+    func requestArchive(
+        context: HistoryWorkflowAdmissionContext,
+        currentStore: PipelineHistoryStore,
+        postAction: HistoryArchivePostAction
+    ) -> HistoryWorkflowCommandResult {
+        let admission = HistoryWorkflowAdmission.archive(
+            state: state,
+            context: context
+        )
+        guard admission == .accepted else { return admission }
+        do {
+            try currentStore.detachForHistoryArchive()
+        } catch {
+            emit(.failed(.historyUnavailable))
+            return .rejected(.historyUnavailable)
+        }
+
+        state.archiveActivity = .transitioning(postAction: postAction)
+        state.archiveSafety = .transitioning
+        emitState()
+
+        let root = storageLayout.rootDirectory
+        let dependencies = dependencies
+        Task.detached(priority: .userInitiated) { [weak self] in
+            do {
+                _ = try dependencies.archiveAndCreateFreshHistory(
+                    root,
+                    dependencies.makeHistoryStore
+                )
+                await self?.completeArchiveSuccess(
+                    postAction: postAction
+                )
+            } catch {
+                await self?.completeArchiveFailure(
+                    .archiveTransitionFailed
+                )
+            }
+        }
+        return .accepted
+    }
+
+    @MainActor
     func synchronize(activeStore: PipelineHistoryStore) {
         let unavailable = activeStore.availability == .unavailable
             || state.archiveSafety == .unresolvedInterruptedTransaction
@@ -406,6 +449,85 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
         state.isHistoryUnavailable = unavailable
         state.showsPersistenceWarning = showsWarning
         emitState()
+    }
+
+    @MainActor
+    private func completeArchiveSuccess(
+        postAction: HistoryArchivePostAction
+    ) {
+        let activeStore = dependencies.makeHistoryStore(
+            storageLayout.historyStoreURL
+        )
+        guard activeStore.availability == .ready,
+              activeStore.durability == .durable,
+              activeStore.verifyHistoryReadable() else {
+            completeArchiveFailure(.freshStoreVerificationFailed)
+            return
+        }
+
+        Self.prepareDirectory(storageLayout.rootDirectory)
+        let audioDirectory = Self.prepareDirectory(
+            storageLayout.audioDirectory
+        )
+        Self.prepareDirectory(storageLayout.transcriptDirectory)
+        Self.prepareDirectory(storageLayout.cloudTranscriptionJobsDirectory)
+        Self.prepareDirectory(storageLayout.cloudTranscriptionTemporaryDirectory)
+        let runtime = HistoryFreshRuntime(
+            historyStore: activeStore,
+            recordingJournalStore:
+                dependencies.makeRecordingJournalStore(audioDirectory),
+            cloudTranscriptionJobStore:
+                dependencies.makeCloudTranscriptionJobStore(storageLayout)
+        )
+        emit(.installRuntime(.fresh(runtime)))
+        refreshSafetyAndSnapshots()
+        state.archiveActivity = .idle
+        synchronizeStateForVerifiedStore(activeStore)
+        emitState()
+        emit(.performPostAction(postAction))
+    }
+
+    @MainActor
+    private func completeArchiveFailure(
+        _ failure: HistoryWorkflowFailure
+    ) {
+        state.archiveSafety = dependencies.inspectArchiveSafety(
+            storageLayout.rootDirectory
+        )
+        state.archiveActivity = .idle
+        state.isHistoryUnavailable = true
+        state.showsPersistenceWarning = true
+        emitState()
+        emit(.failed(failure))
+    }
+
+    @MainActor
+    private func refreshSafetyAndSnapshots() {
+        state.archiveSafety = dependencies.inspectArchiveSafety(
+            storageLayout.rootDirectory
+        )
+        state.snapshots = dependencies.listSnapshots(
+            storageLayout.rootDirectory
+        )
+        let currentIDs = Set(state.snapshots.map(\.id))
+        state.inspections = state.inspections.filter {
+            currentIDs.contains($0.key)
+        }
+        if state.archiveSafety == .unresolvedInterruptedTransaction {
+            state.isHistoryUnavailable = true
+            state.showsPersistenceWarning = true
+        }
+    }
+
+    @MainActor
+    private func synchronizeStateForVerifiedStore(
+        _ activeStore: PipelineHistoryStore
+    ) {
+        state.isHistoryUnavailable =
+            activeStore.availability == .unavailable
+                || state.archiveSafety == .unresolvedInterruptedTransaction
+        state.showsPersistenceWarning = state.isHistoryUnavailable
+            || activeStore.durability == .inMemory
     }
 
     @discardableResult

--- a/Sources/HistoryArchiveRecoveryWorkflow.swift
+++ b/Sources/HistoryArchiveRecoveryWorkflow.swift
@@ -357,8 +357,8 @@ private enum HistorySnapshotOperation: Sendable {
 }
 
 final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
-    let storageLayout: AppStateStorageLayout
-    let dependencies: HistoryArchiveRecoveryWorkflowDependencies
+    private let storageLayout: AppStateStorageLayout
+    private let dependencies: HistoryArchiveRecoveryWorkflowDependencies
     private(set) var state = HistoryWorkflowState.initial
     var onEvent: (@MainActor (HistoryWorkflowEvent) -> Void)?
     private var inspectionQueue: [UUID] = []
@@ -537,6 +537,7 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
         )
         guard admission == .accepted else { return admission }
         state.importResult = nil
+        emitState()
         do {
             try currentStore.detachForArchiveVerification()
         } catch {

--- a/Sources/HistoryArchiveRecoveryWorkflow.swift
+++ b/Sources/HistoryArchiveRecoveryWorkflow.swift
@@ -206,6 +206,13 @@ enum HistoryWorkflowAdmission {
     }
 }
 
+struct HistoryStartupResult {
+    let activeStore: PipelineHistoryStore
+    let state: HistoryWorkflowState
+    let permitsNormalHistoryStartup: Bool
+    let permitsUnresolvedArchiveStartup: Bool
+}
+
 struct HistoryFreshRuntime {
     let historyStore: PipelineHistoryStore
     let recordingJournalStore: RecordingJournalStore
@@ -334,6 +341,82 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
     ) {
         self.storageLayout = storageLayout
         self.dependencies = dependencies
+    }
+
+    func prepareStartup() -> HistoryStartupResult {
+        Self.prepareDirectory(storageLayout.rootDirectory)
+        Self.prepareDirectory(storageLayout.audioDirectory)
+        Self.prepareDirectory(storageLayout.transcriptDirectory)
+
+        let rollbackSafety = dependencies.rollbackInterruptedTransactions(
+            storageLayout.rootDirectory
+        )
+        if rollbackSafety != .unresolvedInterruptedTransaction {
+            _ = try? dependencies.removeExpiredSnapshots(
+                storageLayout.rootDirectory
+            )
+        }
+        let archiveSafety = dependencies.inspectArchiveSafety(
+            storageLayout.rootDirectory
+        )
+        let activeStore = dependencies.makeHistoryStore(
+            storageLayout.historyStoreURL
+        )
+        if activeStore.availability == .ready {
+            activeStore.verifyHistoryReadable()
+        }
+        let unavailable = activeStore.availability == .unavailable
+            || archiveSafety == .unresolvedInterruptedTransaction
+        state = HistoryWorkflowState(
+            archiveSafety: archiveSafety,
+            archiveActivity: .idle,
+            recoveryOperation: .idle,
+            snapshots: dependencies.listSnapshots(
+                storageLayout.rootDirectory
+            ),
+            inspections: [:],
+            inspectionSnapshotID: nil,
+            importResult: nil,
+            isHistoryUnavailable: unavailable,
+            showsPersistenceWarning: unavailable
+                || activeStore.durability == .inMemory
+        )
+        return HistoryStartupResult(
+            activeStore: activeStore,
+            state: state,
+            permitsNormalHistoryStartup:
+                archiveSafety == .normal
+                    && activeStore.availability == .ready,
+            permitsUnresolvedArchiveStartup:
+                archiveSafety == .unresolvedArchive
+                    && activeStore.availability == .ready
+        )
+    }
+
+    @MainActor
+    func synchronize(activeStore: PipelineHistoryStore) {
+        let unavailable = activeStore.availability == .unavailable
+            || state.archiveSafety == .unresolvedInterruptedTransaction
+        let showsWarning = unavailable
+            || activeStore.durability == .inMemory
+        guard state.isHistoryUnavailable != unavailable
+                || state.showsPersistenceWarning != showsWarning else {
+            return
+        }
+        state.isHistoryUnavailable = unavailable
+        state.showsPersistenceWarning = showsWarning
+        emitState()
+    }
+
+    @discardableResult
+    private static func prepareDirectory(_ directory: URL) -> URL {
+        if !FileManager.default.fileExists(atPath: directory.path) {
+            try? FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+        }
+        return directory
     }
 
     @MainActor

--- a/Sources/HistoryArchiveRecoveryWorkflow.swift
+++ b/Sources/HistoryArchiveRecoveryWorkflow.swift
@@ -323,6 +323,10 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
     let dependencies: HistoryArchiveRecoveryWorkflowDependencies
     private(set) var state = HistoryWorkflowState.initial
     var onEvent: (@MainActor (HistoryWorkflowEvent) -> Void)?
+    private var inspectionQueue: [UUID] = []
+    private var inspectionAttemptedIDs = Set<UUID>()
+    private var inspectionRevision = 0
+    private var inspectionActiveHistory: [PipelineHistoryItem] = []
 
     convenience init(
         storageLayout: AppStateStorageLayout,
@@ -394,6 +398,92 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
     }
 
     @MainActor
+    func refreshSnapshots() {
+        refreshSafetyAndSnapshots()
+        emitState()
+    }
+
+    @MainActor
+    func beginInspection(activeHistory: [PipelineHistoryItem]) {
+        guard state.recoveryOperation == .idle,
+              state.inspectionSnapshotID == nil else {
+            return
+        }
+        inspectionActiveHistory = activeHistory
+        inspectionAttemptedIDs = []
+        inspectionQueue = state.snapshots.compactMap {
+            $0.integrity == .ready ? $0.id : nil
+        }
+        startNextInspection()
+    }
+
+    @MainActor
+    func ensureInspection(activeHistory: [PipelineHistoryItem]) {
+        guard state.inspectionSnapshotID == nil,
+              inspectionQueue.isEmpty,
+              inspectionAttemptedIDs.isEmpty,
+              state.inspections.isEmpty else {
+            return
+        }
+        beginInspection(activeHistory: activeHistory)
+    }
+
+    @MainActor
+    func retryInspection(
+        id: UUID,
+        activeHistory: [PipelineHistoryItem]
+    ) -> HistoryWorkflowCommandResult {
+        guard state.recoveryOperation == .idle else {
+            return .rejected(.recoveryOperationInProgress)
+        }
+        guard state.inspectionSnapshotID != id else {
+            return .rejected(.inspectionInProgress)
+        }
+        guard state.snapshots.contains(where: {
+            $0.id == id && $0.integrity == .ready
+        }) else {
+            return .rejected(.snapshotUnavailable)
+        }
+        inspectionActiveHistory = activeHistory
+        inspectionAttemptedIDs.remove(id)
+        inspectionQueue.removeAll { $0 == id }
+        inspectionQueue.insert(id, at: 0)
+        startNextInspection()
+        return .accepted
+    }
+
+    @MainActor
+    func invalidateInspection(
+        activeHistory: [PipelineHistoryItem],
+        shouldReschedule: Bool
+    ) {
+        inspectionRevision &+= 1
+        state.inspections = [:]
+        inspectionQueue = []
+        inspectionAttemptedIDs = []
+        inspectionActiveHistory = activeHistory
+        emitState()
+
+        guard shouldReschedule,
+              state.recoveryOperation == .idle else {
+            return
+        }
+        inspectionQueue = state.snapshots.compactMap { snapshot in
+            guard snapshot.integrity == .ready,
+                  snapshot.status != .inspectionFailed else {
+                return nil
+            }
+            return snapshot.id
+        }
+        inspectionAttemptedIDs = Set(
+            state.snapshots.compactMap { snapshot in
+                snapshot.status == .inspectionFailed ? snapshot.id : nil
+            }
+        )
+        startNextInspection()
+    }
+
+    @MainActor
     @discardableResult
     func requestArchive(
         context: HistoryWorkflowAdmissionContext,
@@ -446,6 +536,87 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
         state.showsPersistenceWarning = state.isHistoryUnavailable
             || activeStore.durability == .inMemory
         return state
+    }
+
+    @MainActor
+    private func startNextInspection() {
+        guard state.recoveryOperation == .idle,
+              state.inspectionSnapshotID == nil else {
+            return
+        }
+        while !inspectionQueue.isEmpty {
+            let snapshotID = inspectionQueue.removeFirst()
+            guard !inspectionAttemptedIDs.contains(snapshotID),
+                  state.snapshots.contains(where: {
+                      $0.id == snapshotID && $0.integrity == .ready
+                  }) else {
+                continue
+            }
+            inspectionAttemptedIDs.insert(snapshotID)
+            state.inspectionSnapshotID = snapshotID
+            emitState()
+            let revision = inspectionRevision
+            let activeHistory = inspectionActiveHistory
+            let root = storageLayout.rootDirectory
+            let inspectSnapshot = dependencies.inspectSnapshot
+            Task.detached(priority: .userInitiated) { [weak self] in
+                do {
+                    let inspection = try inspectSnapshot(
+                        root,
+                        snapshotID,
+                        activeHistory
+                    )
+                    await self?.completeInspection(
+                        inspection,
+                        snapshotID: snapshotID,
+                        revision: revision
+                    )
+                } catch {
+                    await self?.completeInspectionFailure(
+                        snapshotID: snapshotID,
+                        revision: revision
+                    )
+                }
+            }
+            return
+        }
+    }
+
+    @MainActor
+    private func completeInspection(
+        _ inspection: HistoryRecoveryInspection,
+        snapshotID: UUID,
+        revision: Int
+    ) {
+        guard state.inspectionSnapshotID == snapshotID else { return }
+        state.inspectionSnapshotID = nil
+        refreshSafetyAndSnapshots()
+        if inspectionRevision == revision,
+           state.snapshots.contains(where: {
+               $0.id == inspection.snapshotID
+           }) {
+            state.inspections[inspection.snapshotID] = inspection
+        }
+        emitState()
+        startNextInspection()
+    }
+
+    @MainActor
+    private func completeInspectionFailure(
+        snapshotID: UUID,
+        revision: Int
+    ) {
+        guard state.inspectionSnapshotID == snapshotID else { return }
+        state.inspectionSnapshotID = nil
+        refreshSafetyAndSnapshots()
+        if inspectionRevision == revision {
+            state.inspections.removeValue(forKey: snapshotID)
+        }
+        emitState()
+        if inspectionRevision == revision {
+            emit(.failed(.inspectionFailed(snapshotID)))
+        }
+        startNextInspection()
     }
 
     @MainActor

--- a/Sources/HistoryArchiveRecoveryWorkflow.swift
+++ b/Sources/HistoryArchiveRecoveryWorkflow.swift
@@ -369,8 +369,8 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
 
     convenience init(
         storageLayout: AppStateStorageLayout,
-        makeHistoryStore: @escaping
-            HistoryArchiveRecoveryWorkflowDependencies.HistoryStoreFactory
+        makeHistoryStore:
+            @escaping HistoryArchiveRecoveryWorkflowDependencies.HistoryStoreFactory
     ) {
         self.init(
             storageLayout: storageLayout,
@@ -662,6 +662,7 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
         return .accepted
     }
 
+    @MainActor
     @discardableResult
     func synchronize(
         activeStore: PipelineHistoryStore

--- a/Sources/HistoryArchiveRecoveryWorkflow.swift
+++ b/Sources/HistoryArchiveRecoveryWorkflow.swift
@@ -318,6 +318,44 @@ struct HistoryArchiveRecoveryWorkflowDependencies: Sendable {
     }
 }
 
+private enum HistorySnapshotOperation: Sendable {
+    case cancelScheduledDeletion(UUID)
+    case delete(UUID)
+
+    var snapshotID: UUID {
+        switch self {
+        case .cancelScheduledDeletion(let id), .delete(let id):
+            return id
+        }
+    }
+
+    var requiresCompletedSnapshot: Bool {
+        if case .cancelScheduledDeletion = self { return true }
+        return false
+    }
+
+    var recoveryOperation: HistoryRecoveryWorkflowOperation {
+        switch self {
+        case .cancelScheduledDeletion(let id):
+            return .cancellingScheduledDeletion(id)
+        case .delete(let id):
+            return .deletingSnapshot(id)
+        }
+    }
+
+    func perform(
+        root: URL,
+        dependencies: HistoryArchiveRecoveryWorkflowDependencies
+    ) throws {
+        switch self {
+        case .cancelScheduledDeletion(let id):
+            try dependencies.cancelScheduledDeletion(root, id)
+        case .delete(let id):
+            try dependencies.deleteSnapshot(root, id)
+        }
+    }
+}
+
 final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
     let storageLayout: AppStateStorageLayout
     let dependencies: HistoryArchiveRecoveryWorkflowDependencies
@@ -485,6 +523,98 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
 
     @MainActor
     @discardableResult
+    func requestImport(
+        snapshotID: UUID,
+        context: HistoryWorkflowAdmissionContext,
+        currentStore: PipelineHistoryStore,
+        activeHistory: [PipelineHistoryItem],
+        shouldRescheduleInspection: Bool
+    ) -> HistoryWorkflowCommandResult {
+        let admission = HistoryWorkflowAdmission.recoveryImport(
+            state: state,
+            snapshotID: snapshotID,
+            context: context
+        )
+        guard admission == .accepted else { return admission }
+        state.importResult = nil
+        do {
+            try currentStore.detachForArchiveVerification()
+        } catch {
+            emit(.failed(.historyUnavailable))
+            return .rejected(.historyUnavailable)
+        }
+
+        state.recoveryOperation = .importing(snapshotID)
+        emitState()
+        let root = storageLayout.rootDirectory
+        let layout = storageLayout
+        let dependencies = dependencies
+        let priorActiveHistory = activeHistory
+        Task.detached(priority: .userInitiated) { [weak self] in
+            let importStore = dependencies.makeHistoryStore(
+                layout.historyStoreURL
+            )
+            do {
+                guard importStore.availability == .ready,
+                      importStore.durability == .durable,
+                      importStore.verifyHistoryReadable() else {
+                    throw HistoryRecoveryServiceError.snapshotNotReady
+                }
+                let result = try dependencies.importSnapshot(
+                    root,
+                    snapshotID,
+                    importStore,
+                    layout.audioDirectory,
+                    layout.transcriptDirectory
+                )
+                try importStore.detachForArchiveVerification()
+                await self?.completeImportSuccess(
+                    result,
+                    priorActiveHistory: priorActiveHistory,
+                    shouldRescheduleInspection:
+                        shouldRescheduleInspection
+                )
+            } catch {
+                try? importStore.detachForArchiveVerification()
+                await self?.completeImportFailure(
+                    .recoveryImportFailed,
+                    priorActiveHistory: priorActiveHistory,
+                    shouldRescheduleInspection:
+                        shouldRescheduleInspection
+                )
+            }
+        }
+        return .accepted
+    }
+
+    @MainActor
+    func requestCancelScheduledDeletion(
+        snapshotID: UUID,
+        activeHistory: [PipelineHistoryItem],
+        shouldRescheduleInspection: Bool
+    ) -> HistoryWorkflowCommandResult {
+        requestSnapshotOperation(
+            .cancelScheduledDeletion(snapshotID),
+            activeHistory: activeHistory,
+            shouldRescheduleInspection: shouldRescheduleInspection
+        )
+    }
+
+    @MainActor
+    func requestDeleteSnapshot(
+        snapshotID: UUID,
+        activeHistory: [PipelineHistoryItem],
+        shouldRescheduleInspection: Bool
+    ) -> HistoryWorkflowCommandResult {
+        requestSnapshotOperation(
+            .delete(snapshotID),
+            activeHistory: activeHistory,
+            shouldRescheduleInspection: shouldRescheduleInspection
+        )
+    }
+
+    @MainActor
+    @discardableResult
     func requestArchive(
         context: HistoryWorkflowAdmissionContext,
         currentStore: PipelineHistoryStore,
@@ -536,6 +666,154 @@ final class HistoryArchiveRecoveryWorkflow: @unchecked Sendable {
         state.showsPersistenceWarning = state.isHistoryUnavailable
             || activeStore.durability == .inMemory
         return state
+    }
+
+    @MainActor
+    private func requestSnapshotOperation(
+        _ operation: HistorySnapshotOperation,
+        activeHistory: [PipelineHistoryItem],
+        shouldRescheduleInspection: Bool
+    ) -> HistoryWorkflowCommandResult {
+        let admission = HistoryWorkflowAdmission.snapshotOperation(
+            state: state,
+            snapshotID: operation.snapshotID,
+            requiresCompletedSnapshot: operation.requiresCompletedSnapshot
+        )
+        guard admission == .accepted else { return admission }
+        state.importResult = nil
+        state.recoveryOperation = operation.recoveryOperation
+        emitState()
+        let root = storageLayout.rootDirectory
+        let dependencies = dependencies
+        Task.detached(priority: .userInitiated) { [weak self] in
+            do {
+                try operation.perform(
+                    root: root,
+                    dependencies: dependencies
+                )
+                await self?.completeSnapshotOperationSuccess()
+            } catch {
+                await self?.completeSnapshotOperationFailure(
+                    activeHistory: activeHistory,
+                    shouldRescheduleInspection:
+                        shouldRescheduleInspection
+                )
+            }
+        }
+        return .accepted
+    }
+
+    @MainActor
+    private func completeImportSuccess(
+        _ result: HistoryRecoveryImportResult,
+        priorActiveHistory: [PipelineHistoryItem],
+        shouldRescheduleInspection: Bool
+    ) {
+        let reopenedStore = dependencies.makeHistoryStore(
+            storageLayout.historyStoreURL
+        )
+        guard reopenedStore.availability == .ready,
+              reopenedStore.durability == .durable,
+              reopenedStore.verifyHistoryReadable() else {
+            completeImportFailure(
+                .activeStoreReopenFailed,
+                priorActiveHistory: priorActiveHistory,
+                shouldRescheduleInspection: shouldRescheduleInspection,
+                reopenedStore: reopenedStore
+            )
+            return
+        }
+        let history = reopenedStore.loadAllHistory()
+        guard reopenedStore.availability == .ready else {
+            completeImportFailure(
+                .activeStoreReopenFailed,
+                priorActiveHistory: priorActiveHistory,
+                shouldRescheduleInspection: shouldRescheduleInspection,
+                reopenedStore: reopenedStore
+            )
+            return
+        }
+        emit(.installRuntime(.recovered(
+            historyStore: reopenedStore,
+            history: history
+        )))
+        refreshSafetyAndSnapshots()
+        state.recoveryOperation = .idle
+        state.importResult = result.failedRecordCount > 0
+                || result.conflictRecordCount > 0
+            ? result
+            : nil
+        synchronizeStateForVerifiedStore(reopenedStore)
+        invalidateInspection(
+            activeHistory: history,
+            shouldReschedule: shouldRescheduleInspection
+        )
+    }
+
+    @MainActor
+    private func completeImportFailure(
+        _ requestedFailure: HistoryWorkflowFailure,
+        priorActiveHistory: [PipelineHistoryItem],
+        shouldRescheduleInspection: Bool,
+        reopenedStore suppliedStore: PipelineHistoryStore? = nil
+    ) {
+        let reopenedStore = suppliedStore ?? dependencies.makeHistoryStore(
+            storageLayout.historyStoreURL
+        )
+        var activeHistory = priorActiveHistory
+        let failure: HistoryWorkflowFailure
+        if reopenedStore.availability == .ready,
+           reopenedStore.durability == .durable,
+           reopenedStore.verifyHistoryReadable() {
+            activeHistory = reopenedStore.loadAllHistory()
+            if reopenedStore.availability == .ready {
+                emit(.installRuntime(.recovered(
+                    historyStore: reopenedStore,
+                    history: activeHistory
+                )))
+                synchronizeStateForVerifiedStore(reopenedStore)
+                failure = requestedFailure
+            } else {
+                state.isHistoryUnavailable = true
+                state.showsPersistenceWarning = true
+                failure = .activeStoreReopenFailed
+            }
+        } else {
+            state.isHistoryUnavailable = true
+            state.showsPersistenceWarning = true
+            failure = .activeStoreReopenFailed
+        }
+        refreshSafetyAndSnapshots()
+        state.recoveryOperation = .idle
+        state.importResult = nil
+        invalidateInspection(
+            activeHistory: activeHistory,
+            shouldReschedule: shouldRescheduleInspection
+        )
+        emit(.failed(failure))
+    }
+
+    @MainActor
+    private func completeSnapshotOperationSuccess() {
+        refreshSafetyAndSnapshots()
+        state.recoveryOperation = .idle
+        emitState()
+        startNextInspection()
+    }
+
+    @MainActor
+    private func completeSnapshotOperationFailure(
+        activeHistory: [PipelineHistoryItem],
+        shouldRescheduleInspection: Bool
+    ) {
+        refreshSafetyAndSnapshots()
+        state.recoveryOperation = .idle
+        state.importResult = nil
+        invalidateInspection(
+            activeHistory: activeHistory,
+            shouldReschedule: shouldRescheduleInspection
+        )
+        emit(.failed(.snapshotOperationFailed))
     }
 
     @MainActor

--- a/Tests/AppStateHistoryProtectionSourceTests.swift
+++ b/Tests/AppStateHistoryProtectionSourceTests.swift
@@ -78,32 +78,9 @@ struct AppStateHistoryProtectionSourceTests {
             )
         }
 
-        // Every archive-guard condition can only actually block anything while
-        // history is simultaneously unavailable, since `archiveOldHistoryAndStartFresh`
-        // itself requires `isHistoryUnavailable == true` as its own precondition
-        // — and `requireAvailableHistoryForMutation()` blocks the public entry
-        // points (`importAudioFile`, recording start, retry, meeting-summary
-        // generation) from ever running while history is unavailable. That
-        // combination cannot be constructed through the public API without a
-        // real audio/recording/summary pipeline, so these guards remain a
-        // narrow existence check rather than a simulated race.
-        let archiveGuardRange = try source.range(
-            from: "func archiveOldHistoryAndStartFresh(",
-            to: "@MainActor\n    func clearPipelineHistory()"
-        )
-        let archiveGuardBody = String(source[archiveGuardRange])
-        for requiredGuard in [
-            "pendingAudioImportJobIDs.isEmpty",
-            "!cloudTranscriptionHistoryCoordinator.hasActiveWork",
-            "meetingSummaryGeneratingNoteIDs.isEmpty",
-            "pendingRecordingJournalFinalizationCount == 0",
-            "pendingRecordingStartCount == 0"
-        ] {
-            try expect(
-                archiveGuardBody.contains(requiredGuard),
-                "archive continues to wait for \(requiredGuard) before moving history files"
-            )
-        }
+        // Archive admission now has table-driven behavior coverage in
+        // HistoryArchiveRecoveryWorkflowTests. This remaining source check
+        // protects the separate mid-write audio-import tracking invariant.
         try expect(
             source.contains("pendingAudioImportJobIDs.insert(jobID)")
                 && source.contains("pendingAudioImportJobIDs.remove(jobID)"),

--- a/Tests/AppStateHistoryProtectionSourceTests.swift
+++ b/Tests/AppStateHistoryProtectionSourceTests.swift
@@ -160,27 +160,6 @@ struct AppStateHistoryProtectionSourceTests {
             "delayed orphan cleanup uses the startup reference snapshot time"
         )
 
-        // Recovery inspection invalidation must clear stale scheduling state
-        // before any rescheduling can occur, and must only reschedule while
-        // Settings is actually showing the recovery tab. Reproducing this
-        // through the public API requires driving Settings tab navigation
-        // alongside recovery timing, which is out of scope for this suite.
-        let invalidationRange = try source.range(
-            from: "func invalidateHistoryRecoveryInspectionResults()",
-            to: "func importHistoryRecoverySnapshot(id: UUID) -> Bool"
-        )
-        let invalidation = String(source[invalidationRange])
-        try expectOrdered(
-            [
-                "historyRecoveryInspections = [:]",
-                "historyRecoveryInspectionQueue = []",
-                "historyRecoveryInspectionAttemptedIDs = []",
-                "guard selectedSettingsTab == .recovery,"
-            ],
-            in: invalidation,
-            label: "recovery inspection invalidation clears stale scheduling state before it can return"
-        )
-
         // A new recovery import must clear any prior partial-result feedback
         // before it starts, so a stale result from an earlier import cannot be
         // shown alongside a new one. This requires observing state exactly at

--- a/Tests/AppStateHistoryProtectionSourceTests.swift
+++ b/Tests/AppStateHistoryProtectionSourceTests.swift
@@ -160,25 +160,6 @@ struct AppStateHistoryProtectionSourceTests {
             "delayed orphan cleanup uses the startup reference snapshot time"
         )
 
-        // A new recovery import must clear any prior partial-result feedback
-        // before it starts, so a stale result from an earlier import cannot be
-        // shown alongside a new one. This requires observing state exactly at
-        // the instant between synchronous clearing and the detached import
-        // task starting, which is not reliably observable from outside.
-        let importRange = try source.range(
-            from: "func importHistoryRecoverySnapshot(id: UUID) -> Bool",
-            to: "func cancelHistoryRecoveryScheduledDeletion(id: UUID) -> Bool"
-        )
-        let recoveryImport = String(source[importRange])
-        try expectOrdered(
-            [
-                "historyRecoveryImportResult = nil",
-                "try pipelineHistoryStore.detachForArchiveVerification()"
-            ],
-            in: recoveryImport,
-            label: "a new recovery import clears prior partial feedback before detaching history"
-        )
-
         print("AppStateHistoryProtectionSourceTests passed")
     }
 
@@ -195,20 +176,6 @@ struct AppStateHistoryProtectionSourceTests {
             }
         }
         return source
-    }
-
-    private static func expectOrdered(
-        _ markers: [String],
-        in source: String,
-        label: String
-    ) throws {
-        var lowerBound = source.startIndex
-        for marker in markers {
-            guard let range = source.range(of: marker, range: lowerBound..<source.endIndex) else {
-                throw TestFailure("\(label): missing or misordered \(marker)")
-            }
-            lowerBound = range.upperBound
-        }
     }
 
     private static func expect(

--- a/Tests/FullSourceAppStateTestRunner.swift
+++ b/Tests/FullSourceAppStateTestRunner.swift
@@ -17,6 +17,7 @@ struct FullSourceAppStateTestRunner {
             try CredentialStoreTests.main()
             try await AudioImportFileCopyTests.main()
             try LatestValueProgressCoalescerTests.main()
+            try await HistoryArchiveRecoveryWorkflowTests.main()
             try await AppStateStorageSafetyTests.main()
             try AppStateHistoryProtectionSourceTests.main()
             try await AppStateTranscriptionConfigurationTests.main()

--- a/Tests/HistoryArchiveRecoveryWorkflowTests.swift
+++ b/Tests/HistoryArchiveRecoveryWorkflowTests.swift
@@ -18,6 +18,11 @@ struct HistoryArchiveRecoveryWorkflowTests {
         try await testArchiveVerificationFailureNeverInstallsRuntime()
         try await testArchiveTransitionFailureNeverInstallsRuntime()
         try await testArchiveCapturesOriginatingDependencies()
+        try await testInspectionQueueRunsReadySnapshotsInOrder()
+        try await testInspectionRetryMovesSnapshotToFront()
+        try await testInspectionRejectsDuplicateCurrentSnapshot()
+        try await testInspectionInvalidationDropsStaleCompletion()
+        try await testInspectionFailureContinuesToNextSnapshot()
         print("HistoryArchiveRecoveryWorkflowTests passed")
     }
 
@@ -370,6 +375,176 @@ struct HistoryArchiveRecoveryWorkflowTests {
         }
     }
 
+    private static func testInspectionQueueRunsReadySnapshotsInOrder() async throws {
+        let ids = [UUID(), UUID()]
+        try await withInspectionWorkflow(snapshotIDs: ids) { workflow, recorder in
+            await MainActor.run {
+                workflow.beginInspection(activeHistory: [])
+            }
+            try await waitUntil {
+                workflow.state.inspections.count == ids.count
+            }
+            try expect(
+                recorder.startedIDs == ids,
+                "ready snapshots inspect in catalog order"
+            )
+        }
+    }
+
+    private static func testInspectionRetryMovesSnapshotToFront() async throws {
+        let ids = [UUID(), UUID(), UUID()]
+        try await withInspectionWorkflow(snapshotIDs: ids) { workflow, recorder in
+            recorder.block(id: ids[0])
+            await MainActor.run {
+                workflow.beginInspection(activeHistory: [])
+            }
+            try await waitUntil { recorder.startedIDs == [ids[0]] }
+            let retryResult = await MainActor.run {
+                workflow.retryInspection(id: ids[2], activeHistory: [])
+            }
+            try expect(retryResult == .accepted, "eligible retry is accepted")
+            recorder.release(id: ids[0])
+            try await waitUntil { recorder.startedIDs.count == ids.count }
+            try expect(
+                recorder.startedIDs == [ids[0], ids[2], ids[1]],
+                "retry moves one queued snapshot to the front"
+            )
+        }
+    }
+
+    private static func testInspectionRejectsDuplicateCurrentSnapshot() async throws {
+        let id = UUID()
+        try await withInspectionWorkflow(snapshotIDs: [id]) { workflow, recorder in
+            recorder.block(id: id)
+            await MainActor.run {
+                workflow.beginInspection(activeHistory: [])
+            }
+            try await waitUntil { recorder.startedIDs == [id] }
+            let retryResult = await MainActor.run {
+                workflow.retryInspection(id: id, activeHistory: [])
+            }
+            try expect(
+                retryResult == .rejected(.inspectionInProgress),
+                "retry cannot duplicate the current snapshot inspection"
+            )
+            recorder.release(id: id)
+            try await waitUntil { workflow.state.inspections[id] != nil }
+            try expect(
+                recorder.startedIDs == [id],
+                "current snapshot is inspected only once"
+            )
+        }
+    }
+
+    private static func testInspectionInvalidationDropsStaleCompletion() async throws {
+        let id = UUID()
+        try await withInspectionWorkflow(snapshotIDs: [id]) { workflow, recorder in
+            recorder.block(id: id)
+            await MainActor.run {
+                workflow.beginInspection(activeHistory: [])
+            }
+            try await waitUntil { recorder.startedIDs == [id] }
+            await MainActor.run {
+                workflow.invalidateInspection(
+                    activeHistory: [],
+                    shouldReschedule: false
+                )
+            }
+            recorder.release(id: id)
+            try await waitUntil { recorder.completedIDs.contains(id) }
+            try await waitUntil { workflow.state.inspectionSnapshotID == nil }
+            try expect(
+                workflow.state.inspections[id] == nil,
+                "invalidated inspection completion cannot restore stale results"
+            )
+        }
+    }
+
+    private static func testInspectionFailureContinuesToNextSnapshot() async throws {
+        let ids = [UUID(), UUID()]
+        try await withInspectionWorkflow(snapshotIDs: ids) { workflow, recorder in
+            recorder.fail(id: ids[0])
+            await MainActor.run {
+                workflow.beginInspection(activeHistory: [])
+            }
+            try await waitUntil {
+                workflow.state.inspections[ids[1]] != nil
+            }
+            try expect(
+                recorder.startedIDs == ids,
+                "inspection failure continues to the next queued snapshot"
+            )
+            try expect(
+                workflow.state.inspections[ids[0]] == nil,
+                "failed snapshot has no inspection result"
+            )
+        }
+    }
+
+    private static func withInspectionWorkflow(
+        snapshotIDs: [UUID],
+        _ operation: (
+            HistoryArchiveRecoveryWorkflow,
+            InspectionOperationRecorder
+        ) async throws -> Void
+    ) async throws {
+        try await withTemporaryDirectoryAsync { root in
+            let recorder = InspectionOperationRecorder(
+                descriptors: snapshotIDs.map {
+                    recoverySnapshotDescriptor(id: $0, root: root)
+                }
+            )
+            var dependencies = HistoryArchiveRecoveryWorkflowDependencies.live(
+                makeHistoryStore: { PipelineHistoryStore(storeURL: $0) }
+            )
+            dependencies.rollbackInterruptedTransactions = { _ in .normal }
+            dependencies.inspectArchiveSafety = { _ in .normal }
+            dependencies.removeExpiredSnapshots = { _ in [] }
+            dependencies.listSnapshots = { _ in recorder.descriptors }
+            dependencies.inspectSnapshot = { _, id, _ in
+                try recorder.inspect(id: id)
+            }
+            let workflow = HistoryArchiveRecoveryWorkflow(
+                storageLayout: AppStateStorageLayout(rootDirectory: root),
+                dependencies: dependencies
+            )
+            _ = workflow.prepareStartup()
+            try await operation(workflow, recorder)
+        }
+    }
+
+    private static func recoverySnapshotDescriptor(
+        id: UUID,
+        root: URL,
+        status: HistoryRecoverySnapshotStatus = .available,
+        integrity: HistoryRecoverySnapshotIntegrity = .ready
+    ) -> HistoryRecoverySnapshotDescriptor {
+        let snapshot = HistoryArchiveSnapshot(
+            schemaVersion: HistoryArchiveSnapshot.currentSchemaVersion,
+            id: id,
+            archivedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            components: []
+        )
+        return HistoryRecoverySnapshotDescriptor(
+            snapshot: snapshot,
+            snapshotURL: root
+                .appendingPathComponent("Recovery", isDirectory: true)
+                .appendingPathComponent(
+                    "history-\(id.uuidString.lowercased())",
+                    isDirectory: true
+                ),
+            payloadByteCount: 0,
+            integrity: integrity,
+            state: HistoryRecoveryState(
+                snapshotID: id,
+                status: status,
+                completedAt: status == .completed
+                    ? Date(timeIntervalSince1970: 1_700_000_000)
+                    : nil
+            )
+        )
+    }
+
     private static func withArchiveWorkflow(
         freshStoreUnavailable: Bool = false,
         transitionShouldFail: Bool = false,
@@ -716,6 +891,68 @@ private final class ArchiveTransitionRecorder: @unchecked Sendable {
                     "history-\(snapshotID.uuidString.lowercased())",
                     isDirectory: true
                 )
+        )
+    }
+}
+
+private final class InspectionOperationRecorder: @unchecked Sendable {
+    let descriptors: [HistoryRecoverySnapshotDescriptor]
+    private let lock = NSLock()
+    private var started: [UUID] = []
+    private var completed: [UUID] = []
+    private var blocked: [UUID: DispatchSemaphore] = [:]
+    private var failingIDs = Set<UUID>()
+
+    init(descriptors: [HistoryRecoverySnapshotDescriptor]) {
+        self.descriptors = descriptors
+    }
+
+    var startedIDs: [UUID] {
+        lock.withHistoryWorkflowLock { started }
+    }
+
+    var completedIDs: [UUID] {
+        lock.withHistoryWorkflowLock { completed }
+    }
+
+    func block(id: UUID) {
+        lock.withHistoryWorkflowLock {
+            blocked[id] = DispatchSemaphore(value: 0)
+        }
+    }
+
+    func release(id: UUID) {
+        let semaphore = lock.withHistoryWorkflowLock {
+            blocked[id]
+        }
+        semaphore?.signal()
+    }
+
+    func fail(id: UUID) {
+        lock.withHistoryWorkflowLock {
+            _ = failingIDs.insert(id)
+        }
+    }
+
+    func inspect(id: UUID) throws -> HistoryRecoveryInspection {
+        let configuration = lock.withHistoryWorkflowLock {
+            started.append(id)
+            return (blocked[id], failingIDs.contains(id))
+        }
+        configuration.0?.wait()
+        lock.withHistoryWorkflowLock {
+            completed.append(id)
+        }
+        if configuration.1 {
+            throw HistoryWorkflowTestFailure(
+                "intentional inspection failure"
+            )
+        }
+        return HistoryRecoveryInspection(
+            snapshotID: id,
+            readableRecordCount: 1,
+            alreadyPresentRecordCount: 0,
+            conflictRecordCount: 0
         )
     }
 }

--- a/Tests/HistoryArchiveRecoveryWorkflowTests.swift
+++ b/Tests/HistoryArchiveRecoveryWorkflowTests.swift
@@ -28,6 +28,7 @@ struct HistoryArchiveRecoveryWorkflowTests {
         try await testRecoveryImportFailureRestoresVerifiedStore()
         try await testRecoveryReopenFailureNeverInstallsRuntime()
         try testRecoveryImportRejectsInvalidAndReentrantRequests()
+        try await testSnapshotCancellationRefreshesCatalog()
         try await testSnapshotDeleteRefreshesCatalog()
         try await testSnapshotFailureNeverInstallsRuntime()
         try await testSnapshotOperationsWaitForInspection()
@@ -636,6 +637,32 @@ struct HistoryArchiveRecoveryWorkflowTests {
         )
     }
 
+    private static func testSnapshotCancellationRefreshesCatalog() async throws {
+        try await withRecoveryWorkflow(
+            snapshotStatus: .completed
+        ) { workflow, _, recorder, events in
+            let command = await MainActor.run {
+                workflow.requestCancelScheduledDeletion(
+                    snapshotID: recorder.snapshotID,
+                    activeHistory: [],
+                    shouldRescheduleInspection: false
+                )
+            }
+            try expect(
+                command == .accepted,
+                "completed snapshot cancellation is accepted"
+            )
+            try await waitUntil {
+                workflow.state.snapshots.first?.scheduledDeletionAt == nil
+                    && workflow.state.recoveryOperation == .idle
+            }
+            try expect(
+                !events.kinds.contains(.runtimeInstalled),
+                "retention cancellation never replaces active history"
+            )
+        }
+    }
+
     private static func testSnapshotDeleteRefreshesCatalog() async throws {
         try await withRecoveryWorkflow { workflow, _, recorder, events in
             let command = await MainActor.run {
@@ -714,6 +741,7 @@ struct HistoryArchiveRecoveryWorkflowTests {
         importShouldFail: Bool = false,
         deleteShouldFail: Bool = false,
         unavailableStoreCalls: Set<Int> = [],
+        snapshotStatus: HistoryRecoverySnapshotStatus = .available,
         _ operation: (
             HistoryArchiveRecoveryWorkflow,
             HistoryStartupResult,
@@ -726,7 +754,11 @@ struct HistoryArchiveRecoveryWorkflowTests {
             let recorder = RecoveryOperationRecorder(
                 snapshotID: snapshotID,
                 descriptors: [
-                    recoverySnapshotDescriptor(id: snapshotID, root: root),
+                    recoverySnapshotDescriptor(
+                        id: snapshotID,
+                        root: root,
+                        status: snapshotStatus
+                    ),
                 ],
                 importShouldFail: importShouldFail,
                 deleteShouldFail: deleteShouldFail

--- a/Tests/HistoryArchiveRecoveryWorkflowTests.swift
+++ b/Tests/HistoryArchiveRecoveryWorkflowTests.swift
@@ -14,6 +14,10 @@ struct HistoryArchiveRecoveryWorkflowTests {
         try testPublishedUnresolvedArchivePermitsProtectedStartupBranch()
         try testRetentionFailureStillLoadsRecoveryCatalog()
         try testStartupUsesOriginatingStoreFactory()
+        try await testArchiveInstallsVerifiedRuntimeBeforeIdleState()
+        try await testArchiveVerificationFailureNeverInstallsRuntime()
+        try await testArchiveTransitionFailureNeverInstallsRuntime()
+        try await testArchiveCapturesOriginatingDependencies()
         print("HistoryArchiveRecoveryWorkflowTests passed")
     }
 
@@ -242,6 +246,238 @@ struct HistoryArchiveRecoveryWorkflowTests {
         }
     }
 
+    private static func testArchiveInstallsVerifiedRuntimeBeforeIdleState() async throws {
+        try await withArchiveWorkflow { workflow, startup, eventRecorder, _ in
+            let command = await MainActor.run {
+                workflow.requestArchive(
+                    context: .init(),
+                    currentStore: startup.activeStore,
+                    postAction: .openRecovery
+                )
+            }
+            try expect(command == .accepted, "archive command is accepted")
+            try await waitUntil {
+                eventRecorder.kinds.contains(.postAction)
+            }
+            try expect(
+                eventRecorder.kinds == [
+                    .stateChanged,
+                    .runtimeInstalled,
+                    .stateChanged,
+                    .postAction,
+                ],
+                "verified runtime installs before idle state and post-action"
+            )
+            try expect(
+                workflow.state.archiveActivity == .idle
+                    && !workflow.state.isHistoryUnavailable,
+                "successful archive returns the workflow to available idle state"
+            )
+        }
+    }
+
+    private static func testArchiveVerificationFailureNeverInstallsRuntime() async throws {
+        try await withArchiveWorkflow(
+            freshStoreUnavailable: true
+        ) { workflow, startup, eventRecorder, _ in
+            let command = await MainActor.run {
+                workflow.requestArchive(
+                    context: .init(),
+                    currentStore: startup.activeStore,
+                    postAction: .startFresh
+                )
+            }
+            try expect(command == .accepted, "archive failure begins asynchronously")
+            try await waitUntil {
+                eventRecorder.failures.contains(.freshStoreVerificationFailed)
+            }
+            try expect(
+                !eventRecorder.kinds.contains(.runtimeInstalled),
+                "fresh-store verification failure never installs a runtime"
+            )
+            try expect(
+                workflow.state.archiveActivity == .idle
+                    && workflow.state.isHistoryUnavailable,
+                "verification failure leaves protected idle state"
+            )
+        }
+    }
+
+    private static func testArchiveTransitionFailureNeverInstallsRuntime() async throws {
+        try await withArchiveWorkflow(
+            transitionShouldFail: true
+        ) { workflow, startup, eventRecorder, _ in
+            let command = await MainActor.run {
+                workflow.requestArchive(
+                    context: .init(),
+                    currentStore: startup.activeStore,
+                    postAction: .startFresh
+                )
+            }
+            try expect(command == .accepted, "archive transition begins asynchronously")
+            try await waitUntil {
+                eventRecorder.failures.contains(.archiveTransitionFailed)
+            }
+            try expect(
+                !eventRecorder.kinds.contains(.runtimeInstalled),
+                "archive transition failure never installs a runtime"
+            )
+        }
+    }
+
+    private static func testArchiveCapturesOriginatingDependencies() async throws {
+        try await withTemporaryDirectoryAsync { root in
+            let layout = AppStateStorageLayout(rootDirectory: root)
+            let storeRecorder = ArchiveStoreFactoryRecorder()
+            let originatingTransition = ArchiveTransitionRecorder()
+            let unrelatedTransition = ArchiveTransitionRecorder()
+            var dependencies = archiveDependencies(
+                root: root,
+                storeRecorder: storeRecorder,
+                transitionRecorder: originatingTransition
+            )
+            let workflow = HistoryArchiveRecoveryWorkflow(
+                storageLayout: layout,
+                dependencies: dependencies
+            )
+            let startup = workflow.prepareStartup()
+            let eventRecorder = WorkflowEventRecorder()
+            await MainActor.run { eventRecorder.attach(to: workflow) }
+            dependencies.archiveAndCreateFreshHistory = { root, _ in
+                unrelatedTransition.record()
+                return archiveTransitionResult(root: root)
+            }
+
+            let command = await MainActor.run {
+                workflow.requestArchive(
+                    context: .init(),
+                    currentStore: startup.activeStore,
+                    postAction: .startFresh
+                )
+            }
+            try expect(command == .accepted, "archive command is accepted")
+            try await waitUntil {
+                eventRecorder.kinds.contains(.postAction)
+            }
+            try expect(
+                originatingTransition.count == 1,
+                "archive uses the transition captured by the workflow"
+            )
+            try expect(
+                unrelatedTransition.count == 0,
+                "later dependency mutation cannot redirect an active workflow"
+            )
+        }
+    }
+
+    private static func withArchiveWorkflow(
+        freshStoreUnavailable: Bool = false,
+        transitionShouldFail: Bool = false,
+        _ operation: (
+            HistoryArchiveRecoveryWorkflow,
+            HistoryStartupResult,
+            WorkflowEventRecorder,
+            ArchiveTransitionRecorder
+        ) async throws -> Void
+    ) async throws {
+        try await withTemporaryDirectoryAsync { root in
+            let storeRecorder = ArchiveStoreFactoryRecorder(
+                freshStoreUnavailable: freshStoreUnavailable
+            )
+            let transitionRecorder = ArchiveTransitionRecorder(
+                shouldFail: transitionShouldFail
+            )
+            let workflow = HistoryArchiveRecoveryWorkflow(
+                storageLayout: AppStateStorageLayout(rootDirectory: root),
+                dependencies: archiveDependencies(
+                    root: root,
+                    storeRecorder: storeRecorder,
+                    transitionRecorder: transitionRecorder
+                )
+            )
+            let startup = workflow.prepareStartup()
+            let eventRecorder = WorkflowEventRecorder()
+            await MainActor.run { eventRecorder.attach(to: workflow) }
+            try await operation(
+                workflow,
+                startup,
+                eventRecorder,
+                transitionRecorder
+            )
+        }
+    }
+
+    private static func archiveDependencies(
+        root: URL,
+        storeRecorder: ArchiveStoreFactoryRecorder,
+        transitionRecorder: ArchiveTransitionRecorder
+    ) -> HistoryArchiveRecoveryWorkflowDependencies {
+        var dependencies = HistoryArchiveRecoveryWorkflowDependencies.live(
+            makeHistoryStore: { storeRecorder.makeStore(at: $0) }
+        )
+        dependencies.rollbackInterruptedTransactions = { _ in .normal }
+        dependencies.inspectArchiveSafety = { _ in
+            transitionRecorder.count > 0 ? .unresolvedArchive : .normal
+        }
+        dependencies.removeExpiredSnapshots = { _ in [] }
+        dependencies.listSnapshots = { _ in [] }
+        dependencies.archiveAndCreateFreshHistory = { storageRoot, _ in
+            try transitionRecorder.perform(root: storageRoot)
+        }
+        return dependencies
+    }
+
+    private static func archiveTransitionResult(
+        root: URL
+    ) -> HistoryArchiveTransitionResult {
+        let snapshotID = UUID()
+        return HistoryArchiveTransitionResult(
+            snapshot: HistoryArchiveSnapshot(
+                schemaVersion: HistoryArchiveSnapshot.currentSchemaVersion,
+                id: snapshotID,
+                archivedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                components: []
+            ),
+            recoveryDirectory: root
+                .appendingPathComponent("Recovery", isDirectory: true)
+                .appendingPathComponent(
+                    "history-\(snapshotID.uuidString.lowercased())",
+                    isDirectory: true
+                )
+        )
+    }
+
+    private static func waitUntil(
+        timeout: TimeInterval = 2,
+        _ condition: @escaping @Sendable () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() {
+            if Date() >= deadline {
+                throw HistoryWorkflowTestFailure(
+                    "timed out waiting for asynchronous history workflow"
+                )
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+
+    private static func withTemporaryDirectoryAsync(
+        _ operation: (URL) async throws -> Void
+    ) async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "history-workflow-archive-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+        try await operation(root)
+    }
+
     private static func withTemporaryWorkflow(
         _ operation: (
             HistoryArchiveRecoveryWorkflow,
@@ -365,6 +601,122 @@ private final class StartupOperationRecorder: @unchecked Sendable {
             recordedStoreURLs.append(url)
             recordedStores.append(store)
         }
+    }
+}
+
+private enum RecordedWorkflowEventKind: Equatable {
+    case stateChanged
+    case runtimeInstalled
+    case failed
+    case postAction
+}
+
+private final class WorkflowEventRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedKinds: [RecordedWorkflowEventKind] = []
+    private var recordedFailures: [HistoryWorkflowFailure] = []
+
+    var kinds: [RecordedWorkflowEventKind] {
+        lock.withHistoryWorkflowLock { recordedKinds }
+    }
+
+    var failures: [HistoryWorkflowFailure] {
+        lock.withHistoryWorkflowLock { recordedFailures }
+    }
+
+    @MainActor
+    func attach(to workflow: HistoryArchiveRecoveryWorkflow) {
+        workflow.onEvent = { [weak self] event in
+            self?.record(event)
+        }
+    }
+
+    private func record(_ event: HistoryWorkflowEvent) {
+        lock.withHistoryWorkflowLock {
+            switch event {
+            case .stateChanged:
+                recordedKinds.append(.stateChanged)
+            case .installRuntime:
+                recordedKinds.append(.runtimeInstalled)
+            case .failed(let failure):
+                recordedKinds.append(.failed)
+                recordedFailures.append(failure)
+            case .performPostAction:
+                recordedKinds.append(.postAction)
+            }
+        }
+    }
+}
+
+private final class ArchiveStoreFactoryRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var callCount = 0
+    private let freshStoreUnavailable: Bool
+
+    init(freshStoreUnavailable: Bool = false) {
+        self.freshStoreUnavailable = freshStoreUnavailable
+    }
+
+    func makeStore(at url: URL) -> PipelineHistoryStore {
+        let call = lock.withHistoryWorkflowLock { () -> Int in
+            callCount += 1
+            return callCount
+        }
+        guard call > 1, !freshStoreUnavailable else {
+            return PipelineHistoryStore(
+                storeURL: url,
+                persistentStoreLoader: { _ in
+                    HistoryWorkflowTestFailure(
+                        "intentional unavailable archive store"
+                    )
+                }
+            )
+        }
+        return PipelineHistoryStore(storeURL: url)
+    }
+}
+
+private final class ArchiveTransitionRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var executionCount = 0
+    private let shouldFail: Bool
+
+    init(shouldFail: Bool = false) {
+        self.shouldFail = shouldFail
+    }
+
+    var count: Int {
+        lock.withHistoryWorkflowLock { executionCount }
+    }
+
+    func record() {
+        lock.withHistoryWorkflowLock {
+            executionCount += 1
+        }
+    }
+
+    func perform(root: URL) throws -> HistoryArchiveTransitionResult {
+        record()
+        if shouldFail {
+            throw HistoryWorkflowTestFailure(
+                "intentional archive transition failure"
+            )
+        }
+        let snapshotID = UUID()
+        return HistoryArchiveTransitionResult(
+            snapshot: HistoryArchiveSnapshot(
+                schemaVersion: HistoryArchiveSnapshot.currentSchemaVersion,
+                id: snapshotID,
+                archivedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                components: []
+            ),
+            recoveryDirectory: root
+                .appendingPathComponent("Recovery", isDirectory: true)
+                .appendingPathComponent(
+                    "history-\(snapshotID.uuidString.lowercased())",
+                    isDirectory: true
+                )
+        )
     }
 }
 

--- a/Tests/HistoryArchiveRecoveryWorkflowTests.swift
+++ b/Tests/HistoryArchiveRecoveryWorkflowTests.swift
@@ -8,6 +8,12 @@ struct HistoryArchiveRecoveryWorkflowTests {
         try testArchiveAdmissionRejectsEveryApplicationActivity()
         try testArchiveAdmissionRejectsReentrantWorkflowActivity()
         try testMutationAdmissionPreservesDistinctWorkflowFailures()
+        try testStartupRollsBackBeforeRetentionAndInspection()
+        try testUnavailableStoreProtectsHistory()
+        try testUnresolvedRollbackSkipsRetentionAndProtectsHistory()
+        try testPublishedUnresolvedArchivePermitsProtectedStartupBranch()
+        try testRetentionFailureStillLoadsRecoveryCatalog()
+        try testStartupUsesOriginatingStoreFactory()
         print("HistoryArchiveRecoveryWorkflowTests passed")
     }
 
@@ -97,6 +103,225 @@ struct HistoryArchiveRecoveryWorkflowTests {
         )
     }
 
+    private static func testStartupRollsBackBeforeRetentionAndInspection() throws {
+        try withTemporaryWorkflow { workflow, root, recorder in
+            let result = workflow.prepareStartup()
+
+            try expect(
+                Array(recorder.events.prefix(4)) == [
+                    "rollback", "retention", "inspect", "make-store",
+                ],
+                "startup rollback precedes retention, safety inspection, and store construction"
+            )
+            try expect(
+                result.permitsNormalHistoryStartup,
+                "normal verified history permits normal startup work"
+            )
+            try expect(
+                result.state.archiveSafety == .normal
+                    && !result.state.isHistoryUnavailable,
+                "startup result carries normal available state"
+            )
+            try expect(
+                result.activeStore === recorder.madeStores.first,
+                "startup returns the store from the originating factory"
+            )
+            try expect(
+                recorder.madeStoreURLs == [root.appendingPathComponent("PipelineHistory.sqlite")],
+                "startup requests the active history URL"
+            )
+        }
+    }
+
+    private static func testUnavailableStoreProtectsHistory() throws {
+        try withTemporaryWorkflow { workflow, _, recorder in
+            recorder.makeUnavailableStore = true
+
+            let result = workflow.prepareStartup()
+
+            try expect(
+                result.state.isHistoryUnavailable
+                    && result.state.showsPersistenceWarning,
+                "unavailable active store protects history and publishes a warning"
+            )
+            try expect(
+                !result.permitsNormalHistoryStartup
+                    && !result.permitsUnresolvedArchiveStartup,
+                "unavailable active store blocks startup history loading"
+            )
+        }
+    }
+
+    private static func testUnresolvedRollbackSkipsRetentionAndProtectsHistory() throws {
+        try withTemporaryWorkflow { workflow, _, recorder in
+            recorder.rollbackSafety = .unresolvedInterruptedTransaction
+            recorder.inspectedSafety = .unresolvedInterruptedTransaction
+
+            let result = workflow.prepareStartup()
+
+            try expect(
+                !recorder.events.contains("retention"),
+                "unresolved rollback never deletes completed snapshots"
+            )
+            try expect(
+                result.state.isHistoryUnavailable
+                    && result.state.showsPersistenceWarning,
+                "unresolved transaction keeps history protected"
+            )
+            try expect(
+                !result.permitsNormalHistoryStartup
+                    && !result.permitsUnresolvedArchiveStartup,
+                "unresolved transaction blocks all history loading"
+            )
+        }
+    }
+
+    private static func testPublishedUnresolvedArchivePermitsProtectedStartupBranch() throws {
+        try withTemporaryWorkflow { workflow, _, recorder in
+            recorder.inspectedSafety = .unresolvedArchive
+
+            let result = workflow.prepareStartup()
+
+            try expect(
+                result.permitsUnresolvedArchiveStartup
+                    && !result.permitsNormalHistoryStartup,
+                "published unresolved archive uses only its protected startup branch"
+            )
+            try expect(
+                !result.state.isHistoryUnavailable,
+                "verified fresh history stays available beside a published archive"
+            )
+        }
+    }
+
+    private static func testRetentionFailureStillLoadsRecoveryCatalog() throws {
+        try withTemporaryWorkflow { workflow, _, recorder in
+            recorder.failRetention = true
+
+            let result = workflow.prepareStartup()
+
+            try expect(
+                result.permitsNormalHistoryStartup,
+                "best-effort retention failure keeps active history available"
+            )
+            try expect(
+                recorder.events.contains("catalog"),
+                "retention failure still loads the recovery catalog"
+            )
+        }
+    }
+
+    private static func testStartupUsesOriginatingStoreFactory() throws {
+        try withTemporaryDirectory { root in
+            let layout = AppStateStorageLayout(rootDirectory: root)
+            let originatingRecorder = StartupOperationRecorder()
+            let unrelatedRecorder = StartupOperationRecorder()
+            var dependencies = startupDependencies(
+                recorder: originatingRecorder
+            )
+            let workflow = HistoryArchiveRecoveryWorkflow(
+                storageLayout: layout,
+                dependencies: dependencies
+            )
+            dependencies.makeHistoryStore = { url in
+                let store = PipelineHistoryStore(storeURL: url)
+                unrelatedRecorder.recordStore(url: url, store: store)
+                return store
+            }
+
+            let result = workflow.prepareStartup()
+
+            try expect(
+                result.activeStore === originatingRecorder.madeStores.first,
+                "startup remains bound to the factory captured by the workflow"
+            )
+            try expect(
+                unrelatedRecorder.madeStores.isEmpty,
+                "later dependency mutation cannot redirect startup"
+            )
+        }
+    }
+
+    private static func withTemporaryWorkflow(
+        _ operation: (
+            HistoryArchiveRecoveryWorkflow,
+            URL,
+            StartupOperationRecorder
+        ) throws -> Void
+    ) throws {
+        try withTemporaryDirectory { root in
+            let recorder = StartupOperationRecorder()
+            let workflow = HistoryArchiveRecoveryWorkflow(
+                storageLayout: AppStateStorageLayout(rootDirectory: root),
+                dependencies: startupDependencies(recorder: recorder)
+            )
+            try operation(workflow, root, recorder)
+        }
+    }
+
+    private static func startupDependencies(
+        recorder: StartupOperationRecorder
+    ) -> HistoryArchiveRecoveryWorkflowDependencies {
+        var dependencies = HistoryArchiveRecoveryWorkflowDependencies.live(
+            makeHistoryStore: { url in
+                recorder.record("make-store")
+                let store: PipelineHistoryStore
+                if recorder.makeUnavailableStore {
+                    store = PipelineHistoryStore(
+                        storeURL: url,
+                        persistentStoreLoader: { _ in
+                            HistoryWorkflowTestFailure(
+                                "intentional unavailable startup store"
+                            )
+                        }
+                    )
+                } else {
+                    store = PipelineHistoryStore(storeURL: url)
+                }
+                recorder.recordStore(url: url, store: store)
+                return store
+            }
+        )
+        dependencies.rollbackInterruptedTransactions = { _ in
+            recorder.record("rollback")
+            return recorder.rollbackSafety
+        }
+        dependencies.removeExpiredSnapshots = { _ in
+            recorder.record("retention")
+            if recorder.failRetention {
+                throw HistoryWorkflowTestFailure(
+                    "intentional retention cleanup failure"
+                )
+            }
+            return []
+        }
+        dependencies.inspectArchiveSafety = { _ in
+            recorder.record("inspect")
+            return recorder.inspectedSafety
+        }
+        dependencies.listSnapshots = { _ in
+            recorder.record("catalog")
+            return []
+        }
+        return dependencies
+    }
+
+    private static func withTemporaryDirectory(
+        _ operation: (URL) throws -> Void
+    ) throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "history-workflow-startup-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+        try operation(root)
+    }
+
     private static func expect(
         _ condition: @autoclosure () -> Bool,
         _ label: String
@@ -107,10 +332,56 @@ struct HistoryArchiveRecoveryWorkflowTests {
     }
 }
 
+private final class StartupOperationRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedEvents: [String] = []
+    private var recordedStoreURLs: [URL] = []
+    private var recordedStores: [PipelineHistoryStore] = []
+    var rollbackSafety: HistoryArchiveSafety = .normal
+    var inspectedSafety: HistoryArchiveSafety = .normal
+    var makeUnavailableStore = false
+    var failRetention = false
+
+    var events: [String] {
+        lock.withHistoryWorkflowLock { recordedEvents }
+    }
+
+    var madeStoreURLs: [URL] {
+        lock.withHistoryWorkflowLock { recordedStoreURLs }
+    }
+
+    var madeStores: [PipelineHistoryStore] {
+        lock.withHistoryWorkflowLock { recordedStores }
+    }
+
+    func record(_ event: String) {
+        lock.withHistoryWorkflowLock {
+            recordedEvents.append(event)
+        }
+    }
+
+    func recordStore(url: URL, store: PipelineHistoryStore) {
+        lock.withHistoryWorkflowLock {
+            recordedStoreURLs.append(url)
+            recordedStores.append(store)
+        }
+    }
+}
+
 private struct HistoryWorkflowTestFailure: Error, CustomStringConvertible {
     let description: String
 
     init(_ description: String) {
         self.description = description
+    }
+}
+
+private extension NSLock {
+    func withHistoryWorkflowLock<Value>(
+        _ body: () throws -> Value
+    ) rethrows -> Value {
+        lock()
+        defer { unlock() }
+        return try body()
     }
 }

--- a/Tests/HistoryArchiveRecoveryWorkflowTests.swift
+++ b/Tests/HistoryArchiveRecoveryWorkflowTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+#if !QUILL_GROUPED_TEST_RUNNER
+@main
+#endif
+struct HistoryArchiveRecoveryWorkflowTests {
+    static func main() async throws {
+        try testArchiveAdmissionRejectsEveryApplicationActivity()
+        try testArchiveAdmissionRejectsReentrantWorkflowActivity()
+        try testMutationAdmissionPreservesDistinctWorkflowFailures()
+        print("HistoryArchiveRecoveryWorkflowTests passed")
+    }
+
+    private static func testArchiveAdmissionRejectsEveryApplicationActivity() throws {
+        let state = HistoryWorkflowState(
+            archiveSafety: .normal,
+            archiveActivity: .idle,
+            recoveryOperation: .idle,
+            snapshots: [],
+            inspections: [:],
+            inspectionSnapshotID: nil,
+            importResult: nil,
+            isHistoryUnavailable: true,
+            showsPersistenceWarning: true
+        )
+        let blockers: [(String, HistoryWorkflowAdmissionContext)] = [
+            ("recording", .init(isRecording: true)),
+            ("transcription", .init(isTranscribing: true)),
+            ("retry", .init(hasRetryWork: true)),
+            ("transcription job", .init(hasActiveTranscriptionJobs: true)),
+            ("audio import", .init(hasPendingAudioImports: true)),
+            ("cloud history", .init(hasCloudHistoryWork: true)),
+            ("meeting summary", .init(hasMeetingSummaryWork: true)),
+            ("recording journal", .init(hasActiveRecordingJournal: true)),
+            ("recording finalization", .init(hasPendingRecordingFinalization: true)),
+            ("recording start", .init(hasPendingRecordingStart: true)),
+            ("audio-only stop", .init(hasPendingAudioOnlyStops: true)),
+        ]
+
+        for (label, context) in blockers {
+            try expect(
+                HistoryWorkflowAdmission.archive(
+                    state: state,
+                    context: context
+                ) == .rejected(.applicationBusy),
+                "archive rejects active \(label) work"
+            )
+        }
+    }
+
+    private static func testArchiveAdmissionRejectsReentrantWorkflowActivity() throws {
+        var state = HistoryWorkflowState.initial
+        state.isHistoryUnavailable = true
+        state.archiveActivity = .transitioning(postAction: .startFresh)
+        try expect(
+            HistoryWorkflowAdmission.archive(
+                state: state,
+                context: .init()
+            ) == .rejected(.archiveTransitionInProgress),
+            "duplicate archive transition is rejected"
+        )
+
+        state.archiveActivity = .idle
+        state.recoveryOperation = .deletingSnapshot(UUID())
+        try expect(
+            HistoryWorkflowAdmission.archive(
+                state: state,
+                context: .init()
+            ) == .rejected(.recoveryOperationInProgress),
+            "archive is rejected during mutating recovery work"
+        )
+    }
+
+    private static func testMutationAdmissionPreservesDistinctWorkflowFailures() throws {
+        var state = HistoryWorkflowState.initial
+        state.archiveActivity = .transitioning(postAction: .startFresh)
+        try expect(
+            HistoryWorkflowAdmission.mutation(state: state)
+                == .rejected(.archiveTransitionInProgress),
+            "archive activity keeps its distinct mutation rejection"
+        )
+
+        state.archiveActivity = .idle
+        state.recoveryOperation = .importing(UUID())
+        try expect(
+            HistoryWorkflowAdmission.mutation(state: state)
+                == .rejected(.recoveryOperationInProgress),
+            "recovery activity keeps its distinct mutation rejection"
+        )
+
+        state.recoveryOperation = .idle
+        state.isHistoryUnavailable = true
+        try expect(
+            HistoryWorkflowAdmission.mutation(state: state)
+                == .rejected(.historyUnavailable),
+            "unavailable history keeps its distinct mutation rejection"
+        )
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ label: String
+    ) throws {
+        guard condition() else {
+            throw HistoryWorkflowTestFailure(label)
+        }
+    }
+}
+
+private struct HistoryWorkflowTestFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/Tests/HistoryArchiveRecoveryWorkflowTests.swift
+++ b/Tests/HistoryArchiveRecoveryWorkflowTests.swift
@@ -1217,6 +1217,8 @@ private final class ArchiveStoreFactoryRecorder: @unchecked Sendable {
             callCount += 1
             return callCount
         }
+        // The first call creates the unavailable startup state
+        // required for archive admission.
         guard call > 1, !freshStoreUnavailable else {
             return PipelineHistoryStore(
                 storeURL: url,

--- a/Tests/HistoryArchiveRecoveryWorkflowTests.swift
+++ b/Tests/HistoryArchiveRecoveryWorkflowTests.swift
@@ -17,6 +17,7 @@ struct HistoryArchiveRecoveryWorkflowTests {
         try await testArchiveInstallsVerifiedRuntimeBeforeIdleState()
         try await testArchiveVerificationFailureNeverInstallsRuntime()
         try await testArchiveTransitionFailureNeverInstallsRuntime()
+        try await testArchiveFailureRefreshesPublishedSnapshotCatalog()
         try await testArchiveCapturesOriginatingDependencies()
         try await testInspectionQueueRunsReadySnapshotsInOrder()
         try await testInspectionRetryMovesSnapshotToFront()
@@ -29,6 +30,7 @@ struct HistoryArchiveRecoveryWorkflowTests {
         try await testRecoveryReopenFailureNeverInstallsRuntime()
         try testRecoveryImportRejectsInvalidAndReentrantRequests()
         try await testSnapshotCancellationRefreshesCatalog()
+        try await testSnapshotSuccessSynchronizesActiveStoreAvailability()
         try await testSnapshotDeleteRefreshesCatalog()
         try await testSnapshotFailureNeverInstallsRuntime()
         try await testSnapshotOperationsWaitForInspection()
@@ -339,6 +341,31 @@ struct HistoryArchiveRecoveryWorkflowTests {
         }
     }
 
+    private static func testArchiveFailureRefreshesPublishedSnapshotCatalog() async throws {
+        try await withArchiveWorkflow(
+            transitionShouldFail: true,
+            publishesSnapshotBeforeFailure: true
+        ) { workflow, startup, eventRecorder, transitionRecorder in
+            let command = await MainActor.run {
+                workflow.requestArchive(
+                    context: .init(),
+                    currentStore: startup.activeStore,
+                    postAction: .openRecovery
+                )
+            }
+            try expect(command == .accepted, "archive transition begins")
+            try await waitUntil {
+                eventRecorder.failures.contains(.archiveTransitionFailed)
+            }
+            try expect(
+                workflow.state.snapshots.contains(where: {
+                    $0.id == transitionRecorder.publishedSnapshotID
+                }),
+                "archive failure exposes a snapshot published before the error"
+            )
+        }
+    }
+
     private static func testArchiveCapturesOriginatingDependencies() async throws {
         try await withTemporaryDirectoryAsync { root in
             let layout = AppStateStorageLayout(rootDirectory: root)
@@ -640,10 +667,11 @@ struct HistoryArchiveRecoveryWorkflowTests {
     private static func testSnapshotCancellationRefreshesCatalog() async throws {
         try await withRecoveryWorkflow(
             snapshotStatus: .completed
-        ) { workflow, _, recorder, events in
+        ) { workflow, startup, recorder, events in
             let command = await MainActor.run {
                 workflow.requestCancelScheduledDeletion(
                     snapshotID: recorder.snapshotID,
+                    activeStore: startup.activeStore,
                     activeHistory: [],
                     shouldRescheduleInspection: false
                 )
@@ -663,11 +691,41 @@ struct HistoryArchiveRecoveryWorkflowTests {
         }
     }
 
-    private static func testSnapshotDeleteRefreshesCatalog() async throws {
-        try await withRecoveryWorkflow { workflow, _, recorder, events in
+    private static func testSnapshotSuccessSynchronizesActiveStoreAvailability() async throws {
+        try await withRecoveryWorkflow(
+            unavailableStoreCalls: [1]
+        ) { workflow, _, recorder, _ in
+            let readyStore = PipelineHistoryStore(inMemory: true)
+            try expect(
+                workflow.state.isHistoryUnavailable,
+                "fixture begins with stale unavailable workflow state"
+            )
             let command = await MainActor.run {
                 workflow.requestDeleteSnapshot(
                     snapshotID: recorder.snapshotID,
+                    activeStore: readyStore,
+                    activeHistory: [],
+                    shouldRescheduleInspection: false
+                )
+            }
+            try expect(command == .accepted, "snapshot deletion is accepted")
+            try await waitUntil {
+                workflow.state.recoveryOperation == .idle
+                    && workflow.state.snapshots.isEmpty
+            }
+            try expect(
+                !workflow.state.isHistoryUnavailable,
+                "successful snapshot operation synchronizes active store availability"
+            )
+        }
+    }
+
+    private static func testSnapshotDeleteRefreshesCatalog() async throws {
+        try await withRecoveryWorkflow { workflow, startup, recorder, events in
+            let command = await MainActor.run {
+                workflow.requestDeleteSnapshot(
+                    snapshotID: recorder.snapshotID,
+                    activeStore: startup.activeStore,
                     activeHistory: [],
                     shouldRescheduleInspection: false
                 )
@@ -687,10 +745,11 @@ struct HistoryArchiveRecoveryWorkflowTests {
     private static func testSnapshotFailureNeverInstallsRuntime() async throws {
         try await withRecoveryWorkflow(
             deleteShouldFail: true
-        ) { workflow, _, recorder, events in
+        ) { workflow, startup, recorder, events in
             let command = await MainActor.run {
                 workflow.requestDeleteSnapshot(
                     snapshotID: recorder.snapshotID,
+                    activeStore: startup.activeStore,
                     activeHistory: [],
                     shouldRescheduleInspection: false
                 )
@@ -713,7 +772,7 @@ struct HistoryArchiveRecoveryWorkflowTests {
     }
 
     private static func testSnapshotOperationsWaitForInspection() async throws {
-        try await withRecoveryWorkflow { workflow, _, recorder, _ in
+        try await withRecoveryWorkflow { workflow, startup, recorder, _ in
             recorder.blockInspection()
             await MainActor.run {
                 workflow.beginInspection(activeHistory: [])
@@ -722,6 +781,7 @@ struct HistoryArchiveRecoveryWorkflowTests {
             let command = await MainActor.run {
                 workflow.requestDeleteSnapshot(
                     snapshotID: recorder.snapshotID,
+                    activeStore: startup.activeStore,
                     activeHistory: [],
                     shouldRescheduleInspection: false
                 )
@@ -863,6 +923,7 @@ struct HistoryArchiveRecoveryWorkflowTests {
     private static func withArchiveWorkflow(
         freshStoreUnavailable: Bool = false,
         transitionShouldFail: Bool = false,
+        publishesSnapshotBeforeFailure: Bool = false,
         _ operation: (
             HistoryArchiveRecoveryWorkflow,
             HistoryStartupResult,
@@ -875,7 +936,9 @@ struct HistoryArchiveRecoveryWorkflowTests {
                 freshStoreUnavailable: freshStoreUnavailable
             )
             let transitionRecorder = ArchiveTransitionRecorder(
-                shouldFail: transitionShouldFail
+                shouldFail: transitionShouldFail,
+                publishesSnapshotBeforeFailure:
+                    publishesSnapshotBeforeFailure
             )
             let workflow = HistoryArchiveRecoveryWorkflow(
                 storageLayout: AppStateStorageLayout(rootDirectory: root),
@@ -910,7 +973,9 @@ struct HistoryArchiveRecoveryWorkflowTests {
             transitionRecorder.count > 0 ? .unresolvedArchive : .normal
         }
         dependencies.removeExpiredSnapshots = { _ in [] }
-        dependencies.listSnapshots = { _ in [] }
+        dependencies.listSnapshots = { storageRoot in
+            transitionRecorder.snapshots(root: storageRoot)
+        }
         dependencies.archiveAndCreateFreshHistory = { storageRoot, _ in
             try transitionRecorder.perform(root: storageRoot)
         }
@@ -1167,12 +1232,19 @@ private final class ArchiveStoreFactoryRecorder: @unchecked Sendable {
 }
 
 private final class ArchiveTransitionRecorder: @unchecked Sendable {
+    let publishedSnapshotID = UUID()
     private let lock = NSLock()
     private var executionCount = 0
     private let shouldFail: Bool
+    private let publishesSnapshotBeforeFailure: Bool
 
-    init(shouldFail: Bool = false) {
+    init(
+        shouldFail: Bool = false,
+        publishesSnapshotBeforeFailure: Bool = false
+    ) {
         self.shouldFail = shouldFail
+        self.publishesSnapshotBeforeFailure =
+            publishesSnapshotBeforeFailure
     }
 
     var count: Int {
@@ -1183,6 +1255,30 @@ private final class ArchiveTransitionRecorder: @unchecked Sendable {
         lock.withHistoryWorkflowLock {
             executionCount += 1
         }
+    }
+
+    func snapshots(root: URL) -> [HistoryRecoverySnapshotDescriptor] {
+        guard publishesSnapshotBeforeFailure, count > 0 else { return [] }
+        let snapshot = HistoryArchiveSnapshot(
+            schemaVersion: HistoryArchiveSnapshot.currentSchemaVersion,
+            id: publishedSnapshotID,
+            archivedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            components: []
+        )
+        return [
+            HistoryRecoverySnapshotDescriptor(
+                snapshot: snapshot,
+                snapshotURL: root
+                    .appendingPathComponent("Recovery", isDirectory: true)
+                    .appendingPathComponent(
+                        "history-\(publishedSnapshotID.uuidString.lowercased())",
+                        isDirectory: true
+                    ),
+                payloadByteCount: 0,
+                integrity: .ready,
+                state: nil
+            ),
+        ]
     }
 
     func perform(root: URL) throws -> HistoryArchiveTransitionResult {

--- a/Tests/HistoryArchiveRecoveryWorkflowTests.swift
+++ b/Tests/HistoryArchiveRecoveryWorkflowTests.swift
@@ -23,6 +23,14 @@ struct HistoryArchiveRecoveryWorkflowTests {
         try await testInspectionRejectsDuplicateCurrentSnapshot()
         try await testInspectionInvalidationDropsStaleCompletion()
         try await testInspectionFailureContinuesToNextSnapshot()
+        try await testRecoveryImportInstallsVerifiedReopenedStore()
+        try await testRecoveryImportPublishesOnlyPartialFeedback()
+        try await testRecoveryImportFailureRestoresVerifiedStore()
+        try await testRecoveryReopenFailureNeverInstallsRuntime()
+        try testRecoveryImportRejectsInvalidAndReentrantRequests()
+        try await testSnapshotDeleteRefreshesCatalog()
+        try await testSnapshotFailureNeverInstallsRuntime()
+        try await testSnapshotOperationsWaitForInspection()
         print("HistoryArchiveRecoveryWorkflowTests passed")
     }
 
@@ -481,6 +489,281 @@ struct HistoryArchiveRecoveryWorkflowTests {
         }
     }
 
+    private static func testRecoveryImportInstallsVerifiedReopenedStore() async throws {
+        try await withRecoveryWorkflow { workflow, startup, recorder, events in
+            recorder.importResult = HistoryRecoveryImportResult(
+                snapshotID: recorder.snapshotID,
+                importedRecordCount: 1,
+                alreadyPresentRecordCount: 0,
+                conflictRecordCount: 0,
+                failedRecordCount: 0
+            )
+            let command = await MainActor.run {
+                workflow.requestImport(
+                    snapshotID: recorder.snapshotID,
+                    context: .init(),
+                    currentStore: startup.activeStore,
+                    activeHistory: [],
+                    shouldRescheduleInspection: false
+                )
+            }
+            try expect(command == .accepted, "eligible recovery import is accepted")
+            try await waitUntil {
+                events.kinds.contains(.runtimeInstalled)
+                    && workflow.state.recoveryOperation == .idle
+            }
+            try expect(
+                workflow.state.importResult == nil
+                    && !workflow.state.isHistoryUnavailable,
+                "complete import installs available history without partial feedback"
+            )
+        }
+    }
+
+    private static func testRecoveryImportPublishesOnlyPartialFeedback() async throws {
+        try await withRecoveryWorkflow { workflow, startup, recorder, events in
+            let partialResult = HistoryRecoveryImportResult(
+                snapshotID: recorder.snapshotID,
+                importedRecordCount: 0,
+                alreadyPresentRecordCount: 0,
+                conflictRecordCount: 1,
+                failedRecordCount: 0
+            )
+            recorder.importResult = partialResult
+            let command = await MainActor.run {
+                workflow.requestImport(
+                    snapshotID: recorder.snapshotID,
+                    context: .init(),
+                    currentStore: startup.activeStore,
+                    activeHistory: [],
+                    shouldRescheduleInspection: false
+                )
+            }
+            try expect(command == .accepted, "partial recovery import is accepted")
+            try await waitUntil {
+                events.kinds.contains(.runtimeInstalled)
+                    && workflow.state.recoveryOperation == .idle
+            }
+            try expect(
+                workflow.state.importResult == partialResult,
+                "conflict result remains available as partial feedback"
+            )
+        }
+    }
+
+    private static func testRecoveryImportFailureRestoresVerifiedStore() async throws {
+        try await withRecoveryWorkflow(
+            importShouldFail: true
+        ) { workflow, startup, recorder, events in
+            let command = await MainActor.run {
+                workflow.requestImport(
+                    snapshotID: recorder.snapshotID,
+                    context: .init(),
+                    currentStore: startup.activeStore,
+                    activeHistory: [],
+                    shouldRescheduleInspection: false
+                )
+            }
+            try expect(command == .accepted, "failing recovery import starts")
+            try await waitUntil {
+                events.failures.contains(.recoveryImportFailed)
+            }
+            try expect(
+                events.kinds.contains(.runtimeInstalled),
+                "import failure restores a separately verified active store"
+            )
+            try expect(
+                !workflow.state.isHistoryUnavailable
+                    && workflow.state.recoveryOperation == .idle,
+                "verified restoration returns recovery to available idle state"
+            )
+        }
+    }
+
+    private static func testRecoveryReopenFailureNeverInstallsRuntime() async throws {
+        try await withRecoveryWorkflow(
+            unavailableStoreCalls: [3]
+        ) { workflow, startup, recorder, events in
+            let command = await MainActor.run {
+                workflow.requestImport(
+                    snapshotID: recorder.snapshotID,
+                    context: .init(),
+                    currentStore: startup.activeStore,
+                    activeHistory: [],
+                    shouldRescheduleInspection: false
+                )
+            }
+            try expect(command == .accepted, "reopen failure begins after import")
+            try await waitUntil {
+                events.failures.contains(.activeStoreReopenFailed)
+            }
+            try expect(
+                !events.kinds.contains(.runtimeInstalled),
+                "unverified reopened store is never installed"
+            )
+            try expect(
+                workflow.state.isHistoryUnavailable,
+                "reopen failure leaves history protected"
+            )
+        }
+    }
+
+    private static func testRecoveryImportRejectsInvalidAndReentrantRequests() throws {
+        let root = FileManager.default.temporaryDirectory
+        let snapshotID = UUID()
+        let descriptor = recoverySnapshotDescriptor(
+            id: snapshotID,
+            root: root
+        )
+        var state = HistoryWorkflowState.initial
+        try expect(
+            HistoryWorkflowAdmission.recoveryImport(
+                state: state,
+                snapshotID: snapshotID,
+                context: .init()
+            ) == .rejected(.snapshotUnavailable),
+            "unknown recovery snapshot is rejected"
+        )
+        state.snapshots = [descriptor]
+        state.recoveryOperation = .deletingSnapshot(UUID())
+        try expect(
+            HistoryWorkflowAdmission.recoveryImport(
+                state: state,
+                snapshotID: snapshotID,
+                context: .init()
+            ) == .rejected(.recoveryOperationInProgress),
+            "reentrant recovery import is rejected"
+        )
+    }
+
+    private static func testSnapshotDeleteRefreshesCatalog() async throws {
+        try await withRecoveryWorkflow { workflow, _, recorder, events in
+            let command = await MainActor.run {
+                workflow.requestDeleteSnapshot(
+                    snapshotID: recorder.snapshotID,
+                    activeHistory: [],
+                    shouldRescheduleInspection: false
+                )
+            }
+            try expect(command == .accepted, "eligible snapshot deletion is accepted")
+            try await waitUntil {
+                workflow.state.snapshots.isEmpty
+                    && workflow.state.recoveryOperation == .idle
+            }
+            try expect(
+                !events.kinds.contains(.runtimeInstalled),
+                "snapshot deletion never replaces active history"
+            )
+        }
+    }
+
+    private static func testSnapshotFailureNeverInstallsRuntime() async throws {
+        try await withRecoveryWorkflow(
+            deleteShouldFail: true
+        ) { workflow, _, recorder, events in
+            let command = await MainActor.run {
+                workflow.requestDeleteSnapshot(
+                    snapshotID: recorder.snapshotID,
+                    activeHistory: [],
+                    shouldRescheduleInspection: false
+                )
+            }
+            try expect(command == .accepted, "failing snapshot deletion starts")
+            try await waitUntil {
+                events.failures.contains(.snapshotOperationFailed)
+            }
+            try expect(
+                !events.kinds.contains(.runtimeInstalled),
+                "snapshot-only failure never replaces active history"
+            )
+            try expect(
+                workflow.state.snapshots.contains(where: {
+                    $0.id == recorder.snapshotID
+                }),
+                "snapshot-only failure preserves the catalog entry"
+            )
+        }
+    }
+
+    private static func testSnapshotOperationsWaitForInspection() async throws {
+        try await withRecoveryWorkflow { workflow, _, recorder, _ in
+            recorder.blockInspection()
+            await MainActor.run {
+                workflow.beginInspection(activeHistory: [])
+            }
+            try await waitUntil { recorder.inspectionStarted }
+            let command = await MainActor.run {
+                workflow.requestDeleteSnapshot(
+                    snapshotID: recorder.snapshotID,
+                    activeHistory: [],
+                    shouldRescheduleInspection: false
+                )
+            }
+            try expect(
+                command == .rejected(.inspectionInProgress),
+                "snapshot operation waits for current inspection"
+            )
+            recorder.releaseInspection()
+            try await waitUntil {
+                workflow.state.inspectionSnapshotID == nil
+            }
+        }
+    }
+
+    private static func withRecoveryWorkflow(
+        importShouldFail: Bool = false,
+        deleteShouldFail: Bool = false,
+        unavailableStoreCalls: Set<Int> = [],
+        _ operation: (
+            HistoryArchiveRecoveryWorkflow,
+            HistoryStartupResult,
+            RecoveryOperationRecorder,
+            WorkflowEventRecorder
+        ) async throws -> Void
+    ) async throws {
+        try await withTemporaryDirectoryAsync { root in
+            let snapshotID = UUID()
+            let recorder = RecoveryOperationRecorder(
+                snapshotID: snapshotID,
+                descriptors: [
+                    recoverySnapshotDescriptor(id: snapshotID, root: root),
+                ],
+                importShouldFail: importShouldFail,
+                deleteShouldFail: deleteShouldFail
+            )
+            let storeRecorder = RecoveryStoreFactoryRecorder(
+                unavailableCalls: unavailableStoreCalls
+            )
+            var dependencies = HistoryArchiveRecoveryWorkflowDependencies.live(
+                makeHistoryStore: { storeRecorder.makeStore(at: $0) }
+            )
+            dependencies.rollbackInterruptedTransactions = { _ in .normal }
+            dependencies.inspectArchiveSafety = { _ in .normal }
+            dependencies.removeExpiredSnapshots = { _ in [] }
+            dependencies.listSnapshots = { _ in recorder.descriptors }
+            dependencies.inspectSnapshot = { _, id, _ in
+                try recorder.inspect(id: id)
+            }
+            dependencies.importSnapshot = { _, id, _, _, _ in
+                try recorder.importSnapshot(id: id)
+            }
+            dependencies.cancelScheduledDeletion = { _, id in
+                try recorder.cancelScheduledDeletion(id: id)
+            }
+            dependencies.deleteSnapshot = { _, id in
+                try recorder.deleteSnapshot(id: id)
+            }
+            let workflow = HistoryArchiveRecoveryWorkflow(
+                storageLayout: AppStateStorageLayout(rootDirectory: root),
+                dependencies: dependencies
+            )
+            let startup = workflow.prepareStartup()
+            let events = WorkflowEventRecorder()
+            await MainActor.run { events.attach(to: workflow) }
+            try await operation(workflow, startup, recorder, events)
+        }
+    }
+
     private static func withInspectionWorkflow(
         snapshotIDs: [UUID],
         _ operation: (
@@ -892,6 +1175,157 @@ private final class ArchiveTransitionRecorder: @unchecked Sendable {
                     isDirectory: true
                 )
         )
+    }
+}
+
+private final class RecoveryStoreFactoryRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var callCount = 0
+    private let unavailableCalls: Set<Int>
+
+    init(unavailableCalls: Set<Int>) {
+        self.unavailableCalls = unavailableCalls
+    }
+
+    func makeStore(at url: URL) -> PipelineHistoryStore {
+        let call = lock.withHistoryWorkflowLock { () -> Int in
+            callCount += 1
+            return callCount
+        }
+        guard unavailableCalls.contains(call) else {
+            return PipelineHistoryStore(storeURL: url)
+        }
+        return PipelineHistoryStore(
+            storeURL: url,
+            persistentStoreLoader: { _ in
+                HistoryWorkflowTestFailure(
+                    "intentional unavailable recovery store"
+                )
+            }
+        )
+    }
+}
+
+private final class RecoveryOperationRecorder: @unchecked Sendable {
+    let snapshotID: UUID
+    private let lock = NSLock()
+    private var storedDescriptors: [HistoryRecoverySnapshotDescriptor]
+    private var storedImportResult: HistoryRecoveryImportResult
+    private let importShouldFail: Bool
+    private let deleteShouldFail: Bool
+    private var inspectionSemaphore: DispatchSemaphore?
+    private var didStartInspection = false
+
+    init(
+        snapshotID: UUID,
+        descriptors: [HistoryRecoverySnapshotDescriptor],
+        importShouldFail: Bool,
+        deleteShouldFail: Bool
+    ) {
+        self.snapshotID = snapshotID
+        self.storedDescriptors = descriptors
+        self.storedImportResult = HistoryRecoveryImportResult(
+            snapshotID: snapshotID,
+            importedRecordCount: 0,
+            alreadyPresentRecordCount: 0,
+            conflictRecordCount: 0,
+            failedRecordCount: 0
+        )
+        self.importShouldFail = importShouldFail
+        self.deleteShouldFail = deleteShouldFail
+    }
+
+    var descriptors: [HistoryRecoverySnapshotDescriptor] {
+        lock.withHistoryWorkflowLock { storedDescriptors }
+    }
+
+    var importResult: HistoryRecoveryImportResult {
+        get {
+            lock.withHistoryWorkflowLock { storedImportResult }
+        }
+        set {
+            lock.withHistoryWorkflowLock {
+                storedImportResult = newValue
+            }
+        }
+    }
+
+    var inspectionStarted: Bool {
+        lock.withHistoryWorkflowLock { didStartInspection }
+    }
+
+    func blockInspection() {
+        lock.withHistoryWorkflowLock {
+            inspectionSemaphore = DispatchSemaphore(value: 0)
+        }
+    }
+
+    func releaseInspection() {
+        let semaphore = lock.withHistoryWorkflowLock {
+            inspectionSemaphore
+        }
+        semaphore?.signal()
+    }
+
+    func inspect(id: UUID) throws -> HistoryRecoveryInspection {
+        let semaphore = lock.withHistoryWorkflowLock {
+            didStartInspection = true
+            return inspectionSemaphore
+        }
+        semaphore?.wait()
+        return HistoryRecoveryInspection(
+            snapshotID: id,
+            readableRecordCount: 1,
+            alreadyPresentRecordCount: 0,
+            conflictRecordCount: 0
+        )
+    }
+
+    func importSnapshot(id: UUID) throws -> HistoryRecoveryImportResult {
+        guard id == snapshotID else {
+            throw HistoryWorkflowTestFailure("unexpected recovery snapshot")
+        }
+        if importShouldFail {
+            throw HistoryWorkflowTestFailure(
+                "intentional recovery import failure"
+            )
+        }
+        return importResult
+    }
+
+    func cancelScheduledDeletion(id: UUID) throws {
+        try lock.withHistoryWorkflowLock {
+            guard let index = storedDescriptors.firstIndex(where: {
+                $0.id == id
+            }), let state = storedDescriptors[index].state else {
+                throw HistoryWorkflowTestFailure(
+                    "missing completed recovery snapshot"
+                )
+            }
+            var cancelledState = state
+            cancelledState.automaticDeletionCancelledAt = Date(
+                timeIntervalSince1970: 1_700_000_100
+            )
+            let descriptor = storedDescriptors[index]
+            storedDescriptors[index] = HistoryRecoverySnapshotDescriptor(
+                snapshot: descriptor.snapshot,
+                snapshotURL: descriptor.snapshotURL,
+                payloadByteCount: descriptor.payloadByteCount,
+                integrity: descriptor.integrity,
+                state: cancelledState
+            )
+        }
+    }
+
+    func deleteSnapshot(id: UUID) throws {
+        if deleteShouldFail {
+            throw HistoryWorkflowTestFailure(
+                "intentional snapshot deletion failure"
+            )
+        }
+        lock.withHistoryWorkflowLock {
+            storedDescriptors.removeAll { $0.id == id }
+        }
     }
 }
 

--- a/Tests/QuillUserIssueUIContractTests.swift
+++ b/Tests/QuillUserIssueUIContractTests.swift
@@ -9,9 +9,6 @@ struct QuillUserIssueUIContractTests {
         let settings = try source("Sources/SettingsView.swift")
         let menuBar = try source("Sources/MenuBarView.swift")
         let appState = try source("Sources/AppState.swift")
-        let historyWorkflow = try source(
-            "Sources/HistoryArchiveRecoveryWorkflow.swift"
-        )
         let historyRecovery = try source("Sources/HistoryRecoveryView.swift")
 
         try testSharedRenderer(issueView)
@@ -33,7 +30,6 @@ struct QuillUserIssueUIContractTests {
         )
         try testRecoveryImportOutcomePersistsOutsideProgressOverlay(
             appState,
-            historyWorkflow,
             historyRecovery
         )
         try testRecoveryCountGrammarUsesSingularCatalogKeys(historyRecovery)
@@ -308,7 +304,6 @@ struct QuillUserIssueUIContractTests {
 
     private static func testRecoveryImportOutcomePersistsOutsideProgressOverlay(
         _ appState: String,
-        _ historyWorkflow: String,
         _ historyRecovery: String
     ) throws {
         try expect(
@@ -317,9 +312,6 @@ struct QuillUserIssueUIContractTests {
             )
                 && appState.contains(
                     "historyRecoveryImportResult = state.importResult"
-                )
-                && historyWorkflow.contains(
-                    "state.importResult = result.failedRecordCount > 0"
                 ),
             "workflow partial recovery outcomes reach AppState after the operation ends"
         )

--- a/Tests/QuillUserIssueUIContractTests.swift
+++ b/Tests/QuillUserIssueUIContractTests.swift
@@ -9,6 +9,9 @@ struct QuillUserIssueUIContractTests {
         let settings = try source("Sources/SettingsView.swift")
         let menuBar = try source("Sources/MenuBarView.swift")
         let appState = try source("Sources/AppState.swift")
+        let historyWorkflow = try source(
+            "Sources/HistoryArchiveRecoveryWorkflow.swift"
+        )
         let historyRecovery = try source("Sources/HistoryRecoveryView.swift")
 
         try testSharedRenderer(issueView)
@@ -28,7 +31,11 @@ struct QuillUserIssueUIContractTests {
             menuBar,
             appState
         )
-        try testRecoveryImportOutcomePersistsOutsideProgressOverlay(appState, historyRecovery)
+        try testRecoveryImportOutcomePersistsOutsideProgressOverlay(
+            appState,
+            historyWorkflow,
+            historyRecovery
+        )
         try testRecoveryCountGrammarUsesSingularCatalogKeys(historyRecovery)
         print("QuillUserIssueUIContractTests passed")
     }
@@ -301,12 +308,20 @@ struct QuillUserIssueUIContractTests {
 
     private static func testRecoveryImportOutcomePersistsOutsideProgressOverlay(
         _ appState: String,
+        _ historyWorkflow: String,
         _ historyRecovery: String
     ) throws {
         try expect(
-            appState.contains("@Published private(set) var historyRecoveryImportResult")
-                && appState.contains("historyRecoveryImportResult = result"),
-            "AppState publishes partial recovery import outcomes after the operation ends"
+            appState.contains(
+                "@Published private(set) var historyRecoveryImportResult"
+            )
+                && appState.contains(
+                    "historyRecoveryImportResult = state.importResult"
+                )
+                && historyWorkflow.contains(
+                    "state.importResult = result.failedRecordCount > 0"
+                ),
+            "workflow partial recovery outcomes reach AppState after the operation ends"
         )
         try expect(
             historyRecovery.contains("appState.historyRecoveryImportResult")

--- a/docs/superpowers/specs/2026-08-14-history-archive-recovery-workflow-design.md
+++ b/docs/superpowers/specs/2026-08-14-history-archive-recovery-workflow-design.md
@@ -1,0 +1,493 @@
+# History Archive and Recovery Workflow Design
+
+## Summary
+
+Issue #317 extracts Quill's history archive and recovery orchestration from `AppState.swift` into a focused `HistoryArchiveRecoveryWorkflow`.
+
+The low-level storage boundaries already exist:
+
+- `PipelineHistoryStore` owns active Core Data persistence,
+- `HistoryArchiveTransition` owns crash-safe archive publication and rollback,
+- `HistoryRecoveryService` owns snapshot cataloging, inspection, import, retention, and deletion,
+- `NoteAssetStore` owns active audio and transcript files.
+
+The remaining problem is orchestration. `AppState` currently owns startup rollback and safety inspection, recovery catalog state, inspection queues and revisions, detached archive/import/snapshot tasks, active-store verification and replacement, reentrancy guards, persistence-warning derivation, and completion ordering. This design moves that state machine outside `AppState` without changing file formats, user-visible behavior, or ordinary history CRUD ownership.
+
+## Current State
+
+`AppState` currently coordinates three connected phases.
+
+### Startup
+
+During initialization it:
+
+1. prepares the storage directories,
+2. rolls back interrupted archive transactions,
+3. conditionally removes expired completed snapshots,
+4. inspects archive safety,
+5. constructs the active `PipelineHistoryStore`,
+6. derives history availability and persistence warnings,
+7. branches between normal and unresolved-archive startup,
+8. and initializes the recovery snapshot catalog.
+
+The later startup work for recording-journal recovery, history loading, asset-reference validation, orphan sweeping, title migration, and cloud reconciliation is already backed by focused collaborators, but its admission still depends on history safety decisions made inline in `AppState.init`.
+
+### Archive and runtime replacement
+
+`archiveOldHistoryAndStartFresh` checks workflow state plus a long list of unrelated active-work guards, detaches the current store, starts a detached archive transition, verifies the new store, replaces active runtime stores, clears generation-specific UI state, refreshes recovery state, and optionally opens recovery Settings.
+
+### Recovery
+
+`AppState` stores nine pieces of recovery orchestration state directly:
+
+- snapshot catalog,
+- inspection results,
+- current inspection ID,
+- inspection queue,
+- attempted inspection IDs,
+- inspection revision,
+- recovery-operation activity,
+- operation message,
+- and partial import result.
+
+It also starts and completes detached inspection, import, retention-cancellation, and snapshot-deletion operations. These paths repeatedly reconstruct `HistoryRecoveryService`, re-inspect archive safety, refresh the catalog, synchronize persistence state, and resume inspection scheduling.
+
+The low-level types are independently tested, and `AppStateStorageSafetyTests` covers end-to-end safety. The extraction can therefore preserve behavior by moving orchestration rather than redesigning persistence.
+
+## Approaches Considered
+
+### 1. Stateful workflow with typed state and events — recommended
+
+A dedicated workflow owns archive/recovery state, admission decisions, detached task sequencing, revision checks, and verified runtime replacement. It emits complete state snapshots and typed events for `AppState` to publish or apply.
+
+This satisfies the issue's ownership goal while retaining the existing public `AppState` API and normal history CRUD path.
+
+### 2. Stateless disk-operation worker
+
+A worker would perform archive, inspection, import, and snapshot operations, but `AppState` would retain the queue, revisions, activity flags, admission guards, and completion ordering.
+
+This reduces a few detached closures but leaves the central orchestration problem in `AppState`, so it is rejected.
+
+### 3. Move all history persistence behind the workflow
+
+The workflow would own the active store and every history CRUD operation.
+
+This creates a stronger domain boundary but overlaps the broader AppState-store roadmap in #192 and greatly expands the migration surface. It is rejected for #317.
+
+## Architecture
+
+### `HistoryArchiveRecoveryWorkflow`
+
+Create `Sources/HistoryArchiveRecoveryWorkflow.swift` containing the workflow and its focused value types.
+
+The workflow is initialized with instance-owned values captured from the originating `AppStateDependencies`:
+
+```swift
+HistoryArchiveRecoveryWorkflow(
+    storageLayout: dependencies.storageLayout,
+    makeHistoryStore: dependencies.makePipelineHistoryStore
+)
+```
+
+Its initializer may accept optional factories for `HistoryArchiveTransition` and `HistoryRecoveryService` so workflow tests can use deterministic collaborators without adding process-global seams. Production defaults construct the existing concrete types.
+
+The workflow owns:
+
+- archive safety,
+- archive-transition activity,
+- recovery-operation activity,
+- recovery snapshot catalog,
+- recovery inspection results,
+- inspection queue and attempted IDs,
+- inspection revision and current inspection ID,
+- partial recovery import results,
+- and derivation of history mutation availability and persistence warning state.
+
+The workflow does not own ordinary history CRUD. `AppState` continues to use its current `PipelineHistoryStore` for recording, editing, retry, Meeting Summary, delete, and clear operations.
+
+### `HistoryWorkflowState`
+
+`HistoryWorkflowState` is the complete workflow snapshot delivered to `AppState`. It contains:
+
+- `archiveSafety: HistoryArchiveSafety`,
+- archive transition activity,
+- recovery operation activity,
+- `snapshots: [HistoryRecoverySnapshotDescriptor]`,
+- `inspections: [UUID: HistoryRecoveryInspection]`,
+- `inspectionSnapshotID: UUID?`,
+- `importResult: HistoryRecoveryImportResult?`,
+- history availability,
+- and persistence-warning visibility.
+
+Inspection scheduling remains a separate internal lane from mutating recovery operations. This preserves the current concurrency contract: snapshot deletion and retention cancellation wait for inspection to finish, while import admission is not silently changed to add a new inspection guard.
+
+`AppState` keeps its existing `@Published` properties for source compatibility. A single adapter method applies each complete workflow state snapshot; no other `AppState` path writes those workflow-owned fields.
+
+### `HistoryWorkflowAdmissionContext`
+
+`AppState` supplies current non-history activity as an immutable value:
+
+```swift
+struct HistoryWorkflowAdmissionContext: Sendable {
+    let isRecording: Bool
+    let isTranscribing: Bool
+    let hasRetryWork: Bool
+    let hasActiveTranscriptionJobs: Bool
+    let hasPendingAudioImports: Bool
+    let hasCloudHistoryWork: Bool
+    let hasMeetingSummaryWork: Bool
+    let hasActiveRecordingJournal: Bool
+    let hasPendingRecordingFinalization: Bool
+    let hasPendingRecordingStart: Bool
+    let hasPendingAudioOnlyStops: Bool
+}
+```
+
+The workflow combines this value with its own state and snapshot catalog to accept or reject archive, import, retention-cancellation, and snapshot-deletion commands.
+
+Typed rejection reasons replace the long inline guard branches. `AppState` maps them onto the same current user messages.
+
+### `HistoryStartupResult`
+
+Startup preparation remains synchronous because `AppState.init` is synchronous and these operations already run synchronously today.
+
+The workflow performs:
+
+1. interrupted transaction rollback,
+2. best-effort expired completed snapshot cleanup when rollback is not unresolved,
+3. archive safety inspection,
+4. active-store construction and readability verification,
+5. recovery catalog loading,
+6. and initial availability/warning derivation.
+
+It returns:
+
+- the originating active store,
+- initial `HistoryWorkflowState`,
+- whether normal history startup work is permitted,
+- and whether unresolved-archive startup work is permitted.
+
+`AppState` uses those decisions to run the existing recording-journal recovery, history load, asset-reference validation, orphan sweep, migration, and cloud reconciliation code. Those already-focused paths do not move in #317.
+
+### `HistoryWorkflowEvent`
+
+The workflow emits typed Main Actor events:
+
+```swift
+enum HistoryWorkflowEvent {
+    case stateChanged(HistoryWorkflowState)
+    case installRuntime(HistoryRuntimeReplacement)
+    case failed(HistoryWorkflowFailure)
+    case performPostAction(HistoryArchivePostAction)
+}
+```
+
+`AppState` installs the event handler after its stored properties have been initialized. Detached work captures only immutable workflow dependencies and input values. Completion returns to the Main Actor before state or runtime events are emitted.
+
+### `HistoryRuntimeReplacement`
+
+Only a verified store may become active.
+
+Runtime replacement has two forms:
+
+- a fresh archive generation, containing the verified active history store plus newly constructed `RecordingJournalStore` and `CloudTranscriptionJobStore`,
+- a recovery import result, containing the verified reopened active history store and reloaded history.
+
+The fresh-generation replacement also ensures active root, audio, transcript, and cloud-job directories are recreated before the workflow reports history as available.
+
+`AppState` applies the replacement synchronously when it receives the event. It then clears only generation-specific UI/runtime collections that it already clears today: pipeline history, retry and import IDs, cloud progress, Meeting Summary generation/reveal state, and warning-banner state.
+
+Event ordering is fixed:
+
+1. prepare and verify the replacement,
+2. emit `installRuntime`,
+3. update and emit idle workflow state,
+4. emit an optional post-action.
+
+This prevents the UI from observing available history before the verified replacement has been installed.
+
+## Data Flow
+
+### Startup
+
+```text
+AppStateDependencies
+  → HistoryArchiveRecoveryWorkflow.prepareStartup()
+      → rollback interrupted archive transactions
+      → retain snapshots on ambiguous rollback failure
+      → remove only expired completed snapshots when safe
+      → inspect archive safety
+      → construct and verify originating active store
+      → list recovery snapshots
+      → return HistoryStartupResult
+  → AppState runs existing allowed startup history/asset/cloud work
+  → AppState initializes published workflow mirrors
+```
+
+An unresolved interrupted transaction prevents normal history loading and mutation even when the SQLite file itself opens successfully. A published unresolved archive may still use the verified fresh active store, but automatic archive cleanup remains suppressed as it is today.
+
+### Archive
+
+```text
+AppState activity snapshot + current store + post-action
+  → workflow admission
+  → detach current store
+  → publish archiving state
+  → detached HistoryArchiveTransition
+  → reopen and verify fresh store
+  → construct fresh runtime replacement
+  → Main Actor installRuntime event
+  → idle state event
+  → optional open-recovery post-action event
+```
+
+The workflow always uses the store factory captured from the originating `AppState`. Later mutation of a test dependency value cannot redirect an active transition.
+
+### Inspection
+
+```text
+catalog refresh
+  → queue ready snapshots not already attempted
+  → capture snapshot ID + active history + inspection revision
+  → detached HistoryRecoveryService.inspectSnapshot
+  → Main Actor completion
+  → ignore stale revision results
+  → refresh catalog and schedule next inspection
+```
+
+Invalidation increments the revision and clears results, queue, and attempted IDs before any conditional rescheduling. Retry moves one eligible snapshot to the front without allowing duplicate concurrent inspection.
+
+### Recovery import
+
+```text
+AppState activity snapshot + snapshot ID + current store
+  → workflow admission
+  → clear prior import feedback
+  → detach current store
+  → publish importing state
+  → detached active-store verification
+  → HistoryRecoveryService.importSnapshot
+  → detach and reopen active store
+  → verify reopened store and reload history
+  → Main Actor installRuntime event
+  → publish partial result only for conflicts/failures
+  → invalidate and reschedule inspection
+```
+
+A missing or changed history row cannot be resurrected by workflow state: import behavior remains delegated to `HistoryRecoveryService`, which preserves UUID conflict and logical-equivalence rules.
+
+### Snapshot operations
+
+Retention cancellation and explicit snapshot deletion run through one typed snapshot-operation path. They do not detach, replace, or reload the active store. Success and failure both refresh archive safety and the catalog; failure preserves the active store and emits the existing snapshot-operation error through `AppState`.
+
+## Admission and Mutation Guards
+
+Archive admission preserves all current blockers:
+
+- history must already require recovery,
+- archive safety must be normal or a published unresolved archive,
+- no archive or mutating recovery operation may already be active,
+- no recording or transcription may be active,
+- no retry, transcription job, audio import, cloud history work, or Meeting Summary generation may be active,
+- no active recording journal may exist,
+- and no recording finalization, recording start, or audio-only stop may be pending.
+
+Recovery import uses the same active-work blockers but requires available durable history and an eligible ready snapshot.
+
+Ordinary history mutations ask the workflow for mutation availability. Archive transition and mutating recovery activity retain their distinct existing messages; unavailable history retains `historyUnavailableMessage`.
+
+Snapshot deletion and retention cancellation continue to require no mutating recovery operation and no current inspection. The extraction does not add new guards that change existing behavior.
+
+## Error Handling and Safety
+
+### Typed failures
+
+`HistoryWorkflowFailure` distinguishes:
+
+- history unavailable,
+- busy/reentrant command rejection,
+- archive transition failure,
+- fresh-store verification failure,
+- recovery inspection failure,
+- recovery import failure,
+- active-store reopen failure,
+- and snapshot operation failure.
+
+The failure carries no API key, transcript content, note content, absolute user path, or durable secret. `AppState` maps each category to the same existing localized user message.
+
+### Store replacement
+
+- A new store is never exposed before availability, durability, and readability verification succeed.
+- Recovery failure installs a reopened store only when that store independently passes the same verification.
+- Snapshot-only failures never replace the active store.
+- Archive rollback ambiguity remains protected as `unresolvedInterruptedTransaction`.
+
+### Data preservation
+
+- Existing archive and recovery schemas remain unchanged.
+- The seven-day completed-snapshot retention policy remains unchanged.
+- Original stores, snapshots, and assets are never deleted on ambiguous failure.
+- Asset copying and conflict handling remain in `HistoryRecoveryService`.
+- Note-asset cleanup remains in `NoteAssetStore` and is not redesigned.
+
+### Concurrency
+
+- Workflow dependencies and command inputs are copied before detached work begins.
+- Every completion returns to the Main Actor.
+- Activity state blocks duplicate mutating operations.
+- Inspection revision tokens discard stale completion.
+- Weak event delivery prevents a detached task from retaining a discarded `AppState` through its adapter.
+
+## AppState Integration
+
+`AppState` gains one instance-owned workflow property. It continues to expose the existing public and `@Published` API used by views and tests.
+
+The following responsibilities leave `AppState`:
+
+- startup rollback, retention, safety inspection, and initial history-state derivation,
+- archive/recovery admission decisions,
+- inspection queue and revision management,
+- detached archive, inspection, import, and snapshot operations,
+- active-store verification and runtime replacement preparation,
+- recovery catalog refresh sequencing,
+- and persistence-state derivation.
+
+The following remain in `AppState`:
+
+- UI-facing command methods with their existing signatures,
+- published state mirrors,
+- current unrelated activity snapshot construction,
+- applying runtime replacement to AppState-owned fields,
+- generation-specific UI collection resets,
+- user-message and Settings-navigation mapping,
+- ordinary history CRUD,
+- recording-journal recovery and note-asset/cloud startup work,
+- and all non-history workflows.
+
+No process-global workflow factory, mutable current workflow, or static dependency override is introduced.
+
+## Testing Strategy
+
+### New workflow tests
+
+Create `Tests/HistoryArchiveRecoveryWorkflowTests.swift` with direct workflow coverage that does not construct the full UI-facing `AppState`.
+
+#### Startup
+
+- normal durable store,
+- unavailable store,
+- interrupted transaction rollback,
+- unresolved interrupted transaction protection,
+- published unresolved archive handling,
+- safe retention cleanup,
+- and retention failure preservation.
+
+#### Archive
+
+- table-driven coverage for every admission blocker,
+- duplicate/reentrant command rejection,
+- originating store-factory capture,
+- successful verified replacement,
+- fresh-store verification failure,
+- archive transition failure,
+- and post-action ordering after runtime installation.
+
+#### Inspection
+
+- ready-snapshot queue ordering,
+- retry prioritization,
+- duplicate prevention,
+- revision invalidation before rescheduling,
+- stale completion rejection,
+- unreadable inspection failure,
+- and continuation to the next snapshot.
+
+#### Recovery import
+
+- success,
+- partial/conflict result publication,
+- missing or invalid snapshot,
+- duplicate/reentrant rejection,
+- reopened active-store verification failure,
+- active-store restoration after operation failure,
+- and snapshot-only failure isolation.
+
+#### Snapshot management
+
+- retention-cancellation success and failure,
+- explicit deletion success and failure,
+- catalog refresh,
+- and inspection resumption.
+
+### Existing low-level tests
+
+`HistoryArchiveTransitionTests` and `HistoryRecoveryServiceTests` remain the authoritative tests for archive durability, rollback, manifest validation, recovery state, asset copying, conflict handling, and retention. The workflow tests do not duplicate their low-level byte and filesystem assertions.
+
+### AppState adapter tests
+
+Keep narrow end-to-end coverage in `AppStateStorageSafetyTests` for:
+
+- workflow state mirrored into existing published properties,
+- explicit archive creating a fresh separated history,
+- archived note import into fresh history,
+- verified replacement applied before availability,
+- archive completion allowing immediate asset saves,
+- recovery operation blocking ordinary mutation,
+- snapshot-only failure preserving the active store,
+- existing user messages,
+- and recovery Settings post-action.
+
+### Source-test reduction
+
+Move the remaining archive guard, inspection invalidation ordering, and import-result clearing assertions from `AppStateHistoryProtectionSourceTests` into workflow behavior tests. Retain only the defense-in-depth source checks whose races or system-call failures cannot be triggered deterministically through the public boundary.
+
+### Required verification
+
+```bash
+make --no-print-directory _test-transcription
+make check-test-wiring
+make test
+make all BUILD_DIR=/tmp/quill-issue317-build CODESIGN_IDENTITY=Quill
+codesign --verify --deep --strict /tmp/quill-issue317-build/Quill.app
+```
+
+The local `/code-review` runs exactly once at medium effort after focused tests, full tests, and the production build are green.
+
+## Migration Order
+
+1. Add workflow state, admission, failure, startup-result, event, and runtime-replacement value types with direct failing tests.
+2. Implement startup preparation and migrate `AppState.init` safety/store decisions.
+3. Implement workflow archive admission, detached transition, verified replacement, and post-action ordering.
+4. Add the AppState event adapter and migrate archive completion/runtime reset.
+5. Move recovery catalog and inspection scheduling into the workflow.
+6. Move import and snapshot operations into the workflow.
+7. Replace obsolete source assertions with behavior coverage.
+8. Run focused, full, build, signing, and one-time review verification.
+
+Each migration stage keeps existing behavior green and lands as an independently reviewable commit.
+
+## Non-goals
+
+- No Core Data schema change.
+- No archive or recovery manifest/state schema change.
+- No snapshot retention-policy change.
+- No note-asset storage redesign.
+- No cloud transcription, retry, or Meeting Summary workflow extraction.
+- No ordinary history CRUD extraction.
+- No recovery UI or user-copy redesign.
+- No general AppState file split.
+- No change to #192's broader domain-store roadmap.
+
+## Acceptance Criteria
+
+- `HistoryArchiveRecoveryWorkflow` is the single owner of archive/recovery orchestration state outside `AppState.swift`.
+- Startup rollback, retention, archive safety, active-store verification, and initial workflow-state derivation use the workflow.
+- Detached archive, inspection, import, and snapshot operations capture immutable originating dependencies.
+- AppState does not directly schedule or complete history archive/recovery disk transitions.
+- Only verified active stores are installed.
+- Snapshot-only failures never replace active history.
+- All current recording/transcription/retry/import/cloud/summary/journal guards remain behavior-tested.
+- Existing published properties, user messages, Settings navigation, schemas, retention, and stored data remain compatible.
+- Source-shape assertions replaced by the workflow are removed.
+- No process-global dependency seam is introduced.
+- Focused tests, full tests, and the signed production build pass.

--- a/docs/superpowers/specs/2026-08-14-history-archive-recovery-workflow-design.md
+++ b/docs/superpowers/specs/2026-08-14-history-archive-recovery-workflow-design.md
@@ -89,7 +89,7 @@ HistoryArchiveRecoveryWorkflow(
 )
 ```
 
-Its initializer may accept optional factories for `HistoryArchiveTransition` and `HistoryRecoveryService` so workflow tests can use deterministic collaborators without adding process-global seams. Production defaults construct the existing concrete types.
+Its instance-owned `HistoryArchiveRecoveryWorkflowDependencies` bundle supplies closure-based archive, recovery, catalog, retention, and store collaborators. Production defaults delegate those closures to the existing `HistoryArchiveTransition` and `HistoryRecoveryService` concrete types, while workflow tests inject deterministic closures without adding process-global seams.
 
 The workflow owns:
 
@@ -305,7 +305,6 @@ Snapshot deletion and retention cancellation continue to require no mutating rec
 `HistoryWorkflowFailure` distinguishes:
 
 - history unavailable,
-- busy/reentrant command rejection,
 - archive transition failure,
 - fresh-store verification failure,
 - recovery inspection failure,
@@ -313,7 +312,9 @@ Snapshot deletion and retention cancellation continue to require no mutating rec
 - active-store reopen failure,
 - and snapshot operation failure.
 
-The failure carries no API key, transcript content, note content, absolute user path, or durable secret. `AppState` maps each category to the same existing localized user message.
+Command admission failures remain separate in `HistoryWorkflowRejection`, including `archiveTransitionInProgress`, `recoveryOperationInProgress`, and `applicationBusy`.
+
+Failures and rejections carry no API key, transcript content, note content, absolute user path, or durable secret. `AppState` maps each category to the same existing localized user message.
 
 ### Store replacement
 


### PR DESCRIPTION
## Summary

- add an instance-owned `HistoryArchiveRecoveryWorkflow` for startup safety, archive transitions, recovery inspection, import, and snapshot operations
- keep `AppState` as the UI-facing adapter while moving detached work, state transitions, verification, and recovery sequencing behind typed commands and events
- replace the remaining archive/recovery source-shape checks with direct workflow behavior coverage and update the recovery UI contract to follow the new owner

## Verification

- `make check-test-wiring`
- `make test`
- signed production build
- `codesign --verify --deep --strict /tmp/quill-issue317-build/Quill.app`

Closes #317


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 기록 보관 및 복구 작업의 시작 준비, 검사, 가져오기, 삭제, 취소 흐름을 안정화했습니다.
  * 작업 중복, 사용 중인 상태, 손상되거나 완료되지 않은 스냅샷을 사전에 확인해 안전하지 않은 작업을 차단합니다.
  * 복구 실패 시 기존 기록과 스냅샷을 보호하고, 상태 및 오류 정보를 일관되게 반영합니다.
  * 최신이 아닌 검사 결과가 현재 상태를 덮어쓰지 않도록 처리했습니다.

* **테스트**
  * 보관·복구 및 스냅샷 작업의 성공, 실패, 재시도, 취소 시나리오 검증을 확대했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->