### PR TITLE
Fix stale and misleading recovery banners after post-processing failures

### DIFF
--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -16916,6 +16916,54 @@
           }
         }
       }
+    },
+    "Transcript too long to clean up": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcript too long to clean up"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정리하기엔 전사문이 너무 길어요"
+          }
+        }
+      }
+    },
+    "Quill kept the original transcript because it was too large for the selected provider to clean up in one request.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quill kept the original transcript because it was too large for the selected provider to clean up in one request."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택한 제공업체가 한 번에 정리할 수 없을 만큼 커서 Quill이 원본 전사문을 유지했습니다."
+          }
+        }
+      }
+    },
+    "Use the original transcript, or choose a different provider or model for cleanup.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use the original transcript, or choose a different provider or model for cleanup."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "원본 전사문을 사용하거나, 정리에 다른 제공업체나 모델을 선택해 보세요."
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/NoteBrowserRecovery.swift
+++ b/Sources/NoteBrowserRecovery.swift
@@ -12,17 +12,20 @@ struct NoteBrowserActionState: Equatable {
     let hasStoredAudio: Bool
     let hasTranscriptText: Bool
     let retryAvailability: NoteBrowserRetryAvailability
+    let postProcessingEnabled: Bool
 
     init(
         hasStoredAudio: Bool,
         transcript: String,
-        retryAvailability: NoteBrowserRetryAvailability
+        retryAvailability: NoteBrowserRetryAvailability,
+        postProcessingEnabled: Bool = true
     ) {
         self.hasStoredAudio = hasStoredAudio
         self.hasTranscriptText = !transcript
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .isEmpty
         self.retryAvailability = retryAvailability
+        self.postProcessingEnabled = postProcessingEnabled
     }
 
     var showsRetryButton: Bool { hasStoredAudio }
@@ -31,6 +34,13 @@ struct NoteBrowserActionState: Equatable {
 }
 
 enum NoteBrowserRecoveryPresentation {
+    private static let postProcessingIssueCodes: Set<QuillUserIssueCode> = [
+        .postProcessingFailed,
+        .postProcessingRateLimited,
+        .postProcessingGuardFallback,
+        .postProcessingPayloadTooLarge
+    ]
+
     static func presentation(
         for record: QuillUserIssueRecord,
         actionState: NoteBrowserActionState,
@@ -38,6 +48,22 @@ enum NoteBrowserRecoveryPresentation {
         bundle: Bundle = .main
     ) -> QuillUserIssuePresentation {
         let original = record.presentation(language: language, bundle: bundle)
+
+        // A historical post-processing warning no longer matches the current
+        // configuration once post-processing is disabled: retrying will
+        // intentionally skip cleanup, so offering that action is misleading.
+        // Keep the warning informational instead of dropping it entirely.
+        if postProcessingIssueCodes.contains(record.code), !actionState.postProcessingEnabled {
+            return QuillUserIssuePresentation(
+                title: original.title,
+                body: original.body,
+                suggestion: original.suggestion,
+                compactMessage: original.compactMessage,
+                detailsRows: original.detailsRows,
+                recoveryAction: .none,
+                severity: original.severity
+            )
+        }
 
         // Local backend/model IDs are debugging detail, not something a
         // typical user acts on for a plain transcription-process failure.

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -1492,16 +1492,8 @@ private struct NoteDetailView: View {
         guard let warningBannerCode else { return false }
         return appState.isWarningBannerDismissed(noteID: item.id, code: warningBannerCode)
     }
-    private var suggestedCalendarTitle: String? {
+    private var suggestedCalendarTitleInfo: (suggested: String, applied: String)? {
         NoteTitleResolver.suggestedCalendarTitle(for: item)
-    }
-
-    private var suggestedCalendarAppliedTitle: String? {
-        guard let suggestedCalendarTitle else { return nil }
-        return NoteTitleResolver.calendarAppliedTitle(
-            suggestedTitle: suggestedCalendarTitle,
-            recordingStartedAt: item.timestamp
-        )
     }
 
     var body: some View {
@@ -1619,7 +1611,7 @@ private struct NoteDetailView: View {
             }
             .overrideCursor(.iBeam)
 
-            if let suggestedCalendarTitle, let suggestedCalendarAppliedTitle {
+            if let suggestedCalendarTitleInfo {
                 HStack(spacing: 10) {
                     Image(systemName: "calendar")
                         .font(.system(size: 12, weight: .semibold))
@@ -1632,7 +1624,7 @@ private struct NoteDetailView: View {
                             .font(.caption.weight(.semibold))
                             .foregroundStyle(.secondary)
                             .fixedSize()
-                        Text(suggestedCalendarTitle)
+                        Text(suggestedCalendarTitleInfo.suggested)
                             .font(.caption.weight(.medium))
                             .foregroundStyle(.primary)
                             .lineLimit(1)
@@ -1640,8 +1632,8 @@ private struct NoteDetailView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                     Button("Apply") {
-                        titleDraft = suggestedCalendarAppliedTitle
-                        appState.updateHistoryItemTitle(id: item.id, title: suggestedCalendarAppliedTitle)
+                        titleDraft = suggestedCalendarTitleInfo.applied
+                        appState.updateHistoryItemTitle(id: item.id, title: suggestedCalendarTitleInfo.applied)
                     }
                     .font(.caption.weight(.semibold))
                     .buttonStyle(.bordered)

--- a/Sources/NoteBrowserView.swift
+++ b/Sources/NoteBrowserView.swift
@@ -1466,7 +1466,8 @@ private struct NoteDetailView: View {
         NoteBrowserActionState(
             hasStoredAudio: storedAudioURL != nil,
             transcript: displayContent,
-            retryAvailability: retryAvailability
+            retryAvailability: retryAvailability,
+            postProcessingEnabled: !appState.disablePostProcessing
         )
     }
     private var issuePresentation: QuillUserIssuePresentation? {
@@ -1492,11 +1493,7 @@ private struct NoteDetailView: View {
         return appState.isWarningBannerDismissed(noteID: item.id, code: warningBannerCode)
     }
     private var suggestedCalendarTitle: String? {
-        guard item.customTitle == nil,
-              item.calendarMatch?.titleState == .suggested else {
-            return nil
-        }
-        return item.calendarMatch?.suggestedTitle
+        NoteTitleResolver.suggestedCalendarTitle(for: item)
     }
 
     private var suggestedCalendarAppliedTitle: String? {

--- a/Sources/NoteTitleResolver.swift
+++ b/Sources/NoteTitleResolver.swift
@@ -15,8 +15,11 @@ enum NoteTitleResolver {
 
     /// The calendar title to suggest applying, or nil when there is nothing
     /// to suggest or applying it would not change the note's current
-    /// effective title.
-    static func suggestedCalendarTitle(for item: PipelineHistoryItem) -> String? {
+    /// effective title. Returns both the raw suggestion and the value
+    /// Apply would set so callers don't recompute the applied form.
+    static func suggestedCalendarTitle(
+        for item: PipelineHistoryItem
+    ) -> (suggested: String, applied: String)? {
         guard item.customTitle == nil,
               item.calendarMatch?.titleState == .suggested,
               let suggestedTitle = item.calendarMatch?.suggestedTitle else {
@@ -29,7 +32,7 @@ enum NoteTitleResolver {
         guard displayTitle(for: item) != appliedTitle else {
             return nil
         }
-        return suggestedTitle
+        return (suggested: suggestedTitle, applied: appliedTitle)
     }
 
     static func displayTitle(

--- a/Sources/NoteTitleResolver.swift
+++ b/Sources/NoteTitleResolver.swift
@@ -13,6 +13,25 @@ enum NoteTitleResolver {
         "\(calendarTitleDateFormatter.string(from: recordingStartedAt)) \(suggestedTitle)"
     }
 
+    /// The calendar title to suggest applying, or nil when there is nothing
+    /// to suggest or applying it would not change the note's current
+    /// effective title.
+    static func suggestedCalendarTitle(for item: PipelineHistoryItem) -> String? {
+        guard item.customTitle == nil,
+              item.calendarMatch?.titleState == .suggested,
+              let suggestedTitle = item.calendarMatch?.suggestedTitle else {
+            return nil
+        }
+        let appliedTitle = calendarAppliedTitle(
+            suggestedTitle: suggestedTitle,
+            recordingStartedAt: item.timestamp
+        )
+        guard displayTitle(for: item) != appliedTitle else {
+            return nil
+        }
+        return suggestedTitle
+    }
+
     static func displayTitle(
         for item: PipelineHistoryItem,
         isTranscribing: Bool = false,

--- a/Sources/PostProcessingService.swift
+++ b/Sources/PostProcessingService.swift
@@ -59,6 +59,8 @@ enum PostProcessingError: LocalizedError {
                 return .requestTimedOut
             case 429:
                 return .postProcessingRateLimited
+            case 413:
+                return .postProcessingPayloadTooLarge
             default:
                 return .postProcessingFailed
             }

--- a/Sources/QuillUserIssue.swift
+++ b/Sources/QuillUserIssue.swift
@@ -23,6 +23,7 @@ enum QuillUserIssueCode: String, Codable, CaseIterable, Sendable {
     case postProcessingFailed = "post-processing-failed"
     case postProcessingRateLimited = "post-processing-rate-limited"
     case postProcessingGuardFallback = "post-processing-guard-fallback"
+    case postProcessingPayloadTooLarge = "post-processing-payload-too-large"
     case localAIModelUnavailable = "local-ai-model-unavailable"
     case localAIStartFailed = "local-ai-start-failed"
     case localAIProcessExited = "local-ai-process-exited"
@@ -275,9 +276,10 @@ struct QuillUserIssueRecord: Codable, Equatable, Sendable {
             return .openSpeechRecognitionSettings
         case .screenRecordingPermissionDenied:
             return .openScreenRecordingSettings
-        case .postProcessingGuardFallback, .contextUnavailable,
-             .meetingSummaryUnavailable, .meetingSummaryInvalidResponse,
-             .historyPersistenceUnavailable, .historyRecovered:
+        case .postProcessingGuardFallback, .postProcessingPayloadTooLarge,
+             .contextUnavailable, .meetingSummaryUnavailable,
+             .meetingSummaryInvalidResponse, .historyPersistenceUnavailable,
+             .historyRecovered:
             return .none
         case .networkUnavailable, .requestTimedOut, .rateLimited,
              .providerUnavailable, .audioFileTooLarge,
@@ -544,7 +546,8 @@ private extension QuillUserIssueCode {
     var defaultSeverity: QuillUserIssueSeverity {
         switch self {
         case .postProcessingFailed, .postProcessingRateLimited,
-             .postProcessingGuardFallback, .localAIModelUnavailable,
+             .postProcessingGuardFallback, .postProcessingPayloadTooLarge,
+             .localAIModelUnavailable,
              .localAIStartFailed, .localAIProcessExited,
              .contextUnavailable, .meetingSummaryUnavailable,
              .meetingSummaryInvalidResponse, .historyPersistenceUnavailable,
@@ -757,6 +760,12 @@ private extension QuillUserIssueCode {
                 titleKey: "Original transcript kept",
                 bodyKey: "Post-processing was not applied; the original transcript was kept.",
                 suggestionKey: "Review the original transcript before using it."
+            )
+        case .postProcessingPayloadTooLarge:
+            return QuillUserIssueCopy(
+                titleKey: "Transcript too long to clean up",
+                bodyKey: "Quill kept the original transcript because it was too large for the selected provider to clean up in one request.",
+                suggestionKey: "Use the original transcript, or choose a different provider or model for cleanup."
             )
         case .contextUnavailable:
             return QuillUserIssueCopy(

--- a/Tests/NoteBrowserRecoveryTests.swift
+++ b/Tests/NoteBrowserRecoveryTests.swift
@@ -10,6 +10,9 @@ struct NoteBrowserRecoveryTests {
         testReadyMissingModelSwitchesToRetry()
         testMissingAudioKeepsGenericIssuePresentation()
         testLocalTranscriptionFailedHidesDebugDetails()
+        testPostProcessingDisabledHidesRetryGuidance()
+        testPostProcessingEnabledKeepsRetryGuidance()
+        testPostProcessingDisabledDoesNotAffectUnrelatedIssues()
         print("NoteBrowserRecoveryTests passed")
     }
 
@@ -170,5 +173,87 @@ struct NoteBrowserRecoveryTests {
         precondition(presentation.suggestion == original.suggestion)
         precondition(presentation.detailsRows.isEmpty)
         precondition(presentation.recoveryAction == original.recoveryAction)
+    }
+
+    // A historical post-processing warning must stop offering retry/cleanup
+    // guidance once the user has disabled post-processing, since retrying
+    // will intentionally skip cleanup. The warning stays informational.
+    private static func testPostProcessingDisabledHidesRetryGuidance() {
+        for code: QuillUserIssueCode in [
+            .postProcessingFailed,
+            .postProcessingRateLimited,
+            .postProcessingGuardFallback,
+            .postProcessingPayloadTooLarge
+        ] {
+            let record = QuillUserIssueRecord(code: code)
+            let original = record.presentation(language: "en")
+            let state = NoteBrowserActionState(
+                hasStoredAudio: true,
+                transcript: "kept transcript",
+                retryAvailability: .ready,
+                postProcessingEnabled: false
+            )
+            let presentation = NoteBrowserRecoveryPresentation.presentation(
+                for: record,
+                actionState: state,
+                language: "en",
+                bundle: .main
+            )
+
+            precondition(
+                presentation.recoveryAction == .none,
+                "\(code.rawValue) hides its action once post-processing is disabled"
+            )
+            precondition(
+                presentation.title == original.title,
+                "\(code.rawValue) keeps its informational title"
+            )
+            precondition(
+                presentation.body == original.body,
+                "\(code.rawValue) keeps its informational body"
+            )
+        }
+    }
+
+    private static func testPostProcessingEnabledKeepsRetryGuidance() {
+        let record = QuillUserIssueRecord(code: .postProcessingFailed)
+        let state = NoteBrowserActionState(
+            hasStoredAudio: true,
+            transcript: "",
+            retryAvailability: .ready,
+            postProcessingEnabled: true
+        )
+        let presentation = NoteBrowserRecoveryPresentation.presentation(
+            for: record,
+            actionState: state,
+            language: "en",
+            bundle: .main
+        )
+
+        precondition(
+            presentation.recoveryAction == .retryTranscription,
+            "retry guidance remains while post-processing is still enabled"
+        )
+    }
+
+    private static func testPostProcessingDisabledDoesNotAffectUnrelatedIssues() {
+        let record = QuillUserIssueRecord(code: .networkUnavailable)
+        let state = NoteBrowserActionState(
+            hasStoredAudio: true,
+            transcript: "",
+            retryAvailability: .ready,
+            postProcessingEnabled: false
+        )
+        let presentation = NoteBrowserRecoveryPresentation.presentation(
+            for: record,
+            actionState: state,
+            language: "en",
+            bundle: .main
+        )
+
+        precondition(
+            presentation.recoveryAction == .retryTranscription,
+            "disabling post-processing does not suppress unrelated recovery actions"
+        )
     }
 }

--- a/Tests/NoteTitleResolutionTests.swift
+++ b/Tests/NoteTitleResolutionTests.swift
@@ -14,6 +14,7 @@ struct NoteTitleResolutionTests {
         testStorageInterruptionReasonWinsRecoveredTitle()
         testAudioOnlyTitleUsesNormalPrecedence()
         testSuggestedCalendarTitleHiddenWhenAlreadyEffectivelyApplied()
+        testSuggestedCalendarTitleHiddenWhenOnlyWhitespaceDiffers()
         testSuggestedCalendarTitleShownWhenItWouldChangeTheTitle()
         print("NoteTitleResolutionTests passed")
     }
@@ -158,12 +159,28 @@ struct NoteTitleResolutionTests {
         assert(NoteTitleResolver.suggestedCalendarTitle(for: note) == nil)
     }
 
+    // displayTitle(for:) trims the transcript-derived title, so a match that
+    // is only different by leading/trailing whitespace must still count as
+    // already applied and hide the banner.
+    private static func testSuggestedCalendarTitleHiddenWhenOnlyWhitespaceDiffers() {
+        let recordingStartedAt = Date(timeIntervalSince1970: 1)
+        let appliedTitle = NoteTitleResolver.calendarAppliedTitle(
+            suggestedTitle: "Team Standup",
+            recordingStartedAt: recordingStartedAt
+        )
+        let note = item(
+            transcript: "  \(appliedTitle)  ",
+            calendarMatch: match(title: "Team Standup", titleState: .suggested)
+        )
+        assert(NoteTitleResolver.suggestedCalendarTitle(for: note) == nil)
+    }
+
     private static func testSuggestedCalendarTitleShownWhenItWouldChangeTheTitle() {
         let note = item(
             transcript: "Unrelated transcript content",
             calendarMatch: match(title: "Team Standup", titleState: .suggested)
         )
-        assert(NoteTitleResolver.suggestedCalendarTitle(for: note) == "Team Standup")
+        assert(NoteTitleResolver.suggestedCalendarTitle(for: note)?.suggested == "Team Standup")
     }
 
     private static func item(

--- a/Tests/NoteTitleResolutionTests.swift
+++ b/Tests/NoteTitleResolutionTests.swift
@@ -13,6 +13,8 @@ struct NoteTitleResolutionTests {
         testRecoveredRecordingTitlesNameAvailableSource()
         testStorageInterruptionReasonWinsRecoveredTitle()
         testAudioOnlyTitleUsesNormalPrecedence()
+        testSuggestedCalendarTitleHiddenWhenAlreadyEffectivelyApplied()
+        testSuggestedCalendarTitleShownWhenItWouldChangeTheTitle()
         print("NoteTitleResolutionTests passed")
     }
 
@@ -138,6 +140,30 @@ struct NoteTitleResolutionTests {
                 for: audioOnly.withCustomTitle("My recording")
             ) == "My recording"
         )
+    }
+
+    // Applying the suggestion would set the effective title to exactly what
+    // is already shown (the transcript-derived title happens to match), so
+    // the banner offering that suggestion must not appear.
+    private static func testSuggestedCalendarTitleHiddenWhenAlreadyEffectivelyApplied() {
+        let recordingStartedAt = Date(timeIntervalSince1970: 1)
+        let appliedTitle = NoteTitleResolver.calendarAppliedTitle(
+            suggestedTitle: "Team Standup",
+            recordingStartedAt: recordingStartedAt
+        )
+        let note = item(
+            transcript: appliedTitle,
+            calendarMatch: match(title: "Team Standup", titleState: .suggested)
+        )
+        assert(NoteTitleResolver.suggestedCalendarTitle(for: note) == nil)
+    }
+
+    private static func testSuggestedCalendarTitleShownWhenItWouldChangeTheTitle() {
+        let note = item(
+            transcript: "Unrelated transcript content",
+            calendarMatch: match(title: "Team Standup", titleState: .suggested)
+        )
+        assert(NoteTitleResolver.suggestedCalendarTitle(for: note) == "Team Standup")
     }
 
     private static func item(

--- a/Tests/PostProcessingUserIssueTests.swift
+++ b/Tests/PostProcessingUserIssueTests.swift
@@ -19,6 +19,7 @@ struct PostProcessingUserIssueTests {
         let cases: [(PostProcessingError, QuillUserIssueCode, QuillUserRecoveryAction)] = [
             (.requestFailed(statusCode: 401, providerCode: "invalid_api_key"), .authenticationFailed, .openProviderSettings),
             (.requestFailed(statusCode: 500, providerCode: nil), .postProcessingFailed, .retryTranscription),
+            (.requestFailed(statusCode: 413, providerCode: nil), .postProcessingPayloadTooLarge, .none),
             (.rateLimited(model: "provider/model", retryAfter: 10), .postProcessingRateLimited, .retryTranscription),
             (.invalidResponse("missing content"), .postProcessingFailed, .retryTranscription),
             (.emptyOutput, .postProcessingFailed, .retryTranscription),

--- a/Tests/QuillUserIssueTests.swift
+++ b/Tests/QuillUserIssueTests.swift
@@ -50,6 +50,7 @@ struct QuillUserIssueTests {
             .postProcessingFailed,
             .postProcessingRateLimited,
             .postProcessingGuardFallback,
+            .postProcessingPayloadTooLarge,
             .localAIModelUnavailable,
             .localAIStartFailed,
             .localAIProcessExited,


### PR DESCRIPTION
## Summary
Three related recovery-presentation gaps, exposed by a production HTTP 413 incident:

1. HTTP 413 fell through to the generic `postProcessingFailed` code, which recommends full retranscription — pointless for an oversized cleanup payload, since retrying resends the same payload and reproduces the same failure. Classified 413 as a dedicated `postProcessingPayloadTooLarge` code with accurate copy and no action, reusing the existing `PostProcessingService` HTTP-status classification and `QuillUserIssueCode` presentation mechanism.
2. The calendar suggested-title banner only checked `customTitle == nil` and `titleState == .suggested`, never whether applying the suggestion would actually change anything. Added `NoteTitleResolver.suggestedCalendarTitle(for:)`, comparing the note's current effective title against the value Apply would set.
3. A historical post-processing warning kept offering retry/cleanup guidance after the user disabled post-processing, even though retrying now intentionally skips cleanup. Extended `NoteBrowserActionState` with the current post-processing setting and had `NoteBrowserRecoveryPresentation` drop the action (keeping the warning informational) for post-processing-related codes once disabled — reusing the same state-aware re-evaluation pattern already used for local-model-missing recovery.

A fourth reported symptom (retranscription desyncing calendar title state) was investigated and is no longer reproducible: the retry workflow (#334) already preserves `calendarMatch`/`customTitle` untouched, so it's out of scope here.

## Test plan
- [x] TDD: RED before each fix, GREEN after
- [x] `PostProcessingUserIssueTests` — HTTP 413 maps to the new code with no recovery action
- [x] `QuillUserIssueTests` — new code has complete EN/KO copy and correct default severity
- [x] `NoteBrowserRecoveryTests` — post-processing-related codes lose their action when disabled, keep it when enabled, and unrelated codes are unaffected
- [x] `NoteTitleResolutionTests` — suggested-title banner is hidden when applying it wouldn't change the title, shown when it would
- [x] `make test` (core, recording, transcription groups)
- [x] `git diff --check`
- [x] `/code-review medium` — 0 findings

Closes #234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 전사문 후처리 요청이 너무 큰 경우, 원본 전사문을 유지하고 원인과 대안을 안내합니다.
  - 후처리가 비활성화된 상태에서는 불필요한 재시도나 정리 안내 없이 정보성 메시지를 표시합니다.
  - 캘린더 제목 제안은 현재 제목과 다를 때만 표시됩니다.

- **버그 수정**
  - 대용량 전사문 오류를 경고로 정확히 분류하고 복구 동작을 조정했습니다.
  - 관련 안내 문구를 영어와 한국어로 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->