### PR TITLE
Extract the Meeting Summary generation workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ FULL_SOURCE_APP_STATE_TESTS = \
 	Tests/AppStateHistoryProtectionSourceTests.swift \
 	Tests/AppStateTranscriptionConfigurationTests.swift \
 	Tests/AppStateAIProcessingBackendTests.swift \
+	Tests/MeetingSummaryWorkflowTests.swift \
 	Tests/MeetingSummaryAppStateTests.swift
 GROUPED_TEST_SOURCES = $(FULL_SOURCE_TRANSCRIPTION_TESTS) $(FULL_SOURCE_APP_STATE_TESTS)
 GROUPED_RUNNER_SOURCES = Tests/FullSourceTranscriptionTestRunner.swift Tests/FullSourceAppStateTestRunner.swift

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -6486,7 +6486,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     survivingHistory: []
                 )
             }
-            forgetAllMeetingSummaryGenerationState()
+            meetingSummaryWorkflow.forgetAll()
             forgetAllWarningBannerState()
         } catch {
             errorMessage = LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Unable to clear run history"), providerDetail: error.localizedDescription)
@@ -6515,7 +6515,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 cleanupDeletedPipelineHistoryAssets(deletedAssets)
             }
             pipelineHistory.remove(at: index)
-            forgetMeetingSummaryGenerationState(for: id)
+            meetingSummaryWorkflow.forget(noteID: id)
             forgetWarningBannerState(for: id)
         } catch {
             errorMessage = LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Unable to delete run history entry"), providerDetail: error.localizedDescription)
@@ -6613,21 +6613,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
-    private func invalidateMeetingSummaryGeneration(for id: UUID) {
-        meetingSummaryWorkflow.invalidate(noteID: id)
-    }
-
-    @MainActor
-    private func forgetMeetingSummaryGenerationState(for id: UUID) {
-        meetingSummaryWorkflow.forget(noteID: id)
-    }
-
-    @MainActor
-    private func forgetAllMeetingSummaryGenerationState() {
-        meetingSummaryWorkflow.forgetAll()
-    }
-
-    @MainActor
     func generateMeetingSummary(id: UUID) async throws {
         guard let startItem = pipelineHistory.first(where: { $0.id == id }) else {
             throw MeetingSummaryError.invalidInput
@@ -6711,7 +6696,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             throw QuillUserIssueError.historyPersistenceUnavailable()
         }
         pipelineHistory[noteIndex] = updated
-        invalidateMeetingSummaryGeneration(for: noteID)
+        meetingSummaryWorkflow.invalidate(noteID: noteID)
     }
 
     @MainActor
@@ -6776,7 +6761,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             if let index = pipelineHistory.firstIndex(where: { $0.id == id }) {
                 pipelineHistory[index] = updated
             }
-            invalidateMeetingSummaryGeneration(for: id)
+            meetingSummaryWorkflow.invalidate(noteID: id)
         } catch {
             errorMessage = LocalizedUserMessage.providerFailure(prefix: localizedCatalogString("Failed to save transcript edit"), providerDetail: error.localizedDescription)
         }
