### PR TITLE
Extract local model workflows from AppState

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ FULL_SOURCE_APP_STATE_TESTS = \
 	Tests/HistoryArchiveRecoveryWorkflowTests.swift \
 	Tests/TranscriptionRetryWorkflowTests.swift \
 	Tests/NativeWhisperModelWorkflowTests.swift \
+	Tests/LocalAIModelWorkflowTests.swift \
 	Tests/AppStateStorageSafetyTests.swift \
 	Tests/AppStateHistoryProtectionSourceTests.swift \
 	Tests/AppStateTranscriptionConfigurationTests.swift \

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ FULL_SOURCE_APP_STATE_TESTS = \
 	Tests/CredentialStoreTests.swift \
 	Tests/HistoryArchiveRecoveryWorkflowTests.swift \
 	Tests/TranscriptionRetryWorkflowTests.swift \
+	Tests/NativeWhisperModelWorkflowTests.swift \
 	Tests/AppStateStorageSafetyTests.swift \
 	Tests/AppStateHistoryProtectionSourceTests.swift \
 	Tests/AppStateTranscriptionConfigurationTests.swift \

--- a/Sources/AIProcessingBackend.swift
+++ b/Sources/AIProcessingBackend.swift
@@ -151,7 +151,7 @@ struct AIProcessingChoiceDisplay: Identifiable, Equatable {
     var id: String { choice.id }
 }
 
