### PR TITLE
Remove context summary from note header

### DIFF
--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -432,7 +432,6 @@ struct NoteBrowserView: View {
         let q = searchText.lowercased()
         return appState.pipelineHistory.filter {
             $0.postProcessedTranscript.lowercased().contains(q) ||
-            $0.contextSummary.lowercased().contains(q) ||
             ($0.customTitle ?? "").lowercased().contains(q) ||
             ($0.calendarMatch?.title ?? "").lowercased().contains(q)
         }
@@ -1683,7 +1682,6 @@ private struct NoteDetailView: View {
                 detailTimestampLabel(detailTimestamp)
                 statusBadges
                 noteStateIndicator
-                contextSummaryLabel
                 Spacer(minLength: 0)
             }
             VStack(alignment: .leading, spacing: 4) {
@@ -1694,7 +1692,6 @@ private struct NoteDetailView: View {
                 }
                 HStack(spacing: 8) {
                     statusBadges
-                    contextSummaryLabel
                     Spacer(minLength: 0)
                 }
             }
@@ -1728,21 +1725,6 @@ private struct NoteDetailView: View {
                 .font(.system(size: 10, weight: .light))
                 .foregroundStyle(.red.opacity(0.6))
                 .help("Transcription failed")
-        }
-    }
-
-    @ViewBuilder
-    private var contextSummaryLabel: some View {
-        if !item.contextSummary.isEmpty
-            && !item.contextSummary.hasPrefix("Could not")
-            && item.contextSummary != "Context capture disabled" {
-            Text("·")
-                .foregroundStyle(.quaternary)
-                .font(.system(size: 10))
-            Text(item.contextSummary)
-                .font(.system(size: 10, design: .monospaced))
-                .foregroundStyle(.tertiary)
-                .lineLimit(1)
         }
     }
 


### PR DESCRIPTION
## Summary

- Remove the generated Context summary prose from the selected note's metadata header while keeping the compact `CTX` badge.
- Preserve stored Context data for post-processing, persistence, Run Log diagnostics, and other non-header consumers.
- Stop matching Note Browser search against the now-hidden Context summary so every search result has visible matching content.

## Verification

- `make check-test-wiring`
- `make test`
- `make run`
- Verified through the `Quill Dev` accessibility tree that the Context prose is absent and the `CTX` badge remains.
- Addressed the single `/code-review medium` finding and reran the complete test suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 검색 필터에서 컨텍스트 요약을 기준으로 검색하는 조건을 제거했습니다.
  * 노트 메타데이터 화면에서 컨텍스트 요약 라벨이 더 이상 표시되지 않습니다.
  * 두 가지 메타데이터 레이아웃에 동일하게 적용되어 화면 정보가 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->