### PR TITLE
Represent Context inference failures as typed state

### DIFF
--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -446,6 +446,18 @@ Selected text: \(selectedText ?? "None")
             return issue
         }
         guard backendExecutor.choice.isLocal else {
+            if error is AppContextBackendError {
+                return QuillUserIssueError(
+                    record: QuillUserIssueRecord(
+                        code: .invalidProviderResponse,
+                        context: QuillUserIssueContext(
+                            providerHost: URL(string: backendExecutor.cloudBaseURL)?.host,
+                            modelID: backendExecutor.choice.modelID
+                        )
+                    ),
+                    privateDiagnostic: "Unusable Context inference response"
+                )
+            }
             return .cloudTransport(
                 error,
                 providerHost: URL(string: backendExecutor.cloudBaseURL)?.host,

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -412,7 +412,7 @@ Selected text: \(selectedText ?? "None")
             return nil
         }
         guard httpResponse.statusCode == 200 else {
-            return nil
+            throw AppContextBackendError.httpStatus(httpResponse.statusCode)
         }
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let choices = json["choices"] as? [[String: Any]],
@@ -438,6 +438,7 @@ Selected text: \(selectedText ?? "None")
     }
 
     private enum AppContextBackendError: Error {
+        case httpStatus(Int)
         case unusableResponse
     }
 