@@ -7216,7 +7201,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     self.incrementNoteRetryGeneration(for: snapshot.item.id)
                     self.pipelineHistory = self.pipelineHistoryStore.loadAllHistory()
                     if retrySucceeded {
-                        self.invalidateMeetingSummaryGeneration(for: snapshot.item.id)
+                        self.meetingSummaryWorkflow.invalidate(
+                            noteID: snapshot.item.id
+                        )
                         if snapshot.useLocalTranscription,
                            let cloudContext = snapshot.cloudExecutionContext {
                             self.completeCloudTranscriptionHistory(

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2048,8 +2048,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published var selectedSettingsTab: SettingsTab? = .general
     @Published var pipelineHistory: [PipelineHistoryItem] = []
     @Published private(set) var meetingSummaryGeneratingNoteIDs: Set<UUID> = []
-    private var meetingSummaryGenerationRevisionByID: [UUID: Int] = [:]
-    private var meetingSummaryPendingRevealNoteIDs: Set<UUID> = []
+    private let meetingSummaryWorkflow: MeetingSummaryWorkflow
     @Published var debugStatusMessage = "Idle"
     @Published var debugShowsUpdateReminderAfterDictation = false
     @Published var lastRawTranscript = ""
@@ -2433,8 +2432,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
             storageLayout: storageLayout,
             makeHistoryStore: dependencies.makePipelineHistoryStore
         )
+        let meetingSummaryWorkflow = MeetingSummaryWorkflow(
+            dependencies: MeetingSummaryWorkflowDependencies(
+                makeGenerator: dependencies.makeMeetingSummaryGenerator,
+                now: { Date() }
+            )
+        )
         let historyStartup = historyWorkflow.prepareStartup()
         self.historyWorkflow = historyWorkflow
+        self.meetingSummaryWorkflow = meetingSummaryWorkflow
         pipelineHistoryStore = historyStartup.activeStore
         let audioDirectory = storageLayout.audioDirectory
         recordingJournalStore = RecordingJournalStore(
@@ -3094,6 +3100,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         historyWorkflow.onEvent = { [weak self] event in
             self?.applyHistoryWorkflowEvent(event)
+        }
+        meetingSummaryWorkflow.onEvent = { [weak self] event in
+            self?.applyMeetingSummaryWorkflowEvent(event)
         }
 
         overlayManager.onStopButtonPressed = { [weak self] in
@@ -4910,6 +4919,28 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
+    private func applyMeetingSummaryWorkflowEvent(
+        _ event: MeetingSummaryWorkflowEvent
+    ) {
+        switch event {
+        case .stateChanged(let state):
+            applyMeetingSummaryWorkflowState(state)
+        case .itemPersisted(let item):
+            guard let index = pipelineHistory.firstIndex(where: {
+                $0.id == item.id
+            }) else { return }
+            pipelineHistory[index] = item
+        }
+    }
+
+    @MainActor
+    private func applyMeetingSummaryWorkflowState(
+        _ state: MeetingSummaryWorkflowState
+    ) {
+        meetingSummaryGeneratingNoteIDs = state.generatingNoteIDs
+    }
+
+    @MainActor
     private func applyHistoryWorkflowEvent(
         _ event: HistoryWorkflowEvent
     ) {
@@ -4961,8 +4992,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             retryingItemIDs = []
             pendingAudioImportJobIDs = []
             cloudTranscriptionProgressByHistoryID = [:]
-            meetingSummaryGeneratingNoteIDs = []
-            meetingSummaryPendingRevealNoteIDs = []
+            meetingSummaryWorkflow.forgetAll()
             forgetAllWarningBannerState()
         case .recovered(let historyStore, let history):
             pipelineHistoryStore = historyStore
@@ -6541,167 +6571,60 @@ final class AppState: ObservableObject, @unchecked Sendable {
     func meetingSummarySource(
         for item: PipelineHistoryItem
     ) -> MeetingSummarySource {
-        meetingSummarySource(
-            for: item,
-            languageContext: MeetingSummaryLanguageContext(
-                requestedOutputLanguage: "",
-                appliedLanguageCode: "",
-                resolutionSource: .unavailable
-            )
+        MeetingSummaryWorkflow.availabilitySource(for: item)
+    }
+
+    @MainActor
+    private func meetingSummaryWorkflowRequest(
+        for item: PipelineHistoryItem
+    ) -> MeetingSummaryWorkflowRequest {
+        let backendKind: MeetingSummaryBackendKind =
+            meetingSummaryBackendChoice.isLocal ? .local : .cloud
+        return MeetingSummaryWorkflowRequest(
+            noteID: item.id,
+            initialItem: item,
+            requestedOutputLanguage: meetingSummaryOutputLanguage,
+            configuredBackendKind: backendKind,
+            configuredModelID: meetingSummaryBackendChoice.modelID,
+            providerHost: backendKind == .cloud
+                ? URL(string: apiBaseURL)?.host
+                : nil,
+            generatorConfiguration: meetingSummaryGeneratorConfiguration()
         )
     }
 
     @MainActor
-    private func meetingSummarySource(
-        for item: PipelineHistoryItem,
-        languageContext: MeetingSummaryLanguageContext
-    ) -> MeetingSummarySource {
-        let calendar = item.calendarMatch.map { match in
-            MeetingSummaryCalendarContext(
-                title: match.title,
-                start: match.start,
-                end: match.end,
-                attendees: match.attendees.compactMap { attendee in
-                    let name = attendee.displayName?.trimmingCharacters(
-                        in: .whitespacesAndNewlines
-                    ) ?? ""
-                    if !name.isEmpty { return name }
-                    let email = attendee.email?.trimmingCharacters(
-                        in: .whitespacesAndNewlines
-                    ) ?? ""
-                    return email.isEmpty ? nil : email
-                }
-            )
-        }
-        return MeetingSummarySource(
-            transcript: meetingSummaryTranscript(for: item),
-            calendar: calendar,
-            languageContext: languageContext
+    private func meetingSummaryHistoryAccess()
+        -> MeetingSummaryHistoryAccess
+    {
+        let store = pipelineHistoryStore
+        return MeetingSummaryHistoryAccess(
+            durability: { store.durability },
+            item: { id in
+                store.loadAllHistory().first(where: { $0.id == id })
+            },
+            persist: { item, requiresDurableStore in
+                try store.update(
+                    item,
+                    requiresDurableStore: requiresDurableStore
+                )
+            }
         )
-    }
-
-    @MainActor
-    private func meetingSummaryTranscript(for item: PipelineHistoryItem) -> String {
-        let processed = item.postProcessedTranscript.trimmingCharacters(
-            in: .whitespacesAndNewlines
-        )
-        return processed.isEmpty ? item.rawTranscript : processed
-    }
-
-    @MainActor
-    func resolvedMeetingSummaryLanguage(
-        for item: PipelineHistoryItem,
-        transcript: String
-    ) throws -> (
-        context: MeetingSummaryLanguageContext,
-        resolvedSpokenLanguage: SpokenLanguageResolution?
-    ) {
-        let requested = meetingSummaryOutputLanguage.trimmingCharacters(
-            in: .whitespacesAndNewlines
-        )
-        if let explicitCode = TranscriptionLanguage.code(forSummaryOutput: requested) {
-            return (
-                MeetingSummaryLanguageContext(
-                    requestedOutputLanguage: requested,
-                    appliedLanguageCode: explicitCode,
-                    resolutionSource: .configured
-                ),
-                nil
-            )
-        }
-        let existingSpokenLanguage = item.spokenLanguage
-        let requiresTranscriptResolution = existingSpokenLanguage?.source == .transcriptInferred
-            || existingSpokenLanguage?.source == .unavailable
-        let spoken = requiresTranscriptResolution
-            ? SpokenLanguageResolver.resolve(
-                requestedLanguageCode: item.transcriptionLanguageCode,
-                engineLanguageCode: nil,
-                transcript: transcript
-            )
-            : existingSpokenLanguage ?? SpokenLanguageResolver.resolve(
-                requestedLanguageCode: item.transcriptionLanguageCode,
-                engineLanguageCode: nil,
-                transcript: transcript
-            )
-        guard let code = spoken.languageCode else {
-            throw QuillUserIssueError.meetingSummaryLanguageUnavailable()
-        }
-        return (
-            MeetingSummaryLanguageContext(
-                requestedOutputLanguage: "",
-                appliedLanguageCode: code,
-                resolutionSource: spoken.source
-            ),
-            requiresTranscriptResolution || existingSpokenLanguage == nil
-                ? spoken
-                : nil
-        )
-    }
-
-    @MainActor
-    private func meetingSummaryProviderHost(
-        for backendKind: MeetingSummaryBackendKind
-    ) -> String? {
-        guard backendKind == .cloud else { return nil }
-        return URL(string: apiBaseURL)?.host
-    }
-
-    @MainActor
-    private func meetingSummaryIssue(
-        for error: Error,
-        providerHost: String?,
-        backendKind: MeetingSummaryBackendKind,
-        modelID: String
-    ) -> QuillUserIssueRecord {
-        if let issue = error as? QuillUserIssueError {
-            return issue.record
-        }
-        let localBackend = backendKind == .local ? "Local AI" : nil
-        if let summaryError = error as? MeetingSummaryError {
-            return summaryError.userIssue(
-                providerHost: providerHost,
-                modelID: modelID,
-                localBackend: localBackend
-            )
-        }
-        return QuillUserIssueRecord(
-            code: .meetingSummaryUnavailable,
-            context: QuillUserIssueContext(
-                providerHost: providerHost,
-                modelID: modelID,
-                localBackend: localBackend
-            )
-        )
-    }
-
-    @MainActor
-    private func persistMeetingSummaryHistoryItem(
-        _ item: PipelineHistoryItem,
-        at index: Int
-    ) throws {
-        try pipelineHistoryStore.update(item, requiresDurableStore: true)
-        pipelineHistory[index] = item
     }
 
     @MainActor
     private func invalidateMeetingSummaryGeneration(for id: UUID) {
-        meetingSummaryGenerationRevisionByID[id, default: 0] += 1
-        meetingSummaryGeneratingNoteIDs.remove(id)
-        meetingSummaryPendingRevealNoteIDs.remove(id)
+        meetingSummaryWorkflow.invalidate(noteID: id)
     }
 
     @MainActor
     private func forgetMeetingSummaryGenerationState(for id: UUID) {
-        meetingSummaryGenerationRevisionByID.removeValue(forKey: id)
-        meetingSummaryGeneratingNoteIDs.remove(id)
-        meetingSummaryPendingRevealNoteIDs.remove(id)
+        meetingSummaryWorkflow.forget(noteID: id)
     }
 
     @MainActor
     private func forgetAllMeetingSummaryGenerationState() {
-        meetingSummaryGenerationRevisionByID.removeAll()
-        meetingSummaryGeneratingNoteIDs.removeAll()
-        meetingSummaryPendingRevealNoteIDs.removeAll()
+        meetingSummaryWorkflow.forgetAll()
     }
 
     @MainActor
@@ -6712,163 +6635,28 @@ final class AppState: ObservableObject, @unchecked Sendable {
         guard meetingSummaryAvailability(for: startItem) == .available else {
             throw MeetingSummaryError.invalidInput
         }
-        switch pipelineHistoryStore.durability {
-        case .durable:
-            break
-        case .inMemory:
-            throw QuillUserIssueError.historyPersistenceUnavailable()
-        }
 
-        let configuredBackendKind: MeetingSummaryBackendKind = meetingSummaryBackendChoice.isLocal
-            ? .local
-            : .cloud
-        let configuredModelID = meetingSummaryBackendChoice.modelID
-        let generationRevision = meetingSummaryGenerationRevisionByID[id, default: 0]
-        var languageContext: MeetingSummaryLanguageContext?
-        var attemptSourceFingerprint = meetingSummarySource(for: startItem).fingerprint
-        meetingSummaryGeneratingNoteIDs.insert(id)
-        defer {
-            if meetingSummaryGenerationRevisionByID[id, default: 0] == generationRevision {
-                meetingSummaryGeneratingNoteIDs.remove(id)
-            }
-        }
-
-        let source: MeetingSummarySource
-        let result: MeetingSummaryGenerationResult
-        let currentIndex: Int
-        let currentItem: PipelineHistoryItem
-        do {
-            let transcript = meetingSummaryTranscript(for: startItem)
-            let resolvedLanguage = try resolvedMeetingSummaryLanguage(
-                for: startItem,
-                transcript: transcript
-            )
-            languageContext = resolvedLanguage.context
-
-            var sourceItem = startItem
-            if let spokenLanguage = resolvedLanguage.resolvedSpokenLanguage {
-                guard let sourceIndex = pipelineHistory.firstIndex(
-                    where: { $0.id == id }
-                ) else {
-                    throw MeetingSummaryError.sourceChanged
-                }
-                let updated = pipelineHistory[sourceIndex].withSpokenLanguage(
-                    spokenLanguage
-                )
-                try persistMeetingSummaryHistoryItem(
-                    updated,
-                    at: sourceIndex
-                )
-                sourceItem = updated
-            }
-
-            source = meetingSummarySource(
-                for: sourceItem,
-                languageContext: resolvedLanguage.context
-            )
-            attemptSourceFingerprint = source.fingerprint
-            result = try await dependencies.makeMeetingSummaryGenerator(
-                meetingSummaryGeneratorConfiguration()
-            ).generate(source: source)
-
-            guard let index = pipelineHistory.firstIndex(where: { $0.id == id }) else {
-                throw MeetingSummaryError.sourceChanged
-            }
-            let item = pipelineHistory[index]
-            guard meetingSummaryGenerationRevisionByID[id, default: 0] == generationRevision,
-                  meetingSummarySource(for: item).fingerprint == source.fingerprint else {
-                throw MeetingSummaryError.sourceChanged
-            }
-            currentIndex = index
-            currentItem = item
-        } catch {
-            guard let currentIndex = pipelineHistory.firstIndex(
-                where: { $0.id == id }
-            ), meetingSummaryGenerationRevisionByID[id, default: 0] == generationRevision,
-              meetingSummarySource(for: pipelineHistory[currentIndex]).fingerprint
-                == attemptSourceFingerprint else {
-                throw MeetingSummaryError.sourceChanged
-            }
-            if let summaryError = error as? MeetingSummaryError,
-               summaryError == .sourceChanged {
-                throw summaryError
-            }
-            let index = currentIndex
-            do {
-                let providerHost = meetingSummaryProviderHost(
-                    for: configuredBackendKind
-                )
-                let effectiveModelID = (error as? MeetingSummaryError)
-                    .map { $0.effectiveModelID(fallback: configuredModelID) }
-                    ?? configuredModelID
-                let attempt = MeetingSummaryAttempt(
-                    occurredAt: Date(),
-                    outcome: .failed,
-                    backendKind: configuredBackendKind,
-                    modelID: effectiveModelID,
-                    providerHost: providerHost,
-                    language: languageContext,
-                    issue: meetingSummaryIssue(
-                        for: error,
-                        providerHost: providerHost,
-                        backendKind: configuredBackendKind,
-                        modelID: effectiveModelID
-                    ),
-                    sourceFingerprint: attemptSourceFingerprint
-                )
-                let updated = pipelineHistory[index].withMeetingSummaryAttempt(attempt)
-                do {
-                    try persistMeetingSummaryHistoryItem(
-                        updated,
-                        at: index
-                    )
-                } catch {
-                    throw QuillUserIssueError.historyPersistenceUnavailable()
-                }
-            }
-            throw error
-        }
-
-        let envelope = MeetingSummaryEnvelope(
-            schemaVersion: MeetingSummaryEnvelope.currentSchemaVersion,
-            promptVersion: result.promptVersion,
-            generatedAt: Date(),
-            sourceFingerprint: source.fingerprint,
-            modelID: result.modelID,
-            backendKind: result.backendKind,
-            languageContext: source.languageContext,
-            evidenceVerification: result.evidenceVerification == .unverified
-                ? .unverified
-                : nil,
-            content: result.draft.materialized()
-        ).preservingCompletion(from: currentItem.meetingSummary)
-        let attempt = MeetingSummaryAttempt(
-            occurredAt: Date(),
-            outcome: .succeeded,
-            backendKind: result.backendKind,
-            modelID: result.modelID,
-            providerHost: meetingSummaryProviderHost(for: result.backendKind),
-            language: source.languageContext,
-            issue: nil,
-            sourceFingerprint: source.fingerprint
+        let outcome = await meetingSummaryWorkflow.generate(
+            request: meetingSummaryWorkflowRequest(for: startItem),
+            history: meetingSummaryHistoryAccess()
         )
-        let updated = currentItem
-            .withMeetingSummary(envelope)
-            .withMeetingSummaryAttempt(attempt)
-        do {
-            try persistMeetingSummaryHistoryItem(
-                updated,
-                at: currentIndex
-            )
-            meetingSummaryPendingRevealNoteIDs.insert(id)
-        } catch {
+        switch outcome {
+        case .verifiedSuccess, .unverifiedSuccess:
+            return
+        case .invalidInput:
+            throw MeetingSummaryError.invalidInput
+        case .sourceChanged:
+            throw MeetingSummaryError.sourceChanged
+        case .generationFailed(let error):
+            throw error
+        case .persistenceFailed:
             throw QuillUserIssueError.historyPersistenceUnavailable()
         }
     }
 
     @MainActor
     func consumeMeetingSummaryPendingReveal(id: UUID) -> Bool {
-        meetingSummaryPendingRevealNoteIDs.remove(id) != nil
+        meetingSummaryWorkflow.consumePendingReveal(noteID: id)
     }
 
     @MainActor

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -4464,8 +4464,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         )
     }
 
-    func makeMeetingSummaryService() -> MeetingSummaryService {
-        MeetingSummaryService(
+    @MainActor
+    private func meetingSummaryGeneratorConfiguration()
+        -> MeetingSummaryGeneratorConfiguration
+    {
+        MeetingSummaryGeneratorConfiguration(
             backendExecutor: makeAIProcessingBackendExecutor(
                 choice: meetingSummaryBackendChoice
             ),
@@ -6764,8 +6767,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 languageContext: resolvedLanguage.context
             )
             attemptSourceFingerprint = source.fingerprint
-            result = try await dependencies.makeMeetingSummaryGenerator(self)
-                .generate(source: source)
+            result = try await dependencies.makeMeetingSummaryGenerator(
+                meetingSummaryGeneratorConfiguration()
+            ).generate(source: source)
 
             guard let index = pipelineHistory.firstIndex(where: { $0.id == id }) else {
                 throw MeetingSummaryError.sourceChanged

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -6601,7 +6601,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         return MeetingSummaryHistoryAccess(
             durability: { store.durability },
             item: { id in
-                store.loadAllHistory().first(where: { $0.id == id })
+                let history = store.loadAllHistory()
+                guard store.availability == .ready else {
+                    throw PipelineHistoryStoreError.storeUnavailable
+                }
+                return history.first(where: { $0.id == id })
             },
             persist: { item, requiresDurableStore in
                 try store.update(

--- a/Sources/AppStateDependencies.swift
+++ b/Sources/AppStateDependencies.swift
@@ -122,7 +122,8 @@ struct AppStateDependencies {
     var makePipelineHistoryStore:
         @Sendable (URL) -> PipelineHistoryStore
     var makeMeetingSummaryGenerator:
-        @MainActor (AppState) -> any MeetingSummaryGenerating
+        @MainActor (MeetingSummaryGeneratorConfiguration)
+            -> any MeetingSummaryGenerating
     var makeRetryCloudTranscriptionDependencies:
         @Sendable () -> CloudTranscriptionDependencies
 
@@ -133,8 +134,11 @@ struct AppStateDependencies {
             localAI: .live,
             nativeWhisper: .live,
             makePipelineHistoryStore: { PipelineHistoryStore(storeURL: $0) },
-            makeMeetingSummaryGenerator: { appState in
-                appState.makeMeetingSummaryService()
+            makeMeetingSummaryGenerator: { configuration in
+                MeetingSummaryService(
+                    backendExecutor: configuration.backendExecutor,
+                    cloudFallbackModelID: configuration.cloudFallbackModelID
+                )
             },
             makeRetryCloudTranscriptionDependencies: { .live }
         )

--- a/Sources/MeetingSummaryWorkflow.swift
+++ b/Sources/MeetingSummaryWorkflow.swift
@@ -103,19 +103,14 @@ final class MeetingSummaryWorkflow {
                 requestedOutputLanguage: request.requestedOutputLanguage
             )
         } catch {
-            guard isCurrent(
-                noteID: request.noteID,
+            return persistFailure(
+                error,
+                request: request,
+                history: history,
                 revision: generationRevision,
-                sourceFingerprint: initialFingerprint,
-                history: history
-            ) else {
-                return .sourceChanged
-            }
-            finishGeneration(
-                noteID: request.noteID,
-                revision: generationRevision
+                languageContext: nil,
+                sourceFingerprint: initialFingerprint
             )
-            return .generationFailed(error)
         }
 
         var sourceItem = initialItem
@@ -153,23 +148,14 @@ final class MeetingSummaryWorkflow {
         do {
             result = try await generator.generate(source: source)
         } catch {
-            guard isCurrent(
-                noteID: request.noteID,
+            return persistFailure(
+                error,
+                request: request,
+                history: history,
                 revision: generationRevision,
-                sourceFingerprint: source.fingerprint,
-                history: history
-            ) else {
-                return .sourceChanged
-            }
-            finishGeneration(
-                noteID: request.noteID,
-                revision: generationRevision
+                languageContext: source.languageContext,
+                sourceFingerprint: source.fingerprint
             )
-            if let summaryError = error as? MeetingSummaryError,
-               summaryError == .sourceChanged {
-                return .sourceChanged
-            }
-            return .generationFailed(error)
         }
 
         guard let currentItem = currentItem(
@@ -361,6 +347,89 @@ final class MeetingSummaryWorkflow {
         configuredProviderHost: String?
     ) -> String? {
         backendKind == .cloud ? configuredProviderHost : nil
+    }
+
+    static func issue(
+        for error: Error,
+        providerHost: String?,
+        backendKind: MeetingSummaryBackendKind,
+        modelID: String
+    ) -> QuillUserIssueRecord {
+        if let issue = error as? QuillUserIssueError {
+            return issue.record
+        }
+        let localBackend = backendKind == .local ? "Local AI" : nil
+        if let summaryError = error as? MeetingSummaryError {
+            return summaryError.userIssue(
+                providerHost: providerHost,
+                modelID: modelID,
+                localBackend: localBackend
+            )
+        }
+        return QuillUserIssueRecord(
+            code: .meetingSummaryUnavailable,
+            context: QuillUserIssueContext(
+                providerHost: providerHost,
+                modelID: modelID,
+                localBackend: localBackend
+            )
+        )
+    }
+
+    private func persistFailure(
+        _ error: Error,
+        request: MeetingSummaryWorkflowRequest,
+        history: MeetingSummaryHistoryAccess,
+        revision: Int,
+        languageContext: MeetingSummaryLanguageContext?,
+        sourceFingerprint: String
+    ) -> MeetingSummaryWorkflowOutcome {
+        guard let currentItem = currentItem(
+            noteID: request.noteID,
+            revision: revision,
+            sourceFingerprint: sourceFingerprint,
+            history: history
+        ) else {
+            return .sourceChanged
+        }
+        if let summaryError = error as? MeetingSummaryError,
+           summaryError == .sourceChanged {
+            finishGeneration(noteID: request.noteID, revision: revision)
+            return .sourceChanged
+        }
+
+        let effectiveModelID = (error as? MeetingSummaryError)
+            .map { $0.effectiveModelID(fallback: request.configuredModelID) }
+            ?? request.configuredModelID
+        let providerHost = Self.providerHost(
+            backendKind: request.configuredBackendKind,
+            configuredProviderHost: request.providerHost
+        )
+        let attempt = MeetingSummaryAttempt(
+            occurredAt: dependencies.now(),
+            outcome: .failed,
+            backendKind: request.configuredBackendKind,
+            modelID: effectiveModelID,
+            providerHost: providerHost,
+            language: languageContext,
+            issue: Self.issue(
+                for: error,
+                providerHost: providerHost,
+                backendKind: request.configuredBackendKind,
+                modelID: effectiveModelID
+            ),
+            sourceFingerprint: sourceFingerprint
+        )
+        let updated = currentItem.withMeetingSummaryAttempt(attempt)
+        do {
+            try history.persist(updated, true)
+        } catch {
+            finishGeneration(noteID: request.noteID, revision: revision)
+            return .persistenceFailed
+        }
+        onEvent?(.itemPersisted(updated))
+        finishGeneration(noteID: request.noteID, revision: revision)
+        return .generationFailed(error)
     }
 
     private func currentItem(

--- a/Sources/MeetingSummaryWorkflow.swift
+++ b/Sources/MeetingSummaryWorkflow.swift
@@ -26,7 +26,7 @@ struct MeetingSummaryHistoryAccess {
     var durability:
         @MainActor @Sendable () -> PipelineHistoryDurability
     var item:
-        @MainActor @Sendable (UUID) -> PipelineHistoryItem?
+        @MainActor @Sendable (UUID) throws -> PipelineHistoryItem?
     var persist:
         @MainActor @Sendable (PipelineHistoryItem, Bool) throws -> Void
 }
@@ -52,6 +52,12 @@ enum MeetingSummaryWorkflowOutcome {
     case invalidInput
     case sourceChanged
     case generationFailed(Error)
+    case persistenceFailed
+}
+
+private enum MeetingSummaryCurrentItemValidation {
+    case current(PipelineHistoryItem)
+    case stale
     case persistenceFailed
 }
 
@@ -111,17 +117,27 @@ final class MeetingSummaryWorkflow: @unchecked Sendable {
 
         var sourceItem = initialItem
         if let spokenLanguage = resolvedLanguage.resolvedSpokenLanguage {
-            guard let currentItem = currentItem(
+            let currentItem: PipelineHistoryItem
+            switch validateCurrentItem(
                 noteID: request.noteID,
                 revision: generationRevision,
                 sourceFingerprint: initialFingerprint,
                 history: history
-            ) else {
+            ) {
+            case .current(let item):
+                currentItem = item
+            case .stale:
                 finishGeneration(
                     noteID: request.noteID,
                     revision: generationRevision
                 )
                 return .sourceChanged
+            case .persistenceFailed:
+                finishGeneration(
+                    noteID: request.noteID,
+                    revision: generationRevision
+                )
+                return .persistenceFailed
             }
             let updated = currentItem.withSpokenLanguage(spokenLanguage)
             do {
@@ -158,17 +174,27 @@ final class MeetingSummaryWorkflow: @unchecked Sendable {
             )
         }
 
-        guard let currentItem = currentItem(
+        let currentItem: PipelineHistoryItem
+        switch validateCurrentItem(
             noteID: request.noteID,
             revision: generationRevision,
             sourceFingerprint: source.fingerprint,
             history: history
-        ) else {
+        ) {
+        case .current(let item):
+            currentItem = item
+        case .stale:
             finishGeneration(
                 noteID: request.noteID,
                 revision: generationRevision
             )
             return .sourceChanged
+        case .persistenceFailed:
+            finishGeneration(
+                noteID: request.noteID,
+                revision: generationRevision
+            )
+            return .persistenceFailed
         }
         let envelope = MeetingSummaryEnvelope(
             schemaVersion: MeetingSummaryEnvelope.currentSchemaVersion,
@@ -393,14 +419,21 @@ final class MeetingSummaryWorkflow: @unchecked Sendable {
         languageContext: MeetingSummaryLanguageContext?,
         sourceFingerprint: String
     ) -> MeetingSummaryWorkflowOutcome {
-        guard let currentItem = currentItem(
+        let currentItem: PipelineHistoryItem
+        switch validateCurrentItem(
             noteID: request.noteID,
             revision: revision,
             sourceFingerprint: sourceFingerprint,
             history: history
-        ) else {
+        ) {
+        case .current(let item):
+            currentItem = item
+        case .stale:
             finishGeneration(noteID: request.noteID, revision: revision)
             return .sourceChanged
+        case .persistenceFailed:
+            finishGeneration(noteID: request.noteID, revision: revision)
+            return .persistenceFailed
         }
         if let summaryError = error as? MeetingSummaryError,
            summaryError == .sourceChanged {
@@ -443,19 +476,29 @@ final class MeetingSummaryWorkflow: @unchecked Sendable {
     }
 
     @MainActor
-    private func currentItem(
+    private func validateCurrentItem(
         noteID: UUID,
         revision: Int,
         sourceFingerprint: String,
         history: MeetingSummaryHistoryAccess
-    ) -> PipelineHistoryItem? {
-        guard generationRevisionByID[noteID] == revision,
-              let item = history.item(noteID),
-              Self.availabilitySource(for: item).fingerprint
-                == sourceFingerprint else {
-            return nil
+    ) -> MeetingSummaryCurrentItemValidation {
+        guard generationRevisionByID[noteID] == revision else {
+            return .stale
         }
-        return item
+        let item: PipelineHistoryItem
+        do {
+            guard let loadedItem = try history.item(noteID) else {
+                return .stale
+            }
+            item = loadedItem
+        } catch {
+            return .persistenceFailed
+        }
+        guard Self.availabilitySource(for: item).fingerprint
+                == sourceFingerprint else {
+            return .stale
+        }
+        return .current(item)
     }
 
     @MainActor

--- a/Sources/MeetingSummaryWorkflow.swift
+++ b/Sources/MeetingSummaryWorkflow.swift
@@ -55,17 +55,18 @@ enum MeetingSummaryWorkflowOutcome {
     case persistenceFailed
 }
 
-@MainActor
-final class MeetingSummaryWorkflow {
+final class MeetingSummaryWorkflow: @unchecked Sendable {
     private let dependencies: MeetingSummaryWorkflowDependencies
-    private var generationRevisionByID: [UUID: Int] = [:]
-    private(set) var state = MeetingSummaryWorkflowState.initial
-    var onEvent: ((MeetingSummaryWorkflowEvent) -> Void)?
+    @MainActor private var generationRevisionByID: [UUID: Int] = [:]
+    @MainActor private(set) var state = MeetingSummaryWorkflowState.initial
+    nonisolated(unsafe) var onEvent:
+        (@MainActor (MeetingSummaryWorkflowEvent) -> Void)?
 
     init(dependencies: MeetingSummaryWorkflowDependencies) {
         self.dependencies = dependencies
     }
 
+    @MainActor
     func generate(
         request: MeetingSummaryWorkflowRequest,
         history: MeetingSummaryHistoryAccess
@@ -73,16 +74,10 @@ final class MeetingSummaryWorkflow {
         guard history.durability() == .durable else {
             return .persistenceFailed
         }
-        guard let initialItem = history.item(request.noteID) else {
-            return .invalidInput
-        }
+        let initialItem = request.initialItem
         let initialFingerprint = Self.availabilitySource(
-            for: request.initialItem
+            for: initialItem
         ).fingerprint
-        guard Self.availabilitySource(for: initialItem).fingerprint
-                == initialFingerprint else {
-            return .sourceChanged
-        }
 
         let generationRevision = generationRevisionByID[
             request.noteID,
@@ -224,6 +219,7 @@ final class MeetingSummaryWorkflow {
             : .verifiedSuccess
     }
 
+    @MainActor
     func invalidate(noteID: UUID) {
         generationRevisionByID[noteID, default: 0] += 1
         state.generatingNoteIDs.remove(noteID)
@@ -231,6 +227,7 @@ final class MeetingSummaryWorkflow {
         emitState()
     }
 
+    @MainActor
     func forget(noteID: UUID) {
         generationRevisionByID.removeValue(forKey: noteID)
         state.generatingNoteIDs.remove(noteID)
@@ -238,12 +235,14 @@ final class MeetingSummaryWorkflow {
         emitState()
     }
 
+    @MainActor
     func forgetAll() {
         generationRevisionByID.removeAll()
         state = .initial
         emitState()
     }
 
+    @MainActor
     func consumePendingReveal(noteID: UUID) -> Bool {
         let consumed = state.pendingRevealNoteIDs.remove(noteID) != nil
         if consumed { emitState() }
@@ -385,6 +384,7 @@ final class MeetingSummaryWorkflow {
         )
     }
 
+    @MainActor
     private func persistFailure(
         _ error: Error,
         request: MeetingSummaryWorkflowRequest,
@@ -442,6 +442,7 @@ final class MeetingSummaryWorkflow {
         return .generationFailed(error)
     }
 
+    @MainActor
     private func currentItem(
         noteID: UUID,
         revision: Int,
@@ -457,6 +458,7 @@ final class MeetingSummaryWorkflow {
         return item
     }
 
+    @MainActor
     private func finishGeneration(
         noteID: UUID,
         revision: Int,
@@ -472,6 +474,7 @@ final class MeetingSummaryWorkflow {
         emitState()
     }
 
+    @MainActor
     private func emitState() {
         onEvent?(.stateChanged(state))
     }

--- a/Sources/MeetingSummaryWorkflow.swift
+++ b/Sources/MeetingSummaryWorkflow.swift
@@ -66,6 +66,169 @@ final class MeetingSummaryWorkflow {
         self.dependencies = dependencies
     }
 
+    func generate(
+        request: MeetingSummaryWorkflowRequest,
+        history: MeetingSummaryHistoryAccess
+    ) async -> MeetingSummaryWorkflowOutcome {
+        guard history.durability() == .durable else {
+            return .persistenceFailed
+        }
+        guard let initialItem = history.item(request.noteID) else {
+            return .invalidInput
+        }
+        let initialFingerprint = Self.availabilitySource(
+            for: request.initialItem
+        ).fingerprint
+        guard Self.availabilitySource(for: initialItem).fingerprint
+                == initialFingerprint else {
+            return .sourceChanged
+        }
+
+        let generationRevision = generationRevisionByID[
+            request.noteID,
+            default: 0
+        ]
+        state.generatingNoteIDs.insert(request.noteID)
+        emitState()
+
+        let transcript = Self.transcript(for: initialItem)
+        let resolvedLanguage: (
+            context: MeetingSummaryLanguageContext,
+            resolvedSpokenLanguage: SpokenLanguageResolution?
+        )
+        do {
+            resolvedLanguage = try Self.resolvedLanguage(
+                for: initialItem,
+                transcript: transcript,
+                requestedOutputLanguage: request.requestedOutputLanguage
+            )
+        } catch {
+            guard isCurrent(
+                noteID: request.noteID,
+                revision: generationRevision,
+                sourceFingerprint: initialFingerprint,
+                history: history
+            ) else {
+                return .sourceChanged
+            }
+            finishGeneration(
+                noteID: request.noteID,
+                revision: generationRevision
+            )
+            return .generationFailed(error)
+        }
+
+        var sourceItem = initialItem
+        if let spokenLanguage = resolvedLanguage.resolvedSpokenLanguage {
+            guard let currentItem = currentItem(
+                noteID: request.noteID,
+                revision: generationRevision,
+                sourceFingerprint: initialFingerprint,
+                history: history
+            ) else {
+                return .sourceChanged
+            }
+            let updated = currentItem.withSpokenLanguage(spokenLanguage)
+            do {
+                try history.persist(updated, true)
+            } catch {
+                finishGeneration(
+                    noteID: request.noteID,
+                    revision: generationRevision
+                )
+                return .persistenceFailed
+            }
+            onEvent?(.itemPersisted(updated))
+            sourceItem = updated
+        }
+
+        let source = Self.source(
+            for: sourceItem,
+            languageContext: resolvedLanguage.context
+        )
+        let generator = dependencies.makeGenerator(
+            request.generatorConfiguration
+        )
+        let result: MeetingSummaryGenerationResult
+        do {
+            result = try await generator.generate(source: source)
+        } catch {
+            guard isCurrent(
+                noteID: request.noteID,
+                revision: generationRevision,
+                sourceFingerprint: source.fingerprint,
+                history: history
+            ) else {
+                return .sourceChanged
+            }
+            finishGeneration(
+                noteID: request.noteID,
+                revision: generationRevision
+            )
+            if let summaryError = error as? MeetingSummaryError,
+               summaryError == .sourceChanged {
+                return .sourceChanged
+            }
+            return .generationFailed(error)
+        }
+
+        guard let currentItem = currentItem(
+            noteID: request.noteID,
+            revision: generationRevision,
+            sourceFingerprint: source.fingerprint,
+            history: history
+        ) else {
+            return .sourceChanged
+        }
+        let envelope = MeetingSummaryEnvelope(
+            schemaVersion: MeetingSummaryEnvelope.currentSchemaVersion,
+            promptVersion: result.promptVersion,
+            generatedAt: dependencies.now(),
+            sourceFingerprint: source.fingerprint,
+            modelID: result.modelID,
+            backendKind: result.backendKind,
+            languageContext: source.languageContext,
+            evidenceVerification: result.evidenceVerification == .unverified
+                ? .unverified
+                : nil,
+            content: result.draft.materialized()
+        ).preservingCompletion(from: currentItem.meetingSummary)
+        let attempt = MeetingSummaryAttempt(
+            occurredAt: dependencies.now(),
+            outcome: .succeeded,
+            backendKind: result.backendKind,
+            modelID: result.modelID,
+            providerHost: Self.providerHost(
+                backendKind: result.backendKind,
+                configuredProviderHost: request.providerHost
+            ),
+            language: source.languageContext,
+            issue: nil,
+            sourceFingerprint: source.fingerprint
+        )
+        let updated = currentItem
+            .withMeetingSummary(envelope)
+            .withMeetingSummaryAttempt(attempt)
+        do {
+            try history.persist(updated, true)
+        } catch {
+            finishGeneration(
+                noteID: request.noteID,
+                revision: generationRevision
+            )
+            return .persistenceFailed
+        }
+        onEvent?(.itemPersisted(updated))
+        finishGeneration(
+            noteID: request.noteID,
+            revision: generationRevision,
+            pendingReveal: true
+        )
+        return result.evidenceVerification == .unverified
+            ? .unverifiedSuccess
+            : .verifiedSuccess
+    }
+
     func invalidate(noteID: UUID) {
         generationRevisionByID[noteID, default: 0] += 1
         state.generatingNoteIDs.remove(noteID)
@@ -90,6 +253,158 @@ final class MeetingSummaryWorkflow {
         let consumed = state.pendingRevealNoteIDs.remove(noteID) != nil
         if consumed { emitState() }
         return consumed
+    }
+
+    static func transcript(for item: PipelineHistoryItem) -> String {
+        let processed = item.postProcessedTranscript.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        return processed.isEmpty ? item.rawTranscript : processed
+    }
+
+    static func source(
+        for item: PipelineHistoryItem,
+        languageContext: MeetingSummaryLanguageContext
+    ) -> MeetingSummarySource {
+        let calendar = item.calendarMatch.map { match in
+            MeetingSummaryCalendarContext(
+                title: match.title,
+                start: match.start,
+                end: match.end,
+                attendees: match.attendees.compactMap { attendee in
+                    let name = attendee.displayName?.trimmingCharacters(
+                        in: .whitespacesAndNewlines
+                    ) ?? ""
+                    if !name.isEmpty { return name }
+                    let email = attendee.email?.trimmingCharacters(
+                        in: .whitespacesAndNewlines
+                    ) ?? ""
+                    return email.isEmpty ? nil : email
+                }
+            )
+        }
+        return MeetingSummarySource(
+            transcript: transcript(for: item),
+            calendar: calendar,
+            languageContext: languageContext
+        )
+    }
+
+    static func availabilitySource(
+        for item: PipelineHistoryItem
+    ) -> MeetingSummarySource {
+        source(
+            for: item,
+            languageContext: MeetingSummaryLanguageContext(
+                requestedOutputLanguage: "",
+                appliedLanguageCode: "",
+                resolutionSource: .unavailable
+            )
+        )
+    }
+
+    static func resolvedLanguage(
+        for item: PipelineHistoryItem,
+        transcript: String,
+        requestedOutputLanguage: String
+    ) throws -> (
+        context: MeetingSummaryLanguageContext,
+        resolvedSpokenLanguage: SpokenLanguageResolution?
+    ) {
+        let requested = requestedOutputLanguage.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        if let explicitCode = TranscriptionLanguage.code(
+            forSummaryOutput: requested
+        ) {
+            return (
+                MeetingSummaryLanguageContext(
+                    requestedOutputLanguage: requested,
+                    appliedLanguageCode: explicitCode,
+                    resolutionSource: .configured
+                ),
+                nil
+            )
+        }
+        let existingSpokenLanguage = item.spokenLanguage
+        let requiresTranscriptResolution =
+            existingSpokenLanguage?.source == .transcriptInferred
+                || existingSpokenLanguage?.source == .unavailable
+        let spoken = requiresTranscriptResolution
+            ? SpokenLanguageResolver.resolve(
+                requestedLanguageCode: item.transcriptionLanguageCode,
+                engineLanguageCode: nil,
+                transcript: transcript
+            )
+            : existingSpokenLanguage ?? SpokenLanguageResolver.resolve(
+                requestedLanguageCode: item.transcriptionLanguageCode,
+                engineLanguageCode: nil,
+                transcript: transcript
+            )
+        guard let code = spoken.languageCode else {
+            throw QuillUserIssueError.meetingSummaryLanguageUnavailable()
+        }
+        return (
+            MeetingSummaryLanguageContext(
+                requestedOutputLanguage: "",
+                appliedLanguageCode: code,
+                resolutionSource: spoken.source
+            ),
+            requiresTranscriptResolution || existingSpokenLanguage == nil
+                ? spoken
+                : nil
+        )
+    }
+
+    static func providerHost(
+        backendKind: MeetingSummaryBackendKind,
+        configuredProviderHost: String?
+    ) -> String? {
+        backendKind == .cloud ? configuredProviderHost : nil
+    }
+
+    private func currentItem(
+        noteID: UUID,
+        revision: Int,
+        sourceFingerprint: String,
+        history: MeetingSummaryHistoryAccess
+    ) -> PipelineHistoryItem? {
+        guard generationRevisionByID[noteID, default: 0] == revision,
+              let item = history.item(noteID),
+              Self.availabilitySource(for: item).fingerprint
+                == sourceFingerprint else {
+            return nil
+        }
+        return item
+    }
+
+    private func isCurrent(
+        noteID: UUID,
+        revision: Int,
+        sourceFingerprint: String,
+        history: MeetingSummaryHistoryAccess
+    ) -> Bool {
+        currentItem(
+            noteID: noteID,
+            revision: revision,
+            sourceFingerprint: sourceFingerprint,
+            history: history
+        ) != nil
+    }
+
+    private func finishGeneration(
+        noteID: UUID,
+        revision: Int,
+        pendingReveal: Bool = false
+    ) {
+        guard generationRevisionByID[noteID, default: 0] == revision else {
+            return
+        }
+        if pendingReveal {
+            state.pendingRevealNoteIDs.insert(noteID)
+        }
+        state.generatingNoteIDs.remove(noteID)
+        emitState()
     }
 
     private func emitState() {

--- a/Sources/MeetingSummaryWorkflow.swift
+++ b/Sources/MeetingSummaryWorkflow.swift
@@ -88,6 +88,7 @@ final class MeetingSummaryWorkflow {
             request.noteID,
             default: 0
         ]
+        generationRevisionByID[request.noteID] = generationRevision
         state.generatingNoteIDs.insert(request.noteID)
         emitState()
 
@@ -121,6 +122,10 @@ final class MeetingSummaryWorkflow {
                 sourceFingerprint: initialFingerprint,
                 history: history
             ) else {
+                finishGeneration(
+                    noteID: request.noteID,
+                    revision: generationRevision
+                )
                 return .sourceChanged
             }
             let updated = currentItem.withSpokenLanguage(spokenLanguage)
@@ -164,6 +169,10 @@ final class MeetingSummaryWorkflow {
             sourceFingerprint: source.fingerprint,
             history: history
         ) else {
+            finishGeneration(
+                noteID: request.noteID,
+                revision: generationRevision
+            )
             return .sourceChanged
         }
         let envelope = MeetingSummaryEnvelope(
@@ -390,6 +399,7 @@ final class MeetingSummaryWorkflow {
             sourceFingerprint: sourceFingerprint,
             history: history
         ) else {
+            finishGeneration(noteID: request.noteID, revision: revision)
             return .sourceChanged
         }
         if let summaryError = error as? MeetingSummaryError,
@@ -438,7 +448,7 @@ final class MeetingSummaryWorkflow {
         sourceFingerprint: String,
         history: MeetingSummaryHistoryAccess
     ) -> PipelineHistoryItem? {
-        guard generationRevisionByID[noteID, default: 0] == revision,
+        guard generationRevisionByID[noteID] == revision,
               let item = history.item(noteID),
               Self.availabilitySource(for: item).fingerprint
                 == sourceFingerprint else {
@@ -447,26 +457,12 @@ final class MeetingSummaryWorkflow {
         return item
     }
 
-    private func isCurrent(
-        noteID: UUID,
-        revision: Int,
-        sourceFingerprint: String,
-        history: MeetingSummaryHistoryAccess
-    ) -> Bool {
-        currentItem(
-            noteID: noteID,
-            revision: revision,
-            sourceFingerprint: sourceFingerprint,
-            history: history
-        ) != nil
-    }
-
     private func finishGeneration(
         noteID: UUID,
         revision: Int,
         pendingReveal: Bool = false
     ) {
-        guard generationRevisionByID[noteID, default: 0] == revision else {
+        guard generationRevisionByID[noteID] == revision else {
             return
         }
         if pendingReveal {

--- a/Sources/MeetingSummaryWorkflow.swift
+++ b/Sources/MeetingSummaryWorkflow.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+struct MeetingSummaryGeneratorConfiguration: Sendable {
+    let backendExecutor: AIProcessingBackendExecutor
+    let cloudFallbackModelID: String?
+}
+
+struct MeetingSummaryWorkflowDependencies {
+    var makeGenerator:
+        @MainActor (MeetingSummaryGeneratorConfiguration)
+            -> any MeetingSummaryGenerating
+    var now: @Sendable () -> Date
+}
+
+struct MeetingSummaryWorkflowRequest {
+    let noteID: UUID
+    let initialItem: PipelineHistoryItem
+    let requestedOutputLanguage: String
+    let configuredBackendKind: MeetingSummaryBackendKind
+    let configuredModelID: String
+    let providerHost: String?
+    let generatorConfiguration: MeetingSummaryGeneratorConfiguration
+}
+
+struct MeetingSummaryHistoryAccess {
+    var durability:
+        @MainActor @Sendable () -> PipelineHistoryDurability
+    var item:
+        @MainActor @Sendable (UUID) -> PipelineHistoryItem?
+    var persist:
+        @MainActor @Sendable (PipelineHistoryItem, Bool) throws -> Void
+}
+
+struct MeetingSummaryWorkflowState: Equatable, Sendable {
+    var generatingNoteIDs: Set<UUID>
+    var pendingRevealNoteIDs: Set<UUID>
+
+    static let initial = MeetingSummaryWorkflowState(
+        generatingNoteIDs: [],
+        pendingRevealNoteIDs: []
+    )
+}
+
+enum MeetingSummaryWorkflowEvent {
+    case stateChanged(MeetingSummaryWorkflowState)
+    case itemPersisted(PipelineHistoryItem)
+}
+
+enum MeetingSummaryWorkflowOutcome {
+    case verifiedSuccess
+    case unverifiedSuccess
+    case invalidInput
+    case sourceChanged
+    case generationFailed(Error)
+    case persistenceFailed
+}
+
+@MainActor
+final class MeetingSummaryWorkflow {
+    private let dependencies: MeetingSummaryWorkflowDependencies
+    private var generationRevisionByID: [UUID: Int] = [:]
+    private(set) var state = MeetingSummaryWorkflowState.initial
+    var onEvent: ((MeetingSummaryWorkflowEvent) -> Void)?
+
+    init(dependencies: MeetingSummaryWorkflowDependencies) {
+        self.dependencies = dependencies
+    }
+
+    func invalidate(noteID: UUID) {
+        generationRevisionByID[noteID, default: 0] += 1
+        state.generatingNoteIDs.remove(noteID)
+        state.pendingRevealNoteIDs.remove(noteID)
+        emitState()
+    }
+
+    func forget(noteID: UUID) {
+        generationRevisionByID.removeValue(forKey: noteID)
+        state.generatingNoteIDs.remove(noteID)
+        state.pendingRevealNoteIDs.remove(noteID)
+        emitState()
+    }
+
+    func forgetAll() {
+        generationRevisionByID.removeAll()
+        state = .initial
+        emitState()
+    }
+
+    func consumePendingReveal(noteID: UUID) -> Bool {
+        let consumed = state.pendingRevealNoteIDs.remove(noteID) != nil
+        if consumed { emitState() }
+        return consumed
+    }
+
+    private func emitState() {
+        onEvent?(.stateChanged(state))
+    }
+}

--- a/Tests/AppStateTranscriptionConfigurationTests.swift
+++ b/Tests/AppStateTranscriptionConfigurationTests.swift
@@ -3442,24 +3442,28 @@ struct AppStateTranscriptionConfigurationTests {
         assert(clear.contains("try pipelineHistoryStore.clearAll("))
         assert(clear.contains("requiresDurableStore: true"))
         assert(clear.contains("pipelineHistory = []"))
-        assert(clear.contains("forgetAllMeetingSummaryGenerationState()"))
+        assert(clear.contains("meetingSummaryWorkflow.forgetAll()"))
         assert(
             clear.range(of: "pipelineHistory = []")!.lowerBound
-                < clear.range(of: "forgetAllMeetingSummaryGenerationState()")!.lowerBound
+                < clear.range(of: "meetingSummaryWorkflow.forgetAll()")!.lowerBound
         )
         assert(delete.contains("try pipelineHistoryStore.delete("))
         assert(delete.contains("requiresDurableStore: true"))
         assert(delete.contains("pipelineHistory.remove(at: index)"))
-        assert(delete.contains("forgetMeetingSummaryGenerationState(for: id)"))
+        assert(delete.contains("meetingSummaryWorkflow.forget(noteID: id)"))
         assert(
             delete.range(of: "pipelineHistory.remove(at: index)")!.lowerBound
-                < delete.range(of: "forgetMeetingSummaryGenerationState(for: id)")!.lowerBound
+                < delete.range(
+                    of: "meetingSummaryWorkflow.forget(noteID: id)"
+                )!.lowerBound
         )
         assert(retry.contains("try self.pipelineHistoryStore.update("))
         assert(retry.contains("requiresDurableStore: true"))
         assert(
             retry.range(of: "requiresDurableStore: true")!.lowerBound
-                < retry.range(of: "self.invalidateMeetingSummaryGeneration(for: snapshot.item.id)")!.lowerBound
+                < retry.range(
+                    of: "self.meetingSummaryWorkflow.invalidate("
+                )!.lowerBound
         )
     }
 

--- a/Tests/FullSourceAppStateTestRunner.swift
+++ b/Tests/FullSourceAppStateTestRunner.swift
@@ -22,6 +22,7 @@ struct FullSourceAppStateTestRunner {
             try AppStateHistoryProtectionSourceTests.main()
             try await AppStateTranscriptionConfigurationTests.main()
             try await AppStateAIProcessingBackendTests.main()
+            try await MeetingSummaryWorkflowTests.main()
             try await MeetingSummaryAppStateTests.main()
         }
     }

--- a/Tests/MeetingSummaryAppStateTests.swift
+++ b/Tests/MeetingSummaryAppStateTests.swift
@@ -9,6 +9,7 @@ struct MeetingSummaryAppStateTests {
         try await testCreatedAppStateKeepsItsSummaryDependencySnapshot()
         try await testGenerationPersistsOnlyAfterSuccess()
         try await testNonDurableHistoryWarningPreventsSummaryPersistence()
+        try await testHistoryReadFailureMapsToPersistenceWarning()
         try await testLanguageMismatchPreservesSummaryAndRecordsAttempt()
         try await testSuccessfulAttemptSurvivesDurableReload()
         try await testFailedAttemptSurvivesDurableReload()
@@ -537,6 +538,76 @@ struct MeetingSummaryAppStateTests {
                     "new summary is not claimed as durably saved"
                 )
             }
+        }
+    }
+
+    private static func testHistoryReadFailureMapsToPersistenceWarning() async throws {
+        let directoryURL = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let failureToggle = MeetingSummaryFailureToggle()
+        let store = PipelineHistoryStore(
+            storeURL: directoryURL.appendingPathComponent(
+                "PipelineHistory.sqlite"
+            ),
+            historyFetcher: { context, request in
+                if failureToggle.isEnabled {
+                    throw MeetingSummaryAppStateTestFailure(
+                        "Injected history read failure"
+                    )
+                }
+                return try context.fetch(request)
+            }
+        )
+        let item = makeItem(
+            spokenLanguageCode: "en",
+            spokenLanguageResolution: .engineDetected
+        )
+        _ = try store.upsert(
+            item,
+            maxCount: 10,
+            requiresDurableStore: true
+        )
+        let layout = AppStateStorageLayout(rootDirectory: directoryURL)
+        let generator = MeetingSummaryControlledGenerator()
+        let appState = await configuredPersistedAppState(
+            store: store,
+            generator: generator,
+            storageLayout: layout
+        )
+        let task = Task { @MainActor in
+            try await appState.generateMeetingSummary(id: item.id)
+        }
+        await generator.waitUntilStarted()
+        failureToggle.isEnabled = true
+        generator.complete(with: .success(generationResult))
+
+        do {
+            try await task.value
+            throw MeetingSummaryAppStateTestFailure(
+                "Expected history persistence warning"
+            )
+        } catch let issue as QuillUserIssueError {
+            precondition(
+                issue.record.code == .historyPersistenceUnavailable,
+                "history read failure maps to the persistence warning"
+            )
+        } catch let failure as MeetingSummaryAppStateTestFailure {
+            throw failure
+        } catch {
+            throw MeetingSummaryAppStateTestFailure(
+                "Expected persistence warning, got \(error)"
+            )
+        }
+
+        await MainActor.run {
+            precondition(
+                appState.pipelineHistory[0].meetingSummary == nil,
+                "failed history read does not claim a saved Summary"
+            )
+            precondition(
+                appState.meetingSummaryGeneratingNoteIDs.isEmpty,
+                "history read failure clears generation state"
+            )
         }
     }
 
@@ -1388,6 +1459,16 @@ private final class MeetingSummaryGeneratorStub:
         source: MeetingSummarySource
     ) async throws -> MeetingSummaryGenerationResult {
         try await operation(source)
+    }
+}
+
+private final class MeetingSummaryFailureToggle: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = false
+
+    var isEnabled: Bool {
+        get { lock.withLock { value } }
+        set { lock.withLock { value = newValue } }
     }
 }
 

--- a/Tests/MeetingSummaryAppStateTests.swift
+++ b/Tests/MeetingSummaryAppStateTests.swift
@@ -107,10 +107,15 @@ struct MeetingSummaryAppStateTests {
         let secondGenerator = MeetingSummaryGeneratorStub { _ in
             makeGenerationResult(overview: "second generator")
         }
+        let firstRecorder = MeetingSummaryGeneratorConfigurationRecorder()
+        let secondRecorder = MeetingSummaryGeneratorConfigurationRecorder()
         var dependencies = AppStateDependencies.live
         dependencies.storageLayout = firstFixture.storageLayout
         dependencies.makePipelineHistoryStore = { _ in firstFixture.store }
-        dependencies.makeMeetingSummaryGenerator = { _ in firstGenerator }
+        dependencies.makeMeetingSummaryGenerator = { configuration in
+            firstRecorder.record(configuration)
+            return firstGenerator
+        }
         let firstDependencies = dependencies
         let firstState = await MainActor.run {
             let appState = AppState(dependencies: firstDependencies)
@@ -120,12 +125,21 @@ struct MeetingSummaryAppStateTests {
 
         dependencies.storageLayout = secondFixture.storageLayout
         dependencies.makePipelineHistoryStore = { _ in secondFixture.store }
-        dependencies.makeMeetingSummaryGenerator = { _ in secondGenerator }
+        dependencies.makeMeetingSummaryGenerator = { configuration in
+            secondRecorder.record(configuration)
+            return secondGenerator
+        }
         let secondDependencies = dependencies
         let secondState = await MainActor.run {
             let appState = AppState(dependencies: secondDependencies)
             configureSummaryGeneration(appState)
             return appState
+        }
+        let firstExpectedFallbackModelID = await MainActor.run {
+            firstState.meetingSummaryFallbackModel
+        }
+        let secondExpectedFallbackModelID = await MainActor.run {
+            secondState.meetingSummaryFallbackModel
         }
 
         try await firstState.generateMeetingSummary(id: firstItem.id)
@@ -141,6 +155,14 @@ struct MeetingSummaryAppStateTests {
                     == "second generator"
             )
         }
+        precondition(
+            firstRecorder.recordedFallbackModelIDs
+                == [firstExpectedFallbackModelID]
+        )
+        precondition(
+            secondRecorder.recordedFallbackModelIDs
+                == [secondExpectedFallbackModelID]
+        )
     }
 
     private static func testSuccessfulGenerationMarksPendingRevealConsumableOnce() async throws {
@@ -1721,6 +1743,23 @@ private final class MeetingSummaryGeneratorStub:
         source: MeetingSummarySource
     ) async throws -> MeetingSummaryGenerationResult {
         try await operation(source)
+    }
+}
+
+private final class MeetingSummaryGeneratorConfigurationRecorder:
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var fallbackModelIDs: [String?] = []
+
+    func record(_ configuration: MeetingSummaryGeneratorConfiguration) {
+        lock.withLock {
+            fallbackModelIDs.append(configuration.cloudFallbackModelID)
+        }
+    }
+
+    var recordedFallbackModelIDs: [String?] {
+        lock.withLock { fallbackModelIDs }
     }
 }
 

--- a/Tests/MeetingSummaryAppStateTests.swift
+++ b/Tests/MeetingSummaryAppStateTests.swift
@@ -8,24 +8,16 @@ struct MeetingSummaryAppStateTests {
         try await testAppStateInstancesUseIndependentSummaryGenerators()
         try await testCreatedAppStateKeepsItsSummaryDependencySnapshot()
         try await testGenerationPersistsOnlyAfterSuccess()
-        try await testUnverifiedGenerationPersistsSummaryWarningState()
         try await testNonDurableHistoryWarningPreventsSummaryPersistence()
-        try await testFailurePreservesExistingSummary()
-        try await testGroundingFailurePreservesExistingSummaryAndCompletion()
         try await testLanguageMismatchPreservesSummaryAndRecordsAttempt()
-        try await testLegacyAutoNotePersistsInferredKoreanOnGeneration()
         try await testSuccessfulAttemptSurvivesDurableReload()
         try await testFailedAttemptSurvivesDurableReload()
-        try await testFailedAttemptPersistenceFailureRemainsTransient()
-        try await testSourceChangePreservesExistingFailedAttempt()
         try await testTranscriptChangeDiscardsInflightResult()
-        try await testTranscriptChangeFailureDoesNotPersistAttempt()
         try await testSuccessfulRetryInvalidatesInflightSummaryGeneration()
         try await testRetryWithMissingHistoryEntryKeepsSummaryGenerationActive()
         try await testDeleteWithMissingHistoryEntryKeepsSummaryGenerationActive()
         try await testClearWithSaveFailureKeepsSummaryGenerationActive()
         try await testDeleteDuringGenerationDoesNotRestoreSummary()
-        try await testDeleteDuringGenerationFailureDoesNotPersistAttempt()
         try await testTranscriptReplacementReinfersDerivedSpokenLanguage()
         try await testTranscriptReplacementPreservesEngineDetectedLanguage()
         try await testTranscriptEditingPreservesSummaryMetadata()
@@ -37,9 +29,7 @@ struct MeetingSummaryAppStateTests {
         try await testDeleteFailedSummaryStatePersistsAndInvalidatesInflightGeneration()
         try await testFailedSummaryDeletePreservesStateWhenDurableWriteFails()
         try await testDeleteMeetingSummaryWithoutExistingSummaryThrows()
-        try await testFailureAttemptUsesEffectiveFallbackModel()
         try await testSuccessfulGenerationMarksPendingRevealConsumableOnce()
-        try await testFailedGenerationDoesNotMarkPendingReveal()
         print("MeetingSummaryAppStateTests passed")
     }
 
@@ -186,31 +176,6 @@ struct MeetingSummaryAppStateTests {
             precondition(
                 !appState.consumeMeetingSummaryPendingReveal(id: item.id),
                 "pending reveal is consumed only once"
-            )
-        }
-    }
-
-    private static func testFailedGenerationDoesNotMarkPendingReveal() async throws {
-        let item = makeItem()
-        let fixture = try configuredAppStateFixture()
-        defer { fixture.cleanup() }
-        let appState = try await configuredAppState(
-            item: item,
-            store: fixture.store,
-            generator: MeetingSummaryGeneratorStub { _ in
-                throw MeetingSummaryError.invalidResponse(.responseEnvelope)
-            },
-            storageLayout: fixture.storageLayout
-        )
-
-        do {
-            try await appState.generateMeetingSummary(id: item.id)
-        } catch {}
-
-        await MainActor.run {
-            precondition(
-                !appState.consumeMeetingSummaryPendingReveal(id: item.id),
-                "failed generation does not mark pending reveal"
             )
         }
     }
@@ -489,42 +454,6 @@ struct MeetingSummaryAppStateTests {
         }
     }
 
-    private static func testFailureAttemptUsesEffectiveFallbackModel() async throws {
-        let item = makeItem()
-        let fixture = try configuredAppStateFixture()
-        defer { fixture.cleanup() }
-        let appState = try await configuredAppState(
-            item: item,
-            store: fixture.store,
-            generator: MeetingSummaryGeneratorStub { _ in
-                throw MeetingSummaryError.rateLimited(
-                    model: "fallback/model",
-                    retryAfter: 1
-                )
-            },
-            storageLayout: fixture.storageLayout
-        )
-
-        do {
-            try await appState.generateMeetingSummary(id: item.id)
-            throw MeetingSummaryAppStateTestFailure("Expected fallback failure")
-        } catch let failure as MeetingSummaryAppStateTestFailure {
-            throw failure
-        } catch {}
-
-        await MainActor.run {
-            let attempt = appState.pipelineHistory[0].meetingSummaryAttempt
-            precondition(
-                attempt?.modelID == "fallback/model",
-                "failed attempt records the model that returned the terminal failure"
-            )
-            precondition(
-                attempt?.issue?.context.modelID == "fallback/model",
-                "failure Details identify the model that returned the terminal failure"
-            )
-        }
-    }
-
     private static func testGenerationPersistsOnlyAfterSuccess() async throws {
         let generator = MeetingSummaryControlledGenerator()
         let fixture = try configuredAppStateFixture()
@@ -557,39 +486,6 @@ struct MeetingSummaryAppStateTests {
         await MainActor.run {
             precondition(appState.pipelineHistory[0].meetingSummary != nil)
             precondition(appState.meetingSummaryGeneratingNoteIDs.isEmpty)
-        }
-    }
-
-    private static func testUnverifiedGenerationPersistsSummaryWarningState() async throws {
-        let item = makeItem()
-        let fixture = try configuredAppStateFixture()
-        defer { fixture.cleanup() }
-        let unverifiedResult = MeetingSummaryGenerationResult(
-            draft: generationResult.draft,
-            promptVersion: generationResult.promptVersion,
-            modelID: generationResult.modelID,
-            backendKind: generationResult.backendKind,
-            evidenceVerification: .unverified
-        )
-        let appState = try await configuredAppState(
-            item: item,
-            store: fixture.store,
-            generator: MeetingSummaryGeneratorStub { _ in unverifiedResult },
-            storageLayout: fixture.storageLayout
-        )
-
-        try await appState.generateMeetingSummary(id: item.id)
-
-        await MainActor.run {
-            precondition(
-                appState.pipelineHistory[0].meetingSummary?.effectiveEvidenceVerification
-                    == .unverified,
-                "unresolved citations persist an unverified saved summary"
-            )
-            precondition(
-                appState.pipelineHistory[0].meetingSummaryAttempt?.outcome == .succeeded,
-                "unverified evidence remains a successful summary result"
-            )
         }
     }
 
@@ -644,60 +540,6 @@ struct MeetingSummaryAppStateTests {
         }
     }
 
-    private static func testFailurePreservesExistingSummary() async throws {
-        let existing = envelope(completed: true)
-        let item = makeItem().withMeetingSummary(existing)
-        let fixture = try configuredAppStateFixture()
-        defer { fixture.cleanup() }
-        let appState = try await configuredAppState(
-            item: item,
-            store: fixture.store,
-            generator: MeetingSummaryGeneratorStub { _ in
-                throw MeetingSummaryError.invalidResponse(.responseEnvelope)
-            },
-            storageLayout: fixture.storageLayout
-        )
-
-        do {
-            try await appState.generateMeetingSummary(id: item.id)
-            throw MeetingSummaryAppStateTestFailure("Expected generation failure")
-        } catch let failure as MeetingSummaryAppStateTestFailure {
-            throw failure
-        } catch {}
-
-        await MainActor.run {
-            precondition(appState.pipelineHistory[0].meetingSummary == existing)
-        }
-    }
-
-    private static func testGroundingFailurePreservesExistingSummaryAndCompletion() async throws {
-        let existing = envelope(completed: true)
-        let item = makeItem().withMeetingSummary(existing)
-        let fixture = try configuredAppStateFixture()
-        defer { fixture.cleanup() }
-        let appState = try await configuredAppState(
-            item: item,
-            store: fixture.store,
-            generator: MeetingSummaryGeneratorStub { _ in
-                throw MeetingSummaryError.outputRejected(.sourceQuoteNotFound)
-            },
-            storageLayout: fixture.storageLayout
-        )
-
-        do {
-            try await appState.generateMeetingSummary(id: item.id)
-            throw MeetingSummaryAppStateTestFailure("Expected grounding failure")
-        } catch let failure as MeetingSummaryAppStateTestFailure {
-            throw failure
-        } catch {}
-
-        await MainActor.run {
-            let saved = appState.pipelineHistory[0].meetingSummary
-            precondition(saved == existing)
-            precondition(saved?.content.actionItems[0].isCompleted == true)
-        }
-    }
-
     private static func testLanguageMismatchPreservesSummaryAndRecordsAttempt() async throws {
         let existing = envelope(completed: true)
         let item = makeItem(
@@ -728,34 +570,6 @@ struct MeetingSummaryAppStateTests {
             precondition(saved.meetingSummary?.content.actionItems[0].isCompleted == true)
             precondition(saved.meetingSummaryAttempt?.outcome == .failed)
             precondition(saved.meetingSummaryAttempt?.language?.appliedLanguageCode == "ko")
-        }
-    }
-
-    private static func testLegacyAutoNotePersistsInferredKoreanOnGeneration() async throws {
-        let item = makeItem(
-            transcriptionLanguageCode: "auto",
-            rawTranscript: "회의에서 다음 주 화요일에 출시하기로 결정했습니다.",
-            postProcessedTranscript: "회의에서 다음 주 화요일에 출시하기로 결정했습니다."
-        )
-        let fixture = try configuredAppStateFixture()
-        defer { fixture.cleanup() }
-        let appState = try await configuredAppState(
-            item: item,
-            store: fixture.store,
-            generator: MeetingSummaryGeneratorStub { _ in generationResult },
-            storageLayout: fixture.storageLayout
-        )
-
-        try await appState.generateMeetingSummary(id: item.id)
-
-        await MainActor.run {
-            let saved = appState.pipelineHistory[0]
-            precondition(saved.spokenLanguage == SpokenLanguageResolution(
-                languageCode: "ko",
-                source: .transcriptInferred
-            ))
-            precondition(saved.meetingSummary?.languageContext?.appliedLanguageCode == "ko")
-            precondition(saved.meetingSummary?.languageContext?.resolutionSource == .transcriptInferred)
         }
     }
 
@@ -828,59 +642,6 @@ struct MeetingSummaryAppStateTests {
         precondition(persisted.meetingSummaryAttempt?.language?.appliedLanguageCode == "en")
     }
 
-    private static func testFailedAttemptPersistenceFailureRemainsTransient() async throws {
-        let directoryURL = try temporaryDirectory()
-        defer { try? FileManager.default.removeItem(at: directoryURL) }
-        let storeURL = directoryURL.appendingPathComponent("PipelineHistory.sqlite")
-        var shouldFailUpdate = false
-        let store = PipelineHistoryStore(
-            storeURL: storeURL,
-            persistentStoreLoader: PipelineHistoryStore.loadPersistentStoresSynchronously,
-            contextSaver: { context in
-                if shouldFailUpdate {
-                    throw MeetingSummaryAppStateTestFailure("Injected update failure")
-                }
-                try context.save()
-            }
-        )
-        let existing = envelope(completed: true)
-        let item = makeItem(
-            spokenLanguageCode: "en",
-            spokenLanguageResolution: .engineDetected
-        ).withMeetingSummary(existing)
-        _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
-
-        let layout = AppStateStorageLayout(rootDirectory: directoryURL)
-        let appState = await configuredPersistedAppState(
-            store: store,
-            generator: MeetingSummaryGeneratorStub { _ in
-                throw MeetingSummaryError.outputRejected(.languageMismatch)
-            },
-            storageLayout: layout
-        )
-        shouldFailUpdate = true
-
-        do {
-            try await appState.generateMeetingSummary(id: item.id)
-            throw MeetingSummaryAppStateTestFailure("Expected persistence failure")
-        } catch let issue as QuillUserIssueError {
-            precondition(issue.record.code == .historyPersistenceUnavailable)
-        }
-
-        await MainActor.run {
-            let visible = appState.pipelineHistory[0]
-            precondition(visible.meetingSummary == existing)
-            precondition(visible.meetingSummaryAttempt == nil)
-            precondition(!appState.consumeMeetingSummaryPendingReveal(id: item.id))
-        }
-        let reloaded = PipelineHistoryStore(storeURL: storeURL)
-        guard let persisted = reloaded.loadAllHistory().first else {
-            throw MeetingSummaryAppStateTestFailure("Missing reloaded transient item")
-        }
-        precondition(persisted.meetingSummary == existing)
-        precondition(persisted.meetingSummaryAttempt == nil)
-    }
-
     private static func testTranscriptEditingPreservesSummaryMetadata() async throws {
         let attempt = MeetingSummaryAttempt(
             occurredAt: Date(timeIntervalSince1970: 2_100),
@@ -929,50 +690,6 @@ struct MeetingSummaryAppStateTests {
         precondition(persisted.meetingSummaryAttempt == attempt)
     }
 
-    private static func testSourceChangePreservesExistingFailedAttempt() async throws {
-        let generator = MeetingSummaryControlledGenerator()
-        let previousAttempt = MeetingSummaryAttempt(
-            occurredAt: Date(timeIntervalSince1970: 2_100),
-            outcome: .failed,
-            backendKind: .cloud,
-            modelID: "summary/model",
-            providerHost: "api.example.com",
-            language: nil,
-            issue: QuillUserIssueRecord(code: .meetingSummaryUnavailable)
-        )
-        let item = makeItem().withMeetingSummaryAttempt(previousAttempt)
-        let fixture = try configuredAppStateFixture()
-        defer { fixture.cleanup() }
-        let appState = try await configuredAppState(
-            item: item,
-            store: fixture.store,
-            generator: generator,
-            storageLayout: fixture.storageLayout
-        )
-
-        let task = Task { @MainActor in
-            try await appState.generateMeetingSummary(id: item.id)
-        }
-        await generator.waitUntilStarted()
-        await MainActor.run {
-            appState.updateTranscript(id: item.id, text: "Transcript B changed.")
-        }
-        generator.complete(with: .success(generationResult))
-
-        do {
-            try await task.value
-            throw MeetingSummaryAppStateTestFailure("Expected source change")
-        } catch let error as MeetingSummaryError {
-            precondition(error == .sourceChanged)
-        }
-        await MainActor.run {
-            precondition(
-                appState.pipelineHistory[0].meetingSummaryAttempt == previousAttempt,
-                "source invalidation leaves prior attempt historical instead of replacing it"
-            )
-        }
-    }
-
     private static func testTranscriptChangeDiscardsInflightResult() async throws {
         let generator = MeetingSummaryControlledGenerator()
         let item = makeItem()
@@ -1010,39 +727,6 @@ struct MeetingSummaryAppStateTests {
                 appState.pipelineHistory[0].meetingSummaryAttempt == nil,
                 "source invalidation is not persisted as a provider failure"
             )
-        }
-    }
-
-    private static func testTranscriptChangeFailureDoesNotPersistAttempt() async throws {
-        let generator = MeetingSummaryControlledGenerator()
-        let item = makeItem()
-        let fixture = try configuredAppStateFixture()
-        defer { fixture.cleanup() }
-        let appState = try await configuredAppState(
-            item: item,
-            store: fixture.store,
-            generator: generator,
-            storageLayout: fixture.storageLayout
-        )
-
-        let task = Task { @MainActor in
-            try await appState.generateMeetingSummary(id: item.id)
-        }
-        await generator.waitUntilStarted()
-        await MainActor.run {
-            appState.updateTranscript(id: item.id, text: "Transcript B changed.")
-        }
-        generator.complete(with: .failure(URLError(.timedOut)))
-
-        do {
-            try await task.value
-            throw MeetingSummaryAppStateTestFailure("Expected source change")
-        } catch let error as MeetingSummaryError {
-            precondition(error == .sourceChanged)
-        }
-        await MainActor.run {
-            precondition(appState.pipelineHistory[0].meetingSummaryAttempt == nil)
-            precondition(!appState.consumeMeetingSummaryPendingReveal(id: item.id))
         }
     }
 
@@ -1283,45 +967,6 @@ struct MeetingSummaryAppStateTests {
             )
         }
         generator.complete(with: .success(generationResult))
-
-        do {
-            try await task.value
-            throw MeetingSummaryAppStateTestFailure("Expected deletion invalidation")
-        } catch let error as MeetingSummaryError {
-            precondition(error == .sourceChanged)
-        }
-        await MainActor.run {
-            let saved = appState.pipelineHistory[0]
-            precondition(saved.meetingSummary == nil)
-            precondition(saved.meetingSummaryAttempt == nil)
-            precondition(!appState.consumeMeetingSummaryPendingReveal(id: item.id))
-        }
-    }
-
-    private static func testDeleteDuringGenerationFailureDoesNotPersistAttempt() async throws {
-        let generator = MeetingSummaryControlledGenerator()
-        let item = makeItem().withMeetingSummary(envelope(completed: false))
-        let fixture = try configuredAppStateFixture()
-        defer { fixture.cleanup() }
-        let appState = try await configuredAppState(
-            item: item,
-            store: fixture.store,
-            generator: generator,
-            storageLayout: fixture.storageLayout
-        )
-
-        let task = Task { @MainActor in
-            try await appState.generateMeetingSummary(id: item.id)
-        }
-        await generator.waitUntilStarted()
-        try await MainActor.run {
-            try appState.deleteMeetingSummary(noteID: item.id)
-            precondition(
-                !appState.meetingSummaryGeneratingNoteIDs.contains(item.id),
-                "deletion clears generation state before a provider failure returns"
-            )
-        }
-        generator.complete(with: .failure(MeetingSummaryError.invalidResponse(.responseEnvelope)))
 
         do {
             try await task.value

--- a/Tests/MeetingSummaryWorkflowTests.swift
+++ b/Tests/MeetingSummaryWorkflowTests.swift
@@ -16,6 +16,7 @@ struct MeetingSummaryWorkflowTests {
         try await testInferredLanguagePersistenceFailureIsTyped()
         try await testFailedAttemptPersistenceFailureIsTyped()
         try await testSuccessfulSummaryPersistenceFailureIsTyped()
+        try await testNonDurableHistoryRejectsBeforeGeneration()
         try await testStaleSuccessCompletionsAreRejected()
         try await testStaleFailureCompletionsAreRejected()
         try await testStaleGenerationCannotClearNewerGenerationState()
@@ -533,6 +534,48 @@ struct MeetingSummaryWorkflowTests {
         try expect(
             !workflow.consumePendingReveal(noteID: initial.id),
             "failed Summary write creates no pending reveal"
+        )
+    }
+
+    @MainActor
+    private static func testNonDurableHistoryRejectsBeforeGeneration() async throws {
+        let initial = makeWorkflowItem()
+        let history = MeetingSummaryWorkflowHistoryRecorder(item: initial)
+        history.durabilityValue = .inMemory
+        let sourceRecorder = MeetingSummaryWorkflowSourceRecorder()
+        let workflow = MeetingSummaryWorkflow(
+            dependencies: .init(
+                makeGenerator: { _ in
+                    MeetingSummaryWorkflowGeneratorStub { source in
+                        await sourceRecorder.record(source)
+                        return makeWorkflowGenerationResult()
+                    }
+                },
+                now: { Date(timeIntervalSince1970: 2_000) }
+            )
+        )
+
+        let outcome = await workflow.generate(
+            request: makeWorkflowRequest(item: initial),
+            history: history.access
+        )
+        let source = await sourceRecorder.latest()
+
+        try expect(
+            isPersistenceFailure(outcome),
+            "non-durable history is rejected as persistence failure"
+        )
+        try expect(
+            source == nil,
+            "non-durable history is rejected before generator creation"
+        )
+        try expect(
+            history.persistedItems.isEmpty,
+            "non-durable history receives no writes"
+        )
+        try expect(
+            workflow.state == .initial,
+            "non-durable rejection does not mutate workflow state"
         )
     }
 

--- a/Tests/MeetingSummaryWorkflowTests.swift
+++ b/Tests/MeetingSummaryWorkflowTests.swift
@@ -8,6 +8,14 @@ struct MeetingSummaryWorkflowTests {
         try await testStateAndInvalidationCommands()
         try await testVerifiedSuccessPersistsBeforeEventAndPreservesCompletion()
         try await testUnverifiedSuccessPersistsWarningAndAttempt()
+        try await testExplicitLanguageOverridesSpokenLanguage()
+        try await testEngineDetectedLanguageRequiresNoPreliminaryWrite()
+        try await testTranscriptInferredLanguagePersistsBeforeGeneration()
+        try await testUnavailableLanguageReturnsExistingIssue()
+        try await testGenerationFailurePersistsAttemptWithoutReplacingSummary()
+        try await testInferredLanguagePersistenceFailureIsTyped()
+        try await testFailedAttemptPersistenceFailureIsTyped()
+        try await testSuccessfulSummaryPersistenceFailureIsTyped()
         print("MeetingSummaryWorkflowTests passed")
     }
 
@@ -146,6 +154,383 @@ struct MeetingSummaryWorkflowTests {
             "unverified success emits one persisted item"
         )
     }
+
+    @MainActor
+    private static func testExplicitLanguageOverridesSpokenLanguage() async throws {
+        let initial = makeWorkflowItem(
+            spokenLanguageCode: "ko",
+            spokenLanguageResolution: .engineDetected
+        )
+        let history = MeetingSummaryWorkflowHistoryRecorder(item: initial)
+        let sourceRecorder = MeetingSummaryWorkflowSourceRecorder()
+        let workflow = MeetingSummaryWorkflow(
+            dependencies: .init(
+                makeGenerator: { _ in
+                    MeetingSummaryWorkflowGeneratorStub { source in
+                        await sourceRecorder.record(source)
+                        return makeWorkflowGenerationResult()
+                    }
+                },
+                now: { Date(timeIntervalSince1970: 2_000) }
+            )
+        )
+
+        let outcome = await workflow.generate(
+            request: makeWorkflowRequest(
+                item: initial,
+                requestedOutputLanguage: "English"
+            ),
+            history: history.access
+        )
+        let source = await sourceRecorder.latest()
+
+        try expect(isVerifiedSuccess(outcome), "explicit language succeeds")
+        try expect(
+            source?.languageContext.appliedLanguageCode == "en",
+            "explicit output language overrides spoken language"
+        )
+        try expect(
+            source?.languageContext.resolutionSource == .configured,
+            "explicit output language records configured resolution"
+        )
+        try expect(
+            history.persistedItems.count == 1,
+            "explicit language requires only the Summary write"
+        )
+    }
+
+    @MainActor
+    private static func
+        testEngineDetectedLanguageRequiresNoPreliminaryWrite() async throws
+    {
+        let initial = makeWorkflowItem(
+            spokenLanguageCode: "ko",
+            spokenLanguageResolution: .engineDetected
+        )
+        let history = MeetingSummaryWorkflowHistoryRecorder(item: initial)
+        let sourceRecorder = MeetingSummaryWorkflowSourceRecorder()
+        let workflow = MeetingSummaryWorkflow(
+            dependencies: .init(
+                makeGenerator: { _ in
+                    MeetingSummaryWorkflowGeneratorStub { source in
+                        await sourceRecorder.record(source)
+                        return makeWorkflowGenerationResult()
+                    }
+                },
+                now: { Date(timeIntervalSince1970: 2_000) }
+            )
+        )
+
+        let outcome = await workflow.generate(
+            request: makeWorkflowRequest(
+                item: initial,
+                requestedOutputLanguage: ""
+            ),
+            history: history.access
+        )
+        let source = await sourceRecorder.latest()
+
+        try expect(isVerifiedSuccess(outcome), "detected language succeeds")
+        try expect(
+            source?.languageContext.appliedLanguageCode == "ko",
+            "engine-detected language is applied"
+        )
+        try expect(
+            source?.languageContext.resolutionSource == .engineDetected,
+            "engine-detected source is preserved"
+        )
+        try expect(
+            history.persistedItems.count == 1,
+            "engine-detected language requires no preliminary write"
+        )
+    }
+
+    @MainActor
+    private static func
+        testTranscriptInferredLanguagePersistsBeforeGeneration() async throws
+    {
+        let transcript = "회의에서 다음 주 화요일에 출시하기로 결정했습니다."
+        let initial = makeWorkflowItem(
+            transcript: transcript,
+            spokenLanguageCode: nil,
+            spokenLanguageResolution: nil
+        )
+        let history = MeetingSummaryWorkflowHistoryRecorder(item: initial)
+        let eventRecorder = MeetingSummaryWorkflowEventRecorder(history: history)
+        let sourceRecorder = MeetingSummaryWorkflowSourceRecorder()
+        let workflow = MeetingSummaryWorkflow(
+            dependencies: .init(
+                makeGenerator: { _ in
+                    MeetingSummaryWorkflowGeneratorStub { source in
+                        await sourceRecorder.record(source)
+                        return makeWorkflowGenerationResult()
+                    }
+                },
+                now: { Date(timeIntervalSince1970: 2_000) }
+            )
+        )
+        workflow.onEvent = { eventRecorder.record($0) }
+
+        let outcome = await workflow.generate(
+            request: makeWorkflowRequest(
+                item: initial,
+                requestedOutputLanguage: ""
+            ),
+            history: history.access
+        )
+        let source = await sourceRecorder.latest()
+
+        try expect(isVerifiedSuccess(outcome), "inferred language succeeds")
+        try expect(
+            history.persistedItems.first?.spokenLanguage
+                == SpokenLanguageResolution(
+                    languageCode: "ko",
+                    source: .transcriptInferred
+                ),
+            "inferred Korean is durably saved first"
+        )
+        try expect(
+            source?.languageContext.appliedLanguageCode == "ko",
+            "generator receives the inferred Korean language"
+        )
+        try expect(
+            source?.languageContext.resolutionSource == .transcriptInferred,
+            "generator receives transcript-inferred resolution"
+        )
+        try expect(
+            history.operations == ["persist-1", "persist-2"],
+            "language metadata is saved before the Summary"
+        )
+        try expect(
+            eventRecorder.persistedItems.count == 2,
+            "each durable write emits one item event"
+        )
+    }
+
+    @MainActor
+    private static func testUnavailableLanguageReturnsExistingIssue() async throws {
+        let initial = makeWorkflowItem(
+            transcript: "",
+            spokenLanguageCode: nil,
+            spokenLanguageResolution: nil
+        )
+        let history = MeetingSummaryWorkflowHistoryRecorder(item: initial)
+        let workflow = MeetingSummaryWorkflow(
+            dependencies: .init(
+                makeGenerator: { _ in
+                    MeetingSummaryWorkflowGeneratorStub { _ in
+                        makeWorkflowGenerationResult()
+                    }
+                },
+                now: { Date(timeIntervalSince1970: 2_000) }
+            )
+        )
+
+        let outcome = await workflow.generate(
+            request: makeWorkflowRequest(
+                item: initial,
+                requestedOutputLanguage: ""
+            ),
+            history: history.access
+        )
+
+        guard case .generationFailed(let error) = outcome,
+              let issue = error as? QuillUserIssueError else {
+            throw MeetingSummaryWorkflowTestFailure(
+                description: "language failure preserves its user issue"
+            )
+        }
+        try expect(
+            issue.record.code == .meetingSummaryLanguageUnavailable,
+            "unavailable language uses the existing issue code"
+        )
+    }
+
+    @MainActor
+    private static func
+        testGenerationFailurePersistsAttemptWithoutReplacingSummary() async throws
+    {
+        let actionID = UUID()
+        let existing = makeWorkflowEnvelope(actionID: actionID, completed: true)
+        let initial = makeWorkflowItem().withMeetingSummary(existing)
+        let history = MeetingSummaryWorkflowHistoryRecorder(item: initial)
+        let failure = MeetingSummaryError.outputRejected(
+            .languageMismatch,
+            modelID: "fallback/model"
+        )
+        let workflow = MeetingSummaryWorkflow(
+            dependencies: .init(
+                makeGenerator: { _ in
+                    MeetingSummaryWorkflowGeneratorStub { _ in
+                        throw failure
+                    }
+                },
+                now: { Date(timeIntervalSince1970: 2_000) }
+            )
+        )
+
+        let outcome = await workflow.generate(
+            request: makeWorkflowRequest(item: initial),
+            history: history.access
+        )
+
+        try expect(
+            isGenerationFailure(outcome, matching: failure),
+            "generation failure is typed"
+        )
+        try expect(
+            history.storedItem?.meetingSummary == existing,
+            "failure preserves the existing Summary"
+        )
+        try expect(
+            history.storedItem?.meetingSummary?
+                .content.actionItems.first?.isCompleted == true,
+            "failure preserves action completion"
+        )
+        try expect(
+            history.storedItem?.meetingSummaryAttempt?.outcome == .failed,
+            "failure persists a failed attempt"
+        )
+        try expect(
+            history.storedItem?.meetingSummaryAttempt?.modelID
+                == "fallback/model",
+            "failure records the effective model"
+        )
+        try expect(
+            history.storedItem?.meetingSummaryAttempt?.providerHost
+                == "api.example.com",
+            "failure records the captured provider host"
+        )
+    }
+
+    @MainActor
+    private static func testInferredLanguagePersistenceFailureIsTyped() async throws {
+        let initial = makeWorkflowItem(
+            transcript: "회의에서 다음 주 화요일에 출시하기로 결정했습니다.",
+            spokenLanguageCode: nil,
+            spokenLanguageResolution: nil
+        )
+        let history = MeetingSummaryWorkflowHistoryRecorder(item: initial)
+        history.failingPersistCalls = [1]
+        let eventRecorder = MeetingSummaryWorkflowEventRecorder(history: history)
+        let workflow = MeetingSummaryWorkflow(
+            dependencies: .init(
+                makeGenerator: { _ in
+                    MeetingSummaryWorkflowGeneratorStub { _ in
+                        makeWorkflowGenerationResult()
+                    }
+                },
+                now: { Date(timeIntervalSince1970: 2_000) }
+            )
+        )
+        workflow.onEvent = { eventRecorder.record($0) }
+
+        let outcome = await workflow.generate(
+            request: makeWorkflowRequest(
+                item: initial,
+                requestedOutputLanguage: ""
+            ),
+            history: history.access
+        )
+
+        try expect(
+            isPersistenceFailure(outcome),
+            "language persistence failure is typed"
+        )
+        try expect(
+            eventRecorder.persistedItems.isEmpty,
+            "failed language persistence emits no item event"
+        )
+        try expect(
+            !workflow.consumePendingReveal(noteID: initial.id),
+            "failed language persistence creates no pending reveal"
+        )
+    }
+
+    @MainActor
+    private static func testFailedAttemptPersistenceFailureIsTyped() async throws {
+        let initial = makeWorkflowItem()
+        let history = MeetingSummaryWorkflowHistoryRecorder(item: initial)
+        history.failingPersistCalls = [1]
+        let eventRecorder = MeetingSummaryWorkflowEventRecorder(history: history)
+        let workflow = MeetingSummaryWorkflow(
+            dependencies: .init(
+                makeGenerator: { _ in
+                    MeetingSummaryWorkflowGeneratorStub { _ in
+                        throw MeetingSummaryError.outputRejected(
+                            .languageMismatch,
+                            modelID: "fallback/model"
+                        )
+                    }
+                },
+                now: { Date(timeIntervalSince1970: 2_000) }
+            )
+        )
+        workflow.onEvent = { eventRecorder.record($0) }
+
+        let outcome = await workflow.generate(
+            request: makeWorkflowRequest(item: initial),
+            history: history.access
+        )
+
+        try expect(
+            isPersistenceFailure(outcome),
+            "failed-attempt persistence failure is typed"
+        )
+        try expect(
+            eventRecorder.persistedItems.isEmpty,
+            "failed-attempt write emits no item event"
+        )
+        try expect(
+            history.storedItem?.meetingSummaryAttempt == nil,
+            "failed-attempt write does not mutate durable state"
+        )
+        try expect(
+            !workflow.consumePendingReveal(noteID: initial.id),
+            "failed attempt creates no pending reveal"
+        )
+    }
+
+    @MainActor
+    private static func testSuccessfulSummaryPersistenceFailureIsTyped() async throws {
+        let initial = makeWorkflowItem()
+        let history = MeetingSummaryWorkflowHistoryRecorder(item: initial)
+        history.failingPersistCalls = [1]
+        let eventRecorder = MeetingSummaryWorkflowEventRecorder(history: history)
+        let workflow = MeetingSummaryWorkflow(
+            dependencies: .init(
+                makeGenerator: { _ in
+                    MeetingSummaryWorkflowGeneratorStub { _ in
+                        makeWorkflowGenerationResult()
+                    }
+                },
+                now: { Date(timeIntervalSince1970: 2_000) }
+            )
+        )
+        workflow.onEvent = { eventRecorder.record($0) }
+
+        let outcome = await workflow.generate(
+            request: makeWorkflowRequest(item: initial),
+            history: history.access
+        )
+
+        try expect(
+            isPersistenceFailure(outcome),
+            "successful Summary persistence failure is typed"
+        )
+        try expect(
+            eventRecorder.persistedItems.isEmpty,
+            "failed Summary write emits no item event"
+        )
+        try expect(
+            history.storedItem?.meetingSummary == nil,
+            "failed Summary write does not mutate durable state"
+        )
+        try expect(
+            !workflow.consumePendingReveal(noteID: initial.id),
+            "failed Summary write creates no pending reveal"
+        )
+    }
 }
 
 @MainActor
@@ -208,6 +593,18 @@ private final class MeetingSummaryWorkflowEventRecorder {
             itemEventsObservedAfterPersistence = false
         }
         persistedItems.append(item)
+    }
+}
+
+private actor MeetingSummaryWorkflowSourceRecorder {
+    private var sources: [MeetingSummarySource] = []
+
+    func record(_ source: MeetingSummarySource) {
+        sources.append(source)
+    }
+
+    func latest() -> MeetingSummarySource? {
+        sources.last
     }
 }
 
@@ -338,6 +735,24 @@ private func isVerifiedSuccess(_ outcome: MeetingSummaryWorkflowOutcome) -> Bool
 
 private func isUnverifiedSuccess(_ outcome: MeetingSummaryWorkflowOutcome) -> Bool {
     if case .unverifiedSuccess = outcome { return true }
+    return false
+}
+
+private func isGenerationFailure(
+    _ outcome: MeetingSummaryWorkflowOutcome,
+    matching expected: MeetingSummaryError
+) -> Bool {
+    guard case .generationFailed(let error) = outcome,
+          let summaryError = error as? MeetingSummaryError else {
+        return false
+    }
+    return summaryError == expected
+}
+
+private func isPersistenceFailure(
+    _ outcome: MeetingSummaryWorkflowOutcome
+) -> Bool {
+    if case .persistenceFailed = outcome { return true }
     return false
 }
 

--- a/Tests/MeetingSummaryWorkflowTests.swift
+++ b/Tests/MeetingSummaryWorkflowTests.swift
@@ -6,6 +6,8 @@ import Foundation
 struct MeetingSummaryWorkflowTests {
     static func main() async throws {
         try await testStateAndInvalidationCommands()
+        try await testVerifiedSuccessPersistsBeforeEventAndPreservesCompletion()
+        try await testUnverifiedSuccessPersistsWarningAndAttempt()
         print("MeetingSummaryWorkflowTests passed")
     }
 
@@ -50,6 +52,293 @@ struct MeetingSummaryWorkflowTests {
             "missing reveal is not consumed"
         )
     }
+
+    @MainActor
+    private static func
+        testVerifiedSuccessPersistsBeforeEventAndPreservesCompletion() async throws
+    {
+        let actionID = UUID()
+        let initial = makeWorkflowItem().withMeetingSummary(
+            makeWorkflowEnvelope(actionID: actionID, completed: true)
+        )
+        let history = MeetingSummaryWorkflowHistoryRecorder(item: initial)
+        let eventRecorder = MeetingSummaryWorkflowEventRecorder(history: history)
+        let workflow = MeetingSummaryWorkflow(
+            dependencies: .init(
+                makeGenerator: { _ in
+                    MeetingSummaryWorkflowGeneratorStub { _ in
+                        makeWorkflowGenerationResult(actionID: actionID)
+                    }
+                },
+                now: { Date(timeIntervalSince1970: 2_000) }
+            )
+        )
+        workflow.onEvent = { eventRecorder.record($0) }
+
+        let outcome = await workflow.generate(
+            request: makeWorkflowRequest(item: initial),
+            history: history.access
+        )
+
+        try expect(isVerifiedSuccess(outcome), "verified success is typed")
+        try expect(
+            history.storedItem?.meetingSummary?
+                .content.actionItems.first?.isCompleted == true,
+            "successful generation preserves action completion"
+        )
+        try expect(
+            history.storedItem?.meetingSummaryAttempt?.outcome == .succeeded,
+            "successful generation persists a succeeded attempt"
+        )
+        try expect(
+            eventRecorder.itemEventsObservedAfterPersistence,
+            "item events follow durable persistence"
+        )
+        try expect(
+            workflow.consumePendingReveal(noteID: initial.id),
+            "success creates pending reveal"
+        )
+        try expect(
+            !workflow.consumePendingReveal(noteID: initial.id),
+            "pending reveal is consumed once"
+        )
+    }
+
+    @MainActor
+    private static func testUnverifiedSuccessPersistsWarningAndAttempt() async throws {
+        let initial = makeWorkflowItem()
+        let history = MeetingSummaryWorkflowHistoryRecorder(item: initial)
+        let eventRecorder = MeetingSummaryWorkflowEventRecorder(history: history)
+        let workflow = MeetingSummaryWorkflow(
+            dependencies: .init(
+                makeGenerator: { _ in
+                    MeetingSummaryWorkflowGeneratorStub { _ in
+                        makeWorkflowGenerationResult(
+                            evidenceVerification: .unverified
+                        )
+                    }
+                },
+                now: { Date(timeIntervalSince1970: 2_000) }
+            )
+        )
+        workflow.onEvent = { eventRecorder.record($0) }
+
+        let outcome = await workflow.generate(
+            request: makeWorkflowRequest(item: initial),
+            history: history.access
+        )
+
+        try expect(
+            isUnverifiedSuccess(outcome),
+            "unverified success is typed"
+        )
+        try expect(
+            history.storedItem?.meetingSummary?
+                .effectiveEvidenceVerification == .unverified,
+            "unverified evidence state is persisted"
+        )
+        try expect(
+            history.storedItem?.meetingSummaryAttempt?.outcome == .succeeded,
+            "unverified success persists a succeeded attempt"
+        )
+        try expect(
+            eventRecorder.persistedItems.count == 1,
+            "unverified success emits one persisted item"
+        )
+    }
+}
+
+@MainActor
+private final class MeetingSummaryWorkflowHistoryRecorder {
+    var storedItem: PipelineHistoryItem?
+    var durabilityValue: PipelineHistoryDurability = .durable
+    var failingPersistCalls = Set<Int>()
+    private var persistCallCount = 0
+    private(set) var persistedItems: [PipelineHistoryItem] = []
+    private(set) var operations: [String] = []
+
+    init(item: PipelineHistoryItem?) {
+        storedItem = item
+    }
+
+    var access: MeetingSummaryHistoryAccess {
+        MeetingSummaryHistoryAccess(
+            durability: { [weak self] in
+                self?.durabilityValue ?? .inMemory
+            },
+            item: { [weak self] id in
+                guard self?.storedItem?.id == id else { return nil }
+                return self?.storedItem
+            },
+            persist: { [weak self] item, requiresDurableStore in
+                guard let self else { return }
+                persistCallCount += 1
+                operations.append("persist-\(persistCallCount)")
+                if failingPersistCalls.contains(persistCallCount) {
+                    throw MeetingSummaryWorkflowTestFailure(
+                        description: "intentional persistence failure"
+                    )
+                }
+                if requiresDurableStore,
+                   durabilityValue != .durable {
+                    throw MeetingSummaryWorkflowTestFailure(
+                        description: "durable store required"
+                    )
+                }
+                storedItem = item
+                persistedItems.append(item)
+            }
+        )
+    }
+}
+
+@MainActor
+private final class MeetingSummaryWorkflowEventRecorder {
+    private let history: MeetingSummaryWorkflowHistoryRecorder
+    private(set) var persistedItems: [PipelineHistoryItem] = []
+    private(set) var itemEventsObservedAfterPersistence = true
+
+    init(history: MeetingSummaryWorkflowHistoryRecorder) {
+        self.history = history
+    }
+
+    func record(_ event: MeetingSummaryWorkflowEvent) {
+        guard case .itemPersisted(let item) = event else { return }
+        if history.persistedItems.last?.id != item.id {
+            itemEventsObservedAfterPersistence = false
+        }
+        persistedItems.append(item)
+    }
+}
+
+private func makeWorkflowItem(
+    id: UUID = UUID(),
+    transcript: String = "Decision: ship Friday.",
+    spokenLanguageCode: String? = "en",
+    spokenLanguageResolution:
+        SpokenLanguageResolutionSource? = .engineDetected
+) -> PipelineHistoryItem {
+    PipelineHistoryItem(
+        id: id,
+        timestamp: Date(timeIntervalSince1970: 1_000),
+        rawTranscript: transcript,
+        postProcessedTranscript: transcript,
+        postProcessingPrompt: nil,
+        contextSummary: "Excluded context",
+        contextPrompt: nil,
+        contextScreenshotDataURL: nil,
+        contextScreenshotStatus: "No screenshot",
+        postProcessingStatus: "Post-processing succeeded",
+        debugStatus: "Done",
+        customVocabulary: "",
+        usedPostProcessing: false,
+        transcriptionLanguageCode: "auto",
+        spokenLanguageCode: spokenLanguageCode,
+        spokenLanguageResolution: spokenLanguageResolution
+    )
+}
+
+private func makeWorkflowEnvelope(
+    actionID: UUID,
+    completed: Bool
+) -> MeetingSummaryEnvelope {
+    MeetingSummaryEnvelope(
+        schemaVersion: MeetingSummaryEnvelope.currentSchemaVersion,
+        promptVersion: 1,
+        generatedAt: Date(timeIntervalSince1970: 1_500),
+        sourceFingerprint: String(repeating: "c", count: 64),
+        modelID: "summary/model",
+        backendKind: .cloud,
+        content: MeetingSummaryContent(
+            overview: MeetingSummaryEvidenceText(
+                text: "Release review",
+                sourceQuotes: ["Decision: ship Friday."]
+            ),
+            keyPoints: [],
+            decisions: [],
+            actionItems: [
+                MeetingSummaryActionItem(
+                    id: actionID,
+                    task: "Write release notes",
+                    owner: nil,
+                    dueDate: nil,
+                    sourceQuote: "Decision: ship Friday.",
+                    isCompleted: completed
+                )
+            ],
+            openQuestions: []
+        )
+    )
+}
+
+private func makeWorkflowGenerationResult(
+    actionID: UUID = UUID(),
+    evidenceVerification:
+        MeetingSummaryEvidenceVerification = .verified
+) -> MeetingSummaryGenerationResult {
+    MeetingSummaryGenerationResult(
+        draft: MeetingSummaryDraftContentV2(
+            overview: MeetingSummaryEvidenceText(
+                text: "Release review",
+                sourceQuotes: ["Decision: ship Friday."]
+            ),
+            keyPoints: [],
+            decisions: [],
+            actionItems: [
+                MeetingSummaryActionItem(
+                    id: actionID,
+                    task: "Write release notes",
+                    owner: nil,
+                    dueDate: nil,
+                    sourceQuote: "Decision: ship Friday.",
+                    isCompleted: false
+                )
+            ],
+            openQuestions: []
+        ),
+        promptVersion: 1,
+        modelID: "summary/model",
+        backendKind: .cloud,
+        evidenceVerification: evidenceVerification
+    )
+}
+
+private func makeWorkflowGeneratorConfiguration()
+    -> MeetingSummaryGeneratorConfiguration
+{
+    MeetingSummaryGeneratorConfiguration(
+        backendExecutor: AIProcessingBackendExecutor(
+            choice: .cloud(modelID: "summary/model"),
+            cloudBaseURL: "https://api.example.com/openai/v1",
+            cloudAPIKey: "test-key"
+        ),
+        cloudFallbackModelID: "summary/fallback"
+    )
+}
+
+private func makeWorkflowRequest(
+    item: PipelineHistoryItem,
+    requestedOutputLanguage: String = "English"
+) -> MeetingSummaryWorkflowRequest {
+    MeetingSummaryWorkflowRequest(
+        noteID: item.id,
+        initialItem: item,
+        requestedOutputLanguage: requestedOutputLanguage,
+        configuredBackendKind: .cloud,
+        configuredModelID: "summary/model",
+        providerHost: "api.example.com",
+        generatorConfiguration: makeWorkflowGeneratorConfiguration()
+    )
+}
+
+private func isVerifiedSuccess(_ outcome: MeetingSummaryWorkflowOutcome) -> Bool {
+    if case .verifiedSuccess = outcome { return true }
+    return false
+}
+
+private func isUnverifiedSuccess(_ outcome: MeetingSummaryWorkflowOutcome) -> Bool {
+    if case .unverifiedSuccess = outcome { return true }
+    return false
 }
 
 private final class MeetingSummaryWorkflowGeneratorStub:

--- a/Tests/MeetingSummaryWorkflowTests.swift
+++ b/Tests/MeetingSummaryWorkflowTests.swift
@@ -16,6 +16,9 @@ struct MeetingSummaryWorkflowTests {
         try await testInferredLanguagePersistenceFailureIsTyped()
         try await testFailedAttemptPersistenceFailureIsTyped()
         try await testSuccessfulSummaryPersistenceFailureIsTyped()
+        try await testStaleSuccessCompletionsAreRejected()
+        try await testStaleFailureCompletionsAreRejected()
+        try await testStaleGenerationCannotClearNewerGenerationState()
         print("MeetingSummaryWorkflowTests passed")
     }
 
@@ -531,6 +534,179 @@ struct MeetingSummaryWorkflowTests {
             "failed Summary write creates no pending reveal"
         )
     }
+
+    @MainActor
+    private static func testStaleSuccessCompletionsAreRejected() async throws {
+        for mutation in MeetingSummaryWorkflowStaleMutation.allCases {
+            let initial = makeWorkflowItem()
+            let history = MeetingSummaryWorkflowHistoryRecorder(item: initial)
+            let generator = MeetingSummaryWorkflowControlledGenerator()
+            let workflow = MeetingSummaryWorkflow(
+                dependencies: .init(
+                    makeGenerator: { _ in generator },
+                    now: { Date(timeIntervalSince1970: 2_000) }
+                )
+            )
+            let task = Task {
+                await workflow.generate(
+                    request: makeWorkflowRequest(item: initial),
+                    history: history.access
+                )
+            }
+            await generator.waitUntilStarted()
+
+            mutation.apply(
+                initialItem: initial,
+                history: history,
+                workflow: workflow
+            )
+            generator.complete(
+                with: .success(makeWorkflowGenerationResult())
+            )
+            let outcome = await task.value
+
+            try expect(
+                isSourceChanged(outcome),
+                "stale success is rejected after \(mutation.label)"
+            )
+            try expect(
+                history.persistedItems.isEmpty,
+                "stale success is not persisted after \(mutation.label)"
+            )
+            try expect(
+                !workflow.state.generatingNoteIDs.contains(initial.id),
+                "stale success finishes generation after \(mutation.label)"
+            )
+        }
+    }
+
+    @MainActor
+    private static func testStaleFailureCompletionsAreRejected() async throws {
+        for mutation in [
+            MeetingSummaryWorkflowStaleMutation.replaceTranscript,
+            .removeStoredNote
+        ] {
+            let previousAttempt = makeWorkflowAttempt(
+                outcome: .succeeded,
+                modelID: "previous/model"
+            )
+            let initial = makeWorkflowItem()
+                .withMeetingSummaryAttempt(previousAttempt)
+            let history = MeetingSummaryWorkflowHistoryRecorder(item: initial)
+            let generator = MeetingSummaryWorkflowControlledGenerator()
+            let workflow = MeetingSummaryWorkflow(
+                dependencies: .init(
+                    makeGenerator: { _ in generator },
+                    now: { Date(timeIntervalSince1970: 2_000) }
+                )
+            )
+            let task = Task {
+                await workflow.generate(
+                    request: makeWorkflowRequest(item: initial),
+                    history: history.access
+                )
+            }
+            await generator.waitUntilStarted()
+
+            mutation.apply(
+                initialItem: initial,
+                history: history,
+                workflow: workflow
+            )
+            generator.complete(
+                with: .failure(
+                    MeetingSummaryError.outputRejected(
+                        .languageMismatch,
+                        modelID: "failed/model"
+                    )
+                )
+            )
+            let outcome = await task.value
+
+            try expect(
+                isSourceChanged(outcome),
+                "stale failure is rejected after \(mutation.label)"
+            )
+            try expect(
+                history.persistedItems.isEmpty,
+                "stale failure writes no attempt after \(mutation.label)"
+            )
+            if mutation == .replaceTranscript {
+                try expect(
+                    history.storedItem?.meetingSummaryAttempt
+                        == previousAttempt,
+                    "stale failure preserves the previous attempt"
+                )
+            }
+            try expect(
+                !workflow.state.generatingNoteIDs.contains(initial.id),
+                "stale failure finishes generation after \(mutation.label)"
+            )
+        }
+    }
+
+    @MainActor
+    private static func
+        testStaleGenerationCannotClearNewerGenerationState() async throws
+    {
+        let initial = makeWorkflowItem()
+        let history = MeetingSummaryWorkflowHistoryRecorder(item: initial)
+        let firstGenerator = MeetingSummaryWorkflowControlledGenerator()
+        let secondGenerator = MeetingSummaryWorkflowControlledGenerator()
+        var generators: [any MeetingSummaryGenerating] = [
+            firstGenerator,
+            secondGenerator
+        ]
+        let workflow = MeetingSummaryWorkflow(
+            dependencies: .init(
+                makeGenerator: { _ in generators.removeFirst() },
+                now: { Date(timeIntervalSince1970: 2_000) }
+            )
+        )
+        let firstTask = Task {
+            await workflow.generate(
+                request: makeWorkflowRequest(item: initial),
+                history: history.access
+            )
+        }
+        await firstGenerator.waitUntilStarted()
+        workflow.invalidate(noteID: initial.id)
+        let secondTask = Task {
+            await workflow.generate(
+                request: makeWorkflowRequest(item: initial),
+                history: history.access
+            )
+        }
+        await secondGenerator.waitUntilStarted()
+
+        firstGenerator.complete(
+            with: .success(makeWorkflowGenerationResult())
+        )
+        let firstOutcome = await firstTask.value
+
+        try expect(
+            isSourceChanged(firstOutcome),
+            "invalidated generation is stale"
+        )
+        try expect(
+            workflow.state.generatingNoteIDs.contains(initial.id),
+            "stale completion does not clear newer generation state"
+        )
+
+        secondGenerator.complete(
+            with: .success(makeWorkflowGenerationResult())
+        )
+        let secondOutcome = await secondTask.value
+
+        try expect(
+            isVerifiedSuccess(secondOutcome),
+            "newer generation still completes"
+        )
+        try expect(
+            !workflow.state.generatingNoteIDs.contains(initial.id),
+            "newer generation clears its own state"
+        )
+    }
 }
 
 @MainActor
@@ -605,6 +781,57 @@ private actor MeetingSummaryWorkflowSourceRecorder {
 
     func latest() -> MeetingSummarySource? {
         sources.last
+    }
+}
+
+private enum MeetingSummaryWorkflowStaleMutation:
+    CaseIterable,
+    Equatable
+{
+    case replaceTranscript
+    case removeStoredNote
+    case invalidate
+    case forget
+    case forgetAll
+
+    var label: String {
+        switch self {
+        case .replaceTranscript:
+            "transcript replacement"
+        case .removeStoredNote:
+            "note removal"
+        case .invalidate:
+            "invalidation"
+        case .forget:
+            "note forgetting"
+        case .forgetAll:
+            "full forgetting"
+        }
+    }
+
+    @MainActor
+    func apply(
+        initialItem: PipelineHistoryItem,
+        history: MeetingSummaryWorkflowHistoryRecorder,
+        workflow: MeetingSummaryWorkflow
+    ) {
+        switch self {
+        case .replaceTranscript:
+            history.storedItem = makeWorkflowItem(
+                id: initialItem.id,
+                transcript: "Changed transcript."
+            )
+            .withMeetingSummary(initialItem.meetingSummary)
+            .withMeetingSummaryAttempt(initialItem.meetingSummaryAttempt)
+        case .removeStoredNote:
+            history.storedItem = nil
+        case .invalidate:
+            workflow.invalidate(noteID: initialItem.id)
+        case .forget:
+            workflow.forget(noteID: initialItem.id)
+        case .forgetAll:
+            workflow.forgetAll()
+        }
     }
 }
 
@@ -700,6 +927,26 @@ private func makeWorkflowGenerationResult(
     )
 }
 
+private func makeWorkflowAttempt(
+    outcome: MeetingSummaryAttemptOutcome,
+    modelID: String
+) -> MeetingSummaryAttempt {
+    MeetingSummaryAttempt(
+        occurredAt: Date(timeIntervalSince1970: 1_750),
+        outcome: outcome,
+        backendKind: .cloud,
+        modelID: modelID,
+        providerHost: "api.example.com",
+        language: MeetingSummaryLanguageContext(
+            requestedOutputLanguage: "English",
+            appliedLanguageCode: "en",
+            resolutionSource: .configured
+        ),
+        issue: nil,
+        sourceFingerprint: String(repeating: "d", count: 64)
+    )
+}
+
 private func makeWorkflowGeneratorConfiguration()
     -> MeetingSummaryGeneratorConfiguration
 {
@@ -756,6 +1003,13 @@ private func isPersistenceFailure(
     return false
 }
 
+private func isSourceChanged(
+    _ outcome: MeetingSummaryWorkflowOutcome
+) -> Bool {
+    if case .sourceChanged = outcome { return true }
+    return false
+}
+
 private final class MeetingSummaryWorkflowGeneratorStub:
     MeetingSummaryGenerating,
     @unchecked Sendable
@@ -774,6 +1028,65 @@ private final class MeetingSummaryWorkflowGeneratorStub:
         source: MeetingSummarySource
     ) async throws -> MeetingSummaryGenerationResult {
         try await operation(source)
+    }
+}
+
+private final class MeetingSummaryWorkflowControlledGenerator:
+    MeetingSummaryGenerating,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var continuation:
+        CheckedContinuation<MeetingSummaryGenerationResult, Error>?
+    private var startedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var hasStarted = false
+
+    func generate(
+        source: MeetingSummarySource
+    ) async throws -> MeetingSummaryGenerationResult {
+        try await withCheckedThrowingContinuation { continuation in
+            let waiters = lock.withLock {
+                self.continuation = continuation
+                hasStarted = true
+                let values = startedWaiters
+                startedWaiters.removeAll()
+                return values
+            }
+            waiters.forEach { $0.resume() }
+        }
+    }
+
+    func waitUntilStarted() async {
+        if lock.withLock({ hasStarted }) { return }
+        await withCheckedContinuation { continuation in
+            let shouldResume = lock.withLock {
+                if hasStarted { return true }
+                startedWaiters.append(continuation)
+                return false
+            }
+            if shouldResume { continuation.resume() }
+        }
+    }
+
+    func complete(
+        with result: Result<MeetingSummaryGenerationResult, Error>
+    ) {
+        let continuation = lock.withLock {
+            let value = self.continuation
+            self.continuation = nil
+            return value
+        }
+        continuation?.resume(with: result)
+    }
+}
+
+private extension NSLock {
+    func withLock<Value>(
+        _ body: () throws -> Value
+    ) rethrows -> Value {
+        lock()
+        defer { unlock() }
+        return try body()
     }
 }
 

--- a/Tests/MeetingSummaryWorkflowTests.swift
+++ b/Tests/MeetingSummaryWorkflowTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+#if !QUILL_GROUPED_TEST_RUNNER
+@main
+#endif
+struct MeetingSummaryWorkflowTests {
+    static func main() async throws {
+        try await testStateAndInvalidationCommands()
+        print("MeetingSummaryWorkflowTests passed")
+    }
+
+    @MainActor
+    private static func testStateAndInvalidationCommands() async throws {
+        let workflow = MeetingSummaryWorkflow(
+            dependencies: .init(
+                makeGenerator: { _ in
+                    MeetingSummaryWorkflowGeneratorStub { _ in
+                        throw MeetingSummaryError.invalidInput
+                    }
+                },
+                now: { Date(timeIntervalSince1970: 2_000) }
+            )
+        )
+        let noteID = UUID()
+        var states: [MeetingSummaryWorkflowState] = []
+        workflow.onEvent = { event in
+            if case .stateChanged(let state) = event {
+                states.append(state)
+            }
+        }
+
+        workflow.invalidate(noteID: noteID)
+        workflow.forget(noteID: noteID)
+        workflow.forgetAll()
+
+        try expect(
+            workflow.state.generatingNoteIDs.isEmpty,
+            "no generation is active"
+        )
+        try expect(
+            workflow.state.pendingRevealNoteIDs.isEmpty,
+            "no reveal is pending"
+        )
+        try expect(
+            !states.isEmpty,
+            "state commands emit complete snapshots"
+        )
+        try expect(
+            !workflow.consumePendingReveal(noteID: noteID),
+            "missing reveal is not consumed"
+        )
+    }
+}
+
+private final class MeetingSummaryWorkflowGeneratorStub:
+    MeetingSummaryGenerating,
+    @unchecked Sendable
+{
+    typealias Operation = @Sendable (
+        MeetingSummarySource
+    ) async throws -> MeetingSummaryGenerationResult
+
+    private let operation: Operation
+
+    init(operation: @escaping Operation) {
+        self.operation = operation
+    }
+
+    func generate(
+        source: MeetingSummarySource
+    ) async throws -> MeetingSummaryGenerationResult {
+        try await operation(source)
+    }
+}
+
+private struct MeetingSummaryWorkflowTestFailure:
+    Error,
+    CustomStringConvertible
+{
+    let description: String
+}
+
+private func expect(
+    _ condition: @autoclosure () -> Bool,
+    _ description: String
+) throws {
+    guard condition() else {
+        throw MeetingSummaryWorkflowTestFailure(
+            description: description
+        )
+    }
+}

--- a/Tests/MeetingSummaryWorkflowTests.swift
+++ b/Tests/MeetingSummaryWorkflowTests.swift
@@ -19,6 +19,7 @@ struct MeetingSummaryWorkflowTests {
         try await testStaleSuccessCompletionsAreRejected()
         try await testStaleFailureCompletionsAreRejected()
         try await testStaleGenerationCannotClearNewerGenerationState()
+        try await testMissingDurableStartRejectsCompletionAfterGeneratorRuns()
         print("MeetingSummaryWorkflowTests passed")
     }
 
@@ -705,6 +706,45 @@ struct MeetingSummaryWorkflowTests {
         try expect(
             !workflow.state.generatingNoteIDs.contains(initial.id),
             "newer generation clears its own state"
+        )
+    }
+
+    @MainActor
+    private static func
+        testMissingDurableStartRejectsCompletionAfterGeneratorRuns() async throws
+    {
+        let initial = makeWorkflowItem()
+        let history = MeetingSummaryWorkflowHistoryRecorder(item: nil)
+        let sourceRecorder = MeetingSummaryWorkflowSourceRecorder()
+        let workflow = MeetingSummaryWorkflow(
+            dependencies: .init(
+                makeGenerator: { _ in
+                    MeetingSummaryWorkflowGeneratorStub { source in
+                        await sourceRecorder.record(source)
+                        return makeWorkflowGenerationResult()
+                    }
+                },
+                now: { Date(timeIntervalSince1970: 2_000) }
+            )
+        )
+
+        let outcome = await workflow.generate(
+            request: makeWorkflowRequest(item: initial),
+            history: history.access
+        )
+        let source = await sourceRecorder.latest()
+
+        try expect(
+            source != nil,
+            "the captured start item reaches the generator"
+        )
+        try expect(
+            isSourceChanged(outcome),
+            "a missing durable completion target is source changed"
+        )
+        try expect(
+            history.persistedItems.isEmpty,
+            "a missing durable target receives no write"
         )
     }
 }

--- a/docs/superpowers/specs/2026-08-14-meeting-summary-workflow-design.md
+++ b/docs/superpowers/specs/2026-08-14-meeting-summary-workflow-design.md
@@ -194,13 +194,14 @@ The workflow receives a narrow, request-scoped history collaborator:
 ```swift
 struct MeetingSummaryHistoryAccess {
     var durability: @MainActor @Sendable () -> PipelineHistoryDurability
-    var item: @MainActor @Sendable (UUID) -> PipelineHistoryItem?
+    var item:
+        @MainActor @Sendable (UUID) throws -> PipelineHistoryItem?
     var persist:
         @MainActor @Sendable (PipelineHistoryItem, Bool) throws -> Void
 }
 ```
 
-`AppState` constructs it from the current `PipelineHistoryStore` for each generation request. It is not retained as workflow runtime state.
+`AppState` constructs it from the current `PipelineHistoryStore` for each generation request. It is not retained as workflow runtime state. The item lookup throws when the originating store becomes unreadable, allowing the workflow to distinguish a persistence outage from a genuinely missing or changed note.
 
 This request-scoped design coordinates with #317: an archive runtime replacement cannot leave the workflow permanently attached to an old store. Archive admission already blocks while Meeting Summary work is active, so the originating store remains valid for the duration of an accepted attempt.
 
@@ -290,7 +291,7 @@ After generator success or failure, the workflow reloads the current item throug
 2. the current revision matches the captured revision,
 3. and the current source fingerprint matches the attempt fingerprint.
 
-Any mismatch yields `sourceChanged`. The workflow writes neither a success result nor a failed attempt for stale work.
+Any mismatch yields `sourceChanged`. A history lookup failure yields `persistenceFailed` instead, so the caller surfaces the existing history-persistence warning. The workflow writes neither a success result nor a failed attempt for stale or unreadable history.
 
 ### Success
 

--- a/docs/superpowers/specs/2026-08-14-meeting-summary-workflow-design.md
+++ b/docs/superpowers/specs/2026-08-14-meeting-summary-workflow-design.md
@@ -1,0 +1,502 @@
+# Meeting Summary Workflow Design
+
+## Summary
+
+Issue #319 extracts Meeting Summary generation orchestration from `AppState.swift` into an instance-owned `MeetingSummaryWorkflow`.
+
+The existing low-level boundaries remain authoritative:
+
+- `MeetingSummaryService` generates and validates Summary drafts,
+- `MeetingSummarySource` defines source normalization and fingerprints,
+- `MeetingSummaryEnvelope` and `MeetingSummaryAttempt` define durable records,
+- `PipelineHistoryStore` persists active note history,
+- and `AppState` remains the UI-facing owner of settings, public actions, and published mirrors.
+
+The remaining problem is orchestration. `AppState` currently owns generation revisions, in-progress and pending-reveal state, language resolution, source construction, generator invocation, stale-completion checks, successful and failed attempt persistence, existing-summary preservation, and completion ordering. This design moves those responsibilities into a focused workflow without changing prompts, models, schemas, user-facing copy, or Summary output.
+
+## Why #319 Precedes #318
+
+The remaining Phase 2 issues are #318, transcription retry/resume extraction, and #319, Meeting Summary extraction.
+
+#319 should proceed first because:
+
+- #317 now provides a stable history-runtime boundary and makes the current history store replacement rules explicit,
+- successful transcription retry must invalidate in-flight Summary generation,
+- a focused Summary invalidation API gives #318 a stable collaborator instead of a temporary callback into `AppState`,
+- and the current Meeting Summary path already has extensive behavioral coverage in `MeetingSummaryAppStateTests`.
+
+#318 spans cloud checkpoints, durable sidecars, transcript assets, Post-processing, startup reconciliation, and several source-shape test suites. Stabilizing Summary invalidation first avoids changing that broader workflow twice.
+
+## Current State
+
+### Availability and source preparation
+
+`AppState` currently decides whether Summary generation is available by reading:
+
+- the note intent and transcription status,
+- the current transcript,
+- feature enablement,
+- backend readiness,
+- and `meetingSummaryGeneratingNoteIDs`.
+
+It also builds `MeetingSummarySource`, maps calendar attendees, chooses processed or raw transcript text, resolves the output language, and may durably update inferred spoken-language metadata before generation.
+
+### Generation and persistence
+
+`generateMeetingSummary(id:)` currently:
+
+1. finds the starting history item,
+2. verifies availability and durable history,
+3. captures backend and model metadata,
+4. captures a per-note generation revision,
+5. marks the note as generating,
+6. resolves and, when needed, persists spoken-language metadata,
+7. builds and fingerprints the source,
+8. constructs a generator through `AppStateDependencies`,
+9. awaits generation,
+10. rejects stale revisions, changed transcripts, and deleted notes,
+11. persists either a success envelope and attempt or a failed attempt,
+12. preserves the previous Summary and action completion on failure,
+13. records pending reveal only after durable success,
+14. and clears in-progress state when the same generation revision completes.
+
+### External invalidation
+
+Other `AppState` paths directly mutate generation state:
+
+- transcript edit invalidates generation after a successful durable edit,
+- successful transcription retry invalidates generation after durable history replacement,
+- Summary deletion invalidates generation after durable deletion,
+- note deletion forgets note-scoped generation state after durable note deletion,
+- history clear forgets all generation state after durable clear,
+- and archive runtime replacement clears all generation-specific state.
+
+The distinction between invalidate and forget is behaviorally important. Failed or missing note mutations must not silently clear a still-running generation.
+
+## Approaches Considered
+
+### 1. Stateful instance-owned workflow — recommended
+
+A `MeetingSummaryWorkflow` owns revisions, generation activity, pending reveal, source preparation, generator execution, stale-result rejection, attempt persistence ordering, and invalidation. `AppState` supplies immutable request values and a narrow history collaborator, then mirrors workflow events.
+
+This satisfies #319 and provides #318 with a stable Summary invalidation boundary.
+
+### 2. Stateless generation executor
+
+A stateless executor would move generator invocation and envelope construction but leave revisions, pending reveal, persistence, and completion ordering in `AppState`.
+
+This reduces method size but leaves the central race and ownership problem unsolved, so it is rejected.
+
+### 3. Summary domain store
+
+A larger extraction would move generation plus action completion, Summary deletion, and all Summary-related history CRUD behind a dedicated domain store.
+
+That overlaps #192 and expands the migration beyond #319. It is rejected.
+
+## Architecture
+
+### `MeetingSummaryWorkflow`
+
+Create `Sources/MeetingSummaryWorkflow.swift` containing the workflow and its focused value types.
+
+Each `AppState` owns one workflow instance. No static current workflow, mutable process-global factory, or compatibility shim is introduced.
+
+The workflow owns:
+
+- per-note generation revisions,
+- generating note IDs,
+- pending-reveal note IDs,
+- language resolution for a generation attempt,
+- source construction and fingerprint capture,
+- generator construction and execution,
+- stale completion validation,
+- durable success and failed-attempt ordering,
+- and invalidate, forget, and forget-all semantics.
+
+The workflow does not own general history CRUD, Summary UI, action-item editing, Summary deletion, transcript editing, transcription retry, backend settings, or model installation.
+
+### `MeetingSummaryWorkflowState`
+
+```swift
+struct MeetingSummaryWorkflowState: Equatable, Sendable {
+    var generatingNoteIDs: Set<UUID>
+    var pendingRevealNoteIDs: Set<UUID>
+}
+```
+
+Generation revisions remain private implementation state. `AppState` retains its existing `@Published private(set) var meetingSummaryGeneratingNoteIDs` as a compatibility mirror and updates it only from complete workflow state events.
+
+Pending reveal moves fully into the workflow. `AppState.consumeMeetingSummaryPendingReveal(id:)` remains public and delegates to the workflow.
+
+### `MeetingSummaryGeneratorConfiguration`
+
+The current generator dependency takes the entire `AppState`:
+
+```swift
+@MainActor (AppState) -> any MeetingSummaryGenerating
+```
+
+Replace it with a small attempt-scoped value:
+
+```swift
+struct MeetingSummaryGeneratorConfiguration: Sendable {
+    let backendExecutor: AIProcessingBackendExecutor
+    let cloudFallbackModelID: String?
+}
+```
+
+`AppState` builds this configuration from the current backend choice, API settings, Local AI manager, and instance-owned Local AI availability before starting the workflow request. API credentials remain runtime-only inside the backend executor. The configuration is never stored in workflow state, history, attempts, diagnostics, or durable metadata.
+
+`AppStateDependencies.makeMeetingSummaryGenerator` becomes:
+
+```swift
+@MainActor
+(MeetingSummaryGeneratorConfiguration) -> any MeetingSummaryGenerating
+```
+
+The production closure constructs `MeetingSummaryService`. Tests continue to inject deterministic generators without a global replacement seam.
+
+### `MeetingSummaryWorkflowDependencies`
+
+```swift
+struct MeetingSummaryWorkflowDependencies {
+    var makeGenerator:
+        @MainActor (MeetingSummaryGeneratorConfiguration)
+            -> any MeetingSummaryGenerating
+    var now: @Sendable () -> Date
+}
+```
+
+The dependencies are copied into the originating workflow instance. Generator construction remains per attempt and Main Actor isolated. The injectable clock makes attempt and envelope timestamps deterministic in direct workflow tests.
+
+### `MeetingSummaryWorkflowRequest`
+
+A request captures all execution decisions before the first asynchronous boundary:
+
+```swift
+struct MeetingSummaryWorkflowRequest {
+    let noteID: UUID
+    let initialItem: PipelineHistoryItem
+    let requestedOutputLanguage: String
+    let configuredBackendKind: MeetingSummaryBackendKind
+    let configuredModelID: String
+    let providerHost: String?
+    let generatorConfiguration: MeetingSummaryGeneratorConfiguration
+}
+```
+
+The request does not retain `AppState`. Later changes to settings or test dependency variables cannot redirect an active generation.
+
+### `MeetingSummaryHistoryAccess`
+
+The workflow receives a narrow, request-scoped history collaborator:
+
+```swift
+struct MeetingSummaryHistoryAccess {
+    var durability: @MainActor @Sendable () -> PipelineHistoryDurability
+    var item: @MainActor @Sendable (UUID) -> PipelineHistoryItem?
+    var persist:
+        @MainActor @Sendable (PipelineHistoryItem, Bool) throws -> Void
+}
+```
+
+`AppState` constructs it from the current `PipelineHistoryStore` for each generation request. It is not retained as workflow runtime state.
+
+This request-scoped design coordinates with #317: an archive runtime replacement cannot leave the workflow permanently attached to an old store. Archive admission already blocks while Meeting Summary work is active, so the originating store remains valid for the duration of an accepted attempt.
+
+The collaborator exposes only the operations needed for Summary generation. It does not become a competing general history store.
+
+### `MeetingSummaryWorkflowEvent`
+
+```swift
+enum MeetingSummaryWorkflowEvent {
+    case stateChanged(MeetingSummaryWorkflowState)
+    case itemPersisted(PipelineHistoryItem)
+}
+```
+
+Events are delivered on the Main Actor. `itemPersisted` is emitted only after the history collaborator confirms a durable update. `AppState` applies the item to its `pipelineHistory` mirror if the row still exists.
+
+No event contains API credentials, transcript contents beyond the already-existing updated history item, absolute user paths, or raw provider errors.
+
+### `MeetingSummaryWorkflowOutcome`
+
+The workflow returns a typed immediate outcome instead of changing `AppState` error semantics:
+
+```swift
+enum MeetingSummaryWorkflowOutcome {
+    case verifiedSuccess
+    case unverifiedSuccess
+    case invalidInput
+    case sourceChanged
+    case generationFailed(Error)
+    case persistenceFailed
+}
+```
+
+This type is consumed on the Main Actor and is not durable state. `AppState.generateMeetingSummary(id:)` maps outcomes back to the existing public behavior:
+
+- `verifiedSuccess` and `unverifiedSuccess` return normally,
+- `invalidInput` throws `MeetingSummaryError.invalidInput`,
+- `sourceChanged` throws `MeetingSummaryError.sourceChanged`,
+- `generationFailed(error)` rethrows the original error,
+- and `persistenceFailed` throws `QuillUserIssueError.historyPersistenceUnavailable()`.
+
+This preserves existing callers and user-issue mapping while giving direct workflow tests explicit categories.
+
+## Data Flow
+
+### Admission
+
+```text
+AppState.generateMeetingSummary(id:)
+  → find current UI-facing item
+  → existing availability checks
+  → capture backend/model/output-language configuration
+  → create current-store MeetingSummaryHistoryAccess
+  → workflow.generate(request, historyAccess)
+```
+
+The workflow rejects a non-durable store before mutating generation state.
+
+### Language and source preparation
+
+```text
+workflow captures revision and marks note generating
+  → choose processed transcript, falling back to raw transcript
+  → resolve explicit or spoken-language-derived output language
+  → if spoken-language metadata must change:
+      reload current item
+      verify note and revision
+      durable persist updated language metadata
+      emit itemPersisted
+  → build MeetingSummarySource with calendar context
+  → capture source fingerprint
+  → construct generator from captured configuration
+```
+
+Language resolution preserves the current rules:
+
+- explicitly configured Summary output language wins,
+- engine-detected or configured spoken language is retained,
+- transcript-inferred and unavailable language may be recomputed,
+- and missing language produces the existing `meetingSummaryLanguageUnavailable` issue.
+
+### Generator completion validation
+
+After generator success or failure, the workflow reloads the current item through `MeetingSummaryHistoryAccess` and verifies:
+
+1. the note still exists,
+2. the current revision matches the captured revision,
+3. and the current source fingerprint matches the attempt fingerprint.
+
+Any mismatch yields `sourceChanged`. The workflow writes neither a success result nor a failed attempt for stale work.
+
+### Success
+
+```text
+verified current item + generation result
+  → materialize MeetingSummaryEnvelope
+  → preserve action completion from the current existing Summary
+  → create succeeded MeetingSummaryAttempt
+  → durable persist updated item
+  → emit itemPersisted
+  → add pending reveal
+  → clear generating state for matching revision
+  → return verifiedSuccess or unverifiedSuccess
+```
+
+An unverified generation remains a successful durable Summary with the existing evidence warning state.
+
+### Generation failure
+
+```text
+generator/language/grounding/model error
+  → verify current item, revision, and source fingerprint
+  → map the existing QuillUserIssueRecord
+  → create failed MeetingSummaryAttempt
+  → preserve existing Summary and action completion
+  → durable persist updated item
+  → emit itemPersisted
+  → clear generating state for matching revision
+  → return generationFailed(originalError)
+```
+
+`MeetingSummaryError.sourceChanged` bypasses failed-attempt persistence and returns `sourceChanged`.
+
+### Persistence failure
+
+If spoken-language metadata, failed attempt, or successful Summary persistence fails:
+
+- no `itemPersisted` event is emitted,
+- the UI mirror remains unchanged,
+- pending reveal is not added,
+- generating state is cleared only when the captured revision is still current,
+- and the workflow returns `persistenceFailed`.
+
+A failed persistence is never reported as durable success.
+
+## Invalidation Semantics
+
+The workflow exposes three distinct commands.
+
+### `invalidate(noteID:)`
+
+- increments the note revision,
+- removes the note from generating state,
+- clears pending reveal.
+
+Called only after successful durable transcript edit, successful transcription retry, or successful Summary deletion.
+
+### `forget(noteID:)`
+
+- removes the note revision entry entirely,
+- removes generating and pending-reveal state.
+
+Called only after successful durable note deletion.
+
+### `forgetAll()`
+
+- clears all revisions, generating state, and pending reveal.
+
+Called only after successful durable history clear or verified archive runtime replacement.
+
+Missing notes and failed delete or clear operations do not invoke these commands. This preserves the current race semantics covered by `MeetingSummaryAppStateTests`.
+
+## `AppState` Responsibilities After Extraction
+
+`AppState` retains:
+
+- Summary settings and backend readiness,
+- `meetingSummaryAvailability(for:)`,
+- public `meetingSummarySource(for:)` as a thin workflow-source adapter,
+- public `generateMeetingSummary(id:)` and outcome-to-error mapping,
+- the published generating-ID mirror,
+- action-item completion,
+- Summary deletion and its durable mutation guard,
+- transcript editing, retry, note deletion, and history clear,
+- application of `itemPersisted` events to `pipelineHistory`,
+- and UI navigation and user-facing error presentation.
+
+`AppState` no longer owns:
+
+- generation revisions,
+- pending reveal storage,
+- generator execution,
+- language/source preparation for generation,
+- stale completion checks,
+- successful or failed attempt construction,
+- attempt persistence ordering,
+- or generation completion cleanup.
+
+## Error and Safety Rules
+
+- API keys remain runtime-only and never enter durable Summary metadata or diagnostics.
+- Deleted notes cannot be recreated by a late generation.
+- Changed transcripts cannot receive stale Summary or failed-attempt state.
+- Existing Summary and action completion survive generation failure.
+- Failed persistence never updates the `AppState` mirror or pending reveal.
+- Summary JSON schema, source fingerprint version, prompt version, backend/model metadata, evidence verification, and user issues remain compatible.
+- Generator construction remains per attempt and Main Actor isolated.
+- No provider, retry, fallback, prompt, model-selection, or user-copy policy changes are introduced.
+
+## Testing Strategy
+
+### New direct workflow suite
+
+Create `Tests/MeetingSummaryWorkflowTests.swift` covering:
+
+- independent workflow instances and generator factories,
+- originating dependency and configuration capture,
+- verified and unverified success,
+- action completion preservation,
+- configured, engine-detected, and transcript-inferred language,
+- language metadata persistence before generator invocation,
+- failed-attempt persistence and existing Summary preservation,
+- effective fallback model and provider metadata,
+- language, failed-attempt, and success persistence failures,
+- transcript change, note deletion, and revision invalidation races,
+- stale success and stale failure rejection,
+- missing-note non-resurrection,
+- one-shot pending reveal,
+- and invalidate, forget, and forget-all semantics.
+
+The direct suite uses deterministic history closures, generator stubs, and a clock. It does not construct the UI-facing `AppState`.
+
+### Existing AppState suite
+
+Retain `MeetingSummaryAppStateTests` for adapter and integration behavior:
+
+- independent `AppState` instances,
+- public generation API and error mapping,
+- published generating state,
+- UI availability,
+- action completion and Summary deletion,
+- transcript-edit, retry, delete, clear, and archive invalidation routing,
+- history mirror updates,
+- and dependency snapshot ownership.
+
+Workflow-internal tests should migrate to the direct suite rather than being duplicated. Existing AppState tests remain until their replacement behavior is green.
+
+### Existing low-level suites
+
+`MeetingSummaryServiceTests`, `MeetingSummaryOutputValidatorTests`, prompt tests, model tests, and durable decoding tests remain authoritative for generation algorithms, transport behavior, validation, schema compatibility, and rendering. The workflow suite does not duplicate those assertions.
+
+### Source-shape policy
+
+No new exact-source-string assertions are added for workflow internals. Existing source assertions that become invalid solely because ownership moved are removed only after direct behavioral coverage is present. The Summary UI contract may continue checking that it calls the existing public `AppState` route.
+
+### Test wiring and verification
+
+Add the direct workflow suite to the grouped full-source AppState runner and the corresponding Makefile source list.
+
+Verification order:
+
+1. focused direct workflow tests,
+2. existing Meeting Summary AppState tests,
+3. `make check-test-wiring`,
+4. `make test`,
+5. production build with `CODESIGN_IDENTITY=Quill`,
+6. `codesign --verify --deep --strict`,
+7. and `/code-review medium` exactly once after the full tree is green.
+
+## Files
+
+Create:
+
+- `Sources/MeetingSummaryWorkflow.swift`
+- `Tests/MeetingSummaryWorkflowTests.swift`
+- `docs/superpowers/specs/2026-08-14-meeting-summary-workflow-design.md`
+
+Modify:
+
+- `Sources/AppState.swift`
+- `Sources/AppStateDependencies.swift`
+- `Tests/MeetingSummaryAppStateTests.swift`
+- `Tests/FullSourceAppStateTestRunner.swift`
+- `Makefile`
+
+Other tests are changed only when an existing ownership-specific source assertion must be replaced by direct workflow behavior.
+
+## Non-Goals
+
+- No prompt, model, backend, output-schema, Summary UI, or action-item behavior change.
+- No transcription retry/resume extraction; that remains #318.
+- No transcript editing redesign.
+- No general Summary domain store.
+- No `PipelineHistoryStore` format or API redesign.
+- No broader `AppState` split from #192.
+- No compatibility shim that recreates process-global mutable dependency replacement.
+
+## Acceptance Criteria
+
+- Meeting Summary generation has one focused owner outside `AppState.swift`.
+- The workflow is independently testable without constructing `AppState` or replacing a global generator.
+- Active attempts use only captured configuration and the originating request-scoped history collaborator.
+- Success, unverified success, generation failure, source change, deletion, revision invalidation, language handling, persistence failure, and pending reveal are behavior-tested.
+- Existing Summary and action completion survive failed attempts.
+- Deleted or changed notes never receive stale Summary state.
+- Existing durable Summary records decode unchanged.
+- AppState public APIs, published mirrors, settings, UI routes, and user messages remain compatible.
+- No process-global Summary workflow or generator seam is introduced.
+- Focused tests, `make check-test-wiring`, `make test`, signed production build, and code-sign verification pass.


### PR DESCRIPTION
## Summary

- add an instance-owned `MeetingSummaryWorkflow` for language resolution, source construction, generator execution, attempt persistence, pending reveal, and stale-completion rejection
- keep `AppState` as the UI-facing adapter with request-scoped history access, published generating state, public error mapping, and successful-mutation invalidation routes
- move workflow behavior into direct tests while retaining AppState coverage for dependency ownership, durable compatibility, public adapters, and retry/edit/delete/clear integration
- surface persistent-history read failures as the existing history-persistence warning instead of misclassifying them as source changes

## Verification

- `make check-test-wiring`
- `make test`
- signed production build
- `codesign --verify --deep --strict /tmp/quill-issue319-build/Quill.app`
- `/code-review medium` (run once after the full tree was green; the confirmed finding was fixed and the full verification was repeated)

Closes #319


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 회의 요약 생성 흐름을 개선해 생성 중 기록 삭제, 재시도, 전사 및 기록 변경 상황에서도 최신 상태를 안정적으로 유지합니다.
  - 오래된 생성 결과가 현재 회의 기록을 덮어쓰지 않도록 처리합니다.
  - 요약 생성 실패와 저장 오류를 더 일관된 상태와 안내로 반영합니다.
  - 회의 기록의 언어와 음성 언어를 바탕으로 요약 생성 설정을 보정합니다.
  - 요약 생성 상태와 저장된 결과가 기록 삭제 후 올바르게 정리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->