### PR TITLE
Add a final-commit timeout and durable fallback for Realtime transcription

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -9142,10 +9142,6 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    /// Await the realtime WebSocket's final transcript. If it errors out (or
-    /// was never started) fall back to the file-based POST so the user still
-    /// gets a transcript. Runs the realtime commit and file upload in that
-    /// strict order to avoid paying for both when realtime succeeds.
     private static let realtimeCommitTimeoutSeconds: TimeInterval = 10
 
     /// Race an async operation against a timeout. If the timeout wins, the
@@ -9171,6 +9167,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    /// Await the realtime WebSocket's final transcript. If it errors out (or
+    /// was never started) fall back to the file-based POST so the user still
+    /// gets a transcript. Runs the realtime commit and file upload in that
+    /// strict order to avoid paying for both when realtime succeeds.
     private static func resolveRawTranscript(
         realtimeService: RealtimeTranscriptionService?,
         fileService: TranscriptionService,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -9146,6 +9146,31 @@ final class AppState: ObservableObject, @unchecked Sendable {
     /// was never started) fall back to the file-based POST so the user still
     /// gets a transcript. Runs the realtime commit and file upload in that
     /// strict order to avoid paying for both when realtime succeeds.
+    private static let realtimeCommitTimeoutSeconds: TimeInterval = 10
+
+    /// Race an async operation against a timeout. If the timeout wins, the
+    /// operation is cancelled (so its own cancellation handler can clean up)
+    /// and `RealtimeTranscriptionError.commitTimedOut` is thrown.
+    static func raceRealtimeCommitAgainstTimeout(
+        timeoutSeconds: TimeInterval,
+        operation: @escaping @Sendable () async throws -> String
+    ) async throws -> String {
+        try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask {
+                try await operation()
+            }
+            group.addTask {
+                try await Task.sleep(for: .seconds(timeoutSeconds))
+                throw RealtimeTranscriptionError.commitTimedOut
+            }
+            defer { group.cancelAll() }
+            guard let result = try await group.next() else {
+                throw RealtimeTranscriptionError.commitTimedOut
+            }
+            return result
+        }
+    }
+
     private static func resolveRawTranscript(
         realtimeService: RealtimeTranscriptionService?,
         fileService: TranscriptionService,
@@ -9155,10 +9180,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
         if let realtimeService {
             do {
                 try Task.checkCancellation()
-                let text = try await withTaskCancellationHandler {
-                    try await realtimeService.commitAndAwaitFinal()
-                } onCancel: {
-                    realtimeService.cancel()
+                let text = try await Self.raceRealtimeCommitAgainstTimeout(
+                    timeoutSeconds: realtimeCommitTimeoutSeconds
+                ) {
+                    try await withTaskCancellationHandler {
+                        try await realtimeService.commitAndAwaitFinal()
+                    } onCancel: {
+                        realtimeService.cancel()
+                    }
                 }
                 return TranscriptionResult(
                     text: text,

--- a/Sources/RealtimeTranscriptionService.swift
+++ b/Sources/RealtimeTranscriptionService.swift
@@ -8,6 +8,7 @@ enum RealtimeTranscriptionError: LocalizedError {
     case notConnected
     case serverError(code: String, message: String)
     case closedBeforeFinal
+    case commitTimedOut
 
     var errorDescription: String? {
         switch self {
@@ -15,6 +16,7 @@ enum RealtimeTranscriptionError: LocalizedError {
         case .notConnected: return "Realtime transcription socket is not connected"
         case .serverError(let code, let message): return "Realtime server error [\(code)]: \(message)"
         case .closedBeforeFinal: return "Realtime socket closed before emitting the final transcript"
+        case .commitTimedOut: return "Realtime transcript commit did not complete in time"
         }
     }
 }

--- a/Tests/AppStateUserIssueLifecycleSourceTests.swift
+++ b/Tests/AppStateUserIssueLifecycleSourceTests.swift
@@ -14,6 +14,7 @@ struct AppStateUserIssueLifecycleSourceTests {
         try testPostProcessingFallbackPersistsWarningRecord(source)
         try testCorePreparationAndSaveFailuresUseSafePresentation(source)
         try testAudioInputSwitchFailureUsesSafePresentation(source)
+        try testResolveRawTranscriptBoundsRealtimeCommitWait(source)
         try testScopedFlowsDoNotPersistRawLocalizedDescriptions(source)
         print("AppStateUserIssueLifecycleSourceTests passed")
     }
@@ -185,6 +186,35 @@ struct AppStateUserIssueLifecycleSourceTests {
         try expect(
             !inputSwitchFailure.contains("formattedRecordingStartError"),
             "audio input switch failures do not use removed raw formatter"
+        )
+    }
+
+    // A Realtime server that accepts the commit but never emits the final
+    // transcript must not hang the stop flow forever: resolveRawTranscript
+    // must bound the wait and still fall back to file transcription.
+    private static func testResolveRawTranscriptBoundsRealtimeCommitWait(
+        _ source: String
+    ) throws {
+        let resolveBody = block(
+            source,
+            from: "private static func resolveRawTranscript(",
+            to: "private func resolveStoppedRecordingContext("
+        )
+        try expect(
+            resolveBody.contains("Self.raceRealtimeCommitAgainstTimeout("),
+            "resolveRawTranscript bounds the Realtime commit wait with a timeout race"
+        )
+        try expect(
+            !resolveBody.contains("try await realtimeService.commitAndAwaitFinal()\n                } onCancel:"),
+            "resolveRawTranscript no longer awaits the Realtime commit unbounded"
+        )
+        try expect(
+            resolveBody.contains("catch is CancellationError {\n                throw CancellationError()\n            } catch {"),
+            "a timed-out commit still falls through to the existing catch block"
+        )
+        try expect(
+            resolveBody.contains("return try await fileService.transcribe(fileURL: fileURL)"),
+            "a timed-out commit still falls back to file transcription"
         )
     }
 

--- a/Tests/TranscriptionServiceCloudChunkingTests.swift
+++ b/Tests/TranscriptionServiceCloudChunkingTests.swift
@@ -9,6 +9,8 @@ struct TranscriptionServiceCloudChunkingTests {
             try await missingAPIKeyStopsBeforeCloudUpload()
             try await normalizedAPIKeyUsesTrimmedAuthorizationHeader()
             try realtimeMissingAPIKeyStopsBeforeWebSocketCreation()
+            try await realtimeCommitRaceTimesOutWithoutHanging()
+            try await realtimeCommitRaceReturnsResultBeforeTimeout()
             try await smallWAVUsesExistingSingleRequestPath()
             try await smallMP3UsesExistingSingleRequestPath()
             try await cloudVerboseJSONLanguageFlowsIntoResult()
@@ -119,6 +121,39 @@ struct TranscriptionServiceCloudChunkingTests {
             )
         }
         try expectEqual(creations.value, 0, "missing realtime WebSocket count")
+    }
+
+    // A Realtime server that keeps the socket open but never emits the final
+    // committed transcript must not hang the recording-stop flow forever.
+    // The race must finish close to its own timeout, not the operation's.
+    private static func realtimeCommitRaceTimesOutWithoutHanging() async throws {
+        let start = Date()
+        do {
+            _ = try await AppState.raceRealtimeCommitAgainstTimeout(
+                timeoutSeconds: 0.05
+            ) {
+                try await Task.sleep(for: .seconds(999))
+                return "never reached"
+            }
+            throw TestFailure("expected the commit race to time out")
+        } catch let error as RealtimeTranscriptionError {
+            guard case .commitTimedOut = error else {
+                throw TestFailure("expected commitTimedOut, got \(error)")
+            }
+        }
+        let elapsed = Date().timeIntervalSince(start)
+        guard elapsed < 5 else {
+            throw TestFailure("commit race took \(elapsed)s, expected it to time out near 0.05s")
+        }
+    }
+
+    private static func realtimeCommitRaceReturnsResultBeforeTimeout() async throws {
+        let text = try await AppState.raceRealtimeCommitAgainstTimeout(
+            timeoutSeconds: 5
+        ) {
+            "fast result"
+        }
+        try expectEqual(text, "fast result", "commit race result when it finishes first")
     }
 
     private static func smallWAVUsesExistingSingleRequestPath() async throws {


### PR DESCRIPTION
## Summary
- Stopping a Realtime recording could wait forever when the server kept the WebSocket open but never emitted the final committed transcript: `commitAndAwaitFinal()` only resolves on an explicit close or error, and `resolveRawTranscript` wrapped it with no deadline of its own.
- Added `AppState.raceRealtimeCommitAgainstTimeout`, racing the commit wait against a 10-second timeout using the same `withThrowingTaskGroup` pattern already used for the local-transcription timeout in `TranscriptionService`.
- A losing commit is cancelled through the existing `withTaskCancellationHandler` plumbing (`realtimeService.cancel()`), and the new `RealtimeTranscriptionError.commitTimedOut` falls through the existing `catch` block into the existing file-transcription fallback — no new duplicate-note risk, since this function already produces exactly one result per recording.

## Test plan
- [x] TDD: RED before the fix (missing symbols), GREEN after
- [x] New behavioral test: a commit that never resolves times out near its deadline instead of hanging, and a fast commit still returns its result
- [x] New source-shape test confirming `resolveRawTranscript` routes through the timeout race and still falls back to file transcription
- [x] `make test-transcription`, `make test-core`, `make test` (core, recording, transcription groups)
- [x] `git diff --check`
- [x] `/code-review medium` — 2 findings: fixed an orphaned doc comment; skipped extracting a shared generic timeout-race helper (different result/error types, only 2 call sites)

Closes #245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 실시간 전사 커밋에 10초 제한을 추가했습니다.
  * 제한 시간 내 완료되지 않으면 작업을 취소하고 파일 기반 전사로 자동 전환합니다.
  * 실시간 전사 커밋이 정상적으로 완료되면 최종 결과를 반환합니다.

* **버그 수정**
  * 실시간 전사 서비스가 응답하지 않아 처리 과정이 무기한 대기하던 문제를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->