### PR TITLE
Preserve execution metadata when editing transcripts

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -6322,40 +6322,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         case nil:
             replacementSpokenLanguage = nil
         }
-        let updated = PipelineHistoryItem(
-            intent: item.intent,
-            selectedText: item.selectedText,
-            id: item.id,
-            timestamp: item.timestamp,
-            recordingStartedAt: item.recordingStartedAt,
-            recordingEndedAt: item.recordingEndedAt,
-            calendarMatch: item.calendarMatch,
-            rawTranscript: item.rawTranscript,
-            postProcessedTranscript: text,
-            postProcessingPrompt: item.postProcessingPrompt,
-            contextSummary: item.contextSummary,
-            contextPrompt: item.contextPrompt,
-            contextScreenshotDataURL: item.contextScreenshotDataURL,
-            contextScreenshotStatus: item.contextScreenshotStatus,
-            postProcessingStatus: item.postProcessingStatus,
-            debugStatus: item.debugStatus,
-            customVocabulary: item.customVocabulary,
-            customSystemPrompt: item.customSystemPrompt,
-            audioFileName: item.audioFileName,
-            usedLocalTranscription: item.usedLocalTranscription,
-            usedContextCapture: item.usedContextCapture,
-            usedPostProcessing: item.usedPostProcessing,
-            transcriptionLanguageCode: item.transcriptionLanguageCode,
+        let updated = item.copying(
+            meetingSummaryJSON: item.meetingSummaryJSON,
             spokenLanguageCode: replacementSpokenLanguage?.languageCode,
             spokenLanguageResolution: replacementSpokenLanguage?.source,
             meetingSummaryAttempt: item.meetingSummaryAttempt,
-            localTranscriptionModelID: item.localTranscriptionModelID,
-            transcriptFileName: item.transcriptFileName,
-            contextAppName: item.contextAppName,
-            contextBundleIdentifier: item.contextBundleIdentifier,
-            contextWindowTitle: item.contextWindowTitle,
             customTitle: item.customTitle,
-            meetingSummaryJSON: item.meetingSummaryJSON
+            postProcessedTranscript: text
         )
         do {
             try pipelineHistoryStore.update(updated)

--- a/Tests/MeetingSummaryAppStateTests.swift
+++ b/Tests/MeetingSummaryAppStateTests.swift
@@ -21,7 +21,7 @@ struct MeetingSummaryAppStateTests {
         try await testDeleteDuringGenerationDoesNotRestoreSummary()
         try await testTranscriptReplacementReinfersDerivedSpokenLanguage()
         try await testTranscriptReplacementPreservesEngineDetectedLanguage()
-        try await testTranscriptEditingPreservesSummaryMetadata()
+        try await testTranscriptEditingPreservesNonEditedMetadata()
         try await testActionCompletionPersists()
         try await testPostProcessingDisabledDoesNotBlockSummary()
         try await testDeleteMeetingSummaryRemovesEntireSummaryState()
@@ -713,7 +713,7 @@ struct MeetingSummaryAppStateTests {
         precondition(persisted.meetingSummaryAttempt?.language?.appliedLanguageCode == "en")
     }
 
-    private static func testTranscriptEditingPreservesSummaryMetadata() async throws {
+    private static func testTranscriptEditingPreservesNonEditedMetadata() async throws {
         let attempt = MeetingSummaryAttempt(
             occurredAt: Date(timeIntervalSince1970: 2_100),
             outcome: .failed,
@@ -727,14 +727,64 @@ struct MeetingSummaryAppStateTests {
             ),
             issue: QuillUserIssueRecord(code: .meetingSummaryUnavailable)
         )
-        let item = makeItem()
-            .withSpokenLanguage(
-                SpokenLanguageResolution(
-                    languageCode: "ko",
-                    source: .engineDetected
+        let calendarMatch = CalendarEventMatch(
+            accountID: "account-id",
+            calendarID: "calendar-id",
+            eventID: "event-id",
+            title: "Design Review",
+            start: Date(timeIntervalSince1970: 900),
+            end: Date(timeIntervalSince1970: 1_800),
+            attendees: [
+                CalendarEventAttendee(
+                    displayName: "Ada",
+                    email: "ada@example.com"
                 )
-            )
-            .withMeetingSummaryAttempt(attempt)
+            ],
+            matchSource: .overlapSuggestion,
+            titleState: .applied
+        )
+        let item = PipelineHistoryItem(
+            intent: .commandManual,
+            selectedText: "command selection",
+            capturedSelection: "captured context selection",
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            recordingStartedAt: Date(timeIntervalSince1970: 950),
+            recordingEndedAt: Date(timeIntervalSince1970: 1_050),
+            calendarMatch: calendarMatch,
+            rawTranscript: "Original raw transcript.",
+            postProcessedTranscript: "Original processed transcript.",
+            postProcessingPrompt: "post-processing prompt",
+            systemPrompt: "resolved system prompt",
+            contextSummary: "captured context summary",
+            contextSystemPrompt: "context system prompt",
+            contextPrompt: "context prompt",
+            contextScreenshotDataURL: "data:image/png;base64,c2NyZWVuc2hvdA==",
+            contextScreenshotStatus: "available (image/png)",
+            postProcessingStatus: QuillUserIssueRecord(
+                code: .postProcessingFailed
+            ).persistedStatus,
+            aiProcessingOutcome: "raw-fallback:languageMismatch",
+            debugStatus: "post-processing fallback",
+            customVocabulary: "Quill",
+            customSystemPrompt: "custom system prompt",
+            audioFileName: "meeting.wav",
+            usedLocalTranscription: true,
+            usedContextCapture: true,
+            usedPostProcessing: true,
+            transcriptionLanguageCode: "ko",
+            spokenLanguageCode: "ko",
+            spokenLanguageResolution: .engineDetected,
+            meetingSummaryAttempt: attempt,
+            localTranscriptionModelID: "local/model",
+            transcriptFileName: "meeting.txt",
+            contextAppName: "Example App",
+            contextBundleIdentifier: "com.example.app",
+            contextWindowTitle: "Example Window",
+            customTitle: "Edited Note",
+            meetingSummaryJSON: try JSONEncoder().encode(envelope(completed: false))
+        )
+        let originalMetadata = try transcriptEditPreservedMetadata(item)
         let store = PipelineHistoryStore(inMemory: true)
         _ = try store.append(item, maxCount: 10)
         let directoryURL = try temporaryDirectory()
@@ -745,20 +795,46 @@ struct MeetingSummaryAppStateTests {
             storageLayout: layout
         )
 
-        await MainActor.run {
+        let updated = await MainActor.run {
             appState.updateTranscript(id: item.id, text: "Edited transcript.")
-
-            let updated = appState.pipelineHistory[0]
-            precondition(updated.postProcessedTranscript == "Edited transcript.")
-            precondition(updated.spokenLanguage == item.spokenLanguage)
-            precondition(updated.meetingSummaryAttempt == attempt)
+            return appState.pipelineHistory[0]
         }
+
+        precondition(updated.postProcessedTranscript == "Edited transcript.")
+        precondition(
+            updated.capturedSelection == "captured context selection",
+            "Transcript editing must preserve captured selection"
+        )
+        precondition(
+            updated.systemPrompt == "resolved system prompt",
+            "Transcript editing must preserve the resolved system prompt"
+        )
+        precondition(
+            updated.contextSystemPrompt == "context system prompt",
+            "Transcript editing must preserve the Context system prompt"
+        )
+        precondition(
+            updated.aiProcessingOutcome == "raw-fallback:languageMismatch",
+            "Transcript editing must preserve the AI processing outcome"
+        )
+        let updatedMetadata = try transcriptEditPreservedMetadata(updated)
+        precondition(
+            updatedMetadata == originalMetadata,
+            "Transcript editing must preserve every non-edited history field"
+        )
 
         guard let persisted = store.loadAllHistory().first else {
             throw MeetingSummaryAppStateTestFailure("Missing persisted note")
         }
-        precondition(persisted.spokenLanguage == item.spokenLanguage)
-        precondition(persisted.meetingSummaryAttempt == attempt)
+        precondition(
+            persisted.postProcessedTranscript == "Edited transcript.",
+            "Transcript editing must persist the edited transcript"
+        )
+        let persistedMetadata = try transcriptEditPreservedMetadata(persisted)
+        precondition(
+            persistedMetadata == originalMetadata,
+            "Persisted transcript edits must preserve every non-edited history field"
+        )
     }
 
     private static func testTranscriptChangeDiscardsInflightResult() async throws {
@@ -1333,6 +1409,24 @@ struct MeetingSummaryAppStateTests {
             try await Task.sleep(for: .milliseconds(10))
         }
         throw MeetingSummaryAppStateTestFailure("Timed out waiting for retry")
+    }
+
+    private static func transcriptEditPreservedMetadata(
+        _ item: PipelineHistoryItem
+    ) throws -> Data {
+        let encoded = try JSONEncoder().encode(item)
+        guard var object = try JSONSerialization.jsonObject(
+            with: encoded
+        ) as? [String: Any] else {
+            throw MeetingSummaryAppStateTestFailure(
+                "Unable to encode transcript-edit metadata snapshot"
+            )
+        }
+        object.removeValue(forKey: "postProcessedTranscript")
+        return try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.sortedKeys]
+        )
     }
 
     private static func makeItem(

--- a/Tests/MeetingSummaryAppStateTests.swift
+++ b/Tests/MeetingSummaryAppStateTests.swift
@@ -785,11 +785,11 @@ struct MeetingSummaryAppStateTests {
             meetingSummaryJSON: try JSONEncoder().encode(envelope(completed: false))
         )
         let originalMetadata = try transcriptEditPreservedMetadata(item)
-        let store = PipelineHistoryStore(inMemory: true)
-        _ = try store.append(item, maxCount: 10)
         let directoryURL = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         let layout = AppStateStorageLayout(rootDirectory: directoryURL)
+        let store = PipelineHistoryStore(storeURL: layout.historyStoreURL)
+        _ = try store.upsert(item, maxCount: 10, requiresDurableStore: true)
         let appState = await configuredPersistedAppState(
             store: store,
             storageLayout: layout
@@ -823,8 +823,9 @@ struct MeetingSummaryAppStateTests {
             "Transcript editing must preserve every non-edited history field"
         )
 
-        guard let persisted = store.loadAllHistory().first else {
-            throw MeetingSummaryAppStateTestFailure("Missing persisted note")
+        let reloaded = PipelineHistoryStore(storeURL: layout.historyStoreURL)
+        guard let persisted = reloaded.loadAllHistory().first else {
+            throw MeetingSummaryAppStateTestFailure("Missing reloaded persisted note")
         }
         precondition(
             persisted.postProcessedTranscript == "Edited transcript.",


### PR DESCRIPTION
## Summary

- reuse the existing `PipelineHistoryItem.copying` path when a transcript is edited
- preserve captured selection, system prompts, AI processing outcome, and every other non-edited history field
- add regression coverage for both in-memory state and durable history reloads

## Testing

- `make test-transcription`
- `make test`

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 회의 transcript를 편집해도 요약, 음성 언어, 처리 상태, 사용자 지정 제목 등 기존 정보가 유지됩니다.
  * 캘린더 정보와 프롬프트 같은 추가 메타데이터가 메모리와 저장소에서 올바르게 보존됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->