-struct LocalAIModelInstallViewState: Equatable {
+struct LocalAIModelInstallViewState: Equatable, Sendable {
     var status: LocalAIInstallStatus
     var progress: LocalAIDownloadProgress
     var isInstalling: Bool

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -354,19 +354,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     static var applicationTerminationReply: @MainActor (Bool) -> Void = {
         NSApp.reply(toApplicationShouldTerminate: $0)
     }
-    private final class WeakAppStateReference: @unchecked Sendable {
-        weak var value: AppState?
-
-        init(_ value: AppState) {
-            self.value = value
-        }
-    }
-
-    private struct LocalAIModelDeletionOutcome: Sendable {
-        let status: LocalAIInstallStatus
-        let errorDescription: String?
-    }
-
     private struct TranscriptionJob {
         let id: UUID
         let startedAt: Date
@@ -2173,23 +2160,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var activeTranscriptionJobs: [UUID: TranscriptionJob] = [:]
     private var pendingAudioImportJobIDs: Set<UUID> = []
     let localAIServerManager: LocalAIServerManager
+    private let localAIWorkflow: LocalAIModelWorkflow
     @Published private(set) var localAIInstallStates: [String: LocalAIModelInstallViewState] = [:]
     @Published private(set) var contextModelCapabilityWarning: String?
     @Published private var pendingLocalAISelections: [AIProcessingFeature: String] = [:]
-    private var localAIInstallTasks: [String: LocalAIInstallTask] = [:]
-    private var localAIProgressCoalescers:
-        [String: LatestValueProgressCoalescer<LocalAIDownloadProgress>] = [:]
-    private var localAIInstallTokens: [String: UUID] = [:]
-    private var localAICancellingModelIDs: Set<String> = []
-    private var localAIRestartAfterCancellationModelIDs: Set<String> = []
-    private var localAIDeferredInstallModelIDs: Set<String> = []
-    private var localAIDeletionRequestedModelIDs: Set<String> = []
-    private var localAIStatusRefreshGenerations: [String: Int] = [:]
-    private var localAIStatusRefreshPendingModelIDs: Set<String> = []
-    private var localAIStatusRefreshWaiters: [CheckedContinuation<Void, Never>] = []
-    private var localAIInstallQuiescenceWaiters: [CheckedContinuation<Void, Never>] = []
-    private var localAIIdleShutdownTask: Task<Void, Never>?
-    private var hasCompletedLocalAIStatusRefresh = false
 
     @Published var postProcessingBackendChoice: AIProcessingBackendChoice {
         didSet {
@@ -2867,6 +2841,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let shouldRestoreMutedAudio = UserDefaults.standard.bool(forKey: pendingMutedAudioRestoreStorageKey)
 
         self.localAIServerManager = localAIServerManager
+        let localAIWorkflow = LocalAIModelWorkflow(
+            dependencies: dependencies.localAI,
+            serverManager: localAIServerManager
+        )
+        self.localAIWorkflow = localAIWorkflow
         self.contextService = Self.makeAppContextService(
             choice: contextBackendChoice,
             apiKey: apiKey,
@@ -2968,6 +2947,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.nativeWhisperWorkflow.onEvent = { [weak self] event in
             self?.applyNativeWhisperModelWorkflowEvent(event)
         }
+        self.localAIWorkflow.onEvent = { [weak self] event in
+            self?.applyLocalAIModelWorkflowEvent(event)
+        }
         if let cloudReconciliation {
             let cloudDependenciesFactory = dependencies
                 .makeRetryCloudTranscriptionDependencies
@@ -3066,122 +3048,39 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     deinit {
-        localAIIdleShutdownTask?.cancel()
         removeAudioDeviceObservers()
     }
 
     @MainActor
     func startLocalAIIdleShutdownMonitoring() {
-        guard localAIIdleShutdownTask == nil else { return }
-        let manager = localAIServerManager
-        let sleep = dependencies.localAI.idleShutdownSleep
-        localAIIdleShutdownTask = Task {
-            while !Task.isCancelled {
-                do {
-                    try await sleep(30_000_000_000)
-                } catch {
-                    return
-                }
-                guard !Task.isCancelled else { return }
-                await manager.shutdownIfIdle()
-            }
-        }
+        localAIWorkflow.startIdleShutdownMonitoring()
     }
 
     @MainActor
     func stopLocalAIIdleShutdownMonitoring() {
-        localAIIdleShutdownTask?.cancel()
-        localAIIdleShutdownTask = nil
+        localAIWorkflow.stopIdleShutdownMonitoring()
     }
 
     @MainActor
     func localAIInstallState(
         for model: LocalAIModel
     ) -> LocalAIModelInstallViewState {
-        localAIInstallStates[model.id]
-            ?? .initial(model: model, status: .notInstalled)
+        localAIWorkflow.installState(for: model)
     }
 
     @MainActor
     func refreshAllLocalAIInstallStates() {
-        hasCompletedLocalAIStatusRefresh = false
-        localAIStatusRefreshPendingModelIDs = Set(
-            LocalAIModelCatalog.all.map(\.id)
-        )
-        for model in LocalAIModelCatalog.all {
-            if localAIInstallStates[model.id] == nil {
-                localAIInstallStates[model.id] = .initial(
-                    model: model,
-                    status: .notInstalled
-                )
-            }
-            let generation = nextLocalAIStatusRefreshGeneration(for: model)
-            let statusProvider = dependencies.localAI.installStatus
-            let appStateReference = WeakAppStateReference(self)
-            Task.detached(priority: .utility) {
-                let status = statusProvider(model)
-                await MainActor.run {
-                    appStateReference.value?.applyLocalAIStatusRefresh(
-                        status,
-                        for: model,
-                        generation: generation
-                    )
-                }
-            }
-        }
+        localAIWorkflow.refreshAllInstallStates()
     }
 
     @MainActor
     func waitForLocalAIInstallStateRefresh() async {
-        guard !hasCompletedLocalAIStatusRefresh else { return }
-        await withCheckedContinuation { continuation in
-            localAIStatusRefreshWaiters.append(continuation)
-        }
+        await localAIWorkflow.waitForInitialStatusRefresh()
     }
 
     @MainActor
     func waitForLocalAIInstallsToQuiesce() async {
-        guard !localAIInstallTasks.isEmpty else { return }
-        await withCheckedContinuation { continuation in
-            localAIInstallQuiescenceWaiters.append(continuation)
-        }
-    }
-
-    @MainActor
-    private func resumeLocalAIInstallQuiescenceWaitersIfNeeded() {
-        guard localAIInstallTasks.isEmpty else { return }
-        let waiters = localAIInstallQuiescenceWaiters
-        localAIInstallQuiescenceWaiters.removeAll()
-        for waiter in waiters {
-            waiter.resume()
-        }
-    }
-
-    @MainActor
-    private func nextLocalAIStatusRefreshGeneration(
-        for model: LocalAIModel
-    ) -> Int {
-        let generation = localAIStatusRefreshGenerations[model.id, default: 0] + 1
-        localAIStatusRefreshGenerations[model.id] = generation
-        return generation
-    }
-
-    @MainActor
-    private func applyLocalAIStatusRefresh(
-        _ status: LocalAIInstallStatus,
-        for model: LocalAIModel,
-        generation: Int
-    ) {
-        guard localAIStatusRefreshGenerations[model.id] == generation,
-              localAIInstallTasks[model.id] == nil,
-              !localAIDeletionRequestedModelIDs.contains(model.id) else {
-            return
-        }
-        var state = localAIInstallState(for: model)
-        state.status = status
-        localAIInstallStates[model.id] = state
-        localAIStatusRefreshPendingModelIDs.remove(model.id)
-        finishLocalAIStatusRefreshIfReady()
+        await localAIWorkflow.waitForInstallsToQuiesce()
     }
 
     @MainActor
@@ -3208,48 +3107,43 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
-    private func finishLocalAIStatusRefreshIfReady() {
-        guard localAIStatusRefreshPendingModelIDs.isEmpty else { return }
-        hasCompletedLocalAIStatusRefresh = true
-        normalizeAIProcessingChoices()
-        initializeMeetingSummarySettingsIfNeeded()
-        resumeDeferredLocalAIRequests()
-        let waiters = localAIStatusRefreshWaiters
-        localAIStatusRefreshWaiters.removeAll()
-        for waiter in waiters {
-            waiter.resume()
-        }
-    }
-
-    @MainActor
-    private func completeLocalAIStatusOperation(
-        _ status: LocalAIInstallStatus,
-        for model: LocalAIModel
+    private func applyLocalAIModelWorkflowEvent(
+        _ event: LocalAIModelWorkflowEvent
     ) {
-        _ = nextLocalAIStatusRefreshGeneration(for: model)
-        let completedRefresh = localAIStatusRefreshPendingModelIDs.remove(model.id) != nil
-        var state = localAIInstallState(for: model)
-        state.status = status
-        localAIInstallStates[model.id] = state
-        if completedRefresh {
-            finishLocalAIStatusRefreshIfReady()
+        switch event {
+        case .stateChanged(let state):
+            localAIInstallStates = state.installStates
+
+        case .installOutcome(let model, let outcome):
+            switch outcome {
+            case .readyAndAvailable:
+                applyReadyLocalAIModelToWaitingFeatures(model)
+            case .succeededButUnavailable, .cancelled, .failed:
+                clearPendingLocalAISelections(forModelID: model.id)
+            }
+
+        case .deletionOutcome:
+            break
+
+        case .initialStatusRefreshCompleted(let deferredModelIDs):
+            normalizeAIProcessingChoices()
+            initializeMeetingSummarySettingsIfNeeded()
+            resumeDeferredLocalAIRequests(deferredModelIDs: deferredModelIDs)
         }
     }
 
     @MainActor
-    private func resumeDeferredLocalAIRequests() {
+    private func resumeDeferredLocalAIRequests(deferredModelIDs: Set<String>) {
         let pendingModelIDs = Set(pendingLocalAISelections.values)
         for modelID in pendingModelIDs {
             guard let model = LocalAIModelCatalog.model(id: modelID),
-                  !localAIDeletionRequestedModelIDs.contains(modelID) else {
+                  !localAIWorkflow.isDeletionRequested(modelID) else {
                 clearPendingLocalAISelections(forModelID: modelID)
                 continue
             }
             guard isLocalAIModelAvailable(model) else {
                 clearPendingLocalAISelections(forModelID: modelID)
-                var state = localAIInstallState(for: model)
-                state.issue = localAIModelUnavailableIssue(for: model)
-                localAIInstallStates[model.id] = state
+                localAIWorkflow.markUnavailable(model)
                 continue
             }
             if localAIInstallState(for: model).status == .ready {
@@ -3257,25 +3151,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
         }
 
-        let requestedModelIDs = localAIDeferredInstallModelIDs
-        localAIDeferredInstallModelIDs.removeAll()
-        for modelID in requestedModelIDs {
+        for modelID in deferredModelIDs {
             guard let model = LocalAIModelCatalog.model(id: modelID),
-                  !localAIDeletionRequestedModelIDs.contains(modelID) else {
+                  !localAIWorkflow.isDeletionRequested(modelID) else {
                 clearPendingLocalAISelections(forModelID: modelID)
                 continue
             }
             guard isLocalAIModelAvailable(model) else {
                 clearPendingLocalAISelections(forModelID: modelID)
-                var state = localAIInstallState(for: model)
-                state.issue = localAIModelUnavailableIssue(for: model)
-                localAIInstallStates[model.id] = state
+                localAIWorkflow.markUnavailable(model)
                 continue
             }
             if localAIInstallState(for: model).status == .ready {
                 applyReadyLocalAIModelToWaitingFeatures(model)
             } else {
-                startLocalAIInstallIfPossible(model)
+                localAIWorkflow.startInstall(model)
             }
         }
     }
@@ -3479,10 +3369,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func isLocalAIModelAvailable(_ model: LocalAIModel) -> Bool {
-        guard LocalAIModelCatalog.model(id: model.id) == model else {
+        guard localAIWorkflow.canonicalModel(for: model) != nil else {
             return false
         }
-        return dependencies.localAI.processingAvailability().isModelSupported(model)
+        return localAIWorkflow.isModelAvailable(model)
     }
 
     @MainActor
@@ -3526,7 +3416,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         case .cloud:
             return !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         case .localAI(let modelID):
-            guard hasCompletedLocalAIStatusRefresh,
+            guard localAIWorkflow.state.hasCompletedInitialStatusRefresh,
                   let model = LocalAIModelCatalog.model(id: modelID),
                   isLocalAIModelAvailable(model) else {
                 return false
@@ -3567,7 +3457,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         let availability = dependencies.localAI.processingAvailability()
-        if hasCompletedLocalAIStatusRefresh, availability.isSupported {
+        if localAIWorkflow.state.hasCompletedInitialStatusRefresh, availability.isSupported {
             let readyModels = availability.availableModels.filter {
                 $0.capabilities.supports(feature.modelFeature)
                     && (feature != .context || $0.capabilities.modalities.contains(.image))
@@ -3732,10 +3622,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         case .localAI(let modelID):
             guard let model = LocalAIModelCatalog.model(id: modelID),
                   isLocalAIModelAvailable(model),
-                  !localAIDeletionRequestedModelIDs.contains(modelID) else {
+                  !localAIWorkflow.isDeletionRequested(modelID) else {
                 return
             }
-            guard hasCompletedLocalAIStatusRefresh else {
+            guard localAIWorkflow.state.hasCompletedInitialStatusRefresh else {
                 setPendingLocalAIModelID(modelID, for: feature)
                 return
             }
@@ -3753,10 +3643,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         _ model: LocalAIModel,
         autoSelectFor feature: AIProcessingFeature? = nil
     ) {
-        guard !isModelTerminationCleanupPending else { return }
-        guard let canonicalModel = canonicalLocalAIModel(model),
-              isLocalAIModelAvailable(canonicalModel),
-              !localAIDeletionRequestedModelIDs.contains(model.id) else {
+        guard !isModelTerminationCleanupPending,
+              let canonicalModel = localAIWorkflow.canonicalModel(for: model),
+              localAIWorkflow.isModelAvailable(canonicalModel),
+              !localAIWorkflow.isDeletionRequested(model.id) else {
             return
         }
         if let feature {
@@ -3768,167 +3658,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 updateContextModelCapabilityWarning(for: choice)
             }
         }
-        guard hasCompletedLocalAIStatusRefresh else {
-            localAIDeferredInstallModelIDs.insert(model.id)
-            return
-        }
-        if localAIInstallState(for: canonicalModel).status == .ready {
-            applyReadyLocalAIModelToWaitingFeatures(canonicalModel)
-            return
-        }
-        if localAICancellingModelIDs.contains(model.id) {
-            localAIRestartAfterCancellationModelIDs.insert(model.id)
-            return
-        }
-        startLocalAIInstallIfPossible(canonicalModel)
-    }
-
-    @MainActor
-    private func startLocalAIInstallIfPossible(_ model: LocalAIModel) {
-        guard !isModelTerminationCleanupPending else { return }
-        guard localAIInstallTasks[model.id] == nil,
-              !localAICancellingModelIDs.contains(model.id),
-              !localAIDeletionRequestedModelIDs.contains(model.id),
-              isLocalAIModelAvailable(model) else {
-            return
-        }
-
-        let token = UUID()
-        localAIInstallTokens[model.id] = token
-        _ = nextLocalAIStatusRefreshGeneration(for: model)
-        var state = localAIInstallState(for: model)
-        state.isInstalling = true
-        state.issue = nil
-        state.progress = LocalAIDownloadProgress(
-            downloadedBytes: 0,
-            totalBytes: model.approximateBytes
-        )
-        localAIInstallStates[model.id] = state
-
-        let progressCoalescer = LatestValueProgressCoalescer<LocalAIDownloadProgress>(
-            schedule: dependencies.localAI.progressSchedule
-        ) { [weak self] progress in
-            MainActor.assumeIsolated {
-                guard let self,
-                      self.localAIInstallTokens[model.id] == token,
-                      !self.localAICancellingModelIDs.contains(model.id),
-                      !self.localAIDeletionRequestedModelIDs.contains(model.id) else {
-                    return
-                }
-                var state = self.localAIInstallState(for: model)
-                state.progress = progress
-                self.localAIInstallStates[model.id] = state
-            }
-        }
-        localAIProgressCoalescers[model.id] = progressCoalescer
-
-        let statusProvider = dependencies.localAI.installStatus
-        let partialModelDelete = dependencies.localAI.deletePartialModel
-        let startInstall = dependencies.localAI.startInstall
-        localAIInstallTasks[model.id] = startInstall(
-            model,
-            { progress in
-                progressCoalescer.submit(progress)
-            },
-            { [weak self] result in
-                guard let appState = self else { return }
-                Task.detached(priority: .utility) {
-                    let cleanupErrorDescription: String? = {
-                        guard case .failure(.cancelled) = result else {
-                            return nil
-                        }
-                        do {
-                            try partialModelDelete(model)
-                            return nil
-                        } catch {
-                            return error.localizedDescription
-                        }
-                    }()
-                    let status = statusProvider(model)
-                    await MainActor.run {
-                        appState.finishLocalAIInstall(
-                            model: model,
-                            token: token,
-                            result: result,
-                            status: status,
-                            cleanupErrorDescription: cleanupErrorDescription
-                        )
-                    }
-                }
-            }
-        )
-    }
-
-    @MainActor
-    private func finishLocalAIInstall(
-        model: LocalAIModel,
-        token: UUID,
-        result: Result<Void, LocalAIInstallerError>,
-        status: LocalAIInstallStatus,
-        cleanupErrorDescription: String?
-    ) {
-        guard localAIInstallTokens[model.id] == token,
-              localAIInstallTasks.removeValue(forKey: model.id) != nil else {
-            return
-        }
-        localAIProgressCoalescers.removeValue(forKey: model.id)?.invalidate()
-        defer { resumeLocalAIInstallQuiescenceWaitersIfNeeded() }
-        localAIInstallTokens.removeValue(forKey: model.id)
-        let wasCancelling = localAICancellingModelIDs.remove(model.id) != nil
-        let shouldDelete = localAIDeletionRequestedModelIDs.contains(model.id)
-        let shouldRestart = localAIRestartAfterCancellationModelIDs.remove(model.id) != nil
-
-        var state = localAIInstallState(for: model)
-        state.isInstalling = false
-        state.status = status
-        localAIInstallStates[model.id] = state
-        if let cleanupErrorDescription {
-            state.issue = localAIModelUnavailableIssue(for: model)
-            print("Local AI partial cleanup failed: \(cleanupErrorDescription)")
-        } else if shouldDelete {
-            state.issue = nil
-        } else if wasCancelling {
-            state.issue = nil
-        } else {
-            switch result {
-            case .success
-                where status == .ready
-                    && isLocalAIModelAvailable(model):
-                state.issue = nil
-                applyReadyLocalAIModelToWaitingFeatures(model)
-            case .success:
-                clearPendingLocalAISelections(forModelID: model.id)
-                state.issue = localAIModelUnavailableIssue(for: model)
-            case .failure(.cancelled):
-                clearPendingLocalAISelections(forModelID: model.id)
-                state.issue = nil
-            case .failure(let error):
-                clearPendingLocalAISelections(forModelID: model.id)
-                state.issue = localAIModelUnavailableIssue(for: model)
-                print("Local AI install failed: \(error.localizedDescription)")
-            }
-        }
-        localAIInstallStates[model.id] = state
-        completeLocalAIStatusOperation(status, for: model)
-
-        if shouldDelete {
-            beginLocalAIModelDeletion(model)
-            return
-        }
-        guard wasCancelling, shouldRestart else { return }
-        guard cleanupErrorDescription == nil,
-              isLocalAIModelAvailable(model) else {
-            clearPendingLocalAISelections(forModelID: model.id)
-            var unavailableState = localAIInstallState(for: model)
-            unavailableState.issue = localAIModelUnavailableIssue(for: model)
-            localAIInstallStates[model.id] = unavailableState
-            return
-        }
-        if status == .ready {
-            applyReadyLocalAIModelToWaitingFeatures(model)
-        } else {
-            startLocalAIInstallIfPossible(model)
-        }
+        localAIWorkflow.startInstall(canonicalModel)
     }
 
     @MainActor
@@ -3936,9 +3666,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         guard isLocalAIModelAvailable(model),
               localAIInstallState(for: model).status == .ready else {
             clearPendingLocalAISelections(forModelID: model.id)
-            var state = localAIInstallState(for: model)
-            state.issue = localAIModelUnavailableIssue(for: model)
-            localAIInstallStates[model.id] = state
+            localAIWorkflow.markUnavailable(model)
             return
         }
         let choice = AIProcessingBackendChoice.localAI(modelID: model.id)
@@ -3956,29 +3684,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
-    private func canonicalLocalAIModel(_ model: LocalAIModel) -> LocalAIModel? {
-        guard let canonical = LocalAIModelCatalog.model(id: model.id),
-              canonical == model else {
-            return nil
-        }
-        return canonical
-    }
-
-    @MainActor
-    private func localAIModelUnavailableIssue(
-        for model: LocalAIModel
-    ) -> QuillUserIssueRecord {
-        QuillUserIssueRecord(
-            code: .localAIModelUnavailable,
-            severity: .error,
-            context: QuillUserIssueContext(
-                modelID: model.id,
-                localBackend: "Local AI"
-            )
-        )
-    }
-
-    @MainActor
     func cancelPendingLocalAISelection(
         for feature: AIProcessingFeature
     ) {
@@ -3987,22 +3692,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func cancelLocalAIInstall(_ model: LocalAIModel) {
-        guard let canonicalModel = canonicalLocalAIModel(model),
-              let task = localAIInstallTasks[canonicalModel.id] else {
-            return
-        }
-        localAIProgressCoalescers.removeValue(forKey: canonicalModel.id)?.invalidate()
-        localAICancellingModelIDs.insert(canonicalModel.id)
-        localAIRestartAfterCancellationModelIDs.remove(canonicalModel.id)
-        clearPendingLocalAISelections(forModelID: canonicalModel.id)
-        task.cancel()
-        var state = localAIInstallState(for: canonicalModel)
-        state.progress = LocalAIDownloadProgress(
-            downloadedBytes: state.progress.downloadedBytes,
-            totalBytes: state.progress.totalBytes,
-            isCancelled: true
-        )
-        localAIInstallStates[canonicalModel.id] = state
+        guard localAIWorkflow.cancelInstall(model) else { return }
+        clearPendingLocalAISelections(forModelID: model.id)
     }
 
     @MainActor
@@ -4042,7 +3733,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func normalizeAIProcessingChoices() {
-        guard hasCompletedLocalAIStatusRefresh else { return }
+        guard localAIWorkflow.state.hasCompletedInitialStatusRefresh else { return }
         for feature in AIProcessingFeature.allCases {
             let current = currentAIProcessingChoice(for: feature)
             guard isAIProcessingChoiceCompatible(current, for: feature) else {
@@ -4077,93 +3768,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func deleteLocalAIModel(_ model: LocalAIModel) {
-        guard let canonicalModel = canonicalLocalAIModel(model),
-              !localAIDeletionRequestedModelIDs.contains(canonicalModel.id) else {
-            return
-        }
-        localAIDeletionRequestedModelIDs.insert(canonicalModel.id)
-        localAIDeferredInstallModelIDs.remove(canonicalModel.id)
-        localAIRestartAfterCancellationModelIDs.remove(canonicalModel.id)
-        clearPendingLocalAISelections(forModelID: canonicalModel.id)
-
-        if let task = localAIInstallTasks[canonicalModel.id] {
-            localAICancellingModelIDs.insert(canonicalModel.id)
-            task.cancel()
-            var state = localAIInstallState(for: canonicalModel)
-            state.progress = LocalAIDownloadProgress(
-                downloadedBytes: state.progress.downloadedBytes,
-                totalBytes: state.progress.totalBytes,
-                isCancelled: true
-            )
-            localAIInstallStates[canonicalModel.id] = state
-            return
-        }
-        beginLocalAIModelDeletion(canonicalModel)
-    }
-
-    @MainActor
-    private func beginLocalAIModelDeletion(_ model: LocalAIModel) {
-        guard localAIDeletionRequestedModelIDs.contains(model.id),
-              localAIInstallTasks[model.id] == nil else {
-            return
-        }
-        hasCompletedLocalAIStatusRefresh = false
-        localAIStatusRefreshPendingModelIDs.insert(model.id)
-        _ = nextLocalAIStatusRefreshGeneration(for: model)
-        let manager = localAIServerManager
-        let modelDelete = dependencies.localAI.deleteModel
-        let statusProvider = dependencies.localAI.installStatus
-        Task { [weak self] in
-            let outcome: LocalAIModelDeletionOutcome
-            do {
-                outcome = try await manager.withExclusiveMaintenance {
-                    do {
-                        try modelDelete(model)
-                        return LocalAIModelDeletionOutcome(
-                            status: statusProvider(model),
-                            errorDescription: nil
-                        )
-                    } catch {
-                        return LocalAIModelDeletionOutcome(
-                            status: statusProvider(model),
-                            errorDescription: error.localizedDescription
-                        )
-                    }
-                }
-            } catch {
-                guard let self else { return }
-                outcome = LocalAIModelDeletionOutcome(
-                    status: self.localAIInstallState(for: model).status,
-                    errorDescription: error.localizedDescription
-                )
-            }
-            guard let self else { return }
-            self.finishLocalAIModelDeletion(model, outcome: outcome)
-        }
-    }
-
-    @MainActor
-    private func finishLocalAIModelDeletion(
-        _ model: LocalAIModel,
-        outcome: LocalAIModelDeletionOutcome
-    ) {
-        guard localAIDeletionRequestedModelIDs.remove(model.id) != nil else {
-            return
-        }
-        if let errorDescription = outcome.errorDescription {
-            var state = localAIInstallState(for: model)
-            state.isInstalling = false
-            state.status = outcome.status
-            state.issue = localAIModelUnavailableIssue(for: model)
-            localAIInstallStates[model.id] = state
-            print("Local AI model deletion failed: \(errorDescription)")
-        } else {
-            localAIInstallStates[model.id] = .initial(
-                model: model,
-                status: outcome.status
-            )
-        }
-        completeLocalAIStatusOperation(outcome.status, for: model)
+        guard localAIWorkflow.deleteModel(model) else { return }
+        clearPendingLocalAISelections(forModelID: model.id)
     }
 
     private func removeAudioDeviceObservers() {
@@ -8139,7 +7745,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private var hasActiveModelDownload: Bool {
-        isInstallingNativeWhisper || !localAIInstallTasks.isEmpty
+        isInstallingNativeWhisper || localAIWorkflow.hasActiveInstalls
     }
 
     @MainActor
@@ -8150,11 +7756,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func cancelAllLocalAIInstalls() {
-        localAIDeferredInstallModelIDs.removeAll()
-        localAIRestartAfterCancellationModelIDs.removeAll()
         pendingLocalAISelections.removeAll()
-        let activeModelIDs = Set(localAIInstallTasks.keys)
-        for model in LocalAIModelCatalog.all where activeModelIDs.contains(model.id) {
+        for model in LocalAIModelCatalog.all {
             cancelLocalAIInstall(model)
         }
     }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -7785,6 +7785,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         cancelAllLocalAIInstalls()
         stopLocalAIIdleShutdownMonitoring()
         isModelTerminationCleanupPending = true
+        nativeWhisperWorkflow.beginTerminationCleanup()
+        localAIWorkflow.beginTerminationCleanup()
         let manager = localAIServerManager
         Task { [weak self] in
             guard let self else { return }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1284,11 +1284,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
     ) {
         switch event {
         case .stateChanged(let state):
-            nativeWhisperInstallStatus = state.installStatus
-            nativeWhisperInstallProgress = state.installProgress
-            isInstallingNativeWhisper = state.isInstalling
-            nativeWhisperInstallError = state.installError
-            nativeWhisperInstallIssue = state.installIssue
+            update(\AppState.nativeWhisperInstallStatus, to: state.installStatus)
+            update(\AppState.nativeWhisperInstallProgress, to: state.installProgress)
+            update(\AppState.isInstallingNativeWhisper, to: state.isInstalling)
+            update(\AppState.nativeWhisperInstallError, to: state.installError)
+            update(\AppState.nativeWhisperInstallIssue, to: state.installIssue)
 
         case .installCompleted(let outcome):
             scheduleNoteBrowserTranscriptionModeNormalizationForProviderConfiguration()

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1009,16 +1009,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @Published private(set) var nativeWhisperInstallStatus: NativeWhisperInstallStatus
-    @Published private(set) var nativeWhisperInstallProgress = NativeWhisperDownloadProgress(downloadedBytes: 0, totalBytes: NativeWhisperModelCatalog.recommended.approximateBytes)
+    @Published private(set) var nativeWhisperInstallProgress: NativeWhisperDownloadProgress
     @Published private(set) var isInstallingNativeWhisper = false
     @Published private(set) var nativeWhisperInstallError: String?
     @Published private(set) var nativeWhisperInstallIssue: QuillUserIssueRecord?
     @Published private(set) var pendingNativeWhisperAutoSelectionModelID: String?
-    private var nativeWhisperInstallTask: NativeWhisperInstallTask?
-    private var nativeWhisperProgressCoalescer:
-        LatestValueProgressCoalescer<NativeWhisperDownloadProgress>?
-    private var nativeWhisperInstallQuiescenceWaiters: [CheckedContinuation<Void, Never>] = []
-    private var nativeWhisperInstallCancellationMessage: String?
 
     var willAutoSelectNativeWhisperWhenReady: Bool {
         pendingNativeWhisperAutoSelectionModelID != nil
@@ -1261,97 +1256,22 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     func refreshNativeWhisperInstallStatus() {
-        nativeWhisperInstallStatus = dependencies.nativeWhisper.installStatus(
-            .recommended
-        )
+        nativeWhisperWorkflow.refreshInstallStatus()
         scheduleNoteBrowserTranscriptionModeNormalizationForProviderConfiguration()
     }
 
     @MainActor
     func installNativeWhisperModel(autoSelectWhenReady: Bool = true) {
         guard !isModelTerminationCleanupPending else { return }
-        let model = NativeWhisperModelCatalog.recommended
         if autoSelectWhenReady {
-            pendingNativeWhisperAutoSelectionModelID = model.id
+            pendingNativeWhisperAutoSelectionModelID = NativeWhisperModelCatalog.recommended.id
         }
-        guard !isInstallingNativeWhisper else { return }
-        nativeWhisperInstallError = nil
-        nativeWhisperInstallIssue = nil
-        nativeWhisperInstallCancellationMessage = nil
-        isInstallingNativeWhisper = true
-        nativeWhisperInstallProgress = NativeWhisperDownloadProgress(downloadedBytes: 0, totalBytes: model.approximateBytes)
-        let progressCoalescer = LatestValueProgressCoalescer<NativeWhisperDownloadProgress>(
-            schedule: dependencies.nativeWhisper.progressSchedule
-        ) { [weak self] progress in
-            MainActor.assumeIsolated {
-                self?.nativeWhisperInstallProgress = progress
-            }
-        }
-        nativeWhisperProgressCoalescer = progressCoalescer
-        let startInstall = dependencies.nativeWhisper.startInstall
-        nativeWhisperInstallTask = startInstall(
-            model,
-            { progress in
-                progressCoalescer.submit(progress)
-            },
-            { [weak self] result in
-                DispatchQueue.main.async {
-                    self?.finishNativeWhisperInstall(model: model, result: result)
-                }
-            }
-        )
-    }
-
-    @MainActor
-    private func finishNativeWhisperInstall(
-        model: NativeWhisperModel,
-        result: Result<Void, NativeWhisperInstallerError>
-    ) {
-        nativeWhisperProgressCoalescer?.invalidate()
-        nativeWhisperProgressCoalescer = nil
-        nativeWhisperInstallTask = nil
-        defer { resumeNativeWhisperInstallQuiescenceWaitersIfNeeded() }
-        isInstallingNativeWhisper = false
-        refreshNativeWhisperInstallStatus()
-
-        switch result {
-        case .success:
-            if pendingNativeWhisperAutoSelectionModelID == model.id {
-                setNoteBrowserTranscriptionChoice(.nativeWhisper(modelID: model.id))
-            }
-            pendingNativeWhisperAutoSelectionModelID = nil
-        case .failure(.cancelled):
-            pendingNativeWhisperAutoSelectionModelID = nil
-            nativeWhisperInstallError = nativeWhisperInstallCancellationMessage
-            nativeWhisperInstallCancellationMessage = nil
-        case .failure:
-            pendingNativeWhisperAutoSelectionModelID = nil
-            nativeWhisperInstallIssue = QuillUserIssueRecord(
-                code: .localModelMissing,
-                context: QuillUserIssueContext(
-                    modelID: model.id,
-                    localBackend: "Native Whisper"
-                )
-            )
-        }
+        nativeWhisperWorkflow.startInstall()
     }
 
     @MainActor
     func waitForNativeWhisperInstallToQuiesce() async {
-        guard nativeWhisperInstallTask != nil else { return }
-        await withCheckedContinuation { continuation in
-            nativeWhisperInstallQuiescenceWaiters.append(continuation)
-        }
-    }
-
-    @MainActor
-    private func resumeNativeWhisperInstallQuiescenceWaitersIfNeeded() {
-        guard nativeWhisperInstallTask == nil else { return }
-        let waiters = nativeWhisperInstallQuiescenceWaiters
-        nativeWhisperInstallQuiescenceWaiters.removeAll()
-        for waiter in waiters {
-            waiter.resume()
-        }
+        await nativeWhisperWorkflow.waitUntilQuiesced()
     }
 
     @MainActor
@@ -1362,33 +1282,42 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @MainActor
     func cancelNativeWhisperInstall() {
         pendingNativeWhisperAutoSelectionModelID = nil
-        nativeWhisperInstallCancellationMessage = nil
-        nativeWhisperProgressCoalescer?.invalidate()
-        nativeWhisperProgressCoalescer = nil
-        nativeWhisperInstallTask?.cancel()
-        nativeWhisperInstallProgress = NativeWhisperDownloadProgress(
-            downloadedBytes: nativeWhisperInstallProgress.downloadedBytes,
-            totalBytes: nativeWhisperInstallProgress.totalBytes,
-            isCancelled: true
-        )
+        nativeWhisperWorkflow.cancelInstall()
     }
 
     @MainActor
     func deleteNativeWhisperModel() {
-        do {
-            try dependencies.nativeWhisper.deleteModel(.recommended)
-            nativeWhisperInstallError = nil
-            nativeWhisperInstallIssue = nil
-        } catch {
-            nativeWhisperInstallIssue = QuillUserIssueRecord(
-                code: .localModelMissing,
-                context: QuillUserIssueContext(
-                    modelID: NativeWhisperModelCatalog.recommended.id,
-                    localBackend: "Native Whisper"
-                )
-            )
+        nativeWhisperWorkflow.deleteModel()
+        scheduleNoteBrowserTranscriptionModeNormalizationForProviderConfiguration()
+    }
+
+    @MainActor
+    private func applyNativeWhisperModelWorkflowEvent(
+        _ event: NativeWhisperModelWorkflowEvent
+    ) {
+        switch event {
+        case .stateChanged(let state):
+            nativeWhisperInstallStatus = state.installStatus
+            nativeWhisperInstallProgress = state.installProgress
+            isInstallingNativeWhisper = state.isInstalling
+            nativeWhisperInstallError = state.installError
+            nativeWhisperInstallIssue = state.installIssue
+
+        case .installCompleted(let outcome):
+            scheduleNoteBrowserTranscriptionModeNormalizationForProviderConfiguration()
+            switch outcome {
+            case .succeeded:
+                if pendingNativeWhisperAutoSelectionModelID
+                    == NativeWhisperModelCatalog.recommended.id {
+                    setNoteBrowserTranscriptionChoice(
+                        .nativeWhisper(modelID: NativeWhisperModelCatalog.recommended.id)
+                    )
+                }
+                pendingNativeWhisperAutoSelectionModelID = nil
+            case .cancelled, .failed:
+                pendingNativeWhisperAutoSelectionModelID = nil
+            }
         }
-        refreshNativeWhisperInstallStatus()
     }
 
     @MainActor
@@ -2025,6 +1954,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published private(set) var meetingSummaryGeneratingNoteIDs: Set<UUID> = []
     private let meetingSummaryWorkflow: MeetingSummaryWorkflow
     private let transcriptionRetryWorkflow: TranscriptionRetryWorkflow
+    private let nativeWhisperWorkflow: NativeWhisperModelWorkflow
     @Published var debugStatusMessage = "Idle"
     @Published var debugShowsUpdateReminderAfterDictation = false
     @Published var lastRawTranscript = ""
@@ -2400,9 +2330,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     init(dependencies: AppStateDependencies = .live) {
         self.dependencies = dependencies
-        nativeWhisperInstallStatus = dependencies.nativeWhisper.installStatus(
-            .recommended
+        let nativeWhisperWorkflow = NativeWhisperModelWorkflow(
+            dependencies: dependencies.nativeWhisper
         )
+        self.nativeWhisperWorkflow = nativeWhisperWorkflow
+        nativeWhisperInstallStatus = nativeWhisperWorkflow.initialState.installStatus
+        nativeWhisperInstallProgress = nativeWhisperWorkflow.initialState.installProgress
         let storageLayout = dependencies.storageLayout
         let historyWorkflow = HistoryArchiveRecoveryWorkflow(
             storageLayout: storageLayout,
@@ -3031,6 +2964,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.precomputeMacros()
         transcriptionRetryWorkflow.onEvent = { [weak self] event in
             self?.applyTranscriptionRetryWorkflowEvent(event)
+        }
+        self.nativeWhisperWorkflow.onEvent = { [weak self] event in
+            self?.applyNativeWhisperModelWorkflowEvent(event)
         }
         if let cloudReconciliation {
             let cloudDependenciesFactory = dependencies
@@ -8203,7 +8139,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private var hasActiveModelDownload: Bool {
-        nativeWhisperInstallTask != nil || !localAIInstallTasks.isEmpty
+        isInstallingNativeWhisper || !localAIInstallTasks.isEmpty
     }
 
     @MainActor

--- a/Sources/LocalAIModelWorkflow.swift
+++ b/Sources/LocalAIModelWorkflow.swift
@@ -1,0 +1,534 @@
+import Foundation
+
+struct LocalAIModelWorkflowState: Equatable, Sendable {
+    var installStates: [String: LocalAIModelInstallViewState] = [:]
+    var hasCompletedInitialStatusRefresh = false
+}
+
+enum LocalAIModelWorkflowInstallOutcome: Equatable, Sendable {
+    case readyAndAvailable
+    case succeededButUnavailable(QuillUserIssueRecord)
+    case cancelled
+    case failed(QuillUserIssueRecord)
+}
+
+enum LocalAIModelWorkflowEvent {
+    case stateChanged(LocalAIModelWorkflowState)
+    case installOutcome(LocalAIModel, LocalAIModelWorkflowInstallOutcome)
+    case deletionOutcome(LocalAIModel, errorDescription: String?)
+    case initialStatusRefreshCompleted(deferredModelIDs: Set<String>)
+}
+
+private struct LocalAIModelDeletionOutcome: Sendable {
+    let status: LocalAIInstallStatus
+    let errorDescription: String?
+}
+
+@MainActor
+final class LocalAIModelWorkflow: @unchecked Sendable {
+    private let dependencies: AppStateLocalAIDependencies
+    private let serverManager: LocalAIServerManager
+    var onEvent: ((LocalAIModelWorkflowEvent) -> Void)?
+    private(set) var state = LocalAIModelWorkflowState()
+
+    private var installTasks: [String: LocalAIInstallTask] = [:]
+    private var progressCoalescers: [String: LatestValueProgressCoalescer<LocalAIDownloadProgress>] = [:]
+    private var installTokens: [String: UUID] = [:]
+    private var cancellingModelIDs: Set<String> = []
+    private var restartAfterCancellationModelIDs: Set<String> = []
+    private var deferredInstallModelIDs: Set<String> = []
+    private var deletionRequestedModelIDs: Set<String> = []
+    private var statusRefreshGenerations: [String: Int] = [:]
+    private var statusRefreshPendingModelIDs: Set<String> = []
+    private var statusRefreshWaiters: [CheckedContinuation<Void, Never>] = []
+    private var installQuiescenceWaiters: [CheckedContinuation<Void, Never>] = []
+    private var idleShutdownTask: Task<Void, Never>?
+    private var isTerminationCleanupPending = false
+
+    init(
+        dependencies: AppStateLocalAIDependencies,
+        serverManager: LocalAIServerManager
+    ) {
+        self.dependencies = dependencies
+        self.serverManager = serverManager
+    }
+
+    deinit {
+        idleShutdownTask?.cancel()
+    }
+
+    var hasActiveInstalls: Bool { !installTasks.isEmpty }
+
+    // MARK: - Idle shutdown monitoring
+
+    func startIdleShutdownMonitoring() {
+        guard idleShutdownTask == nil else { return }
+        let manager = serverManager
+        let sleep = dependencies.idleShutdownSleep
+        idleShutdownTask = Task {
+            while !Task.isCancelled {
+                do {
+                    try await sleep(30_000_000_000)
+                } catch {
+                    return
+                }
+                guard !Task.isCancelled else { return }
+                await manager.shutdownIfIdle()
+            }
+        }
+    }
+
+    func stopIdleShutdownMonitoring() {
+        idleShutdownTask?.cancel()
+        idleShutdownTask = nil
+    }
+
+    func beginTerminationCleanup() {
+        isTerminationCleanupPending = true
+    }
+
+    // MARK: - Queries
+
+    func installState(for model: LocalAIModel) -> LocalAIModelInstallViewState {
+        state.installStates[model.id] ?? .initial(model: model, status: .notInstalled)
+    }
+
+    func isModelAvailable(_ model: LocalAIModel) -> Bool {
+        dependencies.processingAvailability().isModelSupported(model)
+    }
+
+    func canonicalModel(for model: LocalAIModel) -> LocalAIModel? {
+        guard let canonical = LocalAIModelCatalog.model(id: model.id),
+              canonical == model else {
+            return nil
+        }
+        return canonical
+    }
+
+    func isDeletionRequested(_ modelID: String) -> Bool {
+        deletionRequestedModelIDs.contains(modelID)
+    }
+
+    @discardableResult
+    func markUnavailable(_ model: LocalAIModel) -> QuillUserIssueRecord {
+        let issue = unavailableIssue(for: model)
+        var modelState = installState(for: model)
+        modelState.issue = issue
+        state.installStates[model.id] = modelState
+        emitStateChanged()
+        return issue
+    }
+
+    // MARK: - Status refresh
+
+    func refreshAllInstallStates() {
+        state.hasCompletedInitialStatusRefresh = false
+        statusRefreshPendingModelIDs = Set(LocalAIModelCatalog.all.map(\.id))
+        for model in LocalAIModelCatalog.all {
+            if state.installStates[model.id] == nil {
+                state.installStates[model.id] = .initial(model: model, status: .notInstalled)
+            }
+            let generation = nextStatusRefreshGeneration(for: model)
+            let statusProvider = dependencies.installStatus
+            let workflowReference = WeakLocalAIModelWorkflowReference(self)
+            Task.detached(priority: .utility) {
+                let status = statusProvider(model)
+                await MainActor.run {
+                    workflowReference.value?.applyStatusRefresh(
+                        status,
+                        for: model,
+                        generation: generation
+                    )
+                }
+            }
+        }
+        emitStateChanged()
+    }
+
+    func waitForInitialStatusRefresh() async {
+        guard !state.hasCompletedInitialStatusRefresh else { return }
+        await withCheckedContinuation { continuation in
+            statusRefreshWaiters.append(continuation)
+        }
+    }
+
+    private func nextStatusRefreshGeneration(for model: LocalAIModel) -> Int {
+        let generation = statusRefreshGenerations[model.id, default: 0] + 1
+        statusRefreshGenerations[model.id] = generation
+        return generation
+    }
+
+    private func applyStatusRefresh(
+        _ status: LocalAIInstallStatus,
+        for model: LocalAIModel,
+        generation: Int
+    ) {
+        guard statusRefreshGenerations[model.id] == generation,
+              installTasks[model.id] == nil,
+              !deletionRequestedModelIDs.contains(model.id) else {
+            return
+        }
+        var modelState = installState(for: model)
+        modelState.status = status
+        state.installStates[model.id] = modelState
+        statusRefreshPendingModelIDs.remove(model.id)
+        emitStateChanged()
+        finishStatusRefreshIfReady()
+    }
+
+    private func completeStatusOperation(
+        _ status: LocalAIInstallStatus,
+        for model: LocalAIModel
+    ) {
+        _ = nextStatusRefreshGeneration(for: model)
+        let completedRefresh = statusRefreshPendingModelIDs.remove(model.id) != nil
+        var modelState = installState(for: model)
+        modelState.status = status
+        state.installStates[model.id] = modelState
+        if completedRefresh {
+            finishStatusRefreshIfReady()
+        }
+    }
+
+    private func finishStatusRefreshIfReady() {
+        guard statusRefreshPendingModelIDs.isEmpty else { return }
+        state.hasCompletedInitialStatusRefresh = true
+        let deferredModelIDs = deferredInstallModelIDs
+        deferredInstallModelIDs.removeAll()
+        emitStateChanged()
+        onEvent?(.initialStatusRefreshCompleted(deferredModelIDs: deferredModelIDs))
+        let waiters = statusRefreshWaiters
+        statusRefreshWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func unavailableIssue(for model: LocalAIModel) -> QuillUserIssueRecord {
+        QuillUserIssueRecord(
+            code: .localAIModelUnavailable,
+            severity: .error,
+            context: QuillUserIssueContext(
+                modelID: model.id,
+                localBackend: "Local AI"
+            )
+        )
+    }
+
+    // MARK: - Install
+
+    func startInstall(_ model: LocalAIModel) {
+        guard !isTerminationCleanupPending,
+              let canonical = canonicalModel(for: model),
+              isModelAvailable(canonical),
+              !deletionRequestedModelIDs.contains(model.id) else {
+            return
+        }
+        guard state.hasCompletedInitialStatusRefresh else {
+            deferredInstallModelIDs.insert(model.id)
+            return
+        }
+        if installState(for: canonical).status == .ready {
+            onEvent?(.installOutcome(canonical, .readyAndAvailable))
+            return
+        }
+        if cancellingModelIDs.contains(model.id) {
+            restartAfterCancellationModelIDs.insert(model.id)
+            return
+        }
+        startInstallIfPossible(canonical)
+    }
+
+    private func startInstallIfPossible(_ model: LocalAIModel) {
+        guard installTasks[model.id] == nil,
+              !cancellingModelIDs.contains(model.id),
+              !deletionRequestedModelIDs.contains(model.id),
+              isModelAvailable(model) else {
+            return
+        }
+
+        let token = UUID()
+        installTokens[model.id] = token
+        _ = nextStatusRefreshGeneration(for: model)
+        var modelState = installState(for: model)
+        modelState.isInstalling = true
+        modelState.issue = nil
+        modelState.progress = LocalAIDownloadProgress(
+            downloadedBytes: 0,
+            totalBytes: model.approximateBytes
+        )
+        state.installStates[model.id] = modelState
+        emitStateChanged()
+
+        let progressCoalescer = LatestValueProgressCoalescer<LocalAIDownloadProgress>(
+            schedule: dependencies.progressSchedule
+        ) { [weak self] progress in
+            MainActor.assumeIsolated {
+                guard let self,
+                      self.installTokens[model.id] == token,
+                      !self.cancellingModelIDs.contains(model.id),
+                      !self.deletionRequestedModelIDs.contains(model.id) else {
+                    return
+                }
+                var progressState = self.installState(for: model)
+                progressState.progress = progress
+                self.state.installStates[model.id] = progressState
+                self.emitStateChanged()
+            }
+        }
+        progressCoalescers[model.id] = progressCoalescer
+
+        let statusProvider = dependencies.installStatus
+        let partialModelDelete = dependencies.deletePartialModel
+        let startInstall = dependencies.startInstall
+        installTasks[model.id] = startInstall(
+            model,
+            { progress in progressCoalescer.submit(progress) },
+            { [weak self] result in
+                guard let workflow = self else { return }
+                Task.detached(priority: .utility) {
+                    let cleanupErrorDescription: String? = {
+                        guard case .failure(.cancelled) = result else { return nil }
+                        do {
+                            try partialModelDelete(model)
+                            return nil
+                        } catch {
+                            return error.localizedDescription
+                        }
+                    }()
+                    let status = statusProvider(model)
+                    await MainActor.run {
+                        workflow.finishInstall(
+                            model: model,
+                            token: token,
+                            result: result,
+                            status: status,
+                            cleanupErrorDescription: cleanupErrorDescription
+                        )
+                    }
+                }
+            }
+        )
+    }
+
+    private func finishInstall(
+        model: LocalAIModel,
+        token: UUID,
+        result: Result<Void, LocalAIInstallerError>,
+        status: LocalAIInstallStatus,
+        cleanupErrorDescription: String?
+    ) {
+        guard installTokens[model.id] == token,
+              installTasks.removeValue(forKey: model.id) != nil else {
+            return
+        }
+        progressCoalescers.removeValue(forKey: model.id)?.invalidate()
+        defer { resumeInstallQuiescenceWaitersIfNeeded() }
+        installTokens.removeValue(forKey: model.id)
+        let wasCancelling = cancellingModelIDs.remove(model.id) != nil
+        let shouldDelete = deletionRequestedModelIDs.contains(model.id)
+        let shouldRestart = restartAfterCancellationModelIDs.remove(model.id) != nil
+
+        var modelState = installState(for: model)
+        modelState.isInstalling = false
+        modelState.status = status
+
+        var outcomeToEmit: LocalAIModelWorkflowInstallOutcome?
+        if let cleanupErrorDescription {
+            modelState.issue = unavailableIssue(for: model)
+            print("Local AI partial cleanup failed: \(cleanupErrorDescription)")
+        } else if shouldDelete {
+            modelState.issue = nil
+        } else if wasCancelling {
+            modelState.issue = nil
+        } else {
+            switch result {
+            case .success where status == .ready && isModelAvailable(model):
+                modelState.issue = nil
+                outcomeToEmit = .readyAndAvailable
+            case .success:
+                let issue = unavailableIssue(for: model)
+                modelState.issue = issue
+                outcomeToEmit = .succeededButUnavailable(issue)
+            case .failure(.cancelled):
+                modelState.issue = nil
+                outcomeToEmit = .cancelled
+            case .failure(let error):
+                let issue = unavailableIssue(for: model)
+                modelState.issue = issue
+                outcomeToEmit = .failed(issue)
+                print("Local AI install failed: \(error.localizedDescription)")
+            }
+        }
+        state.installStates[model.id] = modelState
+        emitStateChanged()
+        if let outcomeToEmit {
+            onEvent?(.installOutcome(model, outcomeToEmit))
+        }
+        completeStatusOperation(status, for: model)
+
+        if shouldDelete {
+            beginDeletion(model)
+            return
+        }
+        guard wasCancelling, shouldRestart else { return }
+        guard cleanupErrorDescription == nil, isModelAvailable(model) else {
+            let issue = markUnavailable(model)
+            onEvent?(.installOutcome(model, .succeededButUnavailable(issue)))
+            return
+        }
+        if status == .ready {
+            onEvent?(.installOutcome(model, .readyAndAvailable))
+        } else {
+            startInstallIfPossible(model)
+        }
+    }
+
+    func waitForInstallsToQuiesce() async {
+        guard !installTasks.isEmpty else { return }
+        await withCheckedContinuation { continuation in
+            installQuiescenceWaiters.append(continuation)
+        }
+    }
+
+    private func resumeInstallQuiescenceWaitersIfNeeded() {
+        guard installTasks.isEmpty else { return }
+        let waiters = installQuiescenceWaiters
+        installQuiescenceWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    // MARK: - Cancel
+
+    @discardableResult
+    func cancelInstall(_ model: LocalAIModel) -> Bool {
+        guard let canonical = canonicalModel(for: model),
+              let task = installTasks[canonical.id] else {
+            return false
+        }
+        progressCoalescers.removeValue(forKey: canonical.id)?.invalidate()
+        cancellingModelIDs.insert(canonical.id)
+        restartAfterCancellationModelIDs.remove(canonical.id)
+        task.cancel()
+        var modelState = installState(for: canonical)
+        modelState.progress = LocalAIDownloadProgress(
+            downloadedBytes: modelState.progress.downloadedBytes,
+            totalBytes: modelState.progress.totalBytes,
+            isCancelled: true
+        )
+        state.installStates[canonical.id] = modelState
+        emitStateChanged()
+        return true
+    }
+
+    // MARK: - Delete
+
+    @discardableResult
+    func deleteModel(_ model: LocalAIModel) -> Bool {
+        guard let canonical = canonicalModel(for: model),
+              !deletionRequestedModelIDs.contains(canonical.id) else {
+            return false
+        }
+        deletionRequestedModelIDs.insert(canonical.id)
+        deferredInstallModelIDs.remove(canonical.id)
+        restartAfterCancellationModelIDs.remove(canonical.id)
+
+        if let task = installTasks[canonical.id] {
+            cancellingModelIDs.insert(canonical.id)
+            task.cancel()
+            var modelState = installState(for: canonical)
+            modelState.progress = LocalAIDownloadProgress(
+                downloadedBytes: modelState.progress.downloadedBytes,
+                totalBytes: modelState.progress.totalBytes,
+                isCancelled: true
+            )
+            state.installStates[canonical.id] = modelState
+            emitStateChanged()
+            return true
+        }
+        beginDeletion(canonical)
+        return true
+    }
+
+    private func beginDeletion(_ model: LocalAIModel) {
+        guard deletionRequestedModelIDs.contains(model.id),
+              installTasks[model.id] == nil else {
+            return
+        }
+        state.hasCompletedInitialStatusRefresh = false
+        statusRefreshPendingModelIDs.insert(model.id)
+        _ = nextStatusRefreshGeneration(for: model)
+        let manager = serverManager
+        let modelDelete = dependencies.deleteModel
+        let statusProvider = dependencies.installStatus
+        Task { [weak self] in
+            let outcome: LocalAIModelDeletionOutcome
+            do {
+                outcome = try await manager.withExclusiveMaintenance {
+                    do {
+                        try modelDelete(model)
+                        return LocalAIModelDeletionOutcome(
+                            status: statusProvider(model),
+                            errorDescription: nil
+                        )
+                    } catch {
+                        return LocalAIModelDeletionOutcome(
+                            status: statusProvider(model),
+                            errorDescription: error.localizedDescription
+                        )
+                    }
+                }
+            } catch {
+                guard let self else { return }
+                outcome = LocalAIModelDeletionOutcome(
+                    status: self.installState(for: model).status,
+                    errorDescription: error.localizedDescription
+                )
+            }
+            guard let self else { return }
+            self.finishDeletion(model, outcome: outcome)
+        }
+    }
+
+    private func finishDeletion(
+        _ model: LocalAIModel,
+        outcome: LocalAIModelDeletionOutcome
+    ) {
+        guard deletionRequestedModelIDs.remove(model.id) != nil else {
+            return
+        }
+        if let errorDescription = outcome.errorDescription {
+            var modelState = installState(for: model)
+            modelState.isInstalling = false
+            modelState.status = outcome.status
+            modelState.issue = unavailableIssue(for: model)
+            state.installStates[model.id] = modelState
+            print("Local AI model deletion failed: \(errorDescription)")
+        } else {
+            state.installStates[model.id] = .initial(model: model, status: outcome.status)
+        }
+        emitStateChanged()
+        onEvent?(.deletionOutcome(model, errorDescription: outcome.errorDescription))
+        completeStatusOperation(outcome.status, for: model)
+    }
+
+    // MARK: - Testing seams
+
+    func markInitialRefreshCompletedForTesting() {
+        state.hasCompletedInitialStatusRefresh = true
+    }
+
+    private func emitStateChanged() {
+        onEvent?(.stateChanged(state))
+    }
+}
+
+private final class WeakLocalAIModelWorkflowReference: @unchecked Sendable {
+    weak var value: LocalAIModelWorkflow?
+
+    init(_ value: LocalAIModelWorkflow) {
+        self.value = value
+    }
+}

--- a/Sources/LocalAIModelWorkflow.swift
+++ b/Sources/LocalAIModelWorkflow.swift
@@ -28,6 +28,10 @@ private struct LocalAIModelDeletionOutcome: Sendable {
 final class LocalAIModelWorkflow: @unchecked Sendable {
     private let dependencies: AppStateLocalAIDependencies
     private let serverManager: LocalAIServerManager
+
+    // AppState.init is nonisolated, so production assigns this callback during
+    // construction before workflow activity. Callback delivery remains
+    // MainActor-isolated.
     nonisolated(unsafe) var onEvent:
         (@MainActor (LocalAIModelWorkflowEvent) -> Void)?
     var onStatusRefreshDeliveryForTesting:

--- a/Sources/LocalAIModelWorkflow.swift
+++ b/Sources/LocalAIModelWorkflow.swift
@@ -30,6 +30,8 @@ final class LocalAIModelWorkflow: @unchecked Sendable {
     private let serverManager: LocalAIServerManager
     nonisolated(unsafe) var onEvent:
         (@MainActor (LocalAIModelWorkflowEvent) -> Void)?
+    var onStatusRefreshDeliveryForTesting:
+        (@MainActor (_ model: LocalAIModel, _ generation: Int) -> Void)?
     private(set) var state = LocalAIModelWorkflowState()
 
     private var installTasks: [String: LocalAIInstallTask] = [:]
@@ -164,6 +166,7 @@ final class LocalAIModelWorkflow: @unchecked Sendable {
         for model: LocalAIModel,
         generation: Int
     ) {
+        defer { onStatusRefreshDeliveryForTesting?(model, generation) }
         guard statusRefreshGenerations[model.id] == generation,
               installTasks[model.id] == nil,
               !deletionRequestedModelIDs.contains(model.id) else {

--- a/Sources/LocalAIModelWorkflow.swift
+++ b/Sources/LocalAIModelWorkflow.swift
@@ -240,7 +240,8 @@ final class LocalAIModelWorkflow: @unchecked Sendable {
     }
 
     private func startInstallIfPossible(_ model: LocalAIModel) {
-        guard installTasks[model.id] == nil,
+        guard !isTerminationCleanupPending,
+              installTasks[model.id] == nil,
               !cancellingModelIDs.contains(model.id),
               !deletionRequestedModelIDs.contains(model.id),
               isModelAvailable(model) else {

--- a/Sources/LocalAIModelWorkflow.swift
+++ b/Sources/LocalAIModelWorkflow.swift
@@ -28,7 +28,8 @@ private struct LocalAIModelDeletionOutcome: Sendable {
 final class LocalAIModelWorkflow: @unchecked Sendable {
     private let dependencies: AppStateLocalAIDependencies
     private let serverManager: LocalAIServerManager
-    var onEvent: ((LocalAIModelWorkflowEvent) -> Void)?
+    nonisolated(unsafe) var onEvent:
+        (@MainActor (LocalAIModelWorkflowEvent) -> Void)?
     private(set) var state = LocalAIModelWorkflowState()
 
     private var installTasks: [String: LocalAIInstallTask] = [:]
@@ -45,7 +46,7 @@ final class LocalAIModelWorkflow: @unchecked Sendable {
     private var idleShutdownTask: Task<Void, Never>?
     private var isTerminationCleanupPending = false
 
-    init(
+    nonisolated init(
         dependencies: AppStateLocalAIDependencies,
         serverManager: LocalAIServerManager
     ) {

--- a/Sources/LocalAIModelWorkflow.swift
+++ b/Sources/LocalAIModelWorkflow.swift
@@ -342,8 +342,6 @@ final class LocalAIModelWorkflow: @unchecked Sendable {
             modelState.issue = nil
         } else if wasCancelling {
             modelState.issue = nil
-            // Emit the cancelled outcome for cancellation
-            outcomeToEmit = .cancelled
         } else {
             switch result {
             case .success where status == .ready && isModelAvailable(model):

--- a/Sources/LocalAIModelWorkflow.swift
+++ b/Sources/LocalAIModelWorkflow.swift
@@ -342,6 +342,8 @@ final class LocalAIModelWorkflow: @unchecked Sendable {
             modelState.issue = nil
         } else if wasCancelling {
             modelState.issue = nil
+            // Emit the cancelled outcome for cancellation
+            outcomeToEmit = .cancelled
         } else {
             switch result {
             case .success where status == .ready && isModelAvailable(model):

--- a/Sources/NativeWhisperModel.swift
+++ b/Sources/NativeWhisperModel.swift
@@ -45,7 +45,7 @@ struct NativeWhisperModelCatalog {
     }
 }
 
-enum NativeWhisperInstallStatus: Equatable {
+enum NativeWhisperInstallStatus: Equatable, Sendable {
     case notInstalled
     case partial(downloadedBytes: Int64, expectedBytes: Int64?)
     case ready

--- a/Sources/NativeWhisperModelWorkflow.swift
+++ b/Sources/NativeWhisperModelWorkflow.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+struct NativeWhisperModelWorkflowState: Equatable, Sendable {
+    var installStatus: NativeWhisperInstallStatus
+    var installProgress: NativeWhisperDownloadProgress
+    var isInstalling: Bool
+    var installError: String?
+    var installIssue: QuillUserIssueRecord?
+
+    static func initial(for model: NativeWhisperModel) -> NativeWhisperModelWorkflowState {
+        NativeWhisperModelWorkflowState(
+            installStatus: .notInstalled,
+            installProgress: NativeWhisperDownloadProgress(
+                downloadedBytes: 0,
+                totalBytes: model.approximateBytes
+            ),
+            isInstalling: false,
+            installError: nil,
+            installIssue: nil
+        )
+    }
+}
+
+enum NativeWhisperModelWorkflowOutcome: Equatable, Sendable {
+    case succeeded
+    case cancelled
+    case failed(QuillUserIssueRecord)
+}
+
+enum NativeWhisperModelWorkflowEvent {
+    case stateChanged(NativeWhisperModelWorkflowState)
+    case installCompleted(NativeWhisperModelWorkflowOutcome)
+}
+
+@MainActor
+final class NativeWhisperModelWorkflow: @unchecked Sendable {
+    private let dependencies: AppStateNativeWhisperDependencies
+    private let model: NativeWhisperModel
+    var onEvent: ((NativeWhisperModelWorkflowEvent) -> Void)?
+    private(set) var state: NativeWhisperModelWorkflowState
+
+    private var installTask: NativeWhisperInstallTask?
+    private var progressCoalescer: LatestValueProgressCoalescer<NativeWhisperDownloadProgress>?
+    private var quiescenceWaiters: [CheckedContinuation<Void, Never>] = []
+    private var cancellationMessage: String?
+    private var isTerminationCleanupPending = false
+
+    init(
+        dependencies: AppStateNativeWhisperDependencies,
+        model: NativeWhisperModel = .recommended
+    ) {
+        self.dependencies = dependencies
+        self.model = model
+        state = .initial(for: model)
+    }
+
+    func refreshInstallStatus() {
+        state.installStatus = dependencies.installStatus(model)
+        emitStateChanged()
+    }
+
+    func startInstall() {
+        guard !isTerminationCleanupPending, !state.isInstalling else { return }
+        state.installError = nil
+        state.installIssue = nil
+        cancellationMessage = nil
+        state.isInstalling = true
+        state.installProgress = NativeWhisperDownloadProgress(
+            downloadedBytes: 0,
+            totalBytes: model.approximateBytes
+        )
+        emitStateChanged()
+
+        let coalescer = LatestValueProgressCoalescer<NativeWhisperDownloadProgress>(
+            schedule: dependencies.progressSchedule
+        ) { [weak self] progress in
+            MainActor.assumeIsolated {
+                self?.applyProgress(progress)
+            }
+        }
+        progressCoalescer = coalescer
+        let startInstall = dependencies.startInstall
+        installTask = startInstall(
+            model,
+            { progress in coalescer.submit(progress) },
+            { [weak self] result in
+                DispatchQueue.main.async {
+                    self?.finishInstall(result: result)
+                }
+            }
+        )
+    }
+
+    func cancelInstall() {
+        cancellationMessage = nil
+        progressCoalescer?.invalidate()
+        progressCoalescer = nil
+        installTask?.cancel()
+        state.installProgress = NativeWhisperDownloadProgress(
+            downloadedBytes: state.installProgress.downloadedBytes,
+            totalBytes: state.installProgress.totalBytes,
+            isCancelled: true
+        )
+        emitStateChanged()
+    }
+
+    func deleteModel() {
+        do {
+            try dependencies.deleteModel(model)
+            state.installError = nil
+            state.installIssue = nil
+        } catch {
+            state.installIssue = QuillUserIssueRecord(
+                code: .localModelMissing,
+                context: QuillUserIssueContext(
+                    modelID: model.id,
+                    localBackend: "Native Whisper"
+                )
+            )
+        }
+        refreshInstallStatus()
+    }
+
+    func waitUntilQuiesced() async {
+        guard installTask != nil else { return }
+        await withCheckedContinuation { continuation in
+            quiescenceWaiters.append(continuation)
+        }
+    }
+
+    func beginTerminationCleanup() {
+        isTerminationCleanupPending = true
+    }
+
+    private func applyProgress(_ progress: NativeWhisperDownloadProgress) {
+        state.installProgress = progress
+        emitStateChanged()
+    }
+
+    private func finishInstall(result: Result<Void, NativeWhisperInstallerError>) {
+        progressCoalescer?.invalidate()
+        progressCoalescer = nil
+        installTask = nil
+        defer { resumeQuiescenceWaitersIfNeeded() }
+        state.isInstalling = false
+        state.installStatus = dependencies.installStatus(model)
+
+        switch result {
+        case .success:
+            emitStateChanged()
+            onEvent?(.installCompleted(.succeeded))
+        case .failure(.cancelled):
+            state.installError = cancellationMessage
+            cancellationMessage = nil
+            emitStateChanged()
+            onEvent?(.installCompleted(.cancelled))
+        case .failure:
+            let issue = QuillUserIssueRecord(
+                code: .localModelMissing,
+                context: QuillUserIssueContext(
+                    modelID: model.id,
+                    localBackend: "Native Whisper"
+                )
+            )
+            state.installIssue = issue
+            emitStateChanged()
+            onEvent?(.installCompleted(.failed(issue)))
+        }
+    }
+
+    private func resumeQuiescenceWaitersIfNeeded() {
+        guard installTask == nil else { return }
+        let waiters = quiescenceWaiters
+        quiescenceWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func emitStateChanged() {
+        onEvent?(.stateChanged(state))
+    }
+}

--- a/Sources/NativeWhisperModelWorkflow.swift
+++ b/Sources/NativeWhisperModelWorkflow.swift
@@ -36,7 +36,9 @@ enum NativeWhisperModelWorkflowEvent {
 final class NativeWhisperModelWorkflow: @unchecked Sendable {
     private let dependencies: AppStateNativeWhisperDependencies
     private let model: NativeWhisperModel
-    var onEvent: ((NativeWhisperModelWorkflowEvent) -> Void)?
+    nonisolated let initialState: NativeWhisperModelWorkflowState
+    nonisolated(unsafe) var onEvent:
+        (@MainActor (NativeWhisperModelWorkflowEvent) -> Void)?
     private(set) var state: NativeWhisperModelWorkflowState
 
     private var installTask: NativeWhisperInstallTask?
@@ -45,13 +47,16 @@ final class NativeWhisperModelWorkflow: @unchecked Sendable {
     private var cancellationMessage: String?
     private var isTerminationCleanupPending = false
 
-    init(
+    nonisolated init(
         dependencies: AppStateNativeWhisperDependencies,
         model: NativeWhisperModel = .recommended
     ) {
         self.dependencies = dependencies
         self.model = model
-        state = .initial(for: model)
+        var initialState = NativeWhisperModelWorkflowState.initial(for: model)
+        initialState.installStatus = dependencies.installStatus(model)
+        self.initialState = initialState
+        state = initialState
     }
 
     func refreshInstallStatus() {

--- a/Sources/NativeWhisperModelWorkflow.swift
+++ b/Sources/NativeWhisperModelWorkflow.swift
@@ -36,6 +36,10 @@ enum NativeWhisperModelWorkflowEvent {
 final class NativeWhisperModelWorkflow: @unchecked Sendable {
     private let dependencies: AppStateNativeWhisperDependencies
     private let model: NativeWhisperModel
+
+    // AppState.init is nonisolated, so it reads this immutable snapshot and
+    // assigns the callback before workflow activity. Callback delivery remains
+    // MainActor-isolated.
     nonisolated let initialState: NativeWhisperModelWorkflowState
     nonisolated(unsafe) var onEvent:
         (@MainActor (NativeWhisperModelWorkflowEvent) -> Void)?
@@ -97,6 +101,7 @@ final class NativeWhisperModelWorkflow: @unchecked Sendable {
     }
 
     func cancelInstall() {
+        guard installTask != nil else { return }
         cancellationMessage = nil
         progressCoalescer?.invalidate()
         progressCoalescer = nil

--- a/Tests/AppStateAIProcessingBackendTests.swift
+++ b/Tests/AppStateAIProcessingBackendTests.swift
@@ -2560,21 +2560,32 @@ struct AppStateAIProcessingBackendTests {
             encoding: .utf8
         )
         let state = try appStateSource()
+        let terminationCleanup = sourceBlock(
+            in: state,
+            from: "func requestTerminationAfterModelCleanup(",
+            to: "private var shouldConfirmEscapeCancellation"
+        )
+        let localCancellation = sourceBlock(
+            in: state,
+            from: "private func cancelAllLocalAIInstalls()",
+            to: "func requestTerminationAfterModelCleanup("
+        )
+
         assert(delegate.contains("requestTerminationAfterModelCleanup()"))
         assert(!delegate.contains("requestTerminationWhileNativeWhisperInstalling()"))
-        assert(state.contains("await manager.stop()"))
-        assert(state.contains("cancelAllLocalAIInstalls()"))
-        assert(state.contains("pendingLocalAISelections.removeAll()"))
-        assert(state.contains("nativeWhisperWorkflow.beginTerminationCleanup()"))
-        assert(state.contains("localAIWorkflow.beginTerminationCleanup()"))
-        assert(state.contains("isInstallingNativeWhisper || localAIWorkflow.hasActiveInstalls"))
-        assert(state.contains("waitForNativeWhisperInstallToQuiesce()"))
-        assert(state.contains("waitForLocalAIInstallsToQuiesce()"))
         assert(
-            state.components(
-                separatedBy: "guard !isModelTerminationCleanupPending else { return }"
-            ).count - 1 >= 1
+            terminationCleanup.contains(
+                "guard !isModelTerminationCleanupPending else { return .terminateLater }"
+            )
         )
+        assert(terminationCleanup.contains("cancelAllLocalAIInstalls()"))
+        assert(terminationCleanup.contains("nativeWhisperWorkflow.beginTerminationCleanup()"))
+        assert(terminationCleanup.contains("localAIWorkflow.beginTerminationCleanup()"))
+        assert(terminationCleanup.contains("waitForNativeWhisperInstallToQuiesce()"))
+        assert(terminationCleanup.contains("waitForLocalAIInstallsToQuiesce()"))
+        assert(terminationCleanup.contains("await manager.stop()"))
+        assert(localCancellation.contains("pendingLocalAISelections.removeAll()"))
+        assert(state.contains("isInstallingNativeWhisper || localAIWorkflow.hasActiveInstalls"))
         assert(
             state.contains(
                 "requestTerminationAfterModelCleanup(replyIsAlreadyPending: true)"
@@ -2586,6 +2597,53 @@ struct AppStateAIProcessingBackendTests {
             to: "func deleteNativeWhisperModel()"
         )
         assert(nativeCancellation.contains("nativeWhisperWorkflow.cancelInstall()"))
+
+        let cancelNative = requiredRange(
+            of: "cancelNativeWhisperInstallIfNeeded()",
+            in: terminationCleanup
+        )
+        let cancelLocal = requiredRange(
+            of: "cancelAllLocalAIInstalls()",
+            in: terminationCleanup
+        )
+        let stopIdleMonitoring = requiredRange(
+            of: "stopLocalAIIdleShutdownMonitoring()",
+            in: terminationCleanup
+        )
+        let appStateTerminationFlag = requiredRange(
+            of: "isModelTerminationCleanupPending = true",
+            in: terminationCleanup
+        )
+        let nativeWorkflowTerminationFlag = requiredRange(
+            of: "nativeWhisperWorkflow.beginTerminationCleanup()",
+            in: terminationCleanup
+        )
+        let localWorkflowTerminationFlag = requiredRange(
+            of: "localAIWorkflow.beginTerminationCleanup()",
+            in: terminationCleanup
+        )
+        let waitForNativeQuiescence = requiredRange(
+            of: "await self.waitForNativeWhisperInstallToQuiesce()",
+            in: terminationCleanup
+        )
+        let waitForLocalQuiescence = requiredRange(
+            of: "await self.waitForLocalAIInstallsToQuiesce()",
+            in: terminationCleanup
+        )
+        let stopServer = requiredRange(of: "await manager.stop()", in: terminationCleanup)
+        let terminationReply = requiredRange(
+            of: "Self.applicationTerminationReply(true)",
+            in: terminationCleanup
+        )
+        assert(cancelNative.lowerBound < cancelLocal.lowerBound)
+        assert(cancelLocal.lowerBound < stopIdleMonitoring.lowerBound)
+        assert(stopIdleMonitoring.lowerBound < appStateTerminationFlag.lowerBound)
+        assert(appStateTerminationFlag.lowerBound < nativeWorkflowTerminationFlag.lowerBound)
+        assert(nativeWorkflowTerminationFlag.lowerBound < localWorkflowTerminationFlag.lowerBound)
+        assert(localWorkflowTerminationFlag.lowerBound < waitForNativeQuiescence.lowerBound)
+        assert(waitForNativeQuiescence.lowerBound < waitForLocalQuiescence.lowerBound)
+        assert(waitForLocalQuiescence.lowerBound < stopServer.lowerBound)
+        assert(stopServer.lowerBound < terminationReply.lowerBound)
     }
 
     // Dismissing a warning banner hides it for the note's current retry

--- a/Tests/AppStateAIProcessingBackendTests.swift
+++ b/Tests/AppStateAIProcessingBackendTests.swift
@@ -40,35 +40,28 @@ struct AppStateAIProcessingBackendTests {
         await testSettingsDismissalDisablesAIWithoutReadyModels()
         await testSettingsDismissalFallsBackToReadyLocalAIModel()
         await testSameModelDownloadCoalescesAndSelectsBothFeatures()
-        await testNativeWhisperProgressCoalescesAndCancellationWins()
         await testLocalAIProgressCoalescesAndCompletionWins()
         await testChoosingCloudClearsOnlyOnePendingSelection()
         await testCancelPendingSelectionClearsOnlyOneConsumer()
         await testPendingSelectionChangesPublishObjectWillChange()
         await testCancellationWaitsForCompletionAndRetriesAfterQuiescence()
         try await testIdleShutdownMonitoringIsIdempotentAndStops()
-        await testLocalAIInstallQuiescenceWaitsForActiveWorker()
         try await testTerminationWaitsForLocalAIQuiescenceAndSuppressesDuplicates()
-        try await testNativeWhisperTerminationWaitsForWorkerQuiescence()
         try await testCombinedNativeAndLocalTerminationWaitsForBothWorkers()
         await testTerminationCleanupBlocksNewModelInstalls()
         await testPendingRecordingTerminationCancelRepliesFalseOnce()
         await testPartialCleanupFailureSetsModelIssue()
-        await testInstallerSuccessRequiresReadyStatus()
-        await testInstallerSuccessRechecksHardwareAvailability()
-        await testInstallerFailureClearsPendingAndSetsIssue()
+        await testInstallerFailureClearsPendingSelectionAndMirrorsIssue()
         await testUnsupportedHardwareRejectsLocalSelection()
         await testLowMemoryPreservesStoredLocalChoiceWithoutStartingIt()
-        await testCanonicalModelValidationRejectsForgedModels()
         await testAIProcessingChoiceDisplayMetadata()
         testManagedLocalAIModelResolutionReconcilesRetainedLifecycle()
         await testCloudSelectionPublishesContextChoiceOnce()
         await testSelectionWaitsForInitialStatusRefresh()
-        await testBackgroundStatusRefreshIgnoresStaleGeneration()
         await testAppStateInstancesKeepIndependentLocalAIEnvironments()
         await testExecutorUsesOriginatingLocalAIAvailability()
         try await testDeleteDuringInstallWaitsAndCannotAutoSelect()
-        try await testDeleteFailureAndSuccessStateReset()
+        try await testDeleteFailurePreservesSelectedLocalChoice()
         try await testDeletingOnlyLocalModelDoesNotSubstituteCloud()
         try testEveryBackendExecutorConstructionUsesCentralFactory()
         try testEveryPostProcessingConstructionUsesCentralFactory()
@@ -840,71 +833,6 @@ struct AppStateAIProcessingBackendTests {
         }
     }
 
-    private static func testNativeWhisperProgressCoalescesAndCancellationWins() async {
-        resetAIProcessingDefaults()
-        let statusHarness = NativeWhisperStatusHarness(status: .notInstalled)
-        let installHarness = ControlledNativeWhisperInstallHarness()
-        let scheduler = ProgressScheduleHarness()
-        var dependencies = modelTestDependencies()
-        dependencies.nativeWhisper.installStatus = {
-            statusHarness.installStatus(for: $0)
-        }
-        dependencies.nativeWhisper.startInstall = { model, progress, completion in
-            installHarness.start(
-                model: model,
-                progress: progress,
-                completion: completion
-            )
-        }
-        dependencies.nativeWhisper.progressSchedule = scheduler.schedule
-
-        let appState = await MainActor.run { AppState(dependencies: dependencies) }
-        await MainActor.run {
-            appState.installNativeWhisperModel()
-        }
-        for value in 1...10_000 {
-            installHarness.sendProgress(
-                NativeWhisperDownloadProgress(
-                    downloadedBytes: Int64(value),
-                    totalBytes: 10_000
-                )
-            )
-        }
-
-        precondition(scheduler.scheduledCount == 1)
-        await MainActor.run { scheduler.runNext() }
-        let firstBytes = await MainActor.run {
-            appState.nativeWhisperInstallProgress.downloadedBytes
-        }
-        precondition(firstBytes == 1)
-        precondition(scheduler.scheduledCount == 1)
-        await MainActor.run { scheduler.runNext() }
-        let latestBytes = await MainActor.run {
-            appState.nativeWhisperInstallProgress.downloadedBytes
-        }
-        precondition(latestBytes == 10_000)
-
-        installHarness.sendProgress(
-            NativeWhisperDownloadProgress(
-                downloadedBytes: 10_001,
-                totalBytes: 20_000
-            )
-        )
-        precondition(scheduler.scheduledCount == 1)
-        await MainActor.run {
-            appState.cancelNativeWhisperInstall()
-        }
-        await MainActor.run { scheduler.runAll() }
-        let cancelledProgress = await MainActor.run {
-            appState.nativeWhisperInstallProgress
-        }
-        precondition(cancelledProgress.isCancelled)
-        precondition(cancelledProgress.downloadedBytes == 10_000)
-
-        installHarness.complete(with: .failure(.cancelled))
-        await appState.waitForNativeWhisperInstallToQuiesce()
-    }
-
     private static func testLocalAIProgressCoalescesAndCompletionWins() async {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
@@ -1239,38 +1167,6 @@ struct AppStateAIProcessingBackendTests {
         precondition(sleepHarness.callCount == 2)
     }
 
-    private static func testLocalAIInstallQuiescenceWaitsForActiveWorker() async {
-        resetAIProcessingDefaults()
-        let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
-        let installHarness = LocalAIInstallHarness()
-        let completion = LockedBox(false)
-        var dependencies = modelTestDependencies()
-        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.startInstall = installHarness.start
-        dependencies.localAI.deletePartialModel = { _ in }
-
-        let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState(dependencies: dependencies)
-        await MainActor.run {
-            appState.installLocalAIModel(model)
-        }
-        let waiter = Task {
-            await appState.waitForLocalAIInstallsToQuiesce()
-            completion.set(true)
-        }
-        await yieldMainActor()
-        precondition(!completion.value)
-
-        await MainActor.run {
-            appState.cancelLocalAIInstall(model)
-        }
-        precondition(installHarness.task(for: model, startIndex: 0)?.isCancelled == true)
-
-        installHarness.complete(model: model, with: .failure(.cancelled))
-        await waiter.value
-        precondition(completion.value)
-    }
-
     private static func testTerminationWaitsForLocalAIQuiescenceAndSuppressesDuplicates() async throws {
         let effects = ModelTerminationEffectSnapshot()
         defer { effects.restore() }
@@ -1338,62 +1234,6 @@ struct AppStateAIProcessingBackendTests {
         precondition(partialDeletionHarness.deletedModelIDs == [model.id])
         precondition(partialDeletionHarness.managerWasStoppedValues == [false])
         precondition(installHarness.starts(for: model) == 1)
-        await yieldMainActor()
-        precondition(replyHarness.values == [true])
-    }
-
-    private static func testNativeWhisperTerminationWaitsForWorkerQuiescence() async throws {
-        let effects = ModelTerminationEffectSnapshot()
-        defer { effects.restore() }
-        resetAIProcessingDefaults()
-        let nativeStatusHarness = NativeWhisperStatusHarness(status: .notInstalled)
-        let nativeInstallHarness = ControlledNativeWhisperInstallHarness()
-        let replyHarness = TerminationReplyHarness()
-        let process = TestLocalAIServerProcess()
-        let manager = LocalAIServerManager(
-            launchProcess: { _, _, port, _ in (process, port) },
-            pollHealth: { _ in true },
-            readinessProbe: successfulReadinessProbe,
-            validateModel: { _ in .ready },
-            terminationGracePeriod: 0,
-            waitForProcessExit: { _, _ in true }
-        )
-        var dependencies = modelTestDependencies()
-        dependencies.nativeWhisper.installStatus = {
-            nativeStatusHarness.installStatus(for: $0)
-        }
-        dependencies.nativeWhisper.startInstall = { model, progress, completion in
-            nativeInstallHarness.start(
-                model: model,
-                progress: progress,
-                completion: completion
-            )
-        }
-        dependencies.localAI.makeServerManager = { manager }
-        AppState.modelDownloadQuitAlertPresenter = { .alertFirstButtonReturn }
-        AppState.applicationTerminationReply = replyHarness.reply
-
-        let appState = await makeRefreshedAppState(dependencies: dependencies)
-        _ = try await manager.withBaseURL(for: LocalAIModelCatalog.quality) { $0 }
-        await MainActor.run {
-            appState.installNativeWhisperModel(autoSelectWhenReady: true)
-        }
-        let statusCallsBeforeCancellation = nativeStatusHarness.callCount
-
-        let terminationReply = await MainActor.run {
-            appState.requestTerminationAfterModelCleanup()
-        }
-        precondition(terminationReply == .terminateLater)
-        precondition(nativeInstallHarness.task?.isCancelled == true)
-        precondition(process.isRunning)
-        precondition(replyHarness.values.isEmpty)
-        precondition(nativeStatusHarness.callCount == statusCallsBeforeCancellation)
-
-        nativeInstallHarness.complete(with: .failure(.cancelled))
-        await waitUntil { !appState.isInstallingNativeWhisper }
-        await waitUntil { !process.isRunning }
-        await waitUntil { replyHarness.values == [true] }
-        precondition(nativeStatusHarness.callCount == statusCallsBeforeCancellation + 1)
         await yieldMainActor()
         precondition(replyHarness.values == [true])
     }
@@ -1602,80 +1442,7 @@ struct AppStateAIProcessingBackendTests {
         }
     }
 
-    private static func testInstallerSuccessRequiresReadyStatus() async {
-        resetAIProcessingDefaults()
-        let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
-        let installHarness = LocalAIInstallHarness()
-        var dependencies = modelTestDependencies()
-        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.startInstall = installHarness.start
-
-        let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState(dependencies: dependencies)
-        let originalChoice = await MainActor.run { () -> AIProcessingBackendChoice in
-            let originalChoice = appState.postProcessingBackendChoice
-            appState.selectAIProcessingBackendChoice(
-                .localAI(modelID: model.id),
-                for: .postProcessing
-            )
-            appState.installLocalAIModel(model, autoSelectFor: .postProcessing)
-            return originalChoice
-        }
-
-        installHarness.complete(model: model, with: .success(()))
-        await waitUntil {
-            !appState.localAIInstallState(for: model).isInstalling
-        }
-        await MainActor.run {
-            precondition(appState.postProcessingBackendChoice == originalChoice)
-            precondition(appState.pendingLocalAIModelID(for: .postProcessing) == nil)
-            precondition(
-                appState.localAIInstallState(for: model).issue?.code
-                    == .localAIModelUnavailable
-            )
-            precondition(appState.localAIInstallState(for: model).status == .notInstalled)
-        }
-    }
-
-    private static func testInstallerSuccessRechecksHardwareAvailability() async {
-        resetAIProcessingDefaults()
-        let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
-        let installHarness = LocalAIInstallHarness()
-        let availability = LockedBox(supportedLocalAIAvailability())
-        var dependencies = modelTestDependencies()
-        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.startInstall = installHarness.start
-        dependencies.localAI.processingAvailability = { availability.value }
-
-        let model = LocalAIModelCatalog.quality
-        let appState = await makeRefreshedAppState(dependencies: dependencies)
-        let originalChoice = await MainActor.run { () -> AIProcessingBackendChoice in
-            let originalChoice = appState.contextBackendChoice
-            appState.selectAIProcessingBackendChoice(
-                .localAI(modelID: model.id),
-                for: .context
-            )
-            appState.installLocalAIModel(model, autoSelectFor: .context)
-            return originalChoice
-        }
-
-        statusHarness.set(.ready, for: model)
-        availability.set(unsupportedLocalAIAvailability())
-        installHarness.complete(model: model, with: .success(()))
-        await waitUntil {
-            !appState.localAIInstallState(for: model).isInstalling
-        }
-        await MainActor.run {
-            precondition(appState.contextBackendChoice == originalChoice)
-            precondition(appState.pendingLocalAIModelID(for: .context) == nil)
-            precondition(
-                appState.localAIInstallState(for: model).issue?.code
-                    == .localAIModelUnavailable
-            )
-        }
-    }
-
-    private static func testInstallerFailureClearsPendingAndSetsIssue() async {
+    private static func testInstallerFailureClearsPendingSelectionAndMirrorsIssue() async {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
         let installHarness = LocalAIInstallHarness()
@@ -1777,43 +1544,6 @@ struct AppStateAIProcessingBackendTests {
             precondition(!appState.localAIInstallState(for: model).isInstalling)
         }
         precondition(installHarness.starts(for: model) == 0)
-    }
-
-    private static func testCanonicalModelValidationRejectsForgedModels() async {
-        resetAIProcessingDefaults()
-        let statusHarness = LocalAIStatusHarness(defaultStatus: .notInstalled)
-        let installHarness = LocalAIInstallHarness()
-        let deletionHarness = LocalAIDeletionHarness()
-        var dependencies = modelTestDependencies()
-        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.startInstall = installHarness.start
-
-        let canonical = LocalAIModelCatalog.quality
-        let forged = LocalAIModel(
-            id: canonical.id,
-            displayName: "Forged",
-            description: canonical.description,
-            artifacts: canonical.artifacts,
-            approximateResidentRAMBytes: canonical.approximateResidentRAMBytes
-        )
-        let appState = await makeRefreshedAppState(dependencies: dependencies)
-        dependencies.localAI.deleteModel = { model in
-            deletionHarness.record(modelID: model.id, managerWasStopped: true)
-        }
-        await MainActor.run {
-            precondition(
-                !appState.isAIProcessingChoiceAvailable(
-                    .localAI(modelID: "unknown-local-model"),
-                    for: .postProcessing
-                )
-            )
-            appState.installLocalAIModel(forged, autoSelectFor: .postProcessing)
-            appState.deleteLocalAIModel(forged)
-            precondition(appState.pendingLocalAIModelID(for: .postProcessing) == nil)
-        }
-        await yieldMainActor()
-        precondition(installHarness.starts(for: canonical) == 0)
-        precondition(deletionHarness.callCount == 0)
     }
 
     private static func testAIProcessingChoiceDisplayMetadata() async {
@@ -2044,7 +1774,10 @@ struct AppStateAIProcessingBackendTests {
             statusHarness.releaseBlockedCall()
         }
 
-        let appState = await MainActor.run { AppState(dependencies: dependencies) }
+        let dependenciesSnapshot = dependencies
+        let appState = await MainActor.run {
+            AppState(dependencies: dependenciesSnapshot)
+        }
         statusHarness.waitUntilBlockedCallEntered()
         await MainActor.run {
             appState.selectAIProcessingBackendChoice(
@@ -2070,41 +1803,6 @@ struct AppStateAIProcessingBackendTests {
         precondition(statusHarness.mainThreadCallCount == 0)
     }
 
-    private static func testBackgroundStatusRefreshIgnoresStaleGeneration() async {
-        resetAIProcessingDefaults()
-        let statusHarness = ControlledLocalAIStatusHarness(
-            blockedModelID: LocalAIModelCatalog.quality.id,
-            blockedResult: .ready,
-            subsequentResult: .notInstalled
-        )
-        var dependencies = modelTestDependencies()
-        dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        defer {
-            statusHarness.releaseBlockedCall()
-        }
-
-        let appState = await MainActor.run { AppState(dependencies: dependencies) }
-        statusHarness.waitUntilBlockedCallEntered()
-        await MainActor.run {
-            appState.refreshAllLocalAIInstallStates()
-        }
-        await appState.waitForLocalAIInstallStateRefresh()
-        statusHarness.releaseBlockedCall()
-        await yieldMainActor()
-
-        let callsBeforeReads = statusHarness.callCount
-        await MainActor.run {
-            precondition(
-                appState.localAIInstallState(for: LocalAIModelCatalog.quality).status
-                    == .notInstalled
-            )
-            precondition(!appState.isAIProcessingBackendReady(for: .postProcessing))
-            _ = appState.aiProcessingChoiceDisplays(for: .postProcessing)
-        }
-        precondition(statusHarness.callCount == callsBeforeReads)
-        precondition(statusHarness.mainThreadCallCount == 0)
-    }
-
     private static func testAppStateInstancesKeepIndependentLocalAIEnvironments() async {
         resetAIProcessingDefaults()
         let firstStatus = LocalAIStatusHarness(defaultStatus: .ready)
@@ -2112,18 +1810,20 @@ struct AppStateAIProcessingBackendTests {
         let firstManager = LocalAIServerManager()
         let secondManager = LocalAIServerManager()
         var firstDependencies = modelTestDependencies()
-        firstDependencies.localAI.installStatus = firstStatus.status
+        firstDependencies.localAI.installStatus = { firstStatus.status(for: $0) }
         firstDependencies.localAI.processingAvailability = supportedLocalAIAvailability
         firstDependencies.localAI.makeServerManager = { firstManager }
         var secondDependencies = modelTestDependencies()
-        secondDependencies.localAI.installStatus = secondStatus.status
+        secondDependencies.localAI.installStatus = { secondStatus.status(for: $0) }
         secondDependencies.localAI.processingAvailability = unsupportedLocalAIAvailability
         secondDependencies.localAI.makeServerManager = { secondManager }
+        let firstDependenciesSnapshot = firstDependencies
+        let secondDependenciesSnapshot = secondDependencies
 
         let instances = await MainActor.run {
             (
-                AppState(dependencies: firstDependencies),
-                AppState(dependencies: secondDependencies)
+                AppState(dependencies: firstDependenciesSnapshot),
+                AppState(dependencies: secondDependenciesSnapshot)
             )
         }
         await instances.0.waitForLocalAIInstallStateRefresh()
@@ -2150,8 +1850,9 @@ struct AppStateAIProcessingBackendTests {
         var dependencies = modelTestDependencies()
         dependencies.localAI.installStatus = { _ in .ready }
         dependencies.localAI.processingAvailability = unsupportedLocalAIAvailability
+        let dependenciesSnapshot = dependencies
         let appState = await MainActor.run {
-            AppState(dependencies: dependencies)
+            AppState(dependencies: dependenciesSnapshot)
         }
         await appState.waitForLocalAIInstallStateRefresh()
 
@@ -2241,10 +1942,9 @@ struct AppStateAIProcessingBackendTests {
         precondition(installHarness.starts(for: model) == 1)
     }
 
-    private static func testDeleteFailureAndSuccessStateReset() async throws {
+    private static func testDeleteFailurePreservesSelectedLocalChoice() async throws {
         resetAIProcessingDefaults()
         let statusHarness = LocalAIStatusHarness(defaultStatus: .ready)
-        let deletionHarness = LocalAIDeletionHarness()
         var dependencies = modelTestDependencies()
         let manager = LocalAIServerManager(
             launchProcess: { _, _, port, _ in (TestLocalAIServerProcess(), port) },
@@ -2253,8 +1953,7 @@ struct AppStateAIProcessingBackendTests {
             validateModel: { _ in .ready }
         )
         dependencies.localAI.installStatus = { statusHarness.status(for: $0) }
-        dependencies.localAI.deleteModel = { model in
-            deletionHarness.record(modelID: model.id, managerWasStopped: true)
+        dependencies.localAI.deleteModel = { _ in
             throw TestLocalAILifecycleError.fullDeleteFailed
         }
         dependencies.localAI.makeServerManager = { manager }
@@ -2265,7 +1964,6 @@ struct AppStateAIProcessingBackendTests {
             appState.postProcessingBackendChoice = .localAI(modelID: model.id)
             appState.deleteLocalAIModel(model)
         }
-        await waitUntil { deletionHarness.callCount == 1 }
         await waitUntil {
             appState.localAIInstallState(for: model).issue?.code
                 == .localAIModelUnavailable
@@ -2275,7 +1973,6 @@ struct AppStateAIProcessingBackendTests {
                 appState.postProcessingBackendChoice
                     == .localAI(modelID: model.id)
             )
-            precondition(appState.localAIInstallState(for: model).status == .ready)
         }
     }
 

--- a/Tests/AppStateAIProcessingBackendTests.swift
+++ b/Tests/AppStateAIProcessingBackendTests.swift
@@ -2564,17 +2564,16 @@ struct AppStateAIProcessingBackendTests {
         assert(!delegate.contains("requestTerminationWhileNativeWhisperInstalling()"))
         assert(state.contains("await manager.stop()"))
         assert(state.contains("cancelAllLocalAIInstalls()"))
-        assert(state.contains("localAIDeferredInstallModelIDs.removeAll()"))
-        assert(state.contains("localAIRestartAfterCancellationModelIDs.removeAll()"))
         assert(state.contains("pendingLocalAISelections.removeAll()"))
-        assert(state.contains("nativeWhisperInstallTask != nil"))
-        assert(state.contains("!localAIInstallTasks.isEmpty"))
+        assert(state.contains("nativeWhisperWorkflow.beginTerminationCleanup()"))
+        assert(state.contains("localAIWorkflow.beginTerminationCleanup()"))
+        assert(state.contains("isInstallingNativeWhisper || localAIWorkflow.hasActiveInstalls"))
         assert(state.contains("waitForNativeWhisperInstallToQuiesce()"))
         assert(state.contains("waitForLocalAIInstallsToQuiesce()"))
         assert(
             state.components(
                 separatedBy: "guard !isModelTerminationCleanupPending else { return }"
-            ).count - 1 >= 2
+            ).count - 1 >= 1
         )
         assert(
             state.contains(
@@ -2586,8 +2585,7 @@ struct AppStateAIProcessingBackendTests {
             from: "func cancelNativeWhisperInstall()",
             to: "func deleteNativeWhisperModel()"
         )
-        assert(!nativeCancellation.contains("deletePartialModel"))
-        assert(!nativeCancellation.contains("refreshNativeWhisperInstallStatus()"))
+        assert(nativeCancellation.contains("nativeWhisperWorkflow.cancelInstall()"))
     }
 
     // Dismissing a warning banner hides it for the note's current retry

--- a/Tests/FullSourceAppStateTestRunner.swift
+++ b/Tests/FullSourceAppStateTestRunner.swift
@@ -19,6 +19,7 @@ struct FullSourceAppStateTestRunner {
             try LatestValueProgressCoalescerTests.main()
             try await HistoryArchiveRecoveryWorkflowTests.main()
             try await TranscriptionRetryWorkflowTests.main()
+            try await NativeWhisperModelWorkflowTests.main()
             try await AppStateStorageSafetyTests.main()
             try AppStateHistoryProtectionSourceTests.main()
             try await AppStateTranscriptionConfigurationTests.main()

--- a/Tests/FullSourceAppStateTestRunner.swift
+++ b/Tests/FullSourceAppStateTestRunner.swift
@@ -20,6 +20,7 @@ struct FullSourceAppStateTestRunner {
             try await HistoryArchiveRecoveryWorkflowTests.main()
             try await TranscriptionRetryWorkflowTests.main()
             try await NativeWhisperModelWorkflowTests.main()
+            try await LocalAIModelWorkflowTests.main()
             try await AppStateStorageSafetyTests.main()
             try AppStateHistoryProtectionSourceTests.main()
             try await AppStateTranscriptionConfigurationTests.main()

--- a/Tests/LocalAIModelWorkflowTests.swift
+++ b/Tests/LocalAIModelWorkflowTests.swift
@@ -112,6 +112,8 @@ struct LocalAIModelWorkflowTests {
             serverManager: LocalAIServerManager(store: LocalAIModelStore())
         )
         workflow.markInitialRefreshCompletedForTesting()
+        var events: [LocalAIModelWorkflowEvent] = []
+        workflow.onEvent = { events.append($0) }
 
         workflow.startInstall(model)
         try expect(workflow.cancelInstall(model), "cancel reports it found an active task")
@@ -123,6 +125,13 @@ struct LocalAIModelWorkflowTests {
         try expect(!workflow.installState(for: model).isInstalling, "isInstalling cleared after cancellation")
         try expect(workflow.installState(for: model).issue == nil, "issue cleared after cancellation")
         try expect(workflow.installState(for: model).progress.isCancelled, "progress still marked cancelled after completion")
+        try expect(
+            !events.contains {
+                if case .installOutcome(_, .cancelled) = $0 { return true }
+                return false
+            },
+            "tracked cancellation completion does not emit an installOutcome(.cancelled) event"
+        )
     }
 
     @MainActor

--- a/Tests/LocalAIModelWorkflowTests.swift
+++ b/Tests/LocalAIModelWorkflowTests.swift
@@ -40,7 +40,19 @@ struct LocalAIModelWorkflowTests {
 
     @MainActor
     private static func testCanonicalModelRejectsForgedModels() throws {
-        let workflow = makeWorkflow()
+        let installCalls = LocalAICallCounter()
+        let deleteCalls = LocalAICallCounter()
+        let workflow = LocalAIModelWorkflow(
+            dependencies: dependencies(
+                startInstall: { _, _, _ in
+                    installCalls.increment()
+                    return LocalAIInstallTask()
+                },
+                deleteModel: { _ in deleteCalls.increment() }
+            ),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        workflow.markInitialRefreshCompletedForTesting()
         let real = LocalAIModelCatalog.quality
         try expect(workflow.canonicalModel(for: real) == real, "genuine catalog model is canonical")
 
@@ -55,6 +67,11 @@ struct LocalAIModelWorkflowTests {
             runtime: real.runtime
         )
         try expect(workflow.canonicalModel(for: forged) == nil, "forged model with same id is rejected")
+
+        workflow.startInstall(forged)
+        try expect(!workflow.deleteModel(forged), "forged model delete is rejected")
+        try expectEqual(installCalls.value, 0, "forged model cannot reach install dependency")
+        try expectEqual(deleteCalls.value, 0, "forged model cannot reach delete dependency")
     }
 
     @MainActor
@@ -371,11 +388,21 @@ struct LocalAIModelWorkflowTests {
     private static func testStaleStatusRefreshGenerationIsIgnored() async throws {
         let model = LocalAIModelCatalog.quality
         let statusHarness = OverlappingLocalAIStatusHarness(blockedModelID: model.id)
+        let deliveryHarness = LocalAIStatusRefreshDeliveryHarness(
+            modelID: model.id,
+            generation: 1
+        )
         let workflow = LocalAIModelWorkflow(
             dependencies: dependencies(installStatus: { statusHarness.status(for: $0) }),
             serverManager: LocalAIServerManager(store: LocalAIModelStore())
         )
-        defer { statusHarness.releaseFirstLookup() }
+        workflow.onStatusRefreshDeliveryForTesting = { deliveredModel, generation in
+            deliveryHarness.record(modelID: deliveredModel.id, generation: generation)
+        }
+        defer {
+            workflow.onStatusRefreshDeliveryForTesting = nil
+            statusHarness.releaseFirstLookup()
+        }
 
         workflow.refreshAllInstallStates()
         statusHarness.waitUntilFirstLookupStarts()
@@ -389,7 +416,7 @@ struct LocalAIModelWorkflowTests {
         )
 
         statusHarness.releaseFirstLookup()
-        await statusHarness.waitForStaleDeliveryToDrain()
+        await deliveryHarness.waitForDelivery()
         try expectEqual(
             workflow.installState(for: model).status,
             .notInstalled,
@@ -447,6 +474,10 @@ struct LocalAIModelWorkflowTests {
 
     private static func dependencies(
         installStatus: @escaping @Sendable (LocalAIModel) -> LocalAIInstallStatus = { _ in .notInstalled },
+        startInstall: @escaping AppStateLocalAIDependencies.InstallStarter = { _, _, completion in
+            completion(.failure(.alreadyInProgress))
+            return LocalAIInstallTask()
+        },
         deleteModel: @escaping @Sendable (LocalAIModel) throws -> Void = { _ in },
         processingAvailability: @escaping () -> LocalAIProcessingAvailability = supportedProcessingAvailability
     ) -> AppStateLocalAIDependencies {
@@ -454,10 +485,7 @@ struct LocalAIModelWorkflowTests {
             makeServerManager: { LocalAIServerManager(store: LocalAIModelStore()) },
             idleShutdownSleep: { _ in try await Task.sleep(nanoseconds: UInt64.max) },
             installStatus: installStatus,
-            startInstall: { _, _, completion in
-                completion(.failure(.alreadyInProgress))
-                return LocalAIInstallTask()
-            },
+            startInstall: startInstall,
             progressSchedule: { _, operation in operation() },
             deleteModel: deleteModel,
             deletePartialModel: { _ in },
@@ -517,11 +545,25 @@ struct LocalAIModelWorkflowTests {
         workflow.startInstall(model)
         try expect(workflow.hasActiveInstalls, "install active")
 
-        let quiesceTask = Task { await workflow.waitForInstallsToQuiesce() }
-        try await Task.sleep(nanoseconds: 20_000_000)
+        let waiterStarted = LocalAIValueBox(false)
+        let waiterCompleted = LocalAIValueBox(false)
+        let quiesceTask = Task { @MainActor in
+            waiterStarted.set(true)
+            await workflow.waitForInstallsToQuiesce()
+            waiterCompleted.set(true)
+        }
+        try await waitUntil { waiterStarted.value }
+        try expect(
+            !waiterCompleted.value,
+            "quiescence waiter remains suspended while install is active"
+        )
 
         harness.complete(model: model, with: .success(()))
         await quiesceTask.value
+        try expect(
+            waiterCompleted.value,
+            "quiescence waiter resumes after install completion"
+        )
         try expect(!workflow.hasActiveInstalls, "install no longer active")
     }
 
@@ -564,8 +606,6 @@ private final class OverlappingLocalAIStatusHarness: @unchecked Sendable {
     private let blockedModelID: String
     private var hasStartedFirstLookup = false
     private var mayFinishFirstLookup = false
-    private var staleDeliveryDidDrain = false
-    private var staleDeliveryWaiters: [CheckedContinuation<Void, Never>] = []
 
     init(blockedModelID: String) {
         self.blockedModelID = blockedModelID
@@ -583,13 +623,6 @@ private final class OverlappingLocalAIStatusHarness: @unchecked Sendable {
             condition.wait()
         }
         condition.unlock()
-
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            DispatchQueue.main.async { [self] in
-                self.markStaleDeliveryDrained()
-            }
-        }
         return .ready
     }
 
@@ -615,35 +648,60 @@ private final class OverlappingLocalAIStatusHarness: @unchecked Sendable {
         condition.broadcast()
         condition.unlock()
     }
+}
 
-    func waitForStaleDeliveryToDrain() async {
-        if withConditionLock({ staleDeliveryDidDrain }) { return }
-        await withCheckedContinuation { continuation in
-            let shouldResume = withConditionLock { () -> Bool in
-                if staleDeliveryDidDrain { return true }
-                staleDeliveryWaiters.append(continuation)
-                return false
-            }
-            if shouldResume { continuation.resume() }
-        }
+private final class LocalAIStatusRefreshDeliveryHarness: @unchecked Sendable {
+    private let lock = NSLock()
+    private let modelID: String
+    private let generation: Int
+    private var didObserveDelivery = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(modelID: String, generation: Int) {
+        self.modelID = modelID
+        self.generation = generation
     }
 
-    private func markStaleDeliveryDrained() {
-        let waiters = withConditionLock { () -> [CheckedContinuation<Void, Never>] in
-            staleDeliveryDidDrain = true
-            let waiters = staleDeliveryWaiters
-            staleDeliveryWaiters.removeAll()
-            return waiters
+    func record(modelID: String, generation: Int) {
+        let waiters = lock.withLock { () -> [CheckedContinuation<Void, Never>] in
+            guard modelID == self.modelID,
+                  generation == self.generation,
+                  !didObserveDelivery else {
+                return []
+            }
+            didObserveDelivery = true
+            let continuations = self.waiters
+            self.waiters.removeAll()
+            return continuations
         }
         for waiter in waiters {
             waiter.resume()
         }
     }
 
-    private func withConditionLock<Value>(_ body: () -> Value) -> Value {
-        condition.lock()
-        defer { condition.unlock() }
-        return body()
+    func waitForDelivery() async {
+        if lock.withLock({ didObserveDelivery }) { return }
+        await withCheckedContinuation { continuation in
+            let shouldResume = lock.withLock { () -> Bool in
+                if didObserveDelivery { return true }
+                waiters.append(continuation)
+                return false
+            }
+            if shouldResume { continuation.resume() }
+        }
+    }
+}
+
+private final class LocalAICallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var calls = 0
+
+    var value: Int {
+        lock.withLock { calls }
+    }
+
+    func increment() {
+        lock.withLock { calls += 1 }
     }
 }
 

--- a/Tests/LocalAIModelWorkflowTests.swift
+++ b/Tests/LocalAIModelWorkflowTests.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+#if !QUILL_GROUPED_TEST_RUNNER
+@main
+#endif
+struct LocalAIModelWorkflowTests {
+    static func main() async throws {
+        try testInitialInstallStateIsNotInstalled()
+        try testCanonicalModelRejectsForgedModels()
+        try testIsModelAvailableReflectsProcessingAvailability()
+        try await testStartInstallSucceedsAndEmitsReadyOutcome()
+        print("LocalAIModelWorkflowTests passed")
+    }
+
+    @MainActor
+    private static func testInitialInstallStateIsNotInstalled() throws {
+        let workflow = makeWorkflow()
+        let model = LocalAIModelCatalog.quality
+        try expectEqual(
+            workflow.installState(for: model).status,
+            .notInstalled,
+            "initial install state"
+        )
+    }
+
+    @MainActor
+    private static func testCanonicalModelRejectsForgedModels() throws {
+        let workflow = makeWorkflow()
+        let real = LocalAIModelCatalog.quality
+        try expect(workflow.canonicalModel(for: real) == real, "genuine catalog model is canonical")
+    }
+
+    @MainActor
+    private static func testIsModelAvailableReflectsProcessingAvailability() throws {
+        let model = LocalAIModelCatalog.quality
+        let unsupportedWorkflow = LocalAIModelWorkflow(
+            dependencies: dependencies(
+                processingAvailability: {
+                    LocalAIProcessingAvailability(isAppleSilicon: false, runnerIsExecutable: false)
+                }
+            ),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        try expect(!unsupportedWorkflow.isModelAvailable(model), "unsupported hardware is unavailable")
+
+        let supportedWorkflow = LocalAIModelWorkflow(
+            dependencies: dependencies(
+                processingAvailability: {
+                    LocalAIProcessingAvailability(
+                        isAppleSilicon: true,
+                        runnerIsExecutable: true,
+                        physicalMemory: 32 * 1024 * 1024 * 1024
+                    )
+                }
+            ),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        try expect(supportedWorkflow.isModelAvailable(model), "supported hardware is available")
+    }
+
+    @MainActor
+    private static func testStartInstallSucceedsAndEmitsReadyOutcome() async throws {
+        let model = LocalAIModelCatalog.quality
+        let harness = ControlledLocalAIInstallHarness(finalStatus: .ready)
+        let workflow = LocalAIModelWorkflow(
+            dependencies: harness.dependencies(),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        workflow.markInitialRefreshCompletedForTesting()
+        var events: [LocalAIModelWorkflowEvent] = []
+        workflow.onEvent = { events.append($0) }
+
+        workflow.startInstall(model)
+        try expect(workflow.installState(for: model).isInstalling, "installing after start")
+
+        harness.complete(model: model, with: .success(()))
+        try await waitUntil { !workflow.installState(for: model).isInstalling }
+
+        try expect(
+            events.contains {
+                if case .installOutcome(let outcomeModel, .readyAndAvailable) = $0 {
+                    return outcomeModel.id == model.id
+                }
+                return false
+            },
+            "installOutcome(.readyAndAvailable) fired"
+        )
+    }
+
+    @MainActor
+    private static func waitUntil(
+        timeoutNanoseconds: UInt64 = 2_000_000_000,
+        _ condition: @escaping () -> Bool
+    ) async throws {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        throw TestFailure("timed out waiting for condition")
+    }
+
+    @MainActor
+    private static func makeWorkflow() -> LocalAIModelWorkflow {
+        LocalAIModelWorkflow(
+            dependencies: dependencies(),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+    }
+
+    private static func dependencies(
+        installStatus: @escaping @Sendable (LocalAIModel) -> LocalAIInstallStatus = { _ in .notInstalled },
+        processingAvailability: @escaping () -> LocalAIProcessingAvailability = {
+            LocalAIProcessingAvailability(
+                isAppleSilicon: true,
+                runnerIsExecutable: true,
+                physicalMemory: 32 * 1024 * 1024 * 1024
+            )
+        }
+    ) -> AppStateLocalAIDependencies {
+        AppStateLocalAIDependencies(
+            makeServerManager: { LocalAIServerManager(store: LocalAIModelStore()) },
+            idleShutdownSleep: { _ in try await Task.sleep(nanoseconds: UInt64.max) },
+            installStatus: installStatus,
+            startInstall: { _, _, completion in
+                completion(.failure(.alreadyInProgress))
+                return LocalAIInstallTask()
+            },
+            progressSchedule: { _, operation in operation() },
+            deleteModel: { _ in },
+            deletePartialModel: { _ in },
+            processingAvailability: processingAvailability
+        )
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ label: String
+    ) throws {
+        guard condition() else { throw TestFailure(label) }
+    }
+
+    private static func expectEqual<T: Equatable>(
+        _ actual: T,
+        _ expected: T,
+        _ label: String
+    ) throws {
+        guard actual == expected else {
+            throw TestFailure("\(label): expected \(expected), got \(actual)")
+        }
+    }
+}
+
+private final class ControlledLocalAIInstallHarness: @unchecked Sendable {
+    private let lock = NSLock()
+    private var completions: [String: (Result<Void, LocalAIInstallerError>) -> Void] = [:]
+    private let finalStatus: LocalAIInstallStatus
+
+    init(finalStatus: LocalAIInstallStatus) {
+        self.finalStatus = finalStatus
+    }
+
+    func dependencies() -> AppStateLocalAIDependencies {
+        AppStateLocalAIDependencies(
+            makeServerManager: { LocalAIServerManager(store: LocalAIModelStore()) },
+            idleShutdownSleep: { _ in try await Task.sleep(nanoseconds: UInt64.max) },
+            installStatus: { [weak self] _ in self?.finalStatus ?? .notInstalled },
+            startInstall: { [weak self] model, _, completion in
+                self?.lock.withLock { self?.completions[model.id] = completion }
+                return LocalAIInstallTask()
+            },
+            progressSchedule: { _, operation in operation() },
+            deleteModel: { _ in },
+            deletePartialModel: { _ in },
+            processingAvailability: {
+                LocalAIProcessingAvailability(
+                    isAppleSilicon: true,
+                    runnerIsExecutable: true,
+                    physicalMemory: 32 * 1024 * 1024 * 1024
+                )
+            }
+        )
+    }
+
+    func complete(model: LocalAIModel, with result: Result<Void, LocalAIInstallerError>) {
+        let completion = lock.withLock { completions[model.id] }
+        completion?(result)
+    }
+}
+
+private struct TestFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/Tests/LocalAIModelWorkflowTests.swift
+++ b/Tests/LocalAIModelWorkflowTests.swift
@@ -10,10 +10,14 @@ struct LocalAIModelWorkflowTests {
         try testCanonicalModelRejectsForgedModels()
         try testIsModelAvailableReflectsProcessingAvailability()
         try await testStartInstallSucceedsAndEmitsReadyOutcome()
+        try await testInstallerSuccessWithoutReadyStatusEmitsUnavailableOutcome()
+        try await testInstallerSuccessRechecksProcessingAvailability()
+        try await testFailedInstallEmitsFailedOutcomeWithIssue()
         try await testCancelInstallClearsInstallingStateWithoutEmittingOutcome()
         try await testCancelThenRestartResumesAfterCancellationCompletes()
         try await testDeleteModelDuringInstallCancelsFirst()
         try await testDeleteModelWhenIdleGoesStraightToDeletion()
+        try await testDeleteFailurePreservesReadyStatusAndSetsIssue()
         try await testRefreshAllInstallStatesCompletesAndEmitsDeferredIDs()
         try await testStaleStatusRefreshGenerationIsIgnored()
         try await testInstallRequestedBeforeRefreshCompletesIsDeferredThenReported()
@@ -111,6 +115,103 @@ struct LocalAIModelWorkflowTests {
     }
 
     @MainActor
+    private static func testInstallerSuccessWithoutReadyStatusEmitsUnavailableOutcome() async throws {
+        let model = LocalAIModelCatalog.quality
+        let harness = ControlledLocalAIInstallHarness(finalStatus: .notInstalled)
+        let workflow = LocalAIModelWorkflow(
+            dependencies: harness.dependencies(),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        workflow.markInitialRefreshCompletedForTesting()
+        var events: [LocalAIModelWorkflowEvent] = []
+        workflow.onEvent = { events.append($0) }
+
+        workflow.startInstall(model)
+        harness.complete(model: model, with: .success(()))
+        try await waitUntil { !workflow.installState(for: model).isInstalling }
+
+        let issue = workflow.installState(for: model).issue
+        try expectEqual(issue?.code, .localAIModelUnavailable, "success without ready status issue")
+        try expect(
+            events.contains {
+                if case .installOutcome(
+                    let outcomeModel,
+                    .succeededButUnavailable(let outcomeIssue)
+                ) = $0 {
+                    return outcomeModel.id == model.id && outcomeIssue == issue
+                }
+                return false
+            },
+            "installOutcome(.succeededButUnavailable) fired for non-ready status"
+        )
+    }
+
+    @MainActor
+    private static func testInstallerSuccessRechecksProcessingAvailability() async throws {
+        let model = LocalAIModelCatalog.quality
+        let harness = ControlledLocalAIInstallHarness(finalStatus: .ready)
+        let availability = LocalAIValueBox(supportedProcessingAvailability())
+        let workflow = LocalAIModelWorkflow(
+            dependencies: harness.dependencies(
+                processingAvailability: { availability.value }
+            ),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        workflow.markInitialRefreshCompletedForTesting()
+        var events: [LocalAIModelWorkflowEvent] = []
+        workflow.onEvent = { events.append($0) }
+
+        workflow.startInstall(model)
+        availability.set(unsupportedProcessingAvailability())
+        harness.complete(model: model, with: .success(()))
+        try await waitUntil { !workflow.installState(for: model).isInstalling }
+
+        let issue = workflow.installState(for: model).issue
+        try expectEqual(issue?.code, .localAIModelUnavailable, "availability recheck issue")
+        try expect(
+            events.contains {
+                if case .installOutcome(
+                    let outcomeModel,
+                    .succeededButUnavailable(let outcomeIssue)
+                ) = $0 {
+                    return outcomeModel.id == model.id && outcomeIssue == issue
+                }
+                return false
+            },
+            "installOutcome(.succeededButUnavailable) fired after availability changed"
+        )
+    }
+
+    @MainActor
+    private static func testFailedInstallEmitsFailedOutcomeWithIssue() async throws {
+        let model = LocalAIModelCatalog.quality
+        let harness = ControlledLocalAIInstallHarness(finalStatus: .notInstalled)
+        let workflow = LocalAIModelWorkflow(
+            dependencies: harness.dependencies(),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        workflow.markInitialRefreshCompletedForTesting()
+        var events: [LocalAIModelWorkflowEvent] = []
+        workflow.onEvent = { events.append($0) }
+
+        workflow.startInstall(model)
+        harness.complete(model: model, with: .failure(.downloadFailed("offline")))
+        try await waitUntil { !workflow.installState(for: model).isInstalling }
+
+        let issue = workflow.installState(for: model).issue
+        try expectEqual(issue?.code, .localAIModelUnavailable, "failed install issue")
+        try expect(
+            events.contains {
+                if case .installOutcome(let outcomeModel, .failed(let outcomeIssue)) = $0 {
+                    return outcomeModel.id == model.id && outcomeIssue == issue
+                }
+                return false
+            },
+            "installOutcome(.failed) fired with mirrored issue"
+        )
+    }
+
+    @MainActor
     private static func testCancelInstallClearsInstallingStateWithoutEmittingOutcome() async throws {
         let model = LocalAIModelCatalog.quality
         let harness = ControlledLocalAIInstallHarness(finalStatus: .notInstalled)
@@ -180,7 +281,7 @@ struct LocalAIModelWorkflowTests {
     @MainActor
     private static func testDeleteModelWhenIdleGoesStraightToDeletion() async throws {
         let model = LocalAIModelCatalog.quality
-        var deleteCalled = false
+        let deletionHarness = LocalAIDeletionCallHarness()
         let workflow = LocalAIModelWorkflow(
             dependencies: AppStateLocalAIDependencies(
                 makeServerManager: { LocalAIServerManager(store: LocalAIModelStore()) },
@@ -191,7 +292,7 @@ struct LocalAIModelWorkflowTests {
                     return LocalAIInstallTask()
                 },
                 progressSchedule: { _, operation in operation() },
-                deleteModel: { _ in deleteCalled = true },
+                deleteModel: { deletionHarness.record(model: $0) },
                 deletePartialModel: { _ in },
                 processingAvailability: {
                     LocalAIProcessingAvailability(
@@ -207,10 +308,42 @@ struct LocalAIModelWorkflowTests {
         workflow.onEvent = { events.append($0) }
 
         try expect(workflow.deleteModel(model), "delete accepted when idle")
-        try await waitUntil { deleteCalled }
+        try await waitUntil { deletionHarness.wasCalled }
         try await waitUntil {
             events.contains { if case .deletionOutcome = $0 { return true }; return false }
         }
+    }
+
+    @MainActor
+    private static func testDeleteFailurePreservesReadyStatusAndSetsIssue() async throws {
+        let model = LocalAIModelCatalog.quality
+        let workflow = LocalAIModelWorkflow(
+            dependencies: dependencies(
+                installStatus: { _ in .ready },
+                deleteModel: { _ in throw LocalAIWorkflowTestError.deletionFailed }
+            ),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        var events: [LocalAIModelWorkflowEvent] = []
+        workflow.onEvent = { events.append($0) }
+
+        workflow.refreshAllInstallStates()
+        await workflow.waitForInitialStatusRefresh()
+        try expectEqual(workflow.installState(for: model).status, .ready, "status before delete")
+
+        try expect(workflow.deleteModel(model), "delete accepted for ready model")
+        try await waitUntil {
+            events.contains {
+                if case .deletionOutcome(let outcomeModel, let errorDescription) = $0 {
+                    return outcomeModel.id == model.id && errorDescription != nil
+                }
+                return false
+            }
+        }
+
+        let state = workflow.installState(for: model)
+        try expectEqual(state.status, .ready, "failed delete preserves ready status")
+        try expectEqual(state.issue?.code, .localAIModelUnavailable, "failed delete issue")
     }
 
     @MainActor
@@ -237,19 +370,31 @@ struct LocalAIModelWorkflowTests {
     @MainActor
     private static func testStaleStatusRefreshGenerationIsIgnored() async throws {
         let model = LocalAIModelCatalog.quality
-        let statusBox = LocalAIStatusBox(.notInstalled)
+        let statusHarness = OverlappingLocalAIStatusHarness(blockedModelID: model.id)
         let workflow = LocalAIModelWorkflow(
-            dependencies: dependencies(installStatus: { statusBox.status(for: $0) }),
+            dependencies: dependencies(installStatus: { statusHarness.status(for: $0) }),
             serverManager: LocalAIServerManager(store: LocalAIModelStore())
         )
-        workflow.refreshAllInstallStates()
-        try await waitUntil { workflow.state.hasCompletedInitialStatusRefresh }
+        defer { statusHarness.releaseFirstLookup() }
 
-        // A second refresh bumps the generation; only its result should apply.
-        statusBox.set(.ready, for: model)
         workflow.refreshAllInstallStates()
-        try await waitUntil { workflow.state.hasCompletedInitialStatusRefresh }
-        try expectEqual(workflow.installState(for: model).status, .ready, "latest refresh wins")
+        statusHarness.waitUntilFirstLookupStarts()
+
+        workflow.refreshAllInstallStates()
+        await workflow.waitForInitialStatusRefresh()
+        try expectEqual(
+            workflow.installState(for: model).status,
+            .notInstalled,
+            "newer refresh applies while stale lookup remains blocked"
+        )
+
+        statusHarness.releaseFirstLookup()
+        await statusHarness.waitForStaleDeliveryToDrain()
+        try expectEqual(
+            workflow.installState(for: model).status,
+            .notInstalled,
+            "stale overlapping refresh cannot overwrite newer status"
+        )
     }
 
     @MainActor
@@ -302,13 +447,8 @@ struct LocalAIModelWorkflowTests {
 
     private static func dependencies(
         installStatus: @escaping @Sendable (LocalAIModel) -> LocalAIInstallStatus = { _ in .notInstalled },
-        processingAvailability: @escaping () -> LocalAIProcessingAvailability = {
-            LocalAIProcessingAvailability(
-                isAppleSilicon: true,
-                runnerIsExecutable: true,
-                physicalMemory: 32 * 1024 * 1024 * 1024
-            )
-        }
+        deleteModel: @escaping @Sendable (LocalAIModel) throws -> Void = { _ in },
+        processingAvailability: @escaping () -> LocalAIProcessingAvailability = supportedProcessingAvailability
     ) -> AppStateLocalAIDependencies {
         AppStateLocalAIDependencies(
             makeServerManager: { LocalAIServerManager(store: LocalAIModelStore()) },
@@ -319,10 +459,22 @@ struct LocalAIModelWorkflowTests {
                 return LocalAIInstallTask()
             },
             progressSchedule: { _, operation in operation() },
-            deleteModel: { _ in },
+            deleteModel: deleteModel,
             deletePartialModel: { _ in },
             processingAvailability: processingAvailability
         )
+    }
+
+    private static func supportedProcessingAvailability() -> LocalAIProcessingAvailability {
+        LocalAIProcessingAvailability(
+            isAppleSilicon: true,
+            runnerIsExecutable: true,
+            physicalMemory: 32 * 1024 * 1024 * 1024
+        )
+    }
+
+    private static func unsupportedProcessingAvailability() -> LocalAIProcessingAvailability {
+        LocalAIProcessingAvailability(isAppleSilicon: false, runnerIsExecutable: false)
     }
 
     private static func expect(
@@ -407,21 +559,121 @@ struct LocalAIModelWorkflowTests {
     }
 }
 
-private final class LocalAIStatusBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var overrides: [String: LocalAIInstallStatus] = [:]
-    private let defaultStatus: LocalAIInstallStatus
+private final class OverlappingLocalAIStatusHarness: @unchecked Sendable {
+    private let condition = NSCondition()
+    private let blockedModelID: String
+    private var hasStartedFirstLookup = false
+    private var mayFinishFirstLookup = false
+    private var staleDeliveryDidDrain = false
+    private var staleDeliveryWaiters: [CheckedContinuation<Void, Never>] = []
 
-    init(_ defaultStatus: LocalAIInstallStatus) {
-        self.defaultStatus = defaultStatus
+    init(blockedModelID: String) {
+        self.blockedModelID = blockedModelID
     }
 
     func status(for model: LocalAIModel) -> LocalAIInstallStatus {
-        lock.withLock { overrides[model.id] ?? defaultStatus }
+        condition.lock()
+        guard model.id == blockedModelID, !hasStartedFirstLookup else {
+            condition.unlock()
+            return .notInstalled
+        }
+        hasStartedFirstLookup = true
+        condition.broadcast()
+        while !mayFinishFirstLookup {
+            condition.wait()
+        }
+        condition.unlock()
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            DispatchQueue.main.async { [self] in
+                self.markStaleDeliveryDrained()
+            }
+        }
+        return .ready
     }
 
-    func set(_ status: LocalAIInstallStatus, for model: LocalAIModel) {
-        lock.withLock { overrides[model.id] = status }
+    func waitUntilFirstLookupStarts() {
+        condition.lock()
+        defer { condition.unlock() }
+        let deadline = Date().addingTimeInterval(5)
+        while !hasStartedFirstLookup {
+            precondition(
+                condition.wait(until: deadline),
+                "first status lookup did not enter the controlled overlap"
+            )
+        }
+    }
+
+    func releaseFirstLookup() {
+        condition.lock()
+        guard !mayFinishFirstLookup else {
+            condition.unlock()
+            return
+        }
+        mayFinishFirstLookup = true
+        condition.broadcast()
+        condition.unlock()
+    }
+
+    func waitForStaleDeliveryToDrain() async {
+        if withConditionLock({ staleDeliveryDidDrain }) { return }
+        await withCheckedContinuation { continuation in
+            let shouldResume = withConditionLock { () -> Bool in
+                if staleDeliveryDidDrain { return true }
+                staleDeliveryWaiters.append(continuation)
+                return false
+            }
+            if shouldResume { continuation.resume() }
+        }
+    }
+
+    private func markStaleDeliveryDrained() {
+        let waiters = withConditionLock { () -> [CheckedContinuation<Void, Never>] in
+            staleDeliveryDidDrain = true
+            let waiters = staleDeliveryWaiters
+            staleDeliveryWaiters.removeAll()
+            return waiters
+        }
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func withConditionLock<Value>(_ body: () -> Value) -> Value {
+        condition.lock()
+        defer { condition.unlock() }
+        return body()
+    }
+}
+
+private final class LocalAIDeletionCallHarness: @unchecked Sendable {
+    private let lock = NSLock()
+    private var calledModelIDs: [String] = []
+
+    var wasCalled: Bool {
+        lock.withLock { !calledModelIDs.isEmpty }
+    }
+
+    func record(model: LocalAIModel) {
+        lock.withLock { calledModelIDs.append(model.id) }
+    }
+}
+
+private final class LocalAIValueBox<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue: Value
+
+    init(_ value: Value) {
+        storedValue = value
+    }
+
+    var value: Value {
+        lock.withLock { storedValue }
+    }
+
+    func set(_ value: Value) {
+        lock.withLock { storedValue = value }
     }
 }
 
@@ -434,7 +686,15 @@ private final class ControlledLocalAIInstallHarness: @unchecked Sendable {
         self.finalStatus = finalStatus
     }
 
-    func dependencies() -> AppStateLocalAIDependencies {
+    func dependencies(
+        processingAvailability: @escaping () -> LocalAIProcessingAvailability = {
+            LocalAIProcessingAvailability(
+                isAppleSilicon: true,
+                runnerIsExecutable: true,
+                physicalMemory: 32 * 1024 * 1024 * 1024
+            )
+        }
+    ) -> AppStateLocalAIDependencies {
         AppStateLocalAIDependencies(
             makeServerManager: { LocalAIServerManager(store: LocalAIModelStore()) },
             idleShutdownSleep: { _ in try await Task.sleep(nanoseconds: UInt64.max) },
@@ -446,19 +706,21 @@ private final class ControlledLocalAIInstallHarness: @unchecked Sendable {
             progressSchedule: { _, operation in operation() },
             deleteModel: { _ in },
             deletePartialModel: { _ in },
-            processingAvailability: {
-                LocalAIProcessingAvailability(
-                    isAppleSilicon: true,
-                    runnerIsExecutable: true,
-                    physicalMemory: 32 * 1024 * 1024 * 1024
-                )
-            }
+            processingAvailability: processingAvailability
         )
     }
 
     func complete(model: LocalAIModel, with result: Result<Void, LocalAIInstallerError>) {
         let completion = lock.withLock { completions[model.id] }
         completion?(result)
+    }
+}
+
+private enum LocalAIWorkflowTestError: LocalizedError {
+    case deletionFailed
+
+    var errorDescription: String? {
+        "deletion failed"
     }
 }
 

--- a/Tests/LocalAIModelWorkflowTests.swift
+++ b/Tests/LocalAIModelWorkflowTests.swift
@@ -4,6 +4,7 @@ import Foundation
 @main
 #endif
 struct LocalAIModelWorkflowTests {
+    @MainActor
     static func main() async throws {
         try testInitialInstallStateIsNotInstalled()
         try testCanonicalModelRejectsForgedModels()
@@ -16,6 +17,9 @@ struct LocalAIModelWorkflowTests {
         try await testRefreshAllInstallStatesCompletesAndEmitsDeferredIDs()
         try await testStaleStatusRefreshGenerationIsIgnored()
         try await testInstallRequestedBeforeRefreshCompletesIsDeferredThenReported()
+        try testIdleShutdownMonitoringIsIdempotentAndStops()
+        try await testWaitForInstallsToQuiesceResumesAfterCompletion()
+        try testTerminationCleanupBlocksNewInstalls()
         print("LocalAIModelWorkflowTests passed")
     }
 
@@ -336,6 +340,70 @@ struct LocalAIModelWorkflowTests {
         guard actual == expected else {
             throw TestFailure("\(label): expected \(expected), got \(actual)")
         }
+    }
+
+    @MainActor
+    private static func testIdleShutdownMonitoringIsIdempotentAndStops() throws {
+        let workflow = makeWorkflow()
+        workflow.startIdleShutdownMonitoring()
+        workflow.startIdleShutdownMonitoring()
+        workflow.stopIdleShutdownMonitoring()
+        // No crash and no dangling task is the assertion here; a second
+        // stop() call must also be a safe no-op.
+        workflow.stopIdleShutdownMonitoring()
+    }
+
+    @MainActor
+    private static func testWaitForInstallsToQuiesceResumesAfterCompletion() async throws {
+        let model = LocalAIModelCatalog.quality
+        let harness = ControlledLocalAIInstallHarness(finalStatus: .ready)
+        let workflow = LocalAIModelWorkflow(
+            dependencies: harness.dependencies(),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        workflow.markInitialRefreshCompletedForTesting()
+        workflow.startInstall(model)
+        try expect(workflow.hasActiveInstalls, "install active")
+
+        let quiesceTask = Task { await workflow.waitForInstallsToQuiesce() }
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        harness.complete(model: model, with: .success(()))
+        await quiesceTask.value
+        try expect(!workflow.hasActiveInstalls, "install no longer active")
+    }
+
+    @MainActor
+    private static func testTerminationCleanupBlocksNewInstalls() throws {
+        let model = LocalAIModelCatalog.quality
+        var startCount = 0
+        let workflow = LocalAIModelWorkflow(
+            dependencies: AppStateLocalAIDependencies(
+                makeServerManager: { LocalAIServerManager(store: LocalAIModelStore()) },
+                idleShutdownSleep: { _ in try await Task.sleep(nanoseconds: UInt64.max) },
+                installStatus: { _ in .notInstalled },
+                startInstall: { _, _, completion in
+                    startCount += 1
+                    completion(.failure(.alreadyInProgress))
+                    return LocalAIInstallTask()
+                },
+                progressSchedule: { _, operation in operation() },
+                deleteModel: { _ in },
+                deletePartialModel: { _ in },
+                processingAvailability: {
+                    LocalAIProcessingAvailability(
+                        isAppleSilicon: true,
+                        runnerIsExecutable: true,
+                        physicalMemory: 32 * 1024 * 1024 * 1024
+                    )
+                }
+            ),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        workflow.markInitialRefreshCompletedForTesting()
+        workflow.beginTerminationCleanup()
+        workflow.startInstall(model)
+        try expectEqual(startCount, 0, "no install starts after termination cleanup begins")
     }
 }
 

--- a/Tests/LocalAIModelWorkflowTests.swift
+++ b/Tests/LocalAIModelWorkflowTests.swift
@@ -9,7 +9,7 @@ struct LocalAIModelWorkflowTests {
         try testCanonicalModelRejectsForgedModels()
         try testIsModelAvailableReflectsProcessingAvailability()
         try await testStartInstallSucceedsAndEmitsReadyOutcome()
-        try await testCancelInstallEmitsCancelledOutcome()
+        try await testCancelInstallClearsInstallingStateWithoutEmittingOutcome()
         try await testCancelThenRestartResumesAfterCancellationCompletes()
         try await testDeleteModelDuringInstallCancelsFirst()
         try await testDeleteModelWhenIdleGoesStraightToDeletion()
@@ -104,7 +104,7 @@ struct LocalAIModelWorkflowTests {
     }
 
     @MainActor
-    private static func testCancelInstallEmitsCancelledOutcome() async throws {
+    private static func testCancelInstallClearsInstallingStateWithoutEmittingOutcome() async throws {
         let model = LocalAIModelCatalog.quality
         let harness = ControlledLocalAIInstallHarness(finalStatus: .notInstalled)
         let workflow = LocalAIModelWorkflow(
@@ -112,8 +112,6 @@ struct LocalAIModelWorkflowTests {
             serverManager: LocalAIServerManager(store: LocalAIModelStore())
         )
         workflow.markInitialRefreshCompletedForTesting()
-        var events: [LocalAIModelWorkflowEvent] = []
-        workflow.onEvent = { events.append($0) }
 
         workflow.startInstall(model)
         try expect(workflow.cancelInstall(model), "cancel reports it found an active task")
@@ -122,13 +120,9 @@ struct LocalAIModelWorkflowTests {
         harness.complete(model: model, with: .failure(.cancelled))
         try await waitUntil { !workflow.installState(for: model).isInstalling }
 
-        try expect(
-            events.contains {
-                if case .installOutcome(_, .cancelled) = $0 { return true }
-                return false
-            },
-            "installOutcome(.cancelled) fired"
-        )
+        try expect(!workflow.installState(for: model).isInstalling, "isInstalling cleared after cancellation")
+        try expect(workflow.installState(for: model).issue == nil, "issue cleared after cancellation")
+        try expect(workflow.installState(for: model).progress.isCancelled, "progress still marked cancelled after completion")
     }
 
     @MainActor

--- a/Tests/LocalAIModelWorkflowTests.swift
+++ b/Tests/LocalAIModelWorkflowTests.swift
@@ -270,14 +270,20 @@ struct LocalAIModelWorkflowTests {
         workflow.markInitialRefreshCompletedForTesting()
 
         workflow.startInstall(model)
+        try expectEqual(harness.startCount, 1, "initial install starts once")
         workflow.cancelInstall(model)
         // A second startInstall while cancellation is still in flight requests
         // a restart once the cancelled attempt finishes.
         workflow.startInstall(model)
 
         harness.complete(model: model, with: .failure(.cancelled))
-        try await waitUntil { workflow.installState(for: model).isInstalling }
-        try expect(workflow.installState(for: model).isInstalling, "restarted install is in flight")
+        try await waitUntil { harness.startCount == 2 }
+        try expectEqual(harness.startCount, 2, "replacement install starts after cancellation")
+        try expect(workflow.installState(for: model).isInstalling, "replacement install is in flight")
+
+        try expect(workflow.cancelInstall(model), "replacement install can be cancelled")
+        harness.complete(model: model, with: .failure(.cancelled))
+        try await waitUntil { !workflow.installState(for: model).isInstalling }
     }
 
     @MainActor
@@ -738,10 +744,15 @@ private final class LocalAIValueBox<Value>: @unchecked Sendable {
 private final class ControlledLocalAIInstallHarness: @unchecked Sendable {
     private let lock = NSLock()
     private var completions: [String: (Result<Void, LocalAIInstallerError>) -> Void] = [:]
+    private var startCalls = 0
     private let finalStatus: LocalAIInstallStatus
 
     init(finalStatus: LocalAIInstallStatus) {
         self.finalStatus = finalStatus
+    }
+
+    var startCount: Int {
+        lock.withLock { startCalls }
     }
 
     func dependencies(
@@ -758,7 +769,10 @@ private final class ControlledLocalAIInstallHarness: @unchecked Sendable {
             idleShutdownSleep: { _ in try await Task.sleep(nanoseconds: UInt64.max) },
             installStatus: { [weak self] _ in self?.finalStatus ?? .notInstalled },
             startInstall: { [weak self] model, _, completion in
-                self?.lock.withLock { self?.completions[model.id] = completion }
+                self?.lock.withLock {
+                    self?.startCalls += 1
+                    self?.completions[model.id] = completion
+                }
                 return LocalAIInstallTask()
             },
             progressSchedule: { _, operation in operation() },

--- a/Tests/LocalAIModelWorkflowTests.swift
+++ b/Tests/LocalAIModelWorkflowTests.swift
@@ -9,6 +9,10 @@ struct LocalAIModelWorkflowTests {
         try testCanonicalModelRejectsForgedModels()
         try testIsModelAvailableReflectsProcessingAvailability()
         try await testStartInstallSucceedsAndEmitsReadyOutcome()
+        try await testCancelInstallEmitsCancelledOutcome()
+        try await testCancelThenRestartResumesAfterCancellationCompletes()
+        try await testDeleteModelDuringInstallCancelsFirst()
+        try await testDeleteModelWhenIdleGoesStraightToDeletion()
         print("LocalAIModelWorkflowTests passed")
     }
 
@@ -97,6 +101,106 @@ struct LocalAIModelWorkflowTests {
             },
             "installOutcome(.readyAndAvailable) fired"
         )
+    }
+
+    @MainActor
+    private static func testCancelInstallEmitsCancelledOutcome() async throws {
+        let model = LocalAIModelCatalog.quality
+        let harness = ControlledLocalAIInstallHarness(finalStatus: .notInstalled)
+        let workflow = LocalAIModelWorkflow(
+            dependencies: harness.dependencies(),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        workflow.markInitialRefreshCompletedForTesting()
+        var events: [LocalAIModelWorkflowEvent] = []
+        workflow.onEvent = { events.append($0) }
+
+        workflow.startInstall(model)
+        try expect(workflow.cancelInstall(model), "cancel reports it found an active task")
+        try expect(workflow.installState(for: model).progress.isCancelled, "progress marked cancelled")
+
+        harness.complete(model: model, with: .failure(.cancelled))
+        try await waitUntil { !workflow.installState(for: model).isInstalling }
+
+        try expect(
+            events.contains {
+                if case .installOutcome(_, .cancelled) = $0 { return true }
+                return false
+            },
+            "installOutcome(.cancelled) fired"
+        )
+    }
+
+    @MainActor
+    private static func testCancelThenRestartResumesAfterCancellationCompletes() async throws {
+        let model = LocalAIModelCatalog.quality
+        let harness = ControlledLocalAIInstallHarness(finalStatus: .notInstalled)
+        let workflow = LocalAIModelWorkflow(
+            dependencies: harness.dependencies(),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        workflow.markInitialRefreshCompletedForTesting()
+
+        workflow.startInstall(model)
+        workflow.cancelInstall(model)
+        // A second startInstall while cancellation is still in flight requests
+        // a restart once the cancelled attempt finishes.
+        workflow.startInstall(model)
+
+        harness.complete(model: model, with: .failure(.cancelled))
+        try await waitUntil { workflow.installState(for: model).isInstalling }
+        try expect(workflow.installState(for: model).isInstalling, "restarted install is in flight")
+    }
+
+    @MainActor
+    private static func testDeleteModelDuringInstallCancelsFirst() async throws {
+        let model = LocalAIModelCatalog.quality
+        let harness = ControlledLocalAIInstallHarness(finalStatus: .notInstalled)
+        let workflow = LocalAIModelWorkflow(
+            dependencies: harness.dependencies(),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        workflow.markInitialRefreshCompletedForTesting()
+
+        workflow.startInstall(model)
+        try expect(workflow.deleteModel(model), "delete accepted during install")
+        try expect(workflow.installState(for: model).progress.isCancelled, "install marked cancelled by delete")
+    }
+
+    @MainActor
+    private static func testDeleteModelWhenIdleGoesStraightToDeletion() async throws {
+        let model = LocalAIModelCatalog.quality
+        var deleteCalled = false
+        let workflow = LocalAIModelWorkflow(
+            dependencies: AppStateLocalAIDependencies(
+                makeServerManager: { LocalAIServerManager(store: LocalAIModelStore()) },
+                idleShutdownSleep: { _ in try await Task.sleep(nanoseconds: UInt64.max) },
+                installStatus: { _ in .notInstalled },
+                startInstall: { _, _, completion in
+                    completion(.failure(.alreadyInProgress))
+                    return LocalAIInstallTask()
+                },
+                progressSchedule: { _, operation in operation() },
+                deleteModel: { _ in deleteCalled = true },
+                deletePartialModel: { _ in },
+                processingAvailability: {
+                    LocalAIProcessingAvailability(
+                        isAppleSilicon: true,
+                        runnerIsExecutable: true,
+                        physicalMemory: 32 * 1024 * 1024 * 1024
+                    )
+                }
+            ),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        var events: [LocalAIModelWorkflowEvent] = []
+        workflow.onEvent = { events.append($0) }
+
+        try expect(workflow.deleteModel(model), "delete accepted when idle")
+        try await waitUntil { deleteCalled }
+        try await waitUntil {
+            events.contains { if case .deletionOutcome = $0 { return true }; return false }
+        }
     }
 
     @MainActor

--- a/Tests/LocalAIModelWorkflowTests.swift
+++ b/Tests/LocalAIModelWorkflowTests.swift
@@ -15,7 +15,7 @@ struct LocalAIModelWorkflowTests {
         try await testFailedInstallEmitsFailedOutcomeWithIssue()
         try await testCancelInstallClearsInstallingStateWithoutEmittingOutcome()
         try await testCancelThenRestartResumesAfterCancellationCompletes()
-        try await testDeleteModelDuringInstallCancelsFirst()
+        try testDeleteModelDuringInstallCancelsFirst()
         try await testDeleteModelWhenIdleGoesStraightToDeletion()
         try await testDeleteFailurePreservesReadyStatusAndSetsIssue()
         try await testRefreshAllInstallStatesCompletesAndEmitsDeferredIDs()
@@ -287,7 +287,7 @@ struct LocalAIModelWorkflowTests {
     }
 
     @MainActor
-    private static func testDeleteModelDuringInstallCancelsFirst() async throws {
+    private static func testDeleteModelDuringInstallCancelsFirst() throws {
         let model = LocalAIModelCatalog.quality
         let harness = ControlledLocalAIInstallHarness(finalStatus: .notInstalled)
         let workflow = LocalAIModelWorkflow(
@@ -576,14 +576,14 @@ struct LocalAIModelWorkflowTests {
     @MainActor
     private static func testTerminationCleanupBlocksNewInstalls() throws {
         let model = LocalAIModelCatalog.quality
-        var startCount = 0
+        let startCalls = LocalAICallCounter()
         let workflow = LocalAIModelWorkflow(
             dependencies: AppStateLocalAIDependencies(
                 makeServerManager: { LocalAIServerManager(store: LocalAIModelStore()) },
                 idleShutdownSleep: { _ in try await Task.sleep(nanoseconds: UInt64.max) },
                 installStatus: { _ in .notInstalled },
                 startInstall: { _, _, completion in
-                    startCount += 1
+                    startCalls.increment()
                     completion(.failure(.alreadyInProgress))
                     return LocalAIInstallTask()
                 },
@@ -603,7 +603,11 @@ struct LocalAIModelWorkflowTests {
         workflow.markInitialRefreshCompletedForTesting()
         workflow.beginTerminationCleanup()
         workflow.startInstall(model)
-        try expectEqual(startCount, 0, "no install starts after termination cleanup begins")
+        try expectEqual(
+            startCalls.value,
+            0,
+            "no install starts after termination cleanup begins"
+        )
     }
 }
 

--- a/Tests/LocalAIModelWorkflowTests.swift
+++ b/Tests/LocalAIModelWorkflowTests.swift
@@ -28,6 +28,18 @@ struct LocalAIModelWorkflowTests {
         let workflow = makeWorkflow()
         let real = LocalAIModelCatalog.quality
         try expect(workflow.canonicalModel(for: real) == real, "genuine catalog model is canonical")
+
+        let forged = LocalAIModel(
+            id: real.id,
+            displayName: "Forged Model",
+            description: real.description,
+            artifacts: real.artifacts,
+            approximateResidentRAMBytes: real.approximateResidentRAMBytes,
+            minimumPhysicalMemoryBytes: real.minimumPhysicalMemoryBytes,
+            capabilities: real.capabilities,
+            runtime: real.runtime
+        )
+        try expect(workflow.canonicalModel(for: forged) == nil, "forged model with same id is rejected")
     }
 
     @MainActor

--- a/Tests/LocalAIModelWorkflowTests.swift
+++ b/Tests/LocalAIModelWorkflowTests.swift
@@ -13,6 +13,9 @@ struct LocalAIModelWorkflowTests {
         try await testCancelThenRestartResumesAfterCancellationCompletes()
         try await testDeleteModelDuringInstallCancelsFirst()
         try await testDeleteModelWhenIdleGoesStraightToDeletion()
+        try await testRefreshAllInstallStatesCompletesAndEmitsDeferredIDs()
+        try await testStaleStatusRefreshGenerationIsIgnored()
+        try await testInstallRequestedBeforeRefreshCompletesIsDeferredThenReported()
         print("LocalAIModelWorkflowTests passed")
     }
 
@@ -207,6 +210,72 @@ struct LocalAIModelWorkflowTests {
     }
 
     @MainActor
+    private static func testRefreshAllInstallStatesCompletesAndEmitsDeferredIDs() async throws {
+        let workflow = LocalAIModelWorkflow(
+            dependencies: dependencies(installStatus: { _ in .notInstalled }),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        var events: [LocalAIModelWorkflowEvent] = []
+        workflow.onEvent = { events.append($0) }
+
+        workflow.refreshAllInstallStates()
+        try await waitUntil { workflow.state.hasCompletedInitialStatusRefresh }
+
+        try expect(
+            events.contains {
+                if case .initialStatusRefreshCompleted = $0 { return true }
+                return false
+            },
+            "initialStatusRefreshCompleted fired"
+        )
+    }
+
+    @MainActor
+    private static func testStaleStatusRefreshGenerationIsIgnored() async throws {
+        let model = LocalAIModelCatalog.quality
+        let statusBox = LocalAIStatusBox(.notInstalled)
+        let workflow = LocalAIModelWorkflow(
+            dependencies: dependencies(installStatus: { statusBox.status(for: $0) }),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        workflow.refreshAllInstallStates()
+        try await waitUntil { workflow.state.hasCompletedInitialStatusRefresh }
+
+        // A second refresh bumps the generation; only its result should apply.
+        statusBox.set(.ready, for: model)
+        workflow.refreshAllInstallStates()
+        try await waitUntil { workflow.state.hasCompletedInitialStatusRefresh }
+        try expectEqual(workflow.installState(for: model).status, .ready, "latest refresh wins")
+    }
+
+    @MainActor
+    private static func testInstallRequestedBeforeRefreshCompletesIsDeferredThenReported() async throws {
+        let model = LocalAIModelCatalog.quality
+        let harness = ControlledLocalAIInstallHarness(finalStatus: .notInstalled)
+        let workflow = LocalAIModelWorkflow(
+            dependencies: harness.dependencies(),
+            serverManager: LocalAIServerManager(store: LocalAIModelStore())
+        )
+        var deferredModelIDsSeen: Set<String>?
+        workflow.onEvent = { event in
+            if case .initialStatusRefreshCompleted(let deferredModelIDs) = event {
+                deferredModelIDsSeen = deferredModelIDs
+            }
+        }
+
+        workflow.startInstall(model)
+        try expect(!workflow.installState(for: model).isInstalling, "install deferred before refresh")
+
+        workflow.refreshAllInstallStates()
+        try await waitUntil { workflow.state.hasCompletedInitialStatusRefresh }
+
+        try expect(
+            deferredModelIDsSeen?.contains(model.id) == true,
+            "deferred model ID reported in initialStatusRefreshCompleted event"
+        )
+    }
+
+    @MainActor
     private static func waitUntil(
         timeoutNanoseconds: UInt64 = 2_000_000_000,
         _ condition: @escaping () -> Bool
@@ -267,6 +336,24 @@ struct LocalAIModelWorkflowTests {
         guard actual == expected else {
             throw TestFailure("\(label): expected \(expected), got \(actual)")
         }
+    }
+}
+
+private final class LocalAIStatusBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var overrides: [String: LocalAIInstallStatus] = [:]
+    private let defaultStatus: LocalAIInstallStatus
+
+    init(_ defaultStatus: LocalAIInstallStatus) {
+        self.defaultStatus = defaultStatus
+    }
+
+    func status(for model: LocalAIModel) -> LocalAIInstallStatus {
+        lock.withLock { overrides[model.id] ?? defaultStatus }
+    }
+
+    func set(_ status: LocalAIInstallStatus, for model: LocalAIModel) {
+        lock.withLock { overrides[model.id] = status }
     }
 }
 

--- a/Tests/NativeWhisperModelWorkflowTests.swift
+++ b/Tests/NativeWhisperModelWorkflowTests.swift
@@ -10,6 +10,7 @@ struct NativeWhisperModelWorkflowTests {
         try testRefreshInstallStatusUpdatesStateAndEmitsEvent()
         try await testStartInstallEmitsProgressAndSucceeds()
         try await testProgressCoalescesAndQueuedDeliveryCannotBeatCancellation()
+        try testCancelInstallWhenIdleIsNoOp()
         try await testCancelInstallEmitsCancelledOutcome()
         try await testFailedInstallEmitsFailedOutcomeWithIssue()
         try await testDeleteModelSuccessClearsIssueAndRefreshesStatus()
@@ -138,6 +139,23 @@ struct NativeWhisperModelWorkflowTests {
     }
 
     @MainActor
+    private static func testCancelInstallWhenIdleIsNoOp() throws {
+        let workflow = NativeWhisperModelWorkflow(
+            dependencies: fixedStatusDependencies(.notInstalled)
+        )
+        var events: [NativeWhisperModelWorkflowEvent] = []
+        workflow.onEvent = { events.append($0) }
+
+        workflow.cancelInstall()
+
+        try expect(
+            !workflow.state.installProgress.isCancelled,
+            "idle progress remains unchanged"
+        )
+        try expect(events.isEmpty, "idle cancellation emits no state change")
+    }
+
+    @MainActor
     private static func testCancelInstallEmitsCancelledOutcome() async throws {
         let harness = ControlledInstallHarness()
         let workflow = NativeWhisperModelWorkflow(
@@ -190,29 +208,28 @@ struct NativeWhisperModelWorkflowTests {
 
     @MainActor
     private static func testDeleteModelSuccessClearsIssueAndRefreshesStatus() async throws {
-        // Capture the install completion to simulate a failed install
-        var completionCallback: ((Result<Void, NativeWhisperInstallerError>) -> Void)?
-        final class DeleteTracker {
-            var called = false
-        }
-        let tracker = DeleteTracker()
+        // Capture the install completion to simulate a failed install.
+        let completionCallback = NativeWhisperValueBox<
+            ((Result<Void, NativeWhisperInstallerError>) -> Void)?
+        >(nil)
+        let deleteCalled = NativeWhisperValueBox(false)
 
         let workflow = NativeWhisperModelWorkflow(
             dependencies: AppStateNativeWhisperDependencies(
                 installStatus: { _ in .notInstalled },
                 startInstall: { _, _, completion in
-                    completionCallback = completion
+                    completionCallback.set(completion)
                     return NativeWhisperInstallTask()
                 },
                 progressSchedule: { _, operation in operation() },
-                deleteModel: { _ in tracker.called = true },
+                deleteModel: { _ in deleteCalled.set(true) },
                 makeExecutionSnapshot: { .live(store: NativeWhisperModelStore()) }
             )
         )
 
-        // Drive a failed install to set installIssue
+        // Drive a failed install to set installIssue.
         workflow.startInstall()
-        completionCallback?(.failure(.downloadFailed("offline")))
+        completionCallback.value?(.failure(.downloadFailed("offline")))
         try await waitUntil { !workflow.state.isInstalling }
 
         // Verify issue is set before delete
@@ -225,8 +242,8 @@ struct NativeWhisperModelWorkflowTests {
         // Now delete the model
         workflow.deleteModel()
 
-        // Verify delete was called and issue is cleared
-        try expect(tracker.called, "delete was invoked")
+        // Verify delete was called and issue is cleared.
+        try expect(deleteCalled.value, "delete was invoked")
         try expect(workflow.state.installIssue == nil, "issue cleared on successful delete")
     }
 
@@ -284,12 +301,12 @@ struct NativeWhisperModelWorkflowTests {
 
     @MainActor
     private static func testTerminationCleanupBlocksNewInstalls() throws {
-        var startCount = 0
+        let startCalls = NativeWhisperCallCounter()
         let workflow = NativeWhisperModelWorkflow(
             dependencies: AppStateNativeWhisperDependencies(
                 installStatus: { _ in .notInstalled },
                 startInstall: { _, _, completion in
-                    startCount += 1
+                    startCalls.increment()
                     completion(.failure(.alreadyInProgress))
                     return NativeWhisperInstallTask()
                 },
@@ -300,7 +317,11 @@ struct NativeWhisperModelWorkflowTests {
         )
         workflow.beginTerminationCleanup()
         workflow.startInstall()
-        try expectEqual(startCount, 0, "no install starts after termination cleanup begins")
+        try expectEqual(
+            startCalls.value,
+            0,
+            "no install starts after termination cleanup begins"
+        )
     }
 
     @MainActor
@@ -348,6 +369,19 @@ struct NativeWhisperModelWorkflowTests {
         guard actual == expected else {
             throw TestFailure("\(label): expected \(expected), got \(actual)")
         }
+    }
+}
+
+private final class NativeWhisperCallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var calls = 0
+
+    var value: Int {
+        lock.withLock { calls }
+    }
+
+    func increment() {
+        lock.withLock { calls += 1 }
     }
 }
 

--- a/Tests/NativeWhisperModelWorkflowTests.swift
+++ b/Tests/NativeWhisperModelWorkflowTests.swift
@@ -11,7 +11,7 @@ struct NativeWhisperModelWorkflowTests {
         try await testStartInstallEmitsProgressAndSucceeds()
         try await testCancelInstallEmitsCancelledOutcome()
         try await testFailedInstallEmitsFailedOutcomeWithIssue()
-        try testDeleteModelSuccessClearsIssueAndRefreshesStatus()
+        try await testDeleteModelSuccessClearsIssueAndRefreshesStatus()
         try testDeleteModelFailureSetsIssue()
         try await testWaitUntilQuiescedResumesAfterCompletion()
         try testTerminationCleanupBlocksNewInstalls()
@@ -127,16 +127,19 @@ struct NativeWhisperModelWorkflowTests {
     }
 
     @MainActor
-    private static func testDeleteModelSuccessClearsIssueAndRefreshesStatus() throws {
+    private static func testDeleteModelSuccessClearsIssueAndRefreshesStatus() async throws {
+        // Capture the install completion to simulate a failed install
+        var completionCallback: ((Result<Void, NativeWhisperInstallerError>) -> Void)?
         final class DeleteTracker {
             var called = false
         }
         let tracker = DeleteTracker()
+
         let workflow = NativeWhisperModelWorkflow(
             dependencies: AppStateNativeWhisperDependencies(
                 installStatus: { _ in .notInstalled },
                 startInstall: { _, _, completion in
-                    completion(.failure(.alreadyInProgress))
+                    completionCallback = completion
                     return NativeWhisperInstallTask()
                 },
                 progressSchedule: { _, operation in operation() },
@@ -144,9 +147,25 @@ struct NativeWhisperModelWorkflowTests {
                 makeExecutionSnapshot: { .live(store: NativeWhisperModelStore()) }
             )
         )
+
+        // Drive a failed install to set installIssue
+        workflow.startInstall()
+        completionCallback?(.failure(.downloadFailed("offline")))
+        try await waitUntil { !workflow.state.isInstalling }
+
+        // Verify issue is set before delete
+        try expectEqual(
+            workflow.state.installIssue?.code,
+            .localModelMissing,
+            "failed install sets issue"
+        )
+
+        // Now delete the model
         workflow.deleteModel()
+
+        // Verify delete was called and issue is cleared
         try expect(tracker.called, "delete was invoked")
-        try expect(workflow.state.installIssue == nil, "issue cleared on success")
+        try expect(workflow.state.installIssue == nil, "issue cleared on successful delete")
     }
 
     @MainActor

--- a/Tests/NativeWhisperModelWorkflowTests.swift
+++ b/Tests/NativeWhisperModelWorkflowTests.swift
@@ -4,10 +4,17 @@ import Foundation
 @main
 #endif
 struct NativeWhisperModelWorkflowTests {
+    @MainActor
     static func main() async throws {
         try testInitialStateIsNotInstalled()
         try testRefreshInstallStatusUpdatesStateAndEmitsEvent()
         try await testStartInstallEmitsProgressAndSucceeds()
+        try await testCancelInstallEmitsCancelledOutcome()
+        try await testFailedInstallEmitsFailedOutcomeWithIssue()
+        try testDeleteModelSuccessClearsIssueAndRefreshesStatus()
+        try testDeleteModelFailureSetsIssue()
+        try await testWaitUntilQuiescedResumesAfterCompletion()
+        try testTerminationCleanupBlocksNewInstalls()
         print("NativeWhisperModelWorkflowTests passed")
     }
 
@@ -66,6 +73,140 @@ struct NativeWhisperModelWorkflowTests {
             },
             "installCompleted(.succeeded) event fired"
         )
+    }
+
+    @MainActor
+    private static func testCancelInstallEmitsCancelledOutcome() async throws {
+        let harness = ControlledInstallHarness()
+        let workflow = NativeWhisperModelWorkflow(
+            dependencies: harness.dependencies(finalStatus: .notInstalled)
+        )
+        var events: [NativeWhisperModelWorkflowEvent] = []
+        workflow.onEvent = { events.append($0) }
+
+        workflow.startInstall()
+        workflow.cancelInstall()
+        try expect(workflow.state.installProgress.isCancelled, "progress marked cancelled")
+
+        harness.complete(.failure(.cancelled))
+        try await waitUntil { !workflow.state.isInstalling }
+
+        try expect(
+            events.contains { if case .installCompleted(.cancelled) = $0 { return true }; return false },
+            "installCompleted(.cancelled) event fired"
+        )
+    }
+
+    @MainActor
+    private static func testFailedInstallEmitsFailedOutcomeWithIssue() async throws {
+        let harness = ControlledInstallHarness()
+        let workflow = NativeWhisperModelWorkflow(
+            dependencies: harness.dependencies(finalStatus: .notInstalled)
+        )
+        var events: [NativeWhisperModelWorkflowEvent] = []
+        workflow.onEvent = { events.append($0) }
+
+        workflow.startInstall()
+        harness.complete(.failure(.downloadFailed("offline")))
+        try await waitUntil { !workflow.state.isInstalling }
+
+        try expectEqual(
+            workflow.state.installIssue?.code,
+            .localModelMissing,
+            "failed install sets localModelMissing issue"
+        )
+        try expect(
+            events.contains {
+                if case .installCompleted(.failed(let issue)) = $0 {
+                    return issue.code == .localModelMissing
+                }
+                return false
+            },
+            "installCompleted(.failed) event fired with matching issue"
+        )
+    }
+
+    @MainActor
+    private static func testDeleteModelSuccessClearsIssueAndRefreshesStatus() throws {
+        final class DeleteTracker {
+            var called = false
+        }
+        let tracker = DeleteTracker()
+        let workflow = NativeWhisperModelWorkflow(
+            dependencies: AppStateNativeWhisperDependencies(
+                installStatus: { _ in .notInstalled },
+                startInstall: { _, _, completion in
+                    completion(.failure(.alreadyInProgress))
+                    return NativeWhisperInstallTask()
+                },
+                progressSchedule: { _, operation in operation() },
+                deleteModel: { _ in tracker.called = true },
+                makeExecutionSnapshot: { .live(store: NativeWhisperModelStore()) }
+            )
+        )
+        workflow.deleteModel()
+        try expect(tracker.called, "delete was invoked")
+        try expect(workflow.state.installIssue == nil, "issue cleared on success")
+    }
+
+    @MainActor
+    private static func testDeleteModelFailureSetsIssue() throws {
+        struct DeleteFailure: Error {}
+        let workflow = NativeWhisperModelWorkflow(
+            dependencies: AppStateNativeWhisperDependencies(
+                installStatus: { _ in .notInstalled },
+                startInstall: { _, _, completion in
+                    completion(.failure(.alreadyInProgress))
+                    return NativeWhisperInstallTask()
+                },
+                progressSchedule: { _, operation in operation() },
+                deleteModel: { _ in throw DeleteFailure() },
+                makeExecutionSnapshot: { .live(store: NativeWhisperModelStore()) }
+            )
+        )
+        workflow.deleteModel()
+        try expectEqual(
+            workflow.state.installIssue?.code,
+            .localModelMissing,
+            "delete failure sets localModelMissing issue"
+        )
+    }
+
+    @MainActor
+    private static func testWaitUntilQuiescedResumesAfterCompletion() async throws {
+        let harness = ControlledInstallHarness()
+        let workflow = NativeWhisperModelWorkflow(
+            dependencies: harness.dependencies(finalStatus: .ready)
+        )
+        workflow.startInstall()
+
+        let quiesceTask = Task { await workflow.waitUntilQuiesced() }
+        try await Task.sleep(nanoseconds: 20_000_000)
+        try expect(!quiesceTask.isCancelled, "quiesce task still waiting")
+
+        harness.complete(.success(()))
+        await quiesceTask.value
+    }
+
+    @MainActor
+    private static func testTerminationCleanupBlocksNewInstalls() throws {
+        var startCount = 0
+        let workflow = NativeWhisperModelWorkflow(
+            dependencies: AppStateNativeWhisperDependencies(
+                installStatus: { _ in .notInstalled },
+                startInstall: { _, _, completion in
+                    startCount += 1
+                    completion(.failure(.alreadyInProgress))
+                    return NativeWhisperInstallTask()
+                },
+                progressSchedule: { _, operation in operation() },
+                deleteModel: { _ in },
+                makeExecutionSnapshot: { .live(store: NativeWhisperModelStore()) }
+            )
+        )
+        workflow.beginTerminationCleanup()
+        workflow.startInstall()
+        try expectEqual(startCount, 0, "no install starts after termination cleanup begins")
     }
 
     @MainActor

--- a/Tests/NativeWhisperModelWorkflowTests.swift
+++ b/Tests/NativeWhisperModelWorkflowTests.swift
@@ -9,6 +9,7 @@ struct NativeWhisperModelWorkflowTests {
         try testInitialStateIsNotInstalled()
         try testRefreshInstallStatusUpdatesStateAndEmitsEvent()
         try await testStartInstallEmitsProgressAndSucceeds()
+        try await testProgressCoalescesAndQueuedDeliveryCannotBeatCancellation()
         try await testCancelInstallEmitsCancelledOutcome()
         try await testFailedInstallEmitsFailedOutcomeWithIssue()
         try await testDeleteModelSuccessClearsIssueAndRefreshesStatus()
@@ -73,6 +74,67 @@ struct NativeWhisperModelWorkflowTests {
             },
             "installCompleted(.succeeded) event fired"
         )
+    }
+
+    @MainActor
+    private static func testProgressCoalescesAndQueuedDeliveryCannotBeatCancellation() async throws {
+        let harness = ControlledInstallHarness()
+        let scheduler = ControlledNativeWhisperProgressScheduler()
+        let workflow = NativeWhisperModelWorkflow(
+            dependencies: harness.dependencies(
+                finalStatus: .notInstalled,
+                progressSchedule: scheduler.schedule
+            )
+        )
+
+        workflow.startInstall()
+        for value in 1...10_000 {
+            harness.reportProgress(
+                NativeWhisperDownloadProgress(
+                    downloadedBytes: Int64(value),
+                    totalBytes: 10_000
+                )
+            )
+        }
+
+        try expectEqual(
+            scheduler.scheduledCount,
+            1,
+            "burst coalesces to one scheduled delivery"
+        )
+        scheduler.runNext()
+        try expectEqual(
+            workflow.state.installProgress.downloadedBytes,
+            1,
+            "first progress delivery"
+        )
+        try expectEqual(scheduler.scheduledCount, 1, "latest progress remains coalesced")
+        scheduler.runAll()
+        try expectEqual(
+            workflow.state.installProgress.downloadedBytes,
+            10_000,
+            "latest burst progress delivered"
+        )
+
+        harness.reportProgress(
+            NativeWhisperDownloadProgress(
+                downloadedBytes: 10_001,
+                totalBytes: 20_000
+            )
+        )
+        try expectEqual(scheduler.scheduledCount, 1, "post-burst progress queued")
+
+        workflow.cancelInstall()
+        scheduler.runAll()
+        try expect(workflow.state.installProgress.isCancelled, "cancellation remains final")
+        try expectEqual(
+            workflow.state.installProgress.downloadedBytes,
+            10_000,
+            "queued progress cannot overwrite delivered bytes after cancellation"
+        )
+
+        harness.complete(.failure(.cancelled))
+        try await waitUntil { !workflow.state.isInstalling }
     }
 
     @MainActor
@@ -276,6 +338,38 @@ struct NativeWhisperModelWorkflowTests {
     }
 }
 
+private final class ControlledNativeWhisperProgressScheduler: @unchecked Sendable {
+    typealias Operation = @Sendable () -> Void
+
+    private let lock = NSLock()
+    private var scheduled: [Operation] = []
+
+    var schedule: LatestValueProgressCoalescer<NativeWhisperDownloadProgress>.Schedule {
+        { [weak self] _, operation in
+            self?.lock.withLock {
+                self?.scheduled.append(operation)
+            }
+        }
+    }
+
+    var scheduledCount: Int {
+        lock.withLock { scheduled.count }
+    }
+
+    func runNext() {
+        let operation = lock.withLock {
+            scheduled.isEmpty ? nil : scheduled.removeFirst()
+        }
+        operation?()
+    }
+
+    func runAll() {
+        while scheduledCount > 0 {
+            runNext()
+        }
+    }
+}
+
 private final class ControlledInstallHarness: @unchecked Sendable {
     private let lock = NSLock()
     private var progressCallback: ((NativeWhisperDownloadProgress) -> Void)?
@@ -283,7 +377,10 @@ private final class ControlledInstallHarness: @unchecked Sendable {
     private var finalStatus: NativeWhisperInstallStatus = .notInstalled
 
     func dependencies(
-        finalStatus: NativeWhisperInstallStatus
+        finalStatus: NativeWhisperInstallStatus,
+        progressSchedule: @escaping LatestValueProgressCoalescer<
+            NativeWhisperDownloadProgress
+        >.Schedule = { _, operation in operation() }
     ) -> AppStateNativeWhisperDependencies {
         self.finalStatus = finalStatus
         return AppStateNativeWhisperDependencies(
@@ -295,7 +392,7 @@ private final class ControlledInstallHarness: @unchecked Sendable {
                 }
                 return NativeWhisperInstallTask()
             },
-            progressSchedule: { _, operation in operation() },
+            progressSchedule: progressSchedule,
             deleteModel: { _ in },
             makeExecutionSnapshot: {
                 .live(store: NativeWhisperModelStore())

--- a/Tests/NativeWhisperModelWorkflowTests.swift
+++ b/Tests/NativeWhisperModelWorkflowTests.swift
@@ -261,12 +261,25 @@ struct NativeWhisperModelWorkflowTests {
         )
         workflow.startInstall()
 
-        let quiesceTask = Task { await workflow.waitUntilQuiesced() }
-        try await Task.sleep(nanoseconds: 20_000_000)
-        try expect(!quiesceTask.isCancelled, "quiesce task still waiting")
+        let waiterStarted = NativeWhisperValueBox(false)
+        let waiterCompleted = NativeWhisperValueBox(false)
+        let quiesceTask = Task { @MainActor in
+            waiterStarted.set(true)
+            await workflow.waitUntilQuiesced()
+            waiterCompleted.set(true)
+        }
+        try await waitUntil { waiterStarted.value }
+        try expect(
+            !waiterCompleted.value,
+            "quiescence waiter remains suspended while install is active"
+        )
 
         harness.complete(.success(()))
         await quiesceTask.value
+        try expect(
+            waiterCompleted.value,
+            "quiescence waiter resumes after install completion"
+        )
     }
 
     @MainActor
@@ -335,6 +348,23 @@ struct NativeWhisperModelWorkflowTests {
         guard actual == expected else {
             throw TestFailure("\(label): expected \(expected), got \(actual)")
         }
+    }
+}
+
+private final class NativeWhisperValueBox<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue: Value
+
+    init(_ value: Value) {
+        storedValue = value
+    }
+
+    var value: Value {
+        lock.withLock { storedValue }
+    }
+
+    func set(_ value: Value) {
+        lock.withLock { storedValue = value }
     }
 }
 

--- a/Tests/NativeWhisperModelWorkflowTests.swift
+++ b/Tests/NativeWhisperModelWorkflowTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+#if !QUILL_GROUPED_TEST_RUNNER
+@main
+#endif
+struct NativeWhisperModelWorkflowTests {
+    static func main() async throws {
+        try testInitialStateIsNotInstalled()
+        try testRefreshInstallStatusUpdatesStateAndEmitsEvent()
+        try await testStartInstallEmitsProgressAndSucceeds()
+        print("NativeWhisperModelWorkflowTests passed")
+    }
+
+    @MainActor
+    private static func testInitialStateIsNotInstalled() throws {
+        let workflow = NativeWhisperModelWorkflow(
+            dependencies: fixedStatusDependencies(.notInstalled)
+        )
+        try expectEqual(workflow.state.installStatus, .notInstalled, "initial status")
+        try expect(!workflow.state.isInstalling, "initial not installing")
+        try expectEqual(workflow.state.installProgress.downloadedBytes, 0, "initial progress")
+    }
+
+    @MainActor
+    private static func testRefreshInstallStatusUpdatesStateAndEmitsEvent() throws {
+        let workflow = NativeWhisperModelWorkflow(
+            dependencies: fixedStatusDependencies(.ready)
+        )
+        var events: [NativeWhisperModelWorkflowEvent] = []
+        workflow.onEvent = { events.append($0) }
+
+        workflow.refreshInstallStatus()
+
+        try expectEqual(workflow.state.installStatus, .ready, "refreshed status")
+        guard case .stateChanged(let state)? = events.first else {
+            throw TestFailure("expected a stateChanged event")
+        }
+        try expectEqual(state.installStatus, .ready, "event status")
+    }
+
+    @MainActor
+    private static func testStartInstallEmitsProgressAndSucceeds() async throws {
+        let harness = ControlledInstallHarness()
+        let workflow = NativeWhisperModelWorkflow(
+            dependencies: harness.dependencies(finalStatus: .ready)
+        )
+        var events: [NativeWhisperModelWorkflowEvent] = []
+        workflow.onEvent = { events.append($0) }
+
+        workflow.startInstall()
+        try expect(workflow.state.isInstalling, "installing after start")
+
+        harness.reportProgress(
+            NativeWhisperDownloadProgress(downloadedBytes: 10, totalBytes: 100)
+        )
+        try await waitUntil { workflow.state.installProgress.downloadedBytes == 10 }
+
+        harness.complete(.success(()))
+        try await waitUntil { !workflow.state.isInstalling }
+
+        try expectEqual(workflow.state.installStatus, .ready, "final status")
+        try expect(
+            events.contains { event in
+                if case .installCompleted(.succeeded) = event { return true }
+                return false
+            },
+            "installCompleted(.succeeded) event fired"
+        )
+    }
+
+    @MainActor
+    private static func waitUntil(
+        timeoutNanoseconds: UInt64 = 2_000_000_000,
+        _ condition: @escaping () -> Bool
+    ) async throws {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        throw TestFailure("timed out waiting for condition")
+    }
+
+    private static func fixedStatusDependencies(
+        _ status: NativeWhisperInstallStatus
+    ) -> AppStateNativeWhisperDependencies {
+        AppStateNativeWhisperDependencies(
+            installStatus: { _ in status },
+            startInstall: { _, _, completion in
+                completion(.failure(.alreadyInProgress))
+                return NativeWhisperInstallTask()
+            },
+            progressSchedule: { _, operation in operation() },
+            deleteModel: { _ in },
+            makeExecutionSnapshot: {
+                .live(store: NativeWhisperModelStore())
+            }
+        )
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ label: String
+    ) throws {
+        guard condition() else { throw TestFailure(label) }
+    }
+
+    private static func expectEqual<T: Equatable>(
+        _ actual: T,
+        _ expected: T,
+        _ label: String
+    ) throws {
+        guard actual == expected else {
+            throw TestFailure("\(label): expected \(expected), got \(actual)")
+        }
+    }
+}
+
+private final class ControlledInstallHarness: @unchecked Sendable {
+    private let lock = NSLock()
+    private var progressCallback: ((NativeWhisperDownloadProgress) -> Void)?
+    private var completionCallback: ((Result<Void, NativeWhisperInstallerError>) -> Void)?
+    private var finalStatus: NativeWhisperInstallStatus = .notInstalled
+
+    func dependencies(
+        finalStatus: NativeWhisperInstallStatus
+    ) -> AppStateNativeWhisperDependencies {
+        self.finalStatus = finalStatus
+        return AppStateNativeWhisperDependencies(
+            installStatus: { [weak self] _ in self?.finalStatus ?? .notInstalled },
+            startInstall: { [weak self] _, progress, completion in
+                self?.lock.withLock {
+                    self?.progressCallback = progress
+                    self?.completionCallback = completion
+                }
+                return NativeWhisperInstallTask()
+            },
+            progressSchedule: { _, operation in operation() },
+            deleteModel: { _ in },
+            makeExecutionSnapshot: {
+                .live(store: NativeWhisperModelStore())
+            }
+        )
+    }
+
+    func reportProgress(_ progress: NativeWhisperDownloadProgress) {
+        let callback = lock.withLock { progressCallback }
+        callback?(progress)
+    }
+
+    func complete(_ result: Result<Void, NativeWhisperInstallerError>) {
+        let callback = lock.withLock { completionCallback }
+        callback?(result)
+    }
+}
+
+private struct TestFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/docs/superpowers/specs/2026-08-15-local-model-management-workflow-extraction-design.md
+++ b/docs/superpowers/specs/2026-08-15-local-model-management-workflow-extraction-design.md
@@ -1,0 +1,294 @@
+# Local AI / Native Whisper Model Management Workflow Extraction — Design
+
+## Context
+
+This is issue **#320** in the internal-refactoring roadmap (#321): "split AppState by the stabilized internal boundaries." #320's own issue body explicitly disclaims being the broader AppState domain-store split tracked by **#192** (still blocked by #217) — it is scoped to finishing the relocation of internals for boundaries the refactoring track has already stabilized: history archive/recovery (#317), transcription retry/resume (#318), meeting summary generation (#319), note assets (#314/#324), credentials (#315), and Local AI/model management (#316).
+
+Research into the current codebase (main @ `822d720`, `Sources/AppState.swift` at 12,000 lines) found that five of those six boundaries are already clean thin adapters — `HistoryArchiveRecoveryWorkflow`, `TranscriptionRetryWorkflow`, `MeetingSummaryWorkflow` are each in dedicated files and AppState only holds event-adaptation code and `@Published` mirrors for them; `NoteAssetStore` and `CredentialStore` are computed properties wrapping dedicated files. There is no leftover work there.
+
+**Local AI/model management is the one exception.** #316 ("move Local AI and model installer dependencies to AppState instances") made the raw dependency closures instance-owned (`AppStateLocalAIDependencies`, `AppStateNativeWhisperDependencies` in `Sources/AppStateDependencies.swift`) but did not extract a workflow type. All of the stateful orchestration — per-model install tokens, cancellation, deletion, progress coalescing, status-refresh generations — is still written directly inside `AppState.swift`. This spec scopes #320 down to exactly that: extracting this orchestration into two dedicated workflow files, following the same instance-owned, event-driven pattern already established by `TranscriptionRetryWorkflow.swift`.
+
+## Goals
+
+- Extract the Native Whisper model install/cancel/delete lifecycle into `Sources/NativeWhisperModelWorkflow.swift`.
+- Extract the Local AI (llama.cpp-backed) model install/cancel/delete/status-refresh lifecycle into `Sources/LocalAIModelWorkflow.swift`.
+- Preserve every existing external call site's method name and signature on `AppState` (see "API Surface to Preserve" below) — no UI-visible behavior change.
+- Preserve all existing safety properties: active-token/generation guards against stale completions, deletion-before-reinstall ordering, app-termination quiescence waiting, idle server shutdown monitoring.
+- Replace the tangled current test file with direct workflow behavior tests plus narrower AppState integration tests, matching the pattern from #317–#319.
+
+## Non-Goals
+
+- No work on Settings/UserDefaults persistence, Calendar, Permissions, or Recording — those remain #192's scope (blocked by #217).
+- No change to `AIProcessingBackendChoice` normalization/persistence logic itself (`normalizeAIProcessingChoices`, `initializeMeetingSummarySettingsIfNeeded`, the `postProcessingBackendChoice`/`contextBackendChoice`/`meetingSummaryBackendChoice` `@Published` properties and their `didSet` persistence) — this is Settings-domain logic that happens to consume Local AI install state, not part of the Local AI model-management boundary itself. It stays in `AppState.swift`.
+- No change to `LocalAIServerManager`, `LocalAIInstaller`, `NativeWhisperInstaller`, `LocalAIModelStore`, `NativeWhisperModelStore`, or the model catalogs (`LocalAIModelCatalog`, `NativeWhisperModelCatalog`) — these low-level files are already correctly scoped and stay as-is.
+- No new feature, no new UI, no change to persisted state format, retry policy, or user-facing copy.
+- No growth of the public API surface — the goal is relocation, not redesign.
+
+## Current State Inventory
+
+### Native Whisper lifecycle (`Sources/AppState.swift:1011–1392`, ~150 lines of actual lifecycle code interleaved with ~230 lines of unrelated display/label helpers in the same range)
+
+State:
+- `@Published private(set) var nativeWhisperInstallStatus: NativeWhisperInstallStatus`
+- `@Published private(set) var nativeWhisperInstallProgress: NativeWhisperDownloadProgress`
+- `@Published private(set) var isInstallingNativeWhisper: Bool`
+- `@Published private(set) var nativeWhisperInstallError: String?`
+- `@Published private(set) var nativeWhisperInstallIssue: QuillUserIssueRecord?`
+- `@Published private(set) var pendingNativeWhisperAutoSelectionModelID: String?` — **feature-selection glue, stays in AppState** (see Entanglement Points)
+- `private var nativeWhisperInstallTask: NativeWhisperInstallTask?`
+- `private var nativeWhisperProgressCoalescer: LatestValueProgressCoalescer<NativeWhisperDownloadProgress>?`
+- `private var nativeWhisperInstallQuiescenceWaiters: [CheckedContinuation<Void, Never>]`
+- `private var nativeWhisperInstallCancellationMessage: String?` — dead code today (only ever set to `nil`, read back as `nil`); preserve verbatim, do not "fix."
+
+Functions (pure lifecycle, all move):
+- `refreshNativeWhisperInstallStatus()`
+- `installNativeWhisperModel(autoSelectWhenReady:)` — **entangled**, see below
+- `finishNativeWhisperInstall(model:result:)` — **entangled**, see below
+- `waitForNativeWhisperInstallToQuiesce() async`
+- `resumeNativeWhisperInstallQuiescenceWaitersIfNeeded()`
+- `cancelNativeWhisperInstall()`
+- `deleteNativeWhisperModel()`
+
+Functions that stay (feature-selection glue / UI display, not lifecycle):
+- `cancelNativeWhisperAutoSelection()`
+- `willAutoSelectNativeWhisperWhenReady` (computed; used externally by `SetupView.swift:755`, `SettingsView.swift:4858`)
+- All of `noteBrowserTranscriptionDisplay(for:)`, `nativeWhisperChoice`, `nativeWhisperDisplayName`, `hasNativeLocalWhisperModel`, and the surrounding transcription-choice display helpers (lines ~1023–1260) — these read `nativeWhisperInstallStatus` but are Settings/Note-Browser display logic, not install lifecycle.
+
+### Local AI lifecycle (`Sources/AppState.swift:2245–4260`, ~2,000 lines total; roughly 1,400 lines pure lifecycle, ~600 lines feature-selection glue tightly interleaved)
+
+State (all move to the workflow):
+- `let localAIServerManager: LocalAIServerManager` — **stays instance-owned by AppState** (it's also referenced elsewhere for transcription execution), but the workflow receives it as a runtime dependency for the exclusive-maintenance-before-delete step.
+- `@Published private(set) var localAIInstallStates: [String: LocalAIModelInstallViewState]`
+- `private var localAIInstallTasks: [String: LocalAIInstallTask]`
+- `private var localAIProgressCoalescers: [String: LatestValueProgressCoalescer<LocalAIDownloadProgress>]`
+- `private var localAIInstallTokens: [String: UUID]`
+- `private var localAICancellingModelIDs: Set<String>`
+- `private var localAIRestartAfterCancellationModelIDs: Set<String>`
+- `private var localAIDeletionRequestedModelIDs: Set<String>`
+- `private var localAIStatusRefreshGenerations: [String: Int]`
+- `private var localAIStatusRefreshPendingModelIDs: Set<String>`
+- `private var localAIStatusRefreshWaiters: [CheckedContinuation<Void, Never>]`
+- `private var localAIInstallQuiescenceWaiters: [CheckedContinuation<Void, Never>]`
+- `private var localAIIdleShutdownTask: Task<Void, Never>?`
+- `private var hasCompletedLocalAIStatusRefresh: Bool`
+- `private struct LocalAIModelDeletionOutcome: Sendable` (currently at line 365, physically separated from its usage) — moves to the workflow file.
+
+State that stays on AppState (feature-selection glue):
+- `@Published private var pendingLocalAISelections: [AIProcessingFeature: String]`
+- `@Published private(set) var contextModelCapabilityWarning: String?`
+
+Functions (pure lifecycle, all move, signatures preserved where public):
+- `startLocalAIIdleShutdownMonitoring()`
+- `stopLocalAIIdleShutdownMonitoring()`
+- `localAIInstallState(for:) -> LocalAIModelInstallViewState`
+- `refreshAllLocalAIInstallStates()`
+- `waitForLocalAIInstallStateRefresh() async`
+- `waitForLocalAIInstallsToQuiesce() async`
+- `resumeLocalAIInstallQuiescenceWaitersIfNeeded()`
+- `nextLocalAIStatusRefreshGeneration(for:)`
+- `applyLocalAIStatusRefresh(_:for:generation:)`
+- `completeLocalAIStatusOperation(_:for:)`
+- `startLocalAIInstallIfPossible(_:)` — **entangled**, see below
+- `finishLocalAIInstall(model:token:result:status:cleanupErrorDescription:)` — **entangled**, see below
+- `canonicalLocalAIModel(_:) -> LocalAIModel?`
+- `localAIModelUnavailableIssue(for:) -> QuillUserIssueRecord`
+- `cancelLocalAIInstall(_:)`
+- `deleteLocalAIModel(_:)`
+- `beginLocalAIModelDeletion(_:)`
+- `finishLocalAIModelDeletion(_:outcome:)`
+- `isLocalAIModelAvailable(_:) -> Bool` (reads `dependencies.localAI.processingAvailability()`) — moves; becomes a public query on the workflow since it's a hardware/model-capability predicate independent of AppState's own UI state, and it's already consumed both by lifecycle functions and by glue functions (see below).
+
+Functions that stay (feature-selection glue, settings interaction — not lifecycle):
+- `installLocalAIModel(_:autoSelectFor:)` — **entangled**, see below; stays as the public adapter, but delegates its lifecycle decision to the workflow.
+- `setPendingLocalAIModelID(_:for:)`
+- `clearPendingLocalAISelections(forModelID:)`
+- `waitingFeatures(for:) -> [AIProcessingFeature]`
+- `selectedOrPendingLocalAIModel(for:) -> LocalAIModel?`
+- `pendingLocalAIModelID(for:) -> String?`
+- `discardPendingLocalAISelection(for:)`
+- `discardUndownloadedLocalAISelections()`
+- `applyReadyLocalAIModelToWaitingFeatures(_:)` — **entangled**, see below
+- `resumeDeferredLocalAIRequests()` — **entangled**, see below
+- `unavailableLocalAIChoiceDisplay(...)`
+- `normalizeAIProcessingChoices()`, `normalizedAIProcessingChoice(_:for:)`, `initializeMeetingSummarySettingsIfNeeded()` — Settings-domain, out of scope entirely.
+
+### App-termination fan-out (`Sources/AppState.swift:~8200–8260`)
+
+`requestTerminationAfterModelCleanup(replyIsAlreadyPending:)` cancels both lifecycles, then awaits both quiescence signals, then stops the shared server, then replies to termination. This orchestration **stays on AppState** as a thin fan-out over both workflows' public `cancel...()`/`waitFor...Quiesce()` methods — it is legitimately AppState-level because it also coordinates the shared `localAIServerManager.stop()` and the app-level "quit alert" UI flow (`isModelDownloadQuitAlertPresented`, `modelDownloadQuitAlertPresenter`).
+
+`AppState.deinit` currently does `localAIIdleShutdownTask?.cancel()` directly. Once `localAIIdleShutdownTask` moves into `LocalAIModelWorkflow`, `LocalAIModelWorkflow` gets its own `deinit { idleShutdownTask?.cancel() }` and the line is removed from `AppState.deinit` (it fires automatically when AppState releases the workflow instance).
+
+### External call sites that must keep their exact name/signature on `AppState`
+
+```
+Sources/SetupView.swift:106      appState.refreshNativeWhisperInstallStatus()
+Sources/SettingsView.swift:4933  appState.installNativeWhisperModel()
+Sources/SettingsView.swift:4960  appState.cancelNativeWhisperInstall()
+Sources/SettingsView.swift:4988  appState.installNativeWhisperModel()
+Sources/SettingsView.swift:4997  appState.deleteNativeWhisperModel()
+Sources/SetupView.swift:755      appState.willAutoSelectNativeWhisperWhenReady
+Sources/SettingsView.swift:4858  appState.willAutoSelectNativeWhisperWhenReady
+Sources/NoteBrowserView.swift:870 appState.installedLegacyLocalWhisperModels
+Sources/LocalAIModelRowView.swift:144  appState.deleteLocalAIModel(model)
+Sources/LocalAIModelRowView.swift:239  appState.installLocalAIModel(model, autoSelectFor: feature)
+Sources/LocalAIModelRowView.swift:273  appState.cancelLocalAIInstall(model)
+Sources/AppDelegate.swift:92     appState.startLocalAIIdleShutdownMonitoring()
+```
+
+Plus, called from within `AppState.init`: `refreshAllLocalAIInstallStates()` (tail of `init`, wrapped in a main-thread dispatch — this becomes `localAIWorkflow.refreshAllInstallStates()`).
+
+### Test coverage (`Tests/AppStateAIProcessingBackendTests.swift`, 3,194 lines, 65 test functions)
+
+This file mixes three concerns in the same test functions:
+1. **Pure Local AI/Native Whisper lifecycle** (install/cancel/delete, progress coalescing, quiescence, status-refresh generation guards, termination fan-out) — candidates to move to direct workflow tests.
+2. **Feature-selection glue** (`pendingLocalAISelections`, auto-select-when-ready, `discardUndownloadedLocalAISelections`) — stays as AppState integration tests, now exercised against the workflow's public API instead of internal dictionaries.
+3. **`AIProcessingBackendChoice` normalization/persistence** (legacy migration, cloud/local independence per feature, remembered-cloud-model fallback) — entirely out of scope for #320; stays untouched in this file.
+
+Concretely, at least these already look like clean pure-lifecycle candidates for extraction into direct workflow tests: `testNativeWhisperProgressCoalescesAndCancellationWins`, `testLocalAIProgressCoalescesAndCompletionWins`, `testIdleShutdownMonitoringIsIdempotentAndStops`, `testLocalAIInstallQuiescenceWaitsForActiveWorker`, `testBackgroundStatusRefreshIgnoresStaleGeneration`, `testCanonicalModelValidationRejectsForgedModels`, `testInstallerSuccessRequiresReadyStatus`, `testInstallerSuccessRechecksHardwareAvailability`, `testPartialCleanupFailureSetsModelIssue`, `testDeleteFailureAndSuccessStateReset`, `testAppStateInstancesKeepIndependentLocalAIEnvironments`. Others mix concerns (e.g. `testDiscardUndownloadedSelectionsPreservesStartedDownloads`, `testCancellationWaitsForCompletionAndRetriesAfterQuiescence`, `testDeleteDuringInstallWaitsAndCannotAutoSelect`) and need a per-test judgment call during implementation about whether to split the assertions across a workflow test and an AppState test, or keep as a single AppState integration test if the feature-selection reaction is the actual point of the test. The termination fan-out tests (`testCombinedNativeAndLocalTerminationWaitsForBothWorkers`, `testTerminationRoutesThroughUnifiedModelCleanup`) stay as AppState integration tests since the fan-out itself stays on AppState.
+
+## Entanglement Points (the reason this isn't a mechanical move)
+
+Six places in the current code interleave pure lifecycle control-flow with feature-selection glue or Settings-domain logic in the same function body. Each needs to be split at the call boundary, not just relocated:
+
+1. **`installNativeWhisperModel(autoSelectWhenReady:)`** — records `pendingNativeWhisperAutoSelectionModelID` (glue) *before* checking `isInstallingNativeWhisper` and starting the workflow (lifecycle). Split: AppState's adapter records the pending selection, then unconditionally calls `nativeWhisperWorkflow.startInstall()` (workflow no-ops if already installing, exactly as today).
+
+2. **`finishNativeWhisperInstall(model:result:)`** — on success, reads `pendingNativeWhisperAutoSelectionModelID` and calls `setNoteBrowserTranscriptionChoice(...)` (glue) inline. Split: workflow emits an `.installCompleted(outcome)` event; AppState's event handler performs the auto-select reaction exactly as today.
+
+3. **`installLocalAIModel(_:autoSelectFor:)`** — the guard chain (`canonicalLocalAIModel`, `isLocalAIModelAvailable`, deletion-requested check) gates *both* whether to record the pending feature selection *and* whether to attempt the install. Split: the workflow exposes a query (`canonicalModel(for:) -> LocalAIModel?` or equivalent "is this startable" check) that AppState calls first to decide whether to record the pending selection, then AppState calls `localAIWorkflow.startInstall(model)` unconditionally (workflow re-validates and no-ops internally, same as today's early returns inside `startLocalAIInstallIfPossible`).
+
+4. **`finishLocalAIInstall(...)`** — the result switch directly calls `applyReadyLocalAIModelToWaitingFeatures(model)` (glue) on success-and-ready, or `clearPendingLocalAISelections(forModelID:)` (glue) on the other branches. Split: workflow emits `.installOutcome(model, outcome)` where `outcome` mirrors today's four-way classification (ready-and-available / succeeded-but-unavailable / cancelled / failed); AppState's event handler performs the same reactions it does today, now via the workflow's public query API instead of internal dictionaries.
+
+5. **`resumeDeferredLocalAIRequests()`** (called from `finishLocalAIStatusRefreshIfReady`) — iterates `pendingLocalAISelections` and `localAIDeferredInstallModelIDs` (glue state) but calls `applyReadyLocalAIModelToWaitingFeatures` / `startLocalAIInstallIfPossible` (lifecycle) depending on each model's current status. Split: stays in AppState as glue, but reads model status via `localAIWorkflow.installState(for:)` and starts installs via `localAIWorkflow.startInstall(model)` instead of manipulating lifecycle dictionaries directly. `localAIDeferredInstallModelIDs` itself — currently lifecycle-side state used only to remember "an install was requested before the initial status refresh finished" — moves into the workflow (it's install-attempt bookkeeping, not feature selection), and the workflow replays it internally once its own initial refresh completes, **removing the need for AppState to iterate it at all**. This shrinks `resumeDeferredLocalAIRequests()` to only the `pendingLocalAISelections` iteration.
+
+6. **`finishLocalAIStatusRefreshIfReady()`** — signals "initial catalog refresh done" and directly calls `normalizeAIProcessingChoices()` / `initializeMeetingSummarySettingsIfNeeded()` (Settings-domain) and `resumeDeferredLocalAIRequests()` (glue) inline. Split: workflow emits `.initialStatusRefreshCompleted` once (after internally replaying any deferred installs per point 5); AppState's event handler calls `normalizeAIProcessingChoices()`, `initializeMeetingSummarySettingsIfNeeded()`, and the shrunk `resumeDeferredLocalAIRequests()`, exactly as today, just from an event handler instead of an inline call.
+
+## Architecture
+
+Two new instance-owned workflow types, constructed with `.live`-backed dependency closures exactly like `TranscriptionRetryWorkflow`, each exposing an `onEvent` closure and a `state` property that `AppState` mirrors into its own `@Published` properties.
+
+### `Sources/NativeWhisperModelWorkflow.swift`
+
+```swift
+struct NativeWhisperModelWorkflowState: Equatable, Sendable {
+    var installStatus: NativeWhisperInstallStatus
+    var installProgress: NativeWhisperDownloadProgress
+    var isInstalling: Bool
+    var installError: String?
+    var installIssue: QuillUserIssueRecord?
+}
+
+enum NativeWhisperModelWorkflowOutcome: Equatable, Sendable {
+    case succeeded
+    case cancelled
+    case failed(QuillUserIssueRecord)
+}
+
+enum NativeWhisperModelWorkflowEvent {
+    case stateChanged(NativeWhisperModelWorkflowState)
+    case installCompleted(NativeWhisperModelWorkflowOutcome)
+}
+
+@MainActor
+final class NativeWhisperModelWorkflow {
+    var onEvent: ((NativeWhisperModelWorkflowEvent) -> Void)?
+    private(set) var state: NativeWhisperModelWorkflowState
+
+    func refreshInstallStatus()
+    func startInstall()
+    func cancelInstall()
+    func deleteModel()
+    func waitUntilQuiesced() async
+}
+```
+
+Issue construction (`QuillUserIssueRecord(code: .localModelMissing, ...)`) for both install failure and delete failure moves into the workflow — it depends only on the model catalog, not on AppState's own state, matching the "leftover internals" classification from the initial audit.
+
+### `Sources/LocalAIModelWorkflow.swift`
+
+```swift
+struct LocalAIModelWorkflowState: Equatable, Sendable {
+    var installStates: [String: LocalAIModelInstallViewState]
+    var hasCompletedInitialStatusRefresh: Bool
+}
+
+enum LocalAIModelWorkflowInstallOutcome: Equatable, Sendable {
+    case readyAndAvailable
+    case succeededButUnavailable(QuillUserIssueRecord)
+    case cancelled
+    case failed(QuillUserIssueRecord)
+}
+
+enum LocalAIModelWorkflowEvent {
+    case stateChanged(LocalAIModelWorkflowState)
+    case installOutcome(LocalAIModel, LocalAIModelWorkflowInstallOutcome)
+    case deletionOutcome(LocalAIModel, errorDescription: String?)
+    case initialStatusRefreshCompleted
+}
+
+@MainActor
+final class LocalAIModelWorkflow {
+    var onEvent: ((LocalAIModelWorkflowEvent) -> Void)?
+    private(set) var state: LocalAIModelWorkflowState
+
+    func installState(for model: LocalAIModel) -> LocalAIModelInstallViewState
+    func isModelAvailable(_ model: LocalAIModel) -> Bool
+    func canonicalModel(for model: LocalAIModel) -> LocalAIModel?
+    func refreshAllInstallStates()
+    func waitForInitialStatusRefresh() async
+    func startInstall(_ model: LocalAIModel)
+    func cancelInstall(_ model: LocalAIModel)
+    func deleteModel(_ model: LocalAIModel)
+    func waitForInstallsToQuiesce() async
+    func startIdleShutdownMonitoring()
+    func stopIdleShutdownMonitoring()
+
+    deinit // cancels idleShutdownTask
+}
+```
+
+`startInstall(_:)` internally reproduces today's full guard chain from `installLocalAIModel` + `startLocalAIInstallIfPossible` (canonical-model validation, deletion-requested check, availability check, deferred-until-status-refresh queuing, already-ready short-circuit via `.installOutcome(.readyAndAvailable)`, cancelling-then-restart handling) — it is safe to call unconditionally; it no-ops or defers exactly as the current code does.
+
+### AppState adapter shape
+
+`AppState` gains:
+```swift
+private let nativeWhisperWorkflow: NativeWhisperModelWorkflow
+private let localAIWorkflow: LocalAIModelWorkflow
+```
+
+wired with `onEvent` closures in `init` (before any code path that could fire an event, matching the ordering fix already applied for `TranscriptionRetryWorkflow` in #318 — event handler wiring precedes any workflow call, including the tail-of-`init` `refreshAllLocalAIInstallStates()` call).
+
+`AppState`'s existing `@Published` properties for both lifecycles (`nativeWhisperInstallStatus`, `nativeWhisperInstallProgress`, `isInstallingNativeWhisper`, `nativeWhisperInstallError`, `nativeWhisperInstallIssue`, `localAIInstallStates`) become mirrors updated from `.stateChanged` events, exactly matching the pattern `applyTranscriptionRetryWorkflowState` already uses. All external call sites keep their exact name (see list above) as thin methods that delegate to the workflow and, where an entanglement point requires it, perform the feature-selection reaction described above.
+
+## Data Flow (representative sequences)
+
+**Native Whisper install, auto-select requested:**
+`SettingsView` → `appState.installNativeWhisperModel()` → AppState records `pendingNativeWhisperAutoSelectionModelID` → `nativeWhisperWorkflow.startInstall()` → workflow manages `Task`, emits `.stateChanged` during progress → on completion, workflow emits `.installCompleted(.succeeded)` → AppState's handler checks `pendingNativeWhisperAutoSelectionModelID`, calls `setNoteBrowserTranscriptionChoice(...)`, clears the pending ID.
+
+**Local AI install requested for a feature, status refresh not yet complete:**
+`LocalAIModelRowView` → `appState.installLocalAIModel(model, autoSelectFor: .postProcessing)` → AppState checks `localAIWorkflow.canonicalModel(for:)`/`isModelAvailable(for:)`, records `pendingLocalAISelections[.postProcessing] = model.id` → calls `localAIWorkflow.startInstall(model)` → workflow internally queues the model (deferred, since its own initial refresh isn't done) and no-ops for now → later, workflow's own initial catalog refresh completes → workflow replays the deferred install internally → workflow emits `.initialStatusRefreshCompleted` → AppState's handler calls `normalizeAIProcessingChoices()`, `initializeMeetingSummarySettingsIfNeeded()`, and `resumeDeferredLocalAIRequests()` (now only iterating `pendingLocalAISelections`) → the install proceeds through the workflow's normal `startInstall` path → on success, workflow emits `.installOutcome(model, .readyAndAvailable)` → AppState's handler calls its (retained) `applyReadyLocalAIModelToWaitingFeatures(model)`, which queries `localAIWorkflow.installState(for:)`/`isModelAvailable(for:)` and applies the choice for each waiting feature.
+
+**App termination:**
+`requestTerminationAfterModelCleanup` → `nativeWhisperWorkflow.cancelInstall()` (if installing) → `localAIWorkflow.cancelInstall(model)` for each active model → `localAIWorkflow.stopIdleShutdownMonitoring()` → `await nativeWhisperWorkflow.waitUntilQuiesced()` → `await localAIWorkflow.waitForInstallsToQuiesce()` → `await localAIServerManager.stop()` → reply to termination. Unchanged in shape from today; only the receiver of each call changes.
+
+## Testing Strategy
+
+- New `Tests/NativeWhisperModelWorkflowTests.swift` and `Tests/LocalAIModelWorkflowTests.swift`: direct workflow instance tests (no `AppState`), covering install/cancel/delete, progress coalescing, status-refresh generation guards, quiescence waiting, canonical-model validation, and the deferred-install-replay-on-initial-refresh behavior — migrated from the pure-lifecycle tests identified in `AppStateAIProcessingBackendTests.swift`.
+- `Tests/AppStateAIProcessingBackendTests.swift` keeps: `AIProcessingBackendChoice` normalization/persistence tests (untouched, out of scope), plus narrowed AppState integration tests for feature-selection glue (auto-select-when-ready, pending-selection lifecycle, `discardUndownloadedLocalAISelections`) and the termination fan-out.
+- Each test currently mixing both concerns gets a judgment call during implementation: split into a workflow test plus a narrower AppState test if both halves are independently meaningful, or keep as a single AppState integration test if the point of the test is specifically the AppState-level reaction.
+- `make check-test-wiring` must continue to pass with the new test files registered.
+
+## Safety Invariants Preserved (no behavior change)
+
+- Active-token-per-model-ID guards on Local AI install completion and progress application (`localAIInstallTokens`).
+- Status-refresh generation guards (`localAIStatusRefreshGenerations`) preventing stale background status checks from overwriting newer state.
+- Deletion re-entrancy guard (`localAIDeletionRequestedModelIDs`) and deletion-before-reinstall ordering via `withExclusiveMaintenance` on the shared `localAIServerManager`.
+- Single-instance guard on Native Whisper installs (`isInstallingNativeWhisper`), no token needed since only one install can exist at a time by construction.
+- App-termination quiescence waiting for both lifecycles before stopping the shared server.
+- Vestigial `nativeWhisperInstallCancellationMessage` (currently dead code, always `nil`) is preserved as-is — not "fixed," since this is a pure relocation, not a behavior change.
+
+## Out of Scope / Deferred
+
+- `AIProcessingBackendChoice` normalization/persistence logic and its own extensive test coverage in `AppStateAIProcessingBackendTests.swift`.
+- Any further #192 domain-store work (Settings/Calendar/Permissions/Recording) — remains blocked by #217.
+- `LocalAIServerManager`'s own internal state machine (`idle/starting/running/stopping`) — already a separate, correctly-scoped file; the new `LocalAIModelWorkflow` only calls its existing public `withExclusiveMaintenance`/`stop`/`shutdownIfIdle` methods.

--- a/docs/superpowers/specs/2026-08-15-local-model-management-workflow-extraction-design.md
+++ b/docs/superpowers/specs/2026-08-15-local-model-management-workflow-extraction-design.md
@@ -120,7 +120,7 @@ Functions that stay (feature-selection glue, settings interaction — not lifecy
 
 ### External call sites that must keep their exact name/signature on `AppState`
 
-```
+```text
 Sources/SetupView.swift:106      appState.refreshNativeWhisperInstallStatus()
 Sources/SettingsView.swift:4933  appState.installNativeWhisperModel()
 Sources/SettingsView.swift:4960  appState.cancelNativeWhisperInstall()
@@ -222,22 +222,30 @@ enum LocalAIModelWorkflowEvent {
     case stateChanged(LocalAIModelWorkflowState)
     case installOutcome(LocalAIModel, LocalAIModelWorkflowInstallOutcome)
     case deletionOutcome(LocalAIModel, errorDescription: String?)
-    case initialStatusRefreshCompleted
+    case initialStatusRefreshCompleted(deferredModelIDs: Set<String>)
 }
 
 @MainActor
-final class LocalAIModelWorkflow {
-    var onEvent: ((LocalAIModelWorkflowEvent) -> Void)?
+final class LocalAIModelWorkflow: @unchecked Sendable {
+    nonisolated(unsafe) var onEvent:
+        (@MainActor (LocalAIModelWorkflowEvent) -> Void)?
     private(set) var state: LocalAIModelWorkflowState
+    var hasActiveInstalls: Bool
 
+    func beginTerminationCleanup()
     func installState(for model: LocalAIModel) -> LocalAIModelInstallViewState
     func isModelAvailable(_ model: LocalAIModel) -> Bool
     func canonicalModel(for model: LocalAIModel) -> LocalAIModel?
+    func isDeletionRequested(_ modelID: String) -> Bool
+    @discardableResult
+    func markUnavailable(_ model: LocalAIModel) -> QuillUserIssueRecord
     func refreshAllInstallStates()
     func waitForInitialStatusRefresh() async
     func startInstall(_ model: LocalAIModel)
-    func cancelInstall(_ model: LocalAIModel)
-    func deleteModel(_ model: LocalAIModel)
+    @discardableResult
+    func cancelInstall(_ model: LocalAIModel) -> Bool
+    @discardableResult
+    func deleteModel(_ model: LocalAIModel) -> Bool
     func waitForInstallsToQuiesce() async
     func startIdleShutdownMonitoring()
     func stopIdleShutdownMonitoring()
@@ -266,7 +274,7 @@ wired with `onEvent` closures in `init` (before any code path that could fire an
 `SettingsView` → `appState.installNativeWhisperModel()` → AppState records `pendingNativeWhisperAutoSelectionModelID` → `nativeWhisperWorkflow.startInstall()` → workflow manages `Task`, emits `.stateChanged` during progress → on completion, workflow emits `.installCompleted(.succeeded)` → AppState's handler checks `pendingNativeWhisperAutoSelectionModelID`, calls `setNoteBrowserTranscriptionChoice(...)`, clears the pending ID.
 
 **Local AI install requested for a feature, status refresh not yet complete:**
-`LocalAIModelRowView` → `appState.installLocalAIModel(model, autoSelectFor: .postProcessing)` → AppState checks `localAIWorkflow.canonicalModel(for:)`/`isModelAvailable(for:)`, records `pendingLocalAISelections[.postProcessing] = model.id` → calls `localAIWorkflow.startInstall(model)` → workflow internally queues the model (deferred, since its own initial refresh isn't done) and no-ops for now → later, workflow's own initial catalog refresh completes → workflow replays the deferred install internally → workflow emits `.initialStatusRefreshCompleted` → AppState's handler calls `normalizeAIProcessingChoices()`, `initializeMeetingSummarySettingsIfNeeded()`, and `resumeDeferredLocalAIRequests()` (now only iterating `pendingLocalAISelections`) → the install proceeds through the workflow's normal `startInstall` path → on success, workflow emits `.installOutcome(model, .readyAndAvailable)` → AppState's handler calls its (retained) `applyReadyLocalAIModelToWaitingFeatures(model)`, which queries `localAIWorkflow.installState(for:)`/`isModelAvailable(for:)` and applies the choice for each waiting feature.
+`LocalAIModelRowView` → `appState.installLocalAIModel(model, autoSelectFor: .postProcessing)` → AppState checks `localAIWorkflow.canonicalModel(for:)`/`isModelAvailable(for:)`, records `pendingLocalAISelections[.postProcessing] = model.id` → calls `localAIWorkflow.startInstall(model)` → workflow internally queues the model (deferred, since its own initial refresh isn't done) and no-ops for now → later, workflow's own initial catalog refresh completes → workflow emits `.initialStatusRefreshCompleted(deferredModelIDs:)` → AppState's handler calls `normalizeAIProcessingChoices()`, `initializeMeetingSummarySettingsIfNeeded()`, and `resumeDeferredLocalAIRequests(deferredModelIDs:)` → AppState reapplies ready pending choices and explicitly restarts each deferred non-ready model through `localAIWorkflow.startInstall(_:)` → on success, workflow emits `.installOutcome(model, .readyAndAvailable)` → AppState's handler calls its retained `applyReadyLocalAIModelToWaitingFeatures(model)`, which queries `localAIWorkflow.installState(for:)`/`isModelAvailable(_:)` and applies the choice for each waiting feature.
 
 **App termination:**
 `requestTerminationAfterModelCleanup` → `nativeWhisperWorkflow.cancelInstall()` (if installing) → `localAIWorkflow.cancelInstall(model)` for each active model → `localAIWorkflow.stopIdleShutdownMonitoring()` → `await nativeWhisperWorkflow.waitUntilQuiesced()` → `await localAIWorkflow.waitForInstallsToQuiesce()` → `await localAIServerManager.stop()` → reply to termination. Unchanged in shape from today; only the receiver of each call changes.


### PR DESCRIPTION
## Summary

- Extract Native Whisper and Local AI model lifecycle management into dedicated workflow types while preserving the existing AppState-facing API.
- Move install, cancellation/restart, deletion, status refresh, quiescence, idle shutdown, and termination guards behind the stabilized workflow boundaries.
- Keep feature-selection and settings normalization glue in AppState, and add deterministic direct workflow coverage for concurrency-sensitive behavior.

## Verification

- `make check-test-wiring`
- `make test`
- Signed production build
- Strict deep codesign verification
- `/code-review medium` findings addressed, followed by a fresh full verification run

Closes #320


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - Native Whisper 및 Local AI 모델의 설치·취소·재시도·삭제 흐름을 개선했습니다.
  - 설치 진행률과 상태가 더 안정적으로 반영됩니다.
  - 모델 설치 또는 삭제 실패 시 오류 상태와 선택 정보가 올바르게 유지됩니다.
  - 앱 종료 중 진행 중인 모델 작업을 안전하게 정리하고, 유휴 Local AI 서버를 자동으로 종료합니다.

- **품질 개선**
  - 모델 관리와 앱 종료 과정의 다양한 성공·실패·취소 상황에 대한 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->