@@ -446,6 +447,13 @@ Selected text: \(selectedText ?? "None")
             return issue
         }
         guard backendExecutor.choice.isLocal else {
+            if case .httpStatus(let status) = error as? AppContextBackendError {
+                return .cloudHTTP(
+                    status: status,
+                    providerHost: URL(string: backendExecutor.cloudBaseURL)?.host,
+                    modelID: backendExecutor.choice.modelID
+                )
+            }
             if error is AppContextBackendError {
                 return QuillUserIssueError(
                     record: QuillUserIssueRecord(

--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -217,7 +217,13 @@ Return only two sentences, no labels, no markdown, no extra commentary.
             )
             contextPrompt = nil
             if backendExecutor.choice.isLocal {
-                userIssueRecord = nil
+                let issue = QuillUserIssueError.local(
+                    code: .localAIModelUnavailable,
+                    backend: "Local AI",
+                    modelID: backendExecutor.choice.modelID
+                )
+                issueSink(issue)
+                userIssueRecord = issue.record
             } else {
                 let issue = QuillUserIssueError.missingProviderAPIKey(
                     providerHost: URL(string: backendExecutor.cloudBaseURL)?.host,
@@ -309,10 +315,7 @@ Return only two sentences, no labels, no markdown, no extra commentary.
                 if let lastCloudError {
                     throw lastCloudError
                 }
-                if endpoint.kind == .local {
-                    throw AppContextBackendError.unusableResponse
-                }
-                return nil
+                throw AppContextBackendError.unusableResponse
             }
             guard !Task.isCancelled else {
                 return ContextInferenceOutcome(result: nil, userIssueRecord: nil)

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -10980,7 +10980,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             screenshotDataURL: context.screenshotDataURL,
             screenshotMimeType: context.screenshotMimeType,
             screenshotError: context.screenshotError,
-            userIssueRecord: QuillUserIssueRecord(code: .contextUnavailable)
+            userIssueRecord: context.userIssueRecord ?? QuillUserIssueRecord(code: .contextUnavailable)
         )
     }
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -10949,7 +10949,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     // Context is only worth injecting into post-processing when it was
     // successfully captured: real (non-placeholder) activity text, and no
-    // error-severity issue was recorded while collecting it.
+    // issue of any severity was recorded while collecting it. A recorded
+    // issue means the capture failed, even when it is only ever shown to
+    // the user as a warning.
     private static func isUsableCapturedContext(_ context: AppContext) -> Bool {
         guard !isPlaceholderContextSummary(context.currentActivity) else { return false }
         guard context.userIssueRecord == nil else { return false }

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -10952,7 +10952,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     // error-severity issue was recorded while collecting it.
     private static func isUsableCapturedContext(_ context: AppContext) -> Bool {
         guard !isPlaceholderContextSummary(context.currentActivity) else { return false }
-        guard context.userIssueRecord?.severity != .error else { return false }
+        guard context.userIssueRecord == nil else { return false }
         return true
     }
 

--- a/Tests/AppContextBackendTests.swift
+++ b/Tests/AppContextBackendTests.swift
@@ -10,6 +10,7 @@ struct AppContextBackendTests {
         try await testCloudThrownTransportRetriesWithoutScreenshot()
         try await testCloudRepeatedTransportFailureRecordsStructuredIssue()
         try await testCloudUnusableResponseRecordsStructuredIssue()
+        try await testCloudHTTPStatusPreservesSpecificClassification()
         try await testCloudMissingKeySkipsTransportAndRecordsProviderIssue()
         try testContextFallbackCarriesProviderIssue()
         try testConfiguredContextCollectionPreservesInferenceIssue()
@@ -217,6 +218,52 @@ struct AppContextBackendTests {
         try expect(
             issues.last()?.record.code == .invalidProviderResponse,
             "unusable cloud content is reported as an unusable response, not a down provider"
+        )
+    }
+
+    // A non-200 HTTP response carries a specific, actionable classification
+    // (auth failure, rate limit, provider outage). It must not collapse into
+    // the generic "unusable response" bucket used for a 200 with bad content,
+    // or the user loses the correct recovery guidance.
+    private static func testCloudHTTPStatusPreservesSpecificClassification() async throws {
+        let recorder = ContextRequestRecorder()
+        let issues = ContextIssueRecorder()
+        let service = AppContextService(
+            backendExecutor: AIProcessingBackendExecutor(
+                choice: .cloud(modelID: "qwen/qwen3.6-27b"),
+                cloudBaseURL: "https://api.example.com/openai/v1",
+                cloudAPIKey: "cloud-key"
+            ),
+            customContextPrompt: "",
+            contextModel: "qwen/qwen3.6-27b",
+            transport: { request in
+                recorder.record(request)
+                return (
+                    Data(),
+                    HTTPURLResponse(
+                        url: request.url!,
+                        statusCode: 401,
+                        httpVersion: nil,
+                        headerFields: nil
+                    )!
+                )
+            },
+            issueSink: { issue in issues.record(issue) }
+        )
+
+        let result = await service.inferActivityWithLLM(
+            appName: "Editor",
+            bundleIdentifier: "test.editor",
+            windowTitle: "Document",
+            selectedText: nil,
+            screenshotDataURL: "data:image/jpeg;base64,IMAGE",
+            contextSystemPrompt: AppContextService.defaultContextPrompt
+        )
+
+        try expect(result == nil, "HTTP 401 returns fallback signal")
+        try expect(
+            issues.last()?.record.code == .authenticationFailed,
+            "HTTP 401 keeps its specific classification instead of collapsing into invalidProviderResponse"
         )
     }
 
@@ -610,8 +657,10 @@ struct AppContextBackendTests {
         )
         try expect(sanitizeBody.contains("currentActivity: \"\""), "unusable capture is not injected")
         try expect(
-            sanitizeBody.contains("QuillUserIssueRecord(code: .contextUnavailable)"),
-            "unusable capture attaches the context-unavailable warning"
+            sanitizeBody.contains(
+                "context.userIssueRecord ?? QuillUserIssueRecord(code: .contextUnavailable)"
+            ),
+            "unusable capture preserves its original issue, falling back to a generic warning only when none was recorded"
         )
     }
 

--- a/Tests/AppContextBackendTests.swift
+++ b/Tests/AppContextBackendTests.swift
@@ -215,8 +215,8 @@ struct AppContextBackendTests {
         try expect(result == nil, "unusable cloud content returns fallback signal")
         try expect(recorder.count() == 2, "unusable cloud content exhausts text retry")
         try expect(
-            issues.last() != nil,
-            "unusable cloud content records a structured issue instead of failing silently"
+            issues.last()?.record.code == .invalidProviderResponse,
+            "unusable cloud content is reported as an unusable response, not a down provider"
         )
     }
 

--- a/Tests/AppContextBackendTests.swift
+++ b/Tests/AppContextBackendTests.swift
@@ -9,9 +9,11 @@ struct AppContextBackendTests {
         try await testCloudContextRetriesWithoutScreenshot()
         try await testCloudThrownTransportRetriesWithoutScreenshot()
         try await testCloudRepeatedTransportFailureRecordsStructuredIssue()
+        try await testCloudUnusableResponseRecordsStructuredIssue()
         try await testCloudMissingKeySkipsTransportAndRecordsProviderIssue()
         try testContextFallbackCarriesProviderIssue()
         try testConfiguredContextCollectionPreservesInferenceIssue()
+        try testUnconfiguredLocalContextRecordsModelUnavailableIssue()
         try await testCancellationStopsRetryAndDoesNotRecordIssue()
         try await testLocalRequestUsesEndpointRequestAndSelectedModelIDs()
         try testAppStateContextCaptureGuardsCancelledPublication()
@@ -179,6 +181,45 @@ struct AppContextBackendTests {
         )
     }
 
+    // A cloud response that returns HTTP 200 with unusable content (no
+    // network/transport error) must still be classified as a Context failure
+    // instead of silently falling through with no issue at all — otherwise
+    // the fallback metadata summary would look like real captured context.
+    private static func testCloudUnusableResponseRecordsStructuredIssue() async throws {
+        let recorder = ContextRequestRecorder()
+        let issues = ContextIssueRecorder()
+        let service = AppContextService(
+            backendExecutor: AIProcessingBackendExecutor(
+                choice: .cloud(modelID: "qwen/qwen3.6-27b"),
+                cloudBaseURL: "https://api.example.com/openai/v1",
+                cloudAPIKey: "cloud-key"
+            ),
+            customContextPrompt: "",
+            contextModel: "qwen/qwen3.6-27b",
+            transport: { request in
+                recorder.record(request)
+                return try successResponse(request, "")
+            },
+            issueSink: { issue in issues.record(issue) }
+        )
+
+        let result = await service.inferActivityWithLLM(
+            appName: "Editor",
+            bundleIdentifier: "test.editor",
+            windowTitle: "Document",
+            selectedText: nil,
+            screenshotDataURL: "data:image/jpeg;base64,IMAGE",
+            contextSystemPrompt: AppContextService.defaultContextPrompt
+        )
+
+        try expect(result == nil, "unusable cloud content returns fallback signal")
+        try expect(recorder.count() == 2, "unusable cloud content exhausts text retry")
+        try expect(
+            issues.last() != nil,
+            "unusable cloud content records a structured issue instead of failing silently"
+        )
+    }
+
     private static func testCloudMissingKeySkipsTransportAndRecordsProviderIssue() async throws {
         let recorder = ContextRequestRecorder()
         let issues = ContextIssueRecorder()
@@ -276,6 +317,34 @@ struct AppContextBackendTests {
         try expect(
             source.contains("userIssueRecord: issue.record"),
             "Context inference returns the classified issue"
+        )
+    }
+
+    // Local Context inference that never even attempts a request (the
+    // selected model or hardware isn't configured) must still attach a typed
+    // issue, matching every other Context failure branch, instead of
+    // silently reporting the fallback metadata summary as usable.
+    private static func testUnconfiguredLocalContextRecordsModelUnavailableIssue() throws {
+        let source = try String(
+            contentsOfFile: "Sources/AppContextService.swift",
+            encoding: .utf8
+        )
+        guard let start = source.range(of: "if backendExecutor.choice.isLocal {"),
+              let end = source.range(
+                of: "return AppContext(",
+                range: start.upperBound..<source.endIndex
+              ) else {
+            throw AppContextBackendTestFailure("Context not-configured branch source")
+        }
+        let body = String(source[start.lowerBound..<end.lowerBound])
+
+        try expect(
+            !body.contains("userIssueRecord = nil"),
+            "unconfigured local Context capture must record a typed issue, not silently succeed"
+        )
+        try expect(
+            body.contains(".localAIModelUnavailable"),
+            "unconfigured local Context capture reports the model-unavailable issue"
         )
     }
 
@@ -520,8 +589,8 @@ struct AppContextBackendTests {
             "usability requires non-placeholder activity"
         )
         try expect(
-            usableBody.contains(".severity != .error") || usableBody.contains(".severity == .error"),
-            "usability excludes error-severity capture issues"
+            usableBody.contains("context.userIssueRecord == nil"),
+            "usability requires no captured issue, regardless of severity"
         )
 
         guard let sanitizeStart = source.range(of: "private static func sanitizedCapturedContext("),


### PR DESCRIPTION
## Summary
- Every Context-capture failure branch in `AppContextService` now records a `QuillUserIssueRecord`: an unconfigured local backend, and a cloud response that returns HTTP 200 with unusable content (previously silent, with no issue at all).
- `AppState.isUsableCapturedContext` now excludes captured context whenever any issue was recorded, regardless of severity, instead of only excluding error-severity issues — so warning-severity local-backend failures no longer leak their fallback explanation text into post-processing / Meeting Summary prompts.
- An unusable-but-successful cloud response is classified as `invalidProviderResponse` (not `providerUnavailable`), matching the existing convention for a response that was received but could not be used.

## Test plan
- [x] TDD: new/updated tests in `Tests/AppContextBackendTests.swift` observed RED before each production fix, GREEN after
- [x] `make test-transcription`
- [x] `make test` (core, recording, transcription groups)
- [x] `git diff --check`
- [x] `/code-review medium` — 2 findings, both fixed

Closes #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 로컬 AI 모델을 사용할 수 없을 때 문제 기록이 생성됩니다.
  * 클라우드에서 비정상 응답이 반환되면 명확한 오류로 처리됩니다.
  * 경고를 포함한 모든 문제 기록이 있는 컨텍스트를 사용할 수 없는 상태로 판단합니다.

* **테스트**
  * 로컬 모델 미설정 및 클라우드 비정상 응답 처리를 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->