### PR TITLE
Initialize Note Browser and MCP services after first-run setup

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -94,24 +94,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if !appState.hasCompletedSetup {
             showSetupWindow()
         } else {
-            updateActivationPolicy()
-            // 노트 브라우저 활성화 시 앱 시작과 함께 자동 오픈
-            if appState.noteBrowserEnabled {
-                showNoteBrowserWindow()
-            }
-            appState.startHotkeyMonitoring()
-            appState.startAccessibilityPolling()
-            Task { @MainActor in
-                UpdateManager.shared.startPeriodicChecks()
-            }
-
-            if appState.requiresAccessibility, !AXIsProcessTrusted() {
-                appState.promptForAccessibilityAccess()
-            }
-
-            startMCPServer()
-            appState.startCalendarRecordingReminderScheduling()
-            appState.startGoogleCalendarHealthCheck()
+            startPostSetupServices()
         }
 
     }
@@ -319,23 +302,36 @@ private func showNoteBrowserWindow() {
         appState.hasCompletedSetup = true
         setupWindow?.close()
         setupWindow = nil
+        startPostSetupServices()
+    }
+
+    /// Every service a normal relaunch starts once setup is already
+    /// complete. Finishing the setup wizard must start the same set, so
+    /// this is the single shared entry point for both.
+    @MainActor
+    private func startPostSetupServices() {
         updateActivationPolicy()
+        // 노트 브라우저 활성화 시 앱 시작과 함께 자동 오픈
+        if appState.noteBrowserEnabled {
+            showNoteBrowserWindow()
+        }
         appState.startHotkeyMonitoring()
         appState.startAccessibilityPolling()
-        appState.startCalendarRecordingReminderScheduling()
-        appState.startGoogleCalendarHealthCheck()
         Task { @MainActor in
             UpdateManager.shared.startPeriodicChecks()
         }
 
         if appState.requiresAccessibility, !AXIsProcessTrusted() {
-            Task { @MainActor in
-                appState.promptForAccessibilityAccess()
-            }
+            appState.promptForAccessibilityAccess()
         }
+
+        startMCPServer()
+        appState.startCalendarRecordingReminderScheduling()
+        appState.startGoogleCalendarHealthCheck()
     }
 
     private func startMCPServer() {
+        guard mcpServer == nil else { return }
         let server = MCPServer(appState: appState)
         appState.onTranscriptionCompleted = { [weak server] transcript, context in
             server?.notifyRecordingCompleted(transcript: transcript, context: context)

--- a/Tests/SetupFlowTests.swift
+++ b/Tests/SetupFlowTests.swift
@@ -13,6 +13,7 @@ struct SetupFlowTests {
         testNotificationActionTitles()
         try testSetupContainsExactlyFiveScrollableSteps()
         try testSetupWindowIsResizable()
+        try testSetupCompletionSharesPostSetupInitializationWithLaunch()
         try testNativeWhisperDownloadDoesNotLockProcessing()
         try testShortcutStepConfiguresHoldAndToggle()
         print("SetupFlowTests passed")
@@ -162,6 +163,55 @@ struct SetupFlowTests {
         assert(!setupWindow.contains("window.delegate = setupWindowDelegate"))
         assert(!source.contains("private final class SetupWindowDelegate"))
         assert(!source.contains("cancelNativeWhisperInstallForSetupClose()"))
+    }
+
+    // Finishing setup must start the same named services as a normal
+    // relaunch (MCP, hotkey monitoring, accessibility polling, update
+    // checks, Calendar scheduling and health checks, and an enabled Note
+    // Browser) instead of a narrower, hand-duplicated subset.
+    private static func testSetupCompletionSharesPostSetupInitializationWithLaunch() throws {
+        let source = try String(contentsOfFile: "Sources/AppDelegate.swift", encoding: .utf8)
+
+        let launchBody = sourceBlock(
+            in: source,
+            from: "func applicationDidFinishLaunching(",
+            to: "func applicationShouldTerminate("
+        )
+        assert(launchBody.contains("startPostSetupServices()"))
+        assert(!launchBody.contains("appState.startHotkeyMonitoring()"))
+        assert(!launchBody.contains("startMCPServer()"))
+
+        let completeSetupBody = sourceBlock(
+            in: source,
+            from: "func completeSetup()",
+            to: "private func startPostSetupServices("
+        )
+        assert(completeSetupBody.contains("startPostSetupServices()"))
+        assert(!completeSetupBody.contains("appState.startHotkeyMonitoring()"))
+        assert(!completeSetupBody.contains("appState.startCalendarRecordingReminderScheduling()"))
+
+        let sharedBody = sourceBlock(
+            in: source,
+            from: "private func startPostSetupServices()",
+            to: "private func startMCPServer("
+        )
+        assert(sharedBody.contains("updateActivationPolicy()"))
+        assert(sharedBody.contains("if appState.noteBrowserEnabled"))
+        assert(sharedBody.contains("showNoteBrowserWindow()"))
+        assert(sharedBody.contains("appState.startHotkeyMonitoring()"))
+        assert(sharedBody.contains("appState.startAccessibilityPolling()"))
+        assert(sharedBody.contains("UpdateManager.shared.startPeriodicChecks()"))
+        assert(sharedBody.contains("appState.promptForAccessibilityAccess()"))
+        assert(sharedBody.contains("startMCPServer()"))
+        assert(sharedBody.contains("appState.startCalendarRecordingReminderScheduling()"))
+        assert(sharedBody.contains("appState.startGoogleCalendarHealthCheck()"))
+
+        let mcpBody = sourceBlock(
+            in: source,
+            from: "private func startMCPServer() {",
+            to: "\n}"
+        )
+        assert(mcpBody.contains("guard mcpServer == nil else { return }"))
     }
 
     private static func testNativeWhisperDownloadDoesNotLockProcessing() throws {

--- a/Tests/UpdateManagerSafetyTests.swift
+++ b/Tests/UpdateManagerSafetyTests.swift
@@ -113,7 +113,9 @@ struct UpdateManagerSafetyTests {
             $0.contains("UpdateManager.shared.startPeriodicChecks()")
         }.count
 
-        precondition(activeCallCount == 2, "Expected exactly 2 active periodic update check calls")
+        // Normal relaunch and finishing setup share one post-setup
+        // initializer, so this call now has a single active site.
+        precondition(activeCallCount == 1, "Expected exactly 1 active periodic update check call")
         precondition(
             !source.contains("Quill releases are not distributed through the in-app updater yet."),
             "Expected obsolete in-app updater disabled message to be removed"


### PR DESCRIPTION
## Summary
- Finishing the setup wizard started a narrower, hand-duplicated subset of the services a normal relaunch starts: it never opened an enabled Note Browser and never started the MCP server, so a user who finished onboarding had to quit and relaunch Quill before MCP integrations worked.
- Extracted `startPostSetupServices()` as the single shared entry point used by both `applicationDidFinishLaunching`'s already-set-up branch and `completeSetup()`.
- Guarded `startMCPServer()` against being called more than once, since re-running setup via the menu bar's "Redo Setup" and completing it again now reaches this shared path a second time in the same process.

## Test plan
- [x] TDD: RED before the fix (missing shared function), GREEN after
- [x] New source-shape test confirming both entry points call the shared initializer and it contains every required service, plus the MCP double-start guard
- [x] Updated an existing test that hardcoded "exactly 2" call sites for the periodic update check to reflect the new single shared site
- [x] `make test` (core, recording, transcription groups)
- [x] `git diff --check`
- [x] `/code-review medium` — 0 findings

Closes #248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 초기 설정 완료 후 노트 브라우저가 자동으로 표시되고 관련 서비스가 일관되게 시작됩니다.
  * MCP 서버가 중복으로 시작되지 않도록 안정성이 향상되었습니다.
  * 앱 실행 및 설정 마법사 완료 시 업데이트 확인이 중복 실행되지 않습니다.

* **테스트**
  * 설정 완료 후 서비스 초기화와 중복 실행 방지 동작에 대한 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->