### PR TITLE
Surface a notice when combined capture starts with only one source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -643,6 +643,8 @@ _test-recording: | $(TEST_BUILD_DIR)
 	@$(TEST_BUILD_DIR)/SystemAudioRecorderSourceTests
 	@swiftc -parse-as-library Tests/SystemDefaultAndSystemAudioRecorderSourceTests.swift -o $(TEST_BUILD_DIR)/SystemDefaultAndSystemAudioRecorderSourceTests
 	@$(TEST_BUILD_DIR)/SystemDefaultAndSystemAudioRecorderSourceTests
+	@swiftc -parse-as-library Tests/RecordingOverlayNoticeSourceTests.swift -o $(TEST_BUILD_DIR)/RecordingOverlayNoticeSourceTests
+	@$(TEST_BUILD_DIR)/RecordingOverlayNoticeSourceTests
 	@swiftc -parse-as-library "$(CURDIR)/Sources/CanonicalPCM16WAV.swift" "$(CURDIR)/Sources/AudioMixdownService.swift" "$(CURDIR)/Tests/AudioMixdownServiceTests.swift" -o $(TEST_BUILD_DIR)/AudioMixdownServiceTests
 	@$(TEST_BUILD_DIR)/AudioMixdownServiceTests
 	@swiftc -parse-as-library "$(CURDIR)/Sources/AudioImportConversionService.swift" "$(CURDIR)/Tests/AudioImportConversionServiceTests.swift" -o $(TEST_BUILD_DIR)/AudioImportConversionServiceTests

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ FULL_SOURCE_APP_STATE_TESTS = \
 	Tests/NativeWhisperModelWorkflowTests.swift \
 	Tests/LocalAIModelWorkflowTests.swift \
 	Tests/AppStateStorageSafetyTests.swift \
+	Tests/CombinedCaptureDegradationTests.swift \
 	Tests/AppStateHistoryProtectionSourceTests.swift \
 	Tests/AppStateTranscriptionConfigurationTests.swift \
 	Tests/AppStateAIProcessingBackendTests.swift \

--- a/Resources/Localization/Localizable.xcstrings
+++ b/Resources/Localization/Localizable.xcstrings
@@ -16964,6 +16964,38 @@
           }
         }
       }
+    },
+    "No mic — recording with System Audio only": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No mic — recording with System Audio only"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마이크 없음 — 시스템 오디오만으로 녹음 중"
+          }
+        }
+      }
+    },
+    "No System Audio — recording with Mic only": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No System Audio — recording with Mic only"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 오디오 없음 — 마이크만으로 녹음 중"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -5112,17 +5112,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @MainActor
     private func startSelectedAudioRecorder(
         selection: RecordingAudioSelection
-    ) async throws {
+    ) async throws -> DegradedCombinedCaptureSource? {
         let inputID = selection.inputID
         let controller = try makeActiveSegmentedJournalController(inputID: inputID)
         attachSegmentedJournalSinks(controller.activeSegment, inputID: inputID)
         do {
-            try await startPhysicalAudioRecorder(selection: selection)
+            let degradedSource = try await startPhysicalAudioRecorder(selection: selection)
             controller.startCheckpointing { [weak self] error in
                 DispatchQueue.main.async {
                     self?.reportRecordingJournalCheckpointFailure(error)
                 }
             }
+            return degradedSource
         } catch {
             detachSegmentedJournalSinks()
             activeSegmentedJournalController = nil
@@ -5137,9 +5138,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @MainActor
     private func startPhysicalAudioRecorder(
         selection: RecordingAudioSelection
-    ) async throws {
+    ) async throws -> DegradedCombinedCaptureSource? {
         let inputID = selection.inputID
         let microphoneUsedSystemDefaultFallback: Bool
+        var degradedSource: DegradedCombinedCaptureSource?
         switch AudioRecordingSource(inputID: inputID) {
         case .microphone:
             let result = try audioRecorder.startRecording(deviceUID: inputID)
@@ -5153,11 +5155,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
             )
             microphoneUsedSystemDefaultFallback =
                 result.microphoneUsedSystemDefaultFallback
+            degradedSource = result.missingSource
         }
 
         if microphoneUsedSystemDefaultFallback {
             applySystemDefaultMicrophoneFallback(for: inputID)
         }
+        return degradedSource
     }
 
     @MainActor
@@ -5168,6 +5172,26 @@ final class AppState: ObservableObject, @unchecked Sendable {
             activeAudioInputID = AudioInputDevice.defaultMicrophoneID
         }
         refreshOverlayInputOptions()
+    }
+
+    /// The message a partial combined start surfaces, naming which source
+    /// is missing and which one recording continues with.
+    static func degradedCombinedCaptureMessage(missing: DegradedCombinedCaptureSource) -> String {
+        switch missing {
+        case .microphone:
+            return localizedCatalogString("No mic — recording with System Audio only")
+        case .systemAudio:
+            return localizedCatalogString("No System Audio — recording with Mic only")
+        }
+    }
+
+    @MainActor
+    private func showDegradedCombinedCaptureNoticeIfNeeded(_ degradedSource: DegradedCombinedCaptureSource?) {
+        guard let degradedSource else { return }
+        overlayManager.showDegradedCombinedCaptureNotice(
+            Self.degradedCombinedCaptureMessage(missing: degradedSource),
+            reminderFrame: meetingReminderOverlayManager.visibleOverlayFrame
+        )
     }
 
     private func journalSourceRequests(
@@ -5859,7 +5883,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 Task { [weak self] in
                     guard let self else { return }
                     do {
-                        try await self.startPhysicalAudioRecorder(selection: newSelection)
+                        let degradedSource = try await self.startPhysicalAudioRecorder(selection: newSelection)
                         await MainActor.run {
                             guard self.activeInputSwitchToken == switchToken,
                                   self.isRecording else { return }
@@ -5872,6 +5896,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             .sink { [weak self] level in
                                 self?.overlayManager.updateAudioLevel(level)
                             }
+                            self.showDegradedCombinedCaptureNoticeIfNeeded(degradedSource)
                         }
                     } catch {
                         await MainActor.run {
@@ -8713,13 +8738,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         }
                         self.audioRecorder.onRecordingReady?()
                     } else {
-                        try await self.startSelectedAudioRecorder(selection: audioSelection)
+                        let degradedSource = try await self.startSelectedAudioRecorder(selection: audioSelection)
                         let actualRecordingStartedAt = Date()
                         await MainActor.run {
                             self.markRecordingStarted(actualRecordingStartedAt)
                             if self.isRecording, self.activeRecordingTriggerMode != nil {
                                 onStarted?()
                             }
+                            self.showDegradedCombinedCaptureNoticeIfNeeded(degradedSource)
                         }
                         os_log(.info, log: recordingLog, "selected audio recorder start done: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
                     }
@@ -8749,7 +8775,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 guard let self else { return }
                 let t0 = CFAbsoluteTimeGetCurrent()
                 do {
-                    try await self.startSelectedAudioRecorder(selection: audioSelection)
+                    let degradedSource = try await self.startSelectedAudioRecorder(selection: audioSelection)
                     let actualRecordingStartedAt = Date()
                     os_log(.info, log: recordingLog, "selected audio recorder start done: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
                     await MainActor.run {
@@ -8764,6 +8790,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             .sink { [weak self] level in
                                 self?.overlayManager.updateAudioLevel(level)
                             }
+                        self.showDegradedCombinedCaptureNoticeIfNeeded(degradedSource)
                     }
                 } catch {
                     await MainActor.run {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -321,6 +321,40 @@ enum MeetingSummaryAvailability: Equatable {
     case generationInProgress
 }
 
+struct RecordingStartLifecycle {
+    private(set) var activeID: UUID?
+    private var cleanupID: UUID?
+
+    var isIdle: Bool { activeID == nil }
+
+    mutating func begin(_ id: UUID) -> Bool {
+        guard activeID == nil else { return false }
+        activeID = id
+        cleanupID = nil
+        return true
+    }
+
+    mutating func beginCleanup(for id: UUID) -> Bool {
+        guard activeID == id, cleanupID == nil else { return false }
+        cleanupID = id
+        return true
+    }
+
+    mutating func beginOrAdoptCleanup(fallbackID: UUID) -> UUID {
+        let id = activeID ?? fallbackID
+        activeID = id
+        cleanupID = id
+        return id
+    }
+
+    mutating func finish(_ id: UUID) -> Bool {
+        guard activeID == id else { return false }
+        activeID = nil
+        cleanupID = nil
+        return true
+    }
+}
+
 final class AppState: ObservableObject, @unchecked Sendable {
     static var audioImportCloudTranscriptionDependenciesFactory:
         () -> CloudTranscriptionDependencies = {
@@ -378,9 +412,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private struct PendingRecordingPermissionContext {
+        let startRequestID: UUID
         let triggerMode: RecordingTriggerMode
         let selectionSnapshot: AppSelectionSnapshot?
         let manualCommandRequested: Bool?
+        let onStarted: (@MainActor () -> Void)?
     }
 
     private let apiKeyStorageKey = "groq_api_key"
@@ -1996,22 +2032,38 @@ final class AppState: ObservableObject, @unchecked Sendable {
     let hotkeyManager = HotkeyManager()
     let overlayManager = RecordingOverlayManager()
     @MainActor
-    private lazy var meetingReminderOverlayManager = MeetingReminderOverlayManager { [weak self] in
-        guard let self else {
-            return MeetingReminderOverlayContext(phase: .idle, layout: .centerDropdownFill)
+    private lazy var meetingReminderOverlayManager: MeetingReminderOverlayManager = {
+        let manager = MeetingReminderOverlayManager { [weak self] in
+            guard let self else {
+                return MeetingReminderOverlayContext(
+                    phase: .idle,
+                    layout: .centerDropdownFill
+                )
+            }
+            let phase: MeetingReminderOverlayContext.Phase =
+                if self.isRecording || self.isDebugOverlayActive {
+                    // Treat the debug overlay as recording so the reminder shows
+                    // its recording (wrapping) variant for visual testing.
+                    .recording
+                } else if self.isTranscribing {
+                    .processing
+                } else {
+                    .idle
+                }
+            let layout: MeetingReminderOverlayContext.Layout =
+                self.recordingOverlayLayout == .notchSides
+                    ? .notchSides
+                    : .centerDropdownFill
+            return MeetingReminderOverlayContext(
+                phase: phase,
+                layout: layout
+            )
         }
-        let phase: MeetingReminderOverlayContext.Phase = if self.isRecording || self.isDebugOverlayActive {
-            // Treat the debug overlay as recording so the reminder shows its
-            // recording (wrapping) variant for visual testing in dev builds.
-            .recording
-        } else if self.isTranscribing {
-            .processing
-        } else {
-            .idle
+        manager.onVisibleOverlayFrameChange = { [weak self] frame in
+            self?.overlayManager.recordingReminderFrameDidChange(frame)
         }
-        let layout: MeetingReminderOverlayContext.Layout = self.recordingOverlayLayout == .notchSides ? .notchSides : .centerDropdownFill
-        return MeetingReminderOverlayContext(phase: phase, layout: layout)
-    }
+        return manager
+    }()
     private var accessibilityTimer: Timer?
     private var audioLevelCancellable: AnyCancellable?
     private var debugOverlayTimer: Timer?
@@ -2139,10 +2191,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
-    private func accessibleCurrentRecordingAudioSelection() async -> RecordingAudioSelection? {
+    private func accessibleCurrentRecordingAudioSelection(
+        startRequestID: UUID,
+        onStarted: (@MainActor () -> Void)?
+    ) async -> RecordingAudioSelection? {
         while true {
             let selection = currentRecordingAudioSelection()
-            guard await ensureRecordingInputAccess(for: selection) else {
+            guard await ensureRecordingInputAccess(
+                for: selection,
+                startRequestID: startRequestID,
+                onStarted: onStarted
+            ) else {
                 return nil
             }
             if selection == currentRecordingAudioSelection() {
@@ -2153,6 +2212,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private var activeAudioInputID: String?
     private var activeInputSwitchToken: UUID?
+    private var recordingStartAdmissionLifecycle = RecordingStartLifecycle()
+    private var pendingRecordingStartTask: Task<Void, Never>?
+    private var physicalAudioStartLifecycle = RecordingStartLifecycle()
     private var isActiveInputSwitchPhysicalStopInProgress = false
     private var isCancelConfirmationShowing = false
     private var overlayTranscriptionID: UUID = UUID()
@@ -3018,7 +3080,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
         Task { @MainActor [weak self] in
             self?.meetingReminderOverlayManager.onStart = { [weak self] schedule in
-                guard let self else { return }
+                guard let self,
+                      !self.isRecording,
+                      self.recordingStartAdmissionLifecycle.isIdle,
+                      self.physicalAudioStartLifecycle.isIdle else {
+                    return
+                }
                 self.activeRecordingCalendarSnapshot = RecordingCalendarSnapshot(
                     eventID: schedule.event.id,
                     calendarID: schedule.event.calendarID,
@@ -5064,18 +5131,21 @@ final class AppState: ObservableObject, @unchecked Sendable {
         systemAudioRecorder.onPCM16Samples = nil
         systemDefaultAndSystemAudioRecorder.onRecordingReady = nil
         systemDefaultAndSystemAudioRecorder.onRecordingFailure = nil
+        systemDefaultAndSystemAudioRecorder.onRecordingDegraded = nil
     }
 
     @MainActor
     private func configureSelectedAudioRecorderCallbacks(
         inputID: String,
         onReady: @escaping () -> Void,
-        onFailure: @escaping (Error) -> Void
+        onFailure: @escaping (Error) -> Void,
+        onDegraded: ((DegradedCombinedCaptureSource) -> Void)? = nil
     ) {
         clearAudioRecorderCallbacks()
         if AudioInputDevice.isSystemDefaultAndSystemAudio(inputID) {
             systemDefaultAndSystemAudioRecorder.onRecordingReady = onReady
             systemDefaultAndSystemAudioRecorder.onRecordingFailure = onFailure
+            systemDefaultAndSystemAudioRecorder.onRecordingDegraded = onDegraded
         } else if AudioInputDevice.isSystemAudio(inputID) {
             systemAudioRecorder.onRecordingReady = onReady
             systemAudioRecorder.onRecordingFailure = onFailure
@@ -5111,13 +5181,24 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func startSelectedAudioRecorder(
-        selection: RecordingAudioSelection
+        selection: RecordingAudioSelection,
+        sessionID: UUID
     ) async throws -> DegradedCombinedCaptureSource? {
         let inputID = selection.inputID
         let controller = try makeActiveSegmentedJournalController(inputID: inputID)
         attachSegmentedJournalSinks(controller.activeSegment, inputID: inputID)
         do {
             let degradedSource = try await startPhysicalAudioRecorder(selection: selection)
+            guard isCurrentRecordingSession(sessionID),
+                  activeSegmentedJournalController?.recordingID == sessionID else {
+                return degradedSource
+            }
+            if let degradedSource {
+                try markDegradedJournalSourceUnavailableAtStart(
+                    controller: controller,
+                    degradedSource: degradedSource
+                )
+            }
             controller.startCheckpointing { [weak self] error in
                 DispatchQueue.main.async {
                     self?.reportRecordingJournalCheckpointFailure(error)
@@ -5125,12 +5206,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
             return degradedSource
         } catch {
+            guard isCurrentRecordingSession(sessionID),
+                  activeSegmentedJournalController?.recordingID == sessionID else {
+                throw error
+            }
+            if let sourceFailure = controller.terminalPersistenceFailure {
+                handleRecordingJournalPersistenceFailure(sourceFailure)
+                throw error
+            }
             detachSegmentedJournalSinks()
             activeSegmentedJournalController = nil
-            activeRecordingID = nil
-            cancelPhysicalAudioRecorder(inputID: inputID) { [weak self] in
-                self?.discardSegmentedJournal(controller)
-            }
+            await cancelPhysicalAudioRecorder(inputID: inputID)
+            discardSegmentedJournal(controller)
             throw error
         }
     }
@@ -5174,6 +5261,46 @@ final class AppState: ObservableObject, @unchecked Sendable {
         refreshOverlayInputOptions()
     }
 
+    @MainActor
+    private func isCurrentRecordingSession(_ sessionID: UUID) -> Bool {
+        isRecording
+            && activeRecordingTriggerMode != nil
+            && activeRecordingID == sessionID
+    }
+
+    @MainActor
+    private func finishPhysicalAudioStart(_ operationID: UUID) {
+        _ = physicalAudioStartLifecycle.finish(operationID)
+    }
+
+    @MainActor
+    private func takeLiveTranscriberIfOwned(
+        _ transcriber: any LiveTranscriber
+    ) -> (any LiveTranscriber)? {
+        guard let current = liveTranscriber, current === transcriber else {
+            return nil
+        }
+        liveTranscriber = nil
+        return current
+    }
+
+    @MainActor
+    private func rollbackStalePhysicalAudioStart(
+        operationID: UUID,
+        inputID: String,
+        liveTranscriber: (any LiveTranscriber)? = nil
+    ) {
+        liveTranscriber?.cancel()
+        guard physicalAudioStartLifecycle.beginCleanup(for: operationID) else {
+            return
+        }
+        cancelPhysicalAudioRecorder(inputID: inputID) { [weak self] in
+            Task { @MainActor [weak self] in
+                _ = self?.physicalAudioStartLifecycle.finish(operationID)
+            }
+        }
+    }
+
     /// The message a partial combined start surfaces, naming which source
     /// is missing and which one recording continues with.
     static func degradedCombinedCaptureMessage(missing: DegradedCombinedCaptureSource) -> String {
@@ -5186,12 +5313,60 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
-    private func showDegradedCombinedCaptureNoticeIfNeeded(_ degradedSource: DegradedCombinedCaptureSource?) {
-        guard let degradedSource else { return }
-        overlayManager.showDegradedCombinedCaptureNotice(
-            Self.degradedCombinedCaptureMessage(missing: degradedSource),
+    private func reconcileDegradedCombinedCaptureNotice(
+        _ degradedSource: DegradedCombinedCaptureSource?,
+        sessionID: UUID
+    ) {
+        let message = degradedSource.map {
+            Self.degradedCombinedCaptureMessage(missing: $0)
+        }
+        overlayManager.reconcileDegradedCombinedCaptureNotice(
+            message: message,
+            sessionID: sessionID,
             reminderFrame: meetingReminderOverlayManager.visibleOverlayFrame
         )
+    }
+
+    @MainActor
+    private func checkpointCombinedRecordingJournalAfterFirstReady(
+        inputID: String,
+        sessionID: UUID
+    ) {
+        guard AudioInputDevice.isSystemDefaultAndSystemAudio(inputID) else {
+            return
+        }
+        guard isCurrentRecordingSession(sessionID),
+              let controller = activeSegmentedJournalController,
+              controller.recordingID == sessionID else {
+            return
+        }
+        do {
+            try controller.checkpoint()
+        } catch {
+            reportRecordingJournalCheckpointFailure(error)
+        }
+    }
+
+    private func markDegradedJournalSourceUnavailableAtStart(
+        controller: SegmentedRecordingJournalController,
+        degradedSource: DegradedCombinedCaptureSource
+    ) throws {
+        let sourceKind: RecordingJournalSourceKind = switch degradedSource {
+        case .microphone: .microphone
+        case .systemAudio: .systemAudio
+        }
+        try controller.markActiveSourceUnavailableAtStart(sourceKind)
+    }
+
+    private func markDegradedJournalSourceUnavailableDuringRecording(
+        controller: SegmentedRecordingJournalController,
+        degradedSource: DegradedCombinedCaptureSource
+    ) throws {
+        let sourceKind: RecordingJournalSourceKind = switch degradedSource {
+        case .microphone: .microphone
+        case .systemAudio: .systemAudio
+        }
+        try controller.markActiveSourceUnavailableDuringRecording(sourceKind)
     }
 
     private func journalSourceRequests(
@@ -5273,12 +5448,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
         prepareForRecordingJournalPersistenceFailure(sourceFailure)
         if physicalStopInProgress { return }
 
+        let cleanupID = beginPhysicalAudioCleanup()
         let inputID = activeAudioInputID ?? selectedMicrophoneID
         stopPhysicalAudioRecorder(inputID: inputID) { [weak self] temporaryURLs in
             guard let self else {
                 for url in temporaryURLs { try? FileManager.default.removeItem(at: url) }
                 return
             }
+            _ = self.physicalAudioStartLifecycle.finish(cleanupID)
             self.finishRecordingAfterJournalPersistenceFailure(
                 controller: controller,
                 sourceFailure: sourceFailure,
@@ -5312,6 +5489,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private func prepareForRecordingJournalPersistenceFailure(
         _ sourceFailure: RecordingJournalSourcePersistenceFailure
     ) {
+        overlayManager.endDegradedCombinedCaptureNoticeSession()
         activeRecordingStorageFailureID = sourceFailure.recordingID
         detachSegmentedJournalSinks()
         activeInputSwitchToken = nil
@@ -5514,9 +5692,22 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    private func cancelPhysicalAudioRecorder(inputID: String) async {
+        await withCheckedContinuation { continuation in
+            cancelPhysicalAudioRecorder(inputID: inputID) {
+                continuation.resume()
+            }
+        }
+    }
+
+    private func beginPhysicalAudioCleanup() -> UUID {
+        physicalAudioStartLifecycle.beginOrAdoptCleanup(fallbackID: UUID())
+    }
+
     private func stopActiveAudioRecorder(
         completion: @escaping (StoppedAudioRecording) -> Void
     ) {
+        let cleanupID = beginPhysicalAudioCleanup()
         let inputID = activeAudioInputID ?? selectedMicrophoneID
         stopPhysicalAudioRecorder(inputID: inputID) { [weak self] temporaryURLs in
             guard let self else {
@@ -5529,6 +5720,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 temporaryURLs: temporaryURLs,
                 completion: completion
             )
+            _ = self.physicalAudioStartLifecycle.finish(cleanupID)
         }
     }
 
@@ -5619,12 +5811,17 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     private func cancelActiveAudioRecorder() {
+        let cleanupID = beginPhysicalAudioCleanup()
         let inputID = activeAudioInputID ?? selectedMicrophoneID
         activeInputSwitchToken = nil
         isActiveInputSwitchPhysicalStopInProgress = false
         detachSegmentedJournalSinks()
         cancelPhysicalAudioRecorder(inputID: inputID) { [weak self] in
-            self?.discardActiveSegmentedJournal()
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                _ = self.physicalAudioStartLifecycle.finish(cleanupID)
+                self.discardActiveSegmentedJournal()
+            }
         }
     }
 
@@ -5795,6 +5992,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     /// durable recording manifest.
     @MainActor
     func switchActiveRecordingInput(to newInputID: String) {
+        guard physicalAudioStartLifecycle.isIdle else { return }
         guard isRecording,
               activeInputSwitchToken == nil,
               let controller = activeSegmentedJournalController else {
@@ -5824,6 +6022,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             microphoneDeviceID: selectedMicrophoneDeviceID
         )
         let switchToken = UUID()
+        guard physicalAudioStartLifecycle.begin(switchToken) else { return }
         activeInputSwitchToken = switchToken
         isActiveInputSwitchPhysicalStopInProgress = true
         tearDownLiveTranscriberOffMainThread()
@@ -5840,6 +6039,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             self.isActiveInputSwitchPhysicalStopInProgress = false
             guard self.activeInputSwitchToken == switchToken,
                   self.isRecording else {
+                self.finishPhysicalAudioStart(switchToken)
                 if self.activeRecordingStorageFailureID == controller.recordingID,
                    let sourceFailure = controller.terminalPersistenceFailure {
                     self.finishRecordingAfterJournalPersistenceFailure(
@@ -5870,45 +6070,113 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 self.refreshOverlayInputOptions()
                 self.configureSelectedAudioRecorderCallbacks(
                     inputID: newInputID,
-                    onReady: {},
+                    onReady: { [weak self] in
+                        DispatchQueue.main.async {
+                            guard let self,
+                                  self.isCurrentRecordingSession(controller.recordingID),
+                                  AudioInputDevice.isSameInput(
+                                      self.activeAudioInputID ?? self.selectedMicrophoneID,
+                                      newInputID
+                                  ) else { return }
+                            self.checkpointCombinedRecordingJournalAfterFirstReady(
+                                inputID: newInputID,
+                                sessionID: controller.recordingID
+                            )
+                        }
+                    },
                     onFailure: { [weak self] error in
                         DispatchQueue.main.async {
-                            self?.finishAfterInputSwitchStartFailure(
-                                error,
-                                switchToken: switchToken
+                            guard let self else { return }
+                            if self.activeInputSwitchToken == switchToken {
+                                self.finishAfterInputSwitchStartFailure(
+                                    error,
+                                    switchToken: switchToken
+                                )
+                            } else if self.isCurrentRecordingSession(controller.recordingID),
+                                      AudioInputDevice.isSameInput(
+                                          self.activeAudioInputID ?? self.selectedMicrophoneID,
+                                          newInputID
+                                      ) {
+                                self.handleRecordingFailure(error)
+                            }
+                        }
+                    },
+                    onDegraded: { [weak self] degradedSource in
+                        DispatchQueue.main.async {
+                            guard let self,
+                                  self.isCurrentRecordingSession(controller.recordingID),
+                                  AudioInputDevice.isSameInput(
+                                      self.activeAudioInputID ?? self.selectedMicrophoneID,
+                                      newInputID
+                                  ) else { return }
+                            do {
+                                try self.markDegradedJournalSourceUnavailableDuringRecording(
+                                    controller: controller,
+                                    degradedSource: degradedSource
+                                )
+                            } catch {
+                                self.reportRecordingJournalCheckpointFailure(error)
+                            }
+                            self.reconcileDegradedCombinedCaptureNotice(
+                                degradedSource,
+                                sessionID: controller.recordingID
                             )
                         }
                     }
                 )
-                Task { [weak self] in
+                Task { @MainActor [weak self] in
                     guard let self else { return }
                     do {
                         let degradedSource = try await self.startPhysicalAudioRecorder(selection: newSelection)
-                        await MainActor.run {
-                            guard self.activeInputSwitchToken == switchToken,
-                                  self.isRecording else { return }
-                            self.activeInputSwitchToken = nil
-                            self.isActiveInputSwitchPhysicalStopInProgress = false
-                            self.audioLevelCancellable = self.activeRecorderAudioLevelPublisher(
+                        guard self.activeInputSwitchToken == switchToken,
+                              self.isCurrentRecordingSession(controller.recordingID) else {
+                            self.rollbackStalePhysicalAudioStart(
+                                operationID: switchToken,
                                 inputID: newInputID
                             )
-                            .receive(on: DispatchQueue.main)
-                            .sink { [weak self] level in
-                                self?.overlayManager.updateAudioLevel(level)
-                            }
-                            self.showDegradedCombinedCaptureNoticeIfNeeded(degradedSource)
+                            return
                         }
-                    } catch {
-                        await MainActor.run {
-                            self.finishAfterInputSwitchStartFailure(
-                                error,
-                                switchToken: switchToken
+                        if let degradedSource {
+                            try self.markDegradedJournalSourceUnavailableAtStart(
+                                controller: controller,
+                                degradedSource: degradedSource
                             )
                         }
+                        self.finishPhysicalAudioStart(switchToken)
+                        self.activeInputSwitchToken = nil
+                        self.isActiveInputSwitchPhysicalStopInProgress = false
+                        self.audioLevelCancellable = self.activeRecorderAudioLevelPublisher(
+                            inputID: newInputID
+                        )
+                        .receive(on: DispatchQueue.main)
+                        .sink { [weak self] level in
+                            guard let self,
+                                  self.isCurrentRecordingSession(controller.recordingID) else { return }
+                            self.overlayManager.updateAudioLevel(level)
+                        }
+                        self.reconcileDegradedCombinedCaptureNotice(
+                            degradedSource,
+                            sessionID: controller.recordingID
+                        )
+                    } catch {
+                        guard self.activeInputSwitchToken == switchToken,
+                              self.isCurrentRecordingSession(controller.recordingID) else {
+                            self.rollbackStalePhysicalAudioStart(
+                                operationID: switchToken,
+                                inputID: newInputID
+                            )
+                            return
+                        }
+                        self.finishPhysicalAudioStart(switchToken)
+                        self.finishAfterInputSwitchStartFailure(
+                            error,
+                            switchToken: switchToken
+                        )
                     }
                 }
             } catch {
                 if let sourceFailure = controller.terminalPersistenceFailure {
+                    self.finishPhysicalAudioStart(switchToken)
                     self.handleRecordingJournalPersistenceFailure(
                         sourceFailure,
                         alreadyStoppedTemporaryURLs: temporaryURLs
@@ -5916,6 +6184,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     return
                 }
                 for url in temporaryURLs { try? FileManager.default.removeItem(at: url) }
+                self.finishPhysicalAudioStart(switchToken)
                 self.activeInputSwitchToken = nil
                 self.isActiveInputSwitchPhysicalStopInProgress = false
                 self.preserveActiveSegmentedJournalForRecovery()
@@ -7647,8 +7916,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
         if isRecording {
             stopAndTranscribe()
         } else {
+            if cancelPendingRecordingStart() {
+                shortcutSessionController.reset()
+                return
+            }
             shortcutSessionController.beginManual(mode: .toggle)
-            startRecording(triggerMode: .toggle)
+            if !startRecording(triggerMode: .toggle) {
+                shortcutSessionController.reset()
+            }
         }
     }
 
@@ -7662,7 +7937,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
         mcpLastRecordingFailed = false
         shortcutSessionController.beginManual(mode: .toggle)
-        startRecording(triggerMode: .toggle)
+        guard startRecording(triggerMode: .toggle) else {
+            shortcutSessionController.reset()
+            return false
+        }
         return true
     }
 
@@ -7683,15 +7961,19 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func beginCalendarReminderRecording(onStarted: (@MainActor () -> Void)? = nil) {
-        guard !isRecording else {
-            activeRecordingCalendarSnapshot = nil
+        guard !isRecording,
+              recordingStartAdmissionLifecycle.isIdle,
+              physicalAudioStartLifecycle.isIdle else {
             return
         }
         if transcriptionEnabled {
             lastTranscript = ""
         }
         shortcutSessionController.beginManual(mode: .toggle)
-        startRecording(triggerMode: .toggle, onStarted: onStarted)
+        if !startRecording(triggerMode: .toggle, onStarted: onStarted) {
+            activeRecordingCalendarSnapshot = nil
+            shortcutSessionController.reset()
+        }
     }
 
     @MainActor
@@ -7853,6 +8135,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         guard pendingShortcutStartMode == .toggle || activeRecordingTriggerMode == .toggle else { return }
 
         cancelPendingShortcutStart()
+        _ = cancelPendingRecordingStart()
         shortcutSessionController.reset()
         activeRecordingTriggerMode = nil
         clearAudioRecorderCallbacks()
@@ -7947,7 +8230,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         guard delay > 0 else {
             pendingShortcutStartMode = nil
-            startRecording(triggerMode: mode)
+            if !startRecording(triggerMode: mode) {
+                shortcutSessionController.reset()
+            }
             return
         }
 
@@ -7966,7 +8251,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 guard let self, let pendingMode = self.pendingShortcutStartMode else { return }
                 self.pendingShortcutStartTask = nil
                 self.pendingShortcutStartMode = nil
-                self.startRecording(triggerMode: pendingMode)
+                if !self.startRecording(triggerMode: pendingMode) {
+                    self.shortcutSessionController.reset()
+                }
             }
         }
     }
@@ -8058,9 +8345,55 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
-    private func startRecording(triggerMode: RecordingTriggerMode, onStarted: (@MainActor () -> Void)? = nil) {
-        guard requireAvailableHistoryForMutation() else { return }
-        guard !isRecording else { return }
+    private func completePendingRecordingStartTask(_ startRequestID: UUID) {
+        pendingRecordingStartCount -= 1
+        let permissionRequestOwnsAdmission =
+            pendingMicrophonePermissionContext?.startRequestID == startRequestID
+            || pendingSpeechPermissionContext?.startRequestID == startRequestID
+        if permissionRequestOwnsAdmission {
+            if recordingStartAdmissionLifecycle.activeID == startRequestID {
+                pendingRecordingStartTask = nil
+            }
+            return
+        }
+        if recordingStartAdmissionLifecycle.finish(startRequestID) {
+            pendingRecordingStartTask = nil
+        }
+    }
+
+    @MainActor
+    @discardableResult
+    private func cancelPendingRecordingStart() -> Bool {
+        guard let startRequestID = recordingStartAdmissionLifecycle.activeID else {
+            return false
+        }
+        pendingRecordingStartTask?.cancel()
+        pendingRecordingStartTask = nil
+        _ = recordingStartAdmissionLifecycle.finish(startRequestID)
+        activeRecordingCalendarSnapshot = nil
+        activeRecordingTriggerMode = nil
+        currentSessionIntent = .dictation
+        restoreAudioInterruptionIfNeeded()
+        return true
+    }
+
+    @MainActor
+    @discardableResult
+    private func startRecording(
+        triggerMode: RecordingTriggerMode,
+        onStarted: (@MainActor () -> Void)? = nil
+    ) -> Bool {
+        guard requireAvailableHistoryForMutation() else { return false }
+        guard !isRecording else { return false }
+        guard !isAwaitingMicrophonePermission,
+              !isAwaitingSpeechRecognitionPermission else {
+            return false
+        }
+        guard physicalAudioStartLifecycle.isIdle else { return false }
+        let startRequestID = UUID()
+        guard recordingStartAdmissionLifecycle.begin(startRequestID) else {
+            return false
+        }
         commitSettingsDraftsBeforeRecordingStart()
         let t0 = CFAbsoluteTimeGetCurrent()
         os_log(.info, log: recordingLog, "startRecording() entered")
@@ -8077,19 +8410,30 @@ final class AppState: ObservableObject, @unchecked Sendable {
         cancelPendingShortcutStart()
 
         pendingRecordingStartCount += 1
-        Task { [weak self] in
+        let startTask = Task { [weak self] in
             guard let self else { return }
-            defer { self.pendingRecordingStartCount -= 1 }
+            defer {
+                self.completePendingRecordingStartTask(startRequestID)
+            }
+            guard !Task.isCancelled else { return }
+            guard recordingStartAdmissionLifecycle.activeID == startRequestID else {
+                return
+            }
             let manualCommandRequested = scheduledSelectionSnapshot != nil
                 ? scheduledManualCommandInvocation
                 : hotkeyManager.currentPressedModifiers.contains(commandModeManualModifier.shortcutModifier)
-            guard await prepareRecordingStart(
+            let preparationSucceeded = await prepareRecordingStart(
                 triggerMode: triggerMode,
                 selectionSnapshot: scheduledSelectionSnapshot,
                 selectionSnapshotTask: scheduledSelectionSnapshotTask,
                 manualCommandRequested: manualCommandRequested,
                 startedAt: t0
-            ) else {
+            )
+            guard !Task.isCancelled else { return }
+            guard recordingStartAdmissionLifecycle.activeID == startRequestID else {
+                return
+            }
+            guard preparationSucceeded else {
                 activeRecordingCalendarSnapshot = nil
                 return
             }
@@ -8097,7 +8441,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 activeRecordingCalendarSnapshot = nil
                 return
             }
-            guard let audioSelection = await accessibleCurrentRecordingAudioSelection() else {
+            let accessibleAudioSelection = await accessibleCurrentRecordingAudioSelection(
+                startRequestID: startRequestID,
+                onStarted: onStarted
+            )
+            guard !Task.isCancelled else { return }
+            guard recordingStartAdmissionLifecycle.activeID == startRequestID else {
+                return
+            }
+            guard let audioSelection = accessibleAudioSelection else {
                 if !isAwaitingMicrophonePermission {
                     activeRecordingCalendarSnapshot = nil
                 }
@@ -8112,12 +8464,15 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 applyAudioInterruptionIfNeeded()
             }
             beginRecording(
+                startRequestID: startRequestID,
                 triggerMode: triggerMode,
                 audioSelection: audioSelection,
                 onStarted: onStarted
             )
             os_log(.info, log: recordingLog, "startRecording() finished: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
         }
+        pendingRecordingStartTask = startTask
+        return true
     }
 
     /// Whether the configured recording flow will actually exercise Accessibility.
@@ -8262,15 +8617,20 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func prepareForSpeechRecognitionPermissionPrompt(
+        startRequestID: UUID,
         triggerMode: RecordingTriggerMode,
         selectionSnapshot: AppSelectionSnapshot?,
-        manualCommandRequested: Bool?
+        manualCommandRequested: Bool?,
+        onStarted: (@MainActor () -> Void)?
     ) {
+        pendingRecordingStartCount += 1
         isAwaitingSpeechRecognitionPermission = true
         pendingSpeechPermissionContext = PendingRecordingPermissionContext(
+            startRequestID: startRequestID,
             triggerMode: triggerMode,
             selectionSnapshot: selectionSnapshot,
-            manualCommandRequested: manualCommandRequested
+            manualCommandRequested: manualCommandRequested,
+            onStarted: onStarted
         )
         hotkeyManager.stop()
         shortcutSessionController.reset()
@@ -8304,23 +8664,37 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func ensureRecordingInputAccess(
-        for selection: RecordingAudioSelection
+        for selection: RecordingAudioSelection,
+        startRequestID: UUID,
+        onStarted: (@MainActor () -> Void)?
     ) async -> Bool {
         switch AudioRecordingSource(inputID: selection.inputID) {
         case .microphone:
-            return ensureMicrophoneAccess()
+            return ensureMicrophoneAccess(
+                startRequestID: startRequestID,
+                onStarted: onStarted
+            )
         case .systemAudio:
             return await ensureSystemAudioAccess()
         case .microphoneAndSystemAudio:
-            return await ensureSystemDefaultAndSystemAudioAccess()
+            return await ensureSystemDefaultAndSystemAudioAccess(
+                startRequestID: startRequestID,
+                onStarted: onStarted
+            )
         }
     }
 
     @MainActor
-    private func ensureSystemDefaultAndSystemAudioAccess() async -> Bool {
+    private func ensureSystemDefaultAndSystemAudioAccess(
+        startRequestID: UUID,
+        onStarted: (@MainActor () -> Void)?
+    ) async -> Bool {
         let microphoneStatus = AVCaptureDevice.authorizationStatus(for: .audio)
         if microphoneStatus == .notDetermined {
-            _ = ensureMicrophoneAccess()
+            _ = ensureMicrophoneAccess(
+                startRequestID: startRequestID,
+                onStarted: onStarted
+            )
             return false
         }
 
@@ -8371,7 +8745,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     @MainActor
-    private func ensureMicrophoneAccess() -> Bool {
+    private func ensureMicrophoneAccess(
+        startRequestID: UUID,
+        onStarted: (@MainActor () -> Void)?
+    ) -> Bool {
         let status = AVCaptureDevice.authorizationStatus(for: .audio)
         switch status {
         case .authorized:
@@ -8382,9 +8759,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
 
             prepareForMicrophonePermissionPrompt(
+                startRequestID: startRequestID,
                 triggerMode: triggerMode,
                 selectionSnapshot: pendingSelectionSnapshot ?? contextService.collectSelectionSnapshot(),
-                manualCommandRequested: currentSessionIntent.isManualCommand
+                manualCommandRequested: currentSessionIntent.isManualCommand,
+                onStarted: onStarted
             )
             AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
                 DispatchQueue.main.async {
@@ -8395,25 +8774,58 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     strongSelf.restartHotkeyMonitoring()
 
                     guard let pendingContext else {
-                        strongSelf.pendingRecordingStartCount -= 1
+                        if strongSelf.pendingRecordingStartCount > 0 {
+                            strongSelf.pendingRecordingStartCount -= 1
+                        }
+                        return
+                    }
+                    guard strongSelf.recordingStartAdmissionLifecycle.activeID
+                            == pendingContext.startRequestID else {
+                        strongSelf.completePendingRecordingStartTask(
+                            pendingContext.startRequestID
+                        )
                         return
                     }
                     if granted {
                         strongSelf.errorMessage = nil
                         if pendingContext.triggerMode == .toggle {
-                            Task { @MainActor [weak strongSelf] in
+                            let resumeTask = Task { @MainActor [weak strongSelf] in
                                 guard let strongSelf else { return }
-                                defer { strongSelf.pendingRecordingStartCount -= 1 }
-                                guard await strongSelf.prepareRecordingStart(
+                                defer {
+                                    strongSelf.completePendingRecordingStartTask(
+                                        pendingContext.startRequestID
+                                    )
+                                }
+                                guard strongSelf.recordingStartAdmissionLifecycle.activeID
+                                        == pendingContext.startRequestID else {
+                                    return
+                                }
+                                let preparationSucceeded = await strongSelf.prepareRecordingStart(
                                     triggerMode: .toggle,
                                     selectionSnapshot: pendingContext.selectionSnapshot,
                                     manualCommandRequested: pendingContext.manualCommandRequested
-                                ) else { return }
+                                )
+                                guard strongSelf.recordingStartAdmissionLifecycle.activeID
+                                        == pendingContext.startRequestID else {
+                                    return
+                                }
+                                guard preparationSucceeded else { return }
                                 guard strongSelf.requireAvailableHistoryForMutation() else {
                                     strongSelf.activeRecordingCalendarSnapshot = nil
                                     return
                                 }
-                                guard let audioSelection = await strongSelf.accessibleCurrentRecordingAudioSelection() else { return }
+                                let accessibleAudioSelection = await strongSelf
+                                    .accessibleCurrentRecordingAudioSelection(
+                                        startRequestID: pendingContext.startRequestID,
+                                        onStarted: pendingContext.onStarted
+                                    )
+                                guard strongSelf.recordingStartAdmissionLifecycle.activeID
+                                        == pendingContext.startRequestID else {
+                                    return
+                                }
+                                guard let audioSelection = accessibleAudioSelection else {
+                                    return
+                                }
                                 guard strongSelf.requireAvailableHistoryForMutation() else {
                                     strongSelf.activeRecordingCalendarSnapshot = nil
                                     return
@@ -8423,21 +8835,25 @@ final class AppState: ObservableObject, @unchecked Sendable {
                                     strongSelf.applyAudioInterruptionIfNeeded()
                                 }
                                 strongSelf.beginRecording(
+                                    startRequestID: pendingContext.startRequestID,
                                     triggerMode: .toggle,
-                                    audioSelection: audioSelection
+                                    audioSelection: audioSelection,
+                                    onStarted: pendingContext.onStarted
                                 )
                             }
+                            strongSelf.pendingRecordingStartTask = resumeTask
                         } else {
-                            strongSelf.pendingRecordingStartCount -= 1
                             strongSelf.currentSessionIntent = .dictation
                             strongSelf.statusText = localizedCatalogString("Microphone access granted. Press and hold again to record.")
                             strongSelf.scheduleReadyStatusReset(
                                 after: 2,
                                 matching: [localizedCatalogString("Microphone access granted. Press and hold again to record.")]
                             )
+                            strongSelf.completePendingRecordingStartTask(
+                                pendingContext.startRequestID
+                            )
                         }
                     } else {
-                        strongSelf.pendingRecordingStartCount -= 1
                         strongSelf.activeRecordingCalendarSnapshot = nil
                         strongSelf.errorMessage = localizedCatalogString("Microphone permission denied. Grant access in System Settings > Privacy & Security > Microphone.")
                         strongSelf.statusText = localizedCatalogString("No Microphone")
@@ -8445,6 +8861,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         strongSelf.currentSessionIntent = .dictation
                         strongSelf.shortcutSessionController.reset()
                         strongSelf.showMicrophonePermissionAlert()
+                        strongSelf.completePendingRecordingStartTask(
+                            pendingContext.startRequestID
+                        )
                     }
                 }
             }
@@ -8462,16 +8881,20 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func prepareForMicrophonePermissionPrompt(
+        startRequestID: UUID,
         triggerMode: RecordingTriggerMode,
         selectionSnapshot: AppSelectionSnapshot?,
-        manualCommandRequested: Bool?
+        manualCommandRequested: Bool?,
+        onStarted: (@MainActor () -> Void)?
     ) {
         pendingRecordingStartCount += 1
         isAwaitingMicrophonePermission = true
         pendingMicrophonePermissionContext = PendingRecordingPermissionContext(
+            startRequestID: startRequestID,
             triggerMode: triggerMode,
             selectionSnapshot: selectionSnapshot,
-            manualCommandRequested: manualCommandRequested
+            manualCommandRequested: manualCommandRequested,
+            onStarted: onStarted
         )
         hotkeyManager.stop()
         shortcutSessionController.reset()
@@ -8517,16 +8940,22 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     @MainActor
     private func beginRecording(
+        startRequestID: UUID,
         triggerMode: RecordingTriggerMode,
         audioSelection: RecordingAudioSelection,
         onStarted: (@MainActor () -> Void)? = nil
     ) {
+        guard recordingStartAdmissionLifecycle.activeID == startRequestID,
+              physicalAudioStartLifecycle.isIdle else {
+            return
+        }
         os_log(.info, log: recordingLog, "beginRecording() entered")
         clearPendingOverlayDismissToken()
         overlayTranscriptionID = UUID()
         errorMessage = nil
         let audioInputID = audioSelection.inputID
-        activeRecordingID = UUID()
+        let recordingSessionID = UUID()
+        activeRecordingID = recordingSessionID
         let supportsLiveTranscription = AudioRecordingSource(
             inputID: audioInputID
         ).supportsLiveTranscription
@@ -8548,9 +8977,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     return
                 }
                 prepareForSpeechRecognitionPermissionPrompt(
+                    startRequestID: startRequestID,
                     triggerMode: triggerMode,
                     selectionSnapshot: pendingSelectionSnapshot,
-                    manualCommandRequested: currentSessionIntent.isManualCommand
+                    manualCommandRequested: currentSessionIntent.isManualCommand,
+                    onStarted: onStarted
                 )
                 requestSpeechRecognitionAccess { [weak self] granted in
                     guard let self else { return }
@@ -8560,30 +8991,74 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     self.restartHotkeyMonitoring()
 
                     guard let pendingContext else {
-                        self.activeRecordingID = nil
+                        if self.pendingRecordingStartCount > 0 {
+                            self.pendingRecordingStartCount -= 1
+                        }
+                        return
+                    }
+                    guard self.recordingStartAdmissionLifecycle.activeID
+                            == pendingContext.startRequestID else {
+                        self.completePendingRecordingStartTask(
+                            pendingContext.startRequestID
+                        )
                         return
                     }
                     if granted {
                         self.errorMessage = nil
                         if pendingContext.triggerMode == .toggle {
-                            Task { @MainActor [weak self] in
+                            let resumeTask = Task { @MainActor [weak self] in
                                 guard let self else { return }
-                                guard await self.prepareRecordingStart(
+                                defer {
+                                    self.completePendingRecordingStartTask(
+                                        pendingContext.startRequestID
+                                    )
+                                }
+                                guard self.recordingStartAdmissionLifecycle.activeID
+                                        == pendingContext.startRequestID else {
+                                    return
+                                }
+                                let preparationSucceeded = await self.prepareRecordingStart(
                                     triggerMode: .toggle,
                                     selectionSnapshot: pendingContext.selectionSnapshot,
                                     manualCommandRequested: pendingContext.manualCommandRequested
-                                ) else { return }
-                                guard let audioSelection = await self.accessibleCurrentRecordingAudioSelection() else { return }
+                                )
+                                guard self.recordingStartAdmissionLifecycle.activeID
+                                        == pendingContext.startRequestID else {
+                                    return
+                                }
+                                guard preparationSucceeded else { return }
+                                guard self.requireAvailableHistoryForMutation() else {
+                                    self.activeRecordingCalendarSnapshot = nil
+                                    return
+                                }
+                                let accessibleAudioSelection = await self
+                                    .accessibleCurrentRecordingAudioSelection(
+                                        startRequestID: pendingContext.startRequestID,
+                                        onStarted: pendingContext.onStarted
+                                    )
+                                guard self.recordingStartAdmissionLifecycle.activeID
+                                        == pendingContext.startRequestID else {
+                                    return
+                                }
+                                guard let audioSelection = accessibleAudioSelection else {
+                                    return
+                                }
+                                guard self.requireAvailableHistoryForMutation() else {
+                                    self.activeRecordingCalendarSnapshot = nil
+                                    return
+                                }
                                 self.shortcutSessionController.beginManual(mode: .toggle)
                                 if AudioInputDevice.isMicrophoneOnly(audioSelection.inputID) {
                                     self.applyAudioInterruptionIfNeeded()
                                 }
                                 self.beginRecording(
+                                    startRequestID: pendingContext.startRequestID,
                                     triggerMode: .toggle,
                                     audioSelection: audioSelection,
-                                    onStarted: onStarted
+                                    onStarted: pendingContext.onStarted
                                 )
                             }
+                            self.pendingRecordingStartTask = resumeTask
                         } else {
                             self.currentSessionIntent = .dictation
                             self.restoreAudioInterruptionIfNeeded()
@@ -8591,6 +9066,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             self.scheduleReadyStatusReset(
                                 after: 2,
                                 matching: [localizedCatalogString("Speech Recognition access granted. Press and hold again to record.")]
+                            )
+                            self.completePendingRecordingStartTask(
+                                pendingContext.startRequestID
                             )
                         }
                     } else {
@@ -8603,6 +9081,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                         self.currentSessionIntent = .dictation
                         self.shortcutSessionController.reset()
                         self.showSpeechRecognitionPermissionAlert()
+                        self.completePendingRecordingStartTask(
+                            pendingContext.startRequestID
+                        )
                     }
                 }
                 return
@@ -8623,7 +9104,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
         }
 
+        guard physicalAudioStartLifecycle.begin(recordingSessionID) else {
+            activeRecordingID = nil
+            activeRecordingTranscriptionEnabled = nil
+            return
+        }
         isRecording = true
+        overlayManager.beginDegradedCombinedCaptureNoticeSession(recordingSessionID)
         syncCriticalDictationActivity()
         meetingReminderOverlayManager.refreshVisibleReminder()
         statusText = localizedCatalogString("Starting...")
@@ -8636,7 +9123,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         recordingInitializationTimer = initTimer
         initTimer.schedule(deadline: .now() + 0.2)
         initTimer.setEventHandler { [weak self] in
-            guard let self, !overlayShown else { return }
+            guard let self,
+                  !overlayShown,
+                  self.isCurrentRecordingSession(recordingSessionID) else { return }
             overlayShown = true
             os_log(.info, log: recordingLog, "engine slow — showing initializing overlay")
             self.clearPendingOverlayDismissToken()
@@ -8655,7 +9144,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
             inputID: audioInputID,
             onReady: { [weak self] in
                 DispatchQueue.main.async {
-                    guard let self else { return }
+                    guard let self,
+                          self.isCurrentRecordingSession(recordingSessionID) else { return }
+                    self.checkpointCombinedRecordingJournalAfterFirstReady(
+                        inputID: audioInputID,
+                        sessionID: recordingSessionID
+                    )
                     self.cancelRecordingInitializationTimer()
                     os_log(.info, log: recordingLog, "first real audio — transitioning to waveform")
                     self.statusText = localizedCatalogString("Recording...")
@@ -8663,12 +9157,14 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     if overlayShown {
                         self.overlayManager.transitionToRecording(
                             mode: self.activeRecordingTriggerMode ?? triggerMode,
-                            isCommandMode: self.currentSessionIntent.isCommandMode
+                            isCommandMode: self.currentSessionIntent.isCommandMode,
+                            noticeSessionID: recordingSessionID
                         )
                     } else {
                         self.overlayManager.showRecording(
                             mode: self.activeRecordingTriggerMode ?? triggerMode,
-                            isCommandMode: self.currentSessionIntent.isCommandMode
+                            isCommandMode: self.currentSessionIntent.isCommandMode,
+                            noticeSessionID: recordingSessionID
                         )
                     }
                     self.meetingReminderOverlayManager.refreshVisibleReminder()
@@ -8678,9 +9174,31 @@ final class AppState: ObservableObject, @unchecked Sendable {
             },
             onFailure: { [weak self] error in
                 DispatchQueue.main.async {
-                    guard let self else { return }
+                    guard let self,
+                          self.isCurrentRecordingSession(recordingSessionID) else { return }
                     self.cancelRecordingInitializationTimer()
                     self.handleRecordingFailure(error)
+                }
+            },
+            onDegraded: { [weak self] degradedSource in
+                DispatchQueue.main.async {
+                    guard let self,
+                          self.isCurrentRecordingSession(recordingSessionID) else { return }
+                    if let controller = self.activeSegmentedJournalController,
+                       controller.recordingID == recordingSessionID {
+                        do {
+                            try self.markDegradedJournalSourceUnavailableDuringRecording(
+                                controller: controller,
+                                degradedSource: degradedSource
+                            )
+                        } catch {
+                            self.reportRecordingJournalCheckpointFailure(error)
+                        }
+                    }
+                    self.reconcileDegradedCombinedCaptureNotice(
+                        degradedSource,
+                        sessionID: recordingSessionID
+                    )
                 }
             }
         )
@@ -8696,11 +9214,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
            let transcriber = localTranscriptionModel.makeLiveTranscriber() {
             // Live transcription: initialize before recording starts so the request is ready
             // to receive buffers from the very first sample
-            Task { [weak self] in
+            Task { @MainActor [weak self] in
                 guard let self else { return }
+                var didPublishLiveTranscriber = false
                 do {
                     try await transcriber.start(locale: transcriptionLanguage.sfSpeechLocale)
+                    guard self.isCurrentRecordingSession(recordingSessionID) else {
+                        transcriber.cancel()
+                        self.finishPhysicalAudioStart(recordingSessionID)
+                        return
+                    }
                     self.liveTranscriber = transcriber
+                    didPublishLiveTranscriber = true
                     if !transcriber.handlesRecording {
                         self.setActiveRecorderPCMHandler { [weak transcriber] data in
                             transcriber?.appendPCM16(data)
@@ -8709,95 +9234,137 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
                     transcriber.onAudioLevel = { [weak self] level in
                         Task { @MainActor [weak self] in
-                            self?.overlayManager.updateAudioLevel(level)
+                            guard let self,
+                                  self.isCurrentRecordingSession(recordingSessionID) else { return }
+                            self.overlayManager.updateAudioLevel(level)
                         }
                     }
 
                     // 녹음 시작 전 예비 노트를 생성해 Note Browser에 즉시 표시
-                    let liveID = self.activeRecordingID ?? UUID()
-                    self.activeRecordingID = liveID
+                    let liveID = recordingSessionID
                     self.currentRecordingLiveNoteID = liveID
                     transcriber.onPartialResult = { [weak self] text in
                         Task { @MainActor [weak self] in
-                            self?.updateLiveNoteTranscript(noteID: liveID, text)
+                            guard let self,
+                                  self.isCurrentRecordingSession(recordingSessionID) else { return }
+                            self.updateLiveNoteTranscript(noteID: liveID, text)
                         }
                     }
-                    await MainActor.run {
-                        self.createLiveNote(jobID: liveID, noteID: liveID)
-                    }
+                    self.createLiveNote(jobID: liveID, noteID: liveID)
 
                     let t0 = CFAbsoluteTimeGetCurrent()
                     if transcriber.handlesRecording {
                         // AVAudioEngine이 transcriber.start()에서 이미 시작됨 — 녹음 UI만 트리거
                         let actualRecordingStartedAt = Date()
-                        await MainActor.run {
-                            self.markRecordingStarted(actualRecordingStartedAt)
-                            if self.isRecording, self.activeRecordingTriggerMode != nil {
-                                onStarted?()
-                            }
+                        guard self.isCurrentRecordingSession(recordingSessionID) else {
+                            self.takeLiveTranscriberIfOwned(transcriber)?.cancel()
+                            self.finishPhysicalAudioStart(recordingSessionID)
+                            return
                         }
+                        self.markRecordingStarted(actualRecordingStartedAt)
+                        onStarted?()
+                        self.finishPhysicalAudioStart(recordingSessionID)
                         self.audioRecorder.onRecordingReady?()
                     } else {
-                        let degradedSource = try await self.startSelectedAudioRecorder(selection: audioSelection)
+                        let degradedSource = try await self.startSelectedAudioRecorder(
+                            selection: audioSelection,
+                            sessionID: recordingSessionID
+                        )
                         let actualRecordingStartedAt = Date()
-                        await MainActor.run {
-                            self.markRecordingStarted(actualRecordingStartedAt)
-                            if self.isRecording, self.activeRecordingTriggerMode != nil {
-                                onStarted?()
-                            }
-                            self.showDegradedCombinedCaptureNoticeIfNeeded(degradedSource)
+                        guard self.isCurrentRecordingSession(recordingSessionID) else {
+                            self.rollbackStalePhysicalAudioStart(
+                                operationID: recordingSessionID,
+                                inputID: audioInputID,
+                                liveTranscriber: self.takeLiveTranscriberIfOwned(transcriber)
+                            )
+                            return
                         }
+                        self.finishPhysicalAudioStart(recordingSessionID)
+                        self.markRecordingStarted(actualRecordingStartedAt)
+                        onStarted?()
+                        self.reconcileDegradedCombinedCaptureNotice(
+                            degradedSource,
+                            sessionID: recordingSessionID
+                        )
                         os_log(.info, log: recordingLog, "selected audio recorder start done: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
                     }
-                    await MainActor.run {
-                        guard self.isRecording, self.activeRecordingTriggerMode != nil else { return }
-                        if shouldTranscribe {
-                            self.startContextCapture()
-                        }
-                        if !transcriber.handlesRecording {
-                            self.audioLevelCancellable = self.activeRecorderAudioLevelPublisher(inputID: audioInputID)
-                                .receive(on: DispatchQueue.main)
-                                .sink { [weak self] level in
-                                    self?.overlayManager.updateAudioLevel(level)
-                                }
-                        }
+                    guard self.isCurrentRecordingSession(recordingSessionID) else { return }
+                    if shouldTranscribe {
+                        self.startContextCapture()
                     }
-                } catch {
-                    await MainActor.run {
-                        self.cancelRecordingInitializationTimer()
-                        guard self.isRecording || self.activeRecordingTriggerMode != nil else { return }
-                        self.handleRecordingFailure(error)
-                    }
-                }
-            }
-        } else {
-            Task { [weak self] in
-                guard let self else { return }
-                let t0 = CFAbsoluteTimeGetCurrent()
-                do {
-                    let degradedSource = try await self.startSelectedAudioRecorder(selection: audioSelection)
-                    let actualRecordingStartedAt = Date()
-                    os_log(.info, log: recordingLog, "selected audio recorder start done: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
-                    await MainActor.run {
-                        self.markRecordingStarted(actualRecordingStartedAt)
-                        guard self.isRecording, self.activeRecordingTriggerMode != nil else { return }
-                        onStarted?()
-                        if shouldTranscribe {
-                            self.startContextCapture()
-                        }
+                    if !transcriber.handlesRecording {
                         self.audioLevelCancellable = self.activeRecorderAudioLevelPublisher(inputID: audioInputID)
                             .receive(on: DispatchQueue.main)
                             .sink { [weak self] level in
-                                self?.overlayManager.updateAudioLevel(level)
+                                guard let self,
+                                      self.isCurrentRecordingSession(recordingSessionID) else { return }
+                                self.overlayManager.updateAudioLevel(level)
                             }
-                        self.showDegradedCombinedCaptureNoticeIfNeeded(degradedSource)
                     }
                 } catch {
-                    await MainActor.run {
-                        self.cancelRecordingInitializationTimer()
-                        guard self.isRecording || self.activeRecordingTriggerMode != nil else { return }
-                        self.handleRecordingFailure(error)
+                    self.cancelRecordingInitializationTimer()
+                    let transcriberToCancel = didPublishLiveTranscriber
+                        ? self.takeLiveTranscriberIfOwned(transcriber)
+                        : transcriber
+                    guard self.isCurrentRecordingSession(recordingSessionID) else {
+                        self.rollbackStalePhysicalAudioStart(
+                            operationID: recordingSessionID,
+                            inputID: audioInputID,
+                            liveTranscriber: transcriberToCancel
+                        )
+                        return
                     }
+                    transcriberToCancel?.cancel()
+                    self.finishPhysicalAudioStart(recordingSessionID)
+                    self.handleRecordingFailure(error)
+                }
+            }
+        } else {
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let t0 = CFAbsoluteTimeGetCurrent()
+                do {
+                    let degradedSource = try await self.startSelectedAudioRecorder(
+                        selection: audioSelection,
+                        sessionID: recordingSessionID
+                    )
+                    let actualRecordingStartedAt = Date()
+                    os_log(.info, log: recordingLog, "selected audio recorder start done: %.3fms", (CFAbsoluteTimeGetCurrent() - t0) * 1000)
+                    guard self.isCurrentRecordingSession(recordingSessionID) else {
+                        self.rollbackStalePhysicalAudioStart(
+                            operationID: recordingSessionID,
+                            inputID: audioInputID
+                        )
+                        return
+                    }
+                    self.finishPhysicalAudioStart(recordingSessionID)
+                    self.markRecordingStarted(actualRecordingStartedAt)
+                    onStarted?()
+                    if shouldTranscribe {
+                        self.startContextCapture()
+                    }
+                    self.audioLevelCancellable = self.activeRecorderAudioLevelPublisher(inputID: audioInputID)
+                        .receive(on: DispatchQueue.main)
+                        .sink { [weak self] level in
+                            guard let self,
+                                  self.isCurrentRecordingSession(recordingSessionID) else { return }
+                            self.overlayManager.updateAudioLevel(level)
+                        }
+                    self.reconcileDegradedCombinedCaptureNotice(
+                        degradedSource,
+                        sessionID: recordingSessionID
+                    )
+                } catch {
+                    self.cancelRecordingInitializationTimer()
+                    guard self.isCurrentRecordingSession(recordingSessionID) else {
+                        self.rollbackStalePhysicalAudioStart(
+                            operationID: recordingSessionID,
+                            inputID: audioInputID
+                        )
+                        return
+                    }
+                    self.finishPhysicalAudioStart(recordingSessionID)
+                    self.handleRecordingFailure(error)
                 }
             }
         }
@@ -9479,6 +10046,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @MainActor
     private func stopAndTranscribe() {
         guard activeRecordingStorageFailureID == nil else { return }
+        overlayManager.endDegradedCombinedCaptureNoticeSession()
         cancelPendingShortcutStart()
         cancelRecordingInitializationTimer()
         shortcutSessionController.reset()

--- a/Sources/AudioRecorder.swift
+++ b/Sources/AudioRecorder.swift
@@ -73,6 +73,36 @@ struct AudioRecorderStartResult: Equatable {
     let usedSystemDefaultFallback: Bool
 }
 
+struct AudioRecorderGenerationLifecycle {
+    private(set) var currentID: UUID?
+    private var outputID: ObjectIdentifier?
+
+    mutating func begin(_ id: UUID) {
+        currentID = id
+        outputID = nil
+    }
+
+    mutating func bind(_ output: AnyObject, to id: UUID) -> Bool {
+        guard owns(id) else { return false }
+        outputID = ObjectIdentifier(output)
+        return true
+    }
+
+    func owns(_ id: UUID) -> Bool {
+        currentID == id
+    }
+
+    func generation(for output: AnyObject) -> UUID? {
+        guard outputID == ObjectIdentifier(output) else { return nil }
+        return currentID
+    }
+
+    mutating func invalidateCurrent() {
+        currentID = nil
+        outputID = nil
+    }
+}
+
 enum AudioRecorderError: LocalizedError {
     case invalidInputFormat(String)
     case missingInputDevice
@@ -123,9 +153,19 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     private let _recording = OSAllocatedUnfairLock(initialState: false)
     @Published var audioLevel: Float = 0.0
     private let liveLevelNormalizerLock = OSAllocatedUnfairLock(initialState: LiveAudioLevelNormalizer())
+    private let generationLock = OSAllocatedUnfairLock(
+        initialState: AudioRecorderGenerationLifecycle()
+    )
+    private let callbacksLock = OSAllocatedUnfairLock(initialState: CallbackState())
 
-    var onRecordingReady: (() -> Void)?
-    var onRecordingFailure: ((Error) -> Void)?
+    var onRecordingReady: (() -> Void)? {
+        get { callbacksLock.withLock { $0.onRecordingReady } }
+        set { callbacksLock.withLock { $0.onRecordingReady = newValue } }
+    }
+    var onRecordingFailure: ((Error) -> Void)? {
+        get { callbacksLock.withLock { $0.onRecordingFailure } }
+        set { callbacksLock.withLock { $0.onRecordingFailure = newValue } }
+    }
     private let normalizedPCM16SinkLock =
         OSAllocatedUnfairLock<(any NormalizedPCM16Sink)?>(initialState: nil)
     var normalizedPCM16Sink: (any NormalizedPCM16Sink)? {
@@ -137,7 +177,10 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     /// input rate). Set before ``startRecording`` to stream audio out-of-band
     /// to a realtime transcription socket. The recorder writes a normalized
     /// 16 kHz mono PCM16 WAV file independently for upload-based transcription.
-    var onPCM16Samples: ((Data) -> Void)?
+    var onPCM16Samples: ((Data) -> Void)? {
+        get { callbacksLock.withLock { $0.onPCM16Samples } }
+        set { callbacksLock.withLock { $0.onPCM16Samples = newValue } }
+    }
     private let recordingConverterLock = OSAllocatedUnfairLock<AVAudioConverter?>(initialState: nil)
     private let pcm16ConverterLock = OSAllocatedUnfairLock<AVAudioConverter?>(initialState: nil)
     private var pcm16InputFormat: AVAudioFormat?
@@ -163,6 +206,12 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     private var failureReported = false
     private static let watchdogTimeout: TimeInterval = 2.0
     private static let sampleRateLogLimit = 40
+
+    private struct CallbackState {
+        var onRecordingReady: (() -> Void)?
+        var onRecordingFailure: ((Error) -> Void)?
+        var onPCM16Samples: ((Data) -> Void)?
+    }
 
     override init() {
         super.init()
@@ -225,7 +274,10 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         return (fallbackDevice, true)
     }
 
-    private func installSessionObservers(for session: AVCaptureSession) {
+    private func installSessionObservers(
+        for session: AVCaptureSession,
+        generationID: UUID
+    ) {
         removeSessionObservers()
 
         let runtimeObserver = NotificationCenter.default.addObserver(
@@ -236,7 +288,10 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             let error = notification.userInfo?[AVCaptureSessionErrorKey] as? NSError
             let wrapped = error.map { AudioRecorderError.failedToStartCaptureSession($0.localizedDescription) }
                 ?? AudioRecorderError.failedToStartCaptureSession("Unknown runtime error")
-            self?.reportRecordingFailure(wrapped)
+            self?.reportRecordingFailure(
+                wrapped,
+                expectedGenerationID: generationID
+            )
         }
         sessionObservers.append(runtimeObserver)
 
@@ -245,7 +300,10 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             object: session,
             queue: nil
         ) { [weak self] notification in
-            self?.handleSessionInterrupted(notification)
+            self?.handleSessionInterrupted(
+                notification,
+                expectedGenerationID: generationID
+            )
         }
         sessionObservers.append(interruptionObserver)
 
@@ -254,7 +312,10 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             object: session,
             queue: nil
         ) { [weak self] notification in
-            self?.handleSessionInterruptionEnded(notification)
+            self?.handleSessionInterruptionEnded(
+                notification,
+                expectedGenerationID: generationID
+            )
         }
         sessionObservers.append(interruptionEndedObserver)
     }
@@ -280,8 +341,16 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         audioDataOutput = nil
     }
 
-    private func reportRecordingFailure(_ error: Error, completion: ((URL?) -> Void)? = nil) {
+    private func reportRecordingFailure(
+        _ error: Error,
+        expectedGenerationID: UUID,
+        completion: ((URL?) -> Void)? = nil
+    ) {
+        let onRecordingFailure = self.onRecordingFailure
         sessionQueue.async {
+            guard self.generationLock.withLock({ generation in
+                generation.owns(expectedGenerationID)
+            }) else { return }
             guard !self.failureReported else { return }
             self.failureReported = true
             self.cancelWatchdog()
@@ -296,15 +365,18 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             }
 
             DispatchQueue.main.async {
+                guard self.generationLock.withLock({ generation in
+                    generation.owns(expectedGenerationID)
+                }) else { return }
                 self.isRecording = false
                 self.audioLevel = 0.0
-                self.onRecordingFailure?(error)
+                onRecordingFailure?(error)
                 completion?(nil)
             }
         }
     }
 
-    private func startBufferWatchdog() {
+    private func startBufferWatchdog(generationID: UUID) {
         let baselineCount = _bufferCount.withLock { $0 }
         cancelWatchdog()
 
@@ -312,6 +384,9 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         timer.schedule(deadline: .now() + Self.watchdogTimeout)
         timer.setEventHandler { [weak self] in
             guard let self else { return }
+            guard self.generationLock.withLock({ generation in
+                generation.owns(generationID)
+            }) else { return }
             guard self._recording.withLock({ $0 }) else { return }
             guard !self.isSessionInterrupted else {
                 os_log(.info, log: recordingLog, "watchdog suspended while capture session is interrupted")
@@ -321,7 +396,10 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             let count = self._bufferCount.withLock { $0 }
             if count == baselineCount {
                 os_log(.error, log: recordingLog, "watchdog: no new buffers after %.1fs — giving up", Self.watchdogTimeout)
-                self.reportRecordingFailure(AudioRecorderError.noAudioBuffersReceived)
+                self.reportRecordingFailure(
+                    AudioRecorderError.noAudioBuffersReceived,
+                    expectedGenerationID: generationID
+                )
             } else {
                 os_log(.info, log: recordingLog, "watchdog: %d new buffers after %.1fs — healthy", count - baselineCount, Self.watchdogTimeout)
             }
@@ -362,9 +440,15 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         return shouldKeepFile ? finalizedURL : nil
     }
 
-    private func handleSessionInterrupted(_ notification: Notification) {
+    private func handleSessionInterrupted(
+        _ notification: Notification,
+        expectedGenerationID: UUID
+    ) {
         _ = notification
         sessionQueue.async {
+            guard self.generationLock.withLock({ generation in
+                generation.owns(expectedGenerationID)
+            }) else { return }
             guard self._recording.withLock({ $0 }) else { return }
             self.isSessionInterrupted = true
             self.cancelWatchdog()
@@ -372,13 +456,19 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         }
     }
 
-    private func handleSessionInterruptionEnded(_ notification: Notification) {
+    private func handleSessionInterruptionEnded(
+        _ notification: Notification,
+        expectedGenerationID: UUID
+    ) {
         _ = notification
         sessionQueue.async {
+            guard self.generationLock.withLock({ generation in
+                generation.owns(expectedGenerationID)
+            }) else { return }
             guard self._recording.withLock({ $0 }) else { return }
             self.isSessionInterrupted = false
             os_log(.info, log: recordingLog, "capture session interruption ended — restarting watchdog")
-            self.startBufferWatchdog()
+            self.startBufferWatchdog(generationID: expectedGenerationID)
         }
     }
 
@@ -630,7 +720,8 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
 
     private func makeSession(
         deviceUID: String?,
-        outputURL: URL
+        outputURL: URL,
+        generationID: UUID
     ) throws -> AudioRecorderStartResult {
         teardownSessionLocked()
 
@@ -642,6 +733,11 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
 
         let session = AVCaptureSession()
         let dataOutput = AVCaptureAudioDataOutput()
+        guard generationLock.withLock({ generation in
+            generation.bind(dataOutput, to: generationID)
+        }) else {
+            throw CancellationError()
+        }
         dataOutput.audioSettings = [
             AVFormatIDKey: kAudioFormatLinearPCM,
             AVSampleRateKey: recordingTargetFormat.sampleRate,
@@ -696,7 +792,10 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         fileWriteErrorLock.withLock { _ in
             fileWriteError = nil
         }
-        installSessionObservers(for: session)
+        installSessionObservers(
+            for: session,
+            generationID: generationID
+        )
 
         os_log(.info, log: recordingLog, "configured capture session with device %{public}@ [uid=%{public}@]", device.localizedName, device.uniqueID)
 
@@ -716,6 +815,7 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
 
     @discardableResult
     func startRecording(deviceUID: String? = nil) throws -> AudioRecorderStartResult {
+        let generationID = UUID()
         let t0 = CFAbsoluteTimeGetCurrent()
         recordingStartTime = t0
         _bufferCount.withLock { $0 = 0 }
@@ -731,12 +831,16 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         let startResult: AudioRecorderStartResult
         do {
             startResult = try sessionQueue.sync {
+                self.generationLock.withLock { generation in
+                    generation.begin(generationID)
+                }
                 let result = try self.makeSession(
                     deviceUID: deviceUID,
-                    outputURL: outputURL
+                    outputURL: outputURL,
+                    generationID: generationID
                 )
                 self._recording.withLock { $0 = true }
-                self.startBufferWatchdog()
+                self.startBufferWatchdog(generationID: generationID)
                 return result
             }
         } catch {
@@ -751,6 +855,9 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         }
 
         DispatchQueue.main.async {
+            guard self.generationLock.withLock({ generation in
+                generation.owns(generationID)
+            }) else { return }
             self.isRecording = true
             self.audioLevel = 0.0
         }
@@ -759,6 +866,9 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     }
 
     func stopRecording(completion: @escaping (URL?) -> Void) {
+        generationLock.withLock { generation in
+            generation.invalidateCurrent()
+        }
         let count = _bufferCount.withLock { $0 }
         let elapsed = (CFAbsoluteTimeGetCurrent() - recordingStartTime) * 1000
         os_log(.info, log: recordingLog, "stopRecording() called: %.3fms after start, %d buffers received", elapsed, count)
@@ -782,6 +892,9 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
     }
 
     func cancelRecording(completion: (() -> Void)?) {
+        generationLock.withLock { generation in
+            generation.invalidateCurrent()
+        }
         sessionQueue.async {
             self.cancelWatchdog()
             self.teardownSessionLocked()
@@ -814,7 +927,10 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         }
     }
 
-    private func updateAudioLevel(from sampleBuffer: CMSampleBuffer) -> Float {
+    private func updateAudioLevel(
+        from sampleBuffer: CMSampleBuffer,
+        generationID: UUID
+    ) -> Float {
         guard let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer) else { return 0 }
         guard let sourceFormat = try? validatedPCMBufferFormat(
             AVAudioFormat(cmAudioFormatDescription: formatDescription),
@@ -835,6 +951,9 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         }
 
         DispatchQueue.main.async {
+            guard self.generationLock.withLock({ generation in
+                generation.owns(generationID)
+            }) else { return }
             self.audioLevel = normalizedDisplayLevel
         }
         return rms
@@ -977,6 +1096,9 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
         didOutput sampleBuffer: CMSampleBuffer,
         from connection: AVCaptureConnection
     ) {
+        guard let generationID = generationLock.withLock({ generation in
+            generation.generation(for: output)
+        }) else { return }
         guard _recording.withLock({ $0 }) else { return }
 
         do {
@@ -986,7 +1108,10 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
                 fileWriteError = error
             }
             os_log(.error, log: recordingLog, "audio file write failed: %{public}@", error.localizedDescription)
-            reportRecordingFailure(error)
+            reportRecordingFailure(
+                error,
+                expectedGenerationID: generationID
+            )
             return
         }
 
@@ -997,18 +1122,25 @@ final class AudioRecorder: NSObject, ObservableObject, AVCaptureAudioDataOutputS
             return value
         }
 
-        let rms = updateAudioLevel(from: sampleBuffer)
+        let rms = updateAudioLevel(
+            from: sampleBuffer,
+            generationID: generationID
+        )
         if count <= Self.sampleRateLogLimit {
             let elapsed = (CFAbsoluteTimeGetCurrent() - recordingStartTime) * 1000
             os_log(.info, log: recordingLog, "buffer #%d at %.3fms, rms=%.6f", count, elapsed, rms)
         }
 
-        if !readyFired && rms > 0 {
+        if !readyFired {
             readyFired = true
             let elapsed = (CFAbsoluteTimeGetCurrent() - recordingStartTime) * 1000
-            os_log(.info, log: recordingLog, "FIRST non-silent buffer at %.3fms — recording ready", elapsed)
+            os_log(.info, log: recordingLog, "FIRST valid buffer at %.3fms — recording ready", elapsed)
+            let onRecordingReady = self.onRecordingReady
             DispatchQueue.main.async {
-                self.onRecordingReady?()
+                guard self.generationLock.withLock({ generation in
+                    generation.owns(generationID)
+                }) else { return }
+                onRecordingReady?()
             }
         }
     }

--- a/Sources/MeetingReminderOverlay.swift
+++ b/Sources/MeetingReminderOverlay.swift
@@ -116,6 +116,13 @@ struct MeetingReminderOverlayGeometry {
         }
     }
 
+    static func noticeAnchorFrame(
+        visibleFrame: NSRect,
+        targetFrame: NSRect?
+    ) -> NSRect {
+        targetFrame ?? visibleFrame
+    }
+
     static func frame(for screen: NSScreen, context: MeetingReminderOverlayContext) -> NSRect {
         frame(for: OverlayScreenGeometry(screen: screen), context: context)
     }
@@ -193,6 +200,7 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
     private var panel: NSPanel?
     private var viewModel: MeetingReminderOverlayViewModel?
     private var contentContainer: FixedHostingContainer<AnyView>?
+    private var targetFrame: NSRect?
     private var isHidingVisibleReminder = false
     private var visibleReminder: QueuedReminder?
     private var queue: [QueuedReminder] = []
@@ -204,12 +212,20 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
 
     var onStart: (@MainActor (CalendarRecordingReminderSchedule) -> Void)?
     var onDismiss: (@MainActor (CalendarRecordingReminderSchedule) -> Void)?
+    var onVisibleOverlayFrameChange: (@MainActor (NSRect?) -> Void)?
 
-    /// Frame of the reminder panel while a reminder is actually visible, else
-    /// nil. Lets the recording overlay anchor a notice toast below the card.
+    /// Final frame of the reminder panel while a reminder is visible. During a
+    /// resize animation this returns the target instead of the current
+    /// presentation frame, so recording notices stay below the expanded card.
     var visibleOverlayFrame: NSRect? {
-        guard visibleReminder != nil, let panel, panel.isVisible, panel.alphaValue > 0 else { return nil }
-        return panel.frame
+        guard visibleReminder != nil,
+              let panel,
+              panel.isVisible,
+              panel.alphaValue > 0 else { return nil }
+        return MeetingReminderOverlayGeometry.noticeAnchorFrame(
+            visibleFrame: panel.frame,
+            targetFrame: targetFrame
+        )
     }
 
     init(
@@ -287,6 +303,7 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
         let context = contextProvider()
         let geometry = OverlayScreenGeometry(screen: screen)
         let frame = MeetingReminderOverlayGeometry.frame(for: geometry, context: context)
+        targetFrame = frame
         let variant = MeetingReminderOverlayGeometry.variant(
             for: context,
             hasNotchGeometry: MeetingReminderOverlayGeometry.hasNotchGeometry(for: geometry)
@@ -321,6 +338,7 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
 
         panel?.ignoresMouseEvents = false
         panel?.level = variant.isRecordingContext ? Self.recordingContextLevel : .screenSaver
+        onVisibleOverlayFrameChange?(frame)
 
         if markPresented {
             reminder.onPresented(schedule)
@@ -482,6 +500,8 @@ final class MeetingReminderOverlayManager: CalendarRecordingReminderInAppPresent
         panel = nil
         viewModel = nil
         contentContainer = nil
+        targetFrame = nil
+        onVisibleOverlayFrameChange?(nil)
     }
 
     private func displayData(

--- a/Sources/RecordingJournalModels.swift
+++ b/Sources/RecordingJournalModels.swift
@@ -59,6 +59,7 @@ enum RecordingRecoveryIssueReason: String, Codable, Equatable {
     case sourceMissing
     case sourceTooShort
     case committedPayloadUnavailable
+    case sourceUnavailableDuringRecording
 }
 
 struct RecordingRecoveryIssue: Codable, Equatable {
@@ -76,6 +77,8 @@ struct RecordingJournalSource: Codable, Equatable {
     var committedFrameCount: UInt64
     var firstCommittedFrameOffset: UInt64?
     let segmentID: UUID
+    var unavailableAtStart: Bool? = nil
+    var unavailableDuringRecording: Bool? = nil
 }
 
 struct RecordingJournalSegment: Codable, Equatable {

--- a/Sources/RecordingJournalStore.swift
+++ b/Sources/RecordingJournalStore.swift
@@ -158,6 +158,19 @@ final class RecordingJournalStore {
     private let fileManager: FileManager
     private let manifestWriter: RecordingJournalManifestWriter
 
+    private enum SourceAvailabilityMarker {
+        case unavailableAtStart(UUID)
+        case unavailableDuringRecording(UUID)
+
+        var sourceID: UUID {
+            switch self {
+            case .unavailableAtStart(let sourceID),
+                 .unavailableDuringRecording(let sourceID):
+                return sourceID
+            }
+        }
+    }
+
     init(
         audioDirectory: URL,
         now: @escaping () -> Date = Date.init,
@@ -218,8 +231,7 @@ final class RecordingJournalStore {
                 committedDataByteCount: 0,
                 committedFrameCount: 0,
                 firstCommittedFrameOffset: nil,
-                segmentID: request.segmentID
-            )
+                segmentID: request.segmentID            )
             let manifest = RecordingJournalManifest(
                 schemaVersion: 1,
                 generation: 1,
@@ -324,8 +336,7 @@ final class RecordingJournalStore {
                     committedDataByteCount: 0,
                     committedFrameCount: 0,
                     firstCommittedFrameOffset: nil,
-                    segmentID: request.segmentID
-                )
+                    segmentID: request.segmentID                )
                 let systemAudioSource = RecordingJournalSource(
                     id: request.systemAudioSourceID,
                     kind: .systemAudio,
@@ -334,8 +345,7 @@ final class RecordingJournalStore {
                     committedDataByteCount: 0,
                     committedFrameCount: 0,
                     firstCommittedFrameOffset: nil,
-                    segmentID: request.segmentID
-                )
+                    segmentID: request.segmentID                )
                 let manifest = RecordingJournalManifest(
                     schemaVersion: 1,
                     generation: 1,
@@ -448,8 +458,7 @@ final class RecordingJournalStore {
                             committedDataByteCount: 0,
                             committedFrameCount: 0,
                             firstCommittedFrameOffset: nil,
-                            segmentID: request.segmentID
-                        )
+                            segmentID: request.segmentID                        )
                     },
                     segments: [RecordingJournalSegment(
                         id: request.segmentID,
@@ -573,8 +582,7 @@ final class RecordingJournalStore {
                         committedDataByteCount: 0,
                         committedFrameCount: 0,
                         firstCommittedFrameOffset: nil,
-                        segmentID: segmentID
-                    )
+                        segmentID: segmentID                    )
                 }
                 let (nextGeneration, overflow) =
                     manifest.generation.addingReportingOverflow(1)
@@ -614,6 +622,28 @@ final class RecordingJournalStore {
         }
     }
 
+    func markSourceUnavailableAtStart(
+        recordingID: UUID,
+        sourceID: UUID
+    ) throws -> RecordingJournalManifest {
+        try recordCheckpoints(
+            recordingID: recordingID,
+            commitsBySourceID: [:],
+            availabilityMarker: .unavailableAtStart(sourceID)
+        )
+    }
+
+    func markSourceUnavailableDuringRecording(
+        recordingID: UUID,
+        sourceID: UUID
+    ) throws -> RecordingJournalManifest {
+        try recordCheckpoints(
+            recordingID: recordingID,
+            commitsBySourceID: [:],
+            availabilityMarker: .unavailableDuringRecording(sourceID)
+        )
+    }
+
     func recordCheckpoint(
         recordingID: UUID,
         sourceID: UUID,
@@ -629,11 +659,48 @@ final class RecordingJournalStore {
         recordingID: UUID,
         commitsBySourceID: [UUID: RecordingJournalSourceCommit]
     ) throws -> RecordingJournalManifest {
+        try recordCheckpoints(
+            recordingID: recordingID,
+            commitsBySourceID: commitsBySourceID,
+            availabilityMarker: nil
+        )
+    }
+
+    func recordCheckpointsMarkingSourceUnavailableAtStart(
+        recordingID: UUID,
+        commitsBySourceID: [UUID: RecordingJournalSourceCommit],
+        sourceID: UUID
+    ) throws -> RecordingJournalManifest {
+        try recordCheckpoints(
+            recordingID: recordingID,
+            commitsBySourceID: commitsBySourceID,
+            availabilityMarker: .unavailableAtStart(sourceID)
+        )
+    }
+
+    func recordCheckpointsMarkingSourceUnavailableDuringRecording(
+        recordingID: UUID,
+        commitsBySourceID: [UUID: RecordingJournalSourceCommit],
+        sourceID: UUID
+    ) throws -> RecordingJournalManifest {
+        try recordCheckpoints(
+            recordingID: recordingID,
+            commitsBySourceID: commitsBySourceID,
+            availabilityMarker: .unavailableDuringRecording(sourceID)
+        )
+    }
+
+    private func recordCheckpoints(
+        recordingID: UUID,
+        commitsBySourceID: [UUID: RecordingJournalSourceCommit],
+        availabilityMarker: SourceAvailabilityMarker?
+    ) throws -> RecordingJournalManifest {
         try lock.withLock {
             var manifest = try loadManifestUnlocked(recordingID: recordingID)
             guard manifest.state == .recording
-                    || manifest.state == .stopping
-                    || manifest.state == .recoverable else {
+                    || availabilityMarker == nil
+                        && (manifest.state == .stopping
+                            || manifest.state == .recoverable) else {
                 throw RecordingJournalStoreError.invalidCheckpointState(
                     manifest.state
                 )
@@ -643,7 +710,32 @@ final class RecordingJournalStore {
                 commitsBySourceID,
                 in: manifest
             )
-            guard !changedUpdates.isEmpty else { return manifest }
+            let markerIndex: Int?
+            let shouldMarkAvailability: Bool
+            if let availabilityMarker {
+                guard let index = manifest.sources.firstIndex(where: {
+                    $0.id == availabilityMarker.sourceID
+                }) else {
+                    throw RecordingJournalStoreError.sourceNotFound(
+                        availabilityMarker.sourceID
+                    )
+                }
+                markerIndex = index
+                switch availabilityMarker {
+                case .unavailableAtStart:
+                    shouldMarkAvailability =
+                        manifest.sources[index].unavailableAtStart != true
+                case .unavailableDuringRecording:
+                    shouldMarkAvailability =
+                        manifest.sources[index].unavailableDuringRecording != true
+                }
+            } else {
+                markerIndex = nil
+                shouldMarkAvailability = false
+            }
+            guard !changedUpdates.isEmpty || shouldMarkAvailability else {
+                return manifest
+            }
 
             let (nextGeneration, generationOverflow) =
                 manifest.generation.addingReportingOverflow(1)
@@ -660,6 +752,16 @@ final class RecordingJournalStore {
                     commit.frameCount
                 manifest.sources[index].firstCommittedFrameOffset =
                     commit.firstCommittedFrameOffset
+            }
+            if shouldMarkAvailability,
+               let markerIndex,
+               let availabilityMarker {
+                switch availabilityMarker {
+                case .unavailableAtStart:
+                    manifest.sources[markerIndex].unavailableAtStart = true
+                case .unavailableDuringRecording:
+                    manifest.sources[markerIndex].unavailableDuringRecording = true
+                }
             }
             manifest.generation = nextGeneration
             manifest.updatedAt = now()

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -205,6 +205,12 @@ final class RecordingOverlayManager {
     /// Identifies the in-flight notice so its scheduled dismissal only fires if
     /// that same notice is still showing.
     private var noticeToken: UUID?
+    /// Separate panel for the degraded combined-capture notice, kept apart from
+    /// `noticeWindow` so an unrelated transient notice (which reuses and
+    /// auto-dismisses `noticeWindow`) can never silently overwrite or expire
+    /// this persistent, user-dismissed-only notice.
+    private var degradedCaptureNoticeWindow: NSPanel?
+    private var degradedCaptureNoticeToken: UUID?
     private let notchSideRegionWidth: CGFloat = 92
     private let notchSidePanelHeight: CGFloat = 38
     private let notchSideHorizontalInset: CGFloat = 8
@@ -495,6 +501,81 @@ final class RecordingOverlayManager {
         }
     }
 
+    /// Surface that a combined recording started with only one source: the
+    /// pill above keeps showing the surviving source's waveform untouched
+    /// (the phase stays `.recording`); this is a separate informational
+    /// panel below it, like `showRecordingNotice`. Unlike that notice, it
+    /// does not auto-dismiss — nothing about it changes what gets recorded,
+    /// so there is no decision to time out, but it must stay long enough
+    /// that a user who missed it while joining the meeting still sees it
+    /// later. It is dismissed only by the user (hover-reveal ×) or when the
+    /// recording session ends.
+    func showDegradedCombinedCaptureNotice(_ message: String, reminderFrame: NSRect?) {
+        DispatchQueue.main.async {
+            guard self.overlayState.phase == .recording,
+                  let anchor = self.noticeAnchorFrame(reminderFrame: reminderFrame) else {
+                return
+            }
+            self.showAnchoredDegradedCaptureNotice(message, anchor: anchor)
+        }
+    }
+
+    private func showAnchoredDegradedCaptureNotice(_ message: String, anchor: NSRect) {
+        let token = UUID()
+        degradedCaptureNoticeToken = token
+
+        let height: CGFloat = 34
+        let gap: CGFloat = 6
+        let estimatedFit = CGFloat(message.count) * 6.8 + 66
+        let minFit = min(360, max(200, estimatedFit))
+        var width = minFit
+        if let screenWidth = screenGeometry?.screenFrame.width {
+            width = min(width, screenWidth - 32)
+        }
+        let frame = NSRect(
+            x: anchor.midX - width / 2,
+            y: anchor.minY - gap - height,
+            width: width,
+            height: height
+        )
+
+        let panel = degradedCaptureNoticeWindow ?? makeOverlayPanel(width: frame.width, height: frame.height)
+        panel.hasShadow = true
+        panel.ignoresMouseEvents = false
+        panel.contentView = makeTransparentContent(
+            width: frame.width,
+            height: frame.height,
+            rootView: DegradedCaptureNoticeView(message: message) { [weak self] in
+                guard let self, self.degradedCaptureNoticeToken == token else { return }
+                self.degradedCaptureNoticeToken = nil
+                self.dismissDegradedCaptureNotice()
+            }
+        )
+        let isAlreadyVisible = panel.isVisible && panel.alphaValue > 0
+        panel.setFrame(frame, display: true)
+        if !isAlreadyVisible {
+            panel.alphaValue = 0
+        }
+        panel.orderFrontRegardless()
+        degradedCaptureNoticeWindow = panel
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.16
+            panel.animator().alphaValue = 1
+        }
+    }
+
+    private func dismissDegradedCaptureNotice() {
+        guard let panel = degradedCaptureNoticeWindow else { return }
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.16
+            panel.animator().alphaValue = 0
+        }, completionHandler: { [weak self, weak panel] in
+            guard let self, self.degradedCaptureNoticeToken == nil else { return }
+            panel?.orderOut(nil)
+        })
+    }
+
     private func dismissNoticeToast() {
         guard let panel = noticeWindow else { return }
         NSAnimationContext.runAnimationGroup({ context in
@@ -731,6 +812,8 @@ final class RecordingOverlayManager {
         // doesn't linger after the session ends.
         noticeToken = nil
         noticeWindow?.orderOut(nil)
+        degradedCaptureNoticeToken = nil
+        degradedCaptureNoticeWindow?.orderOut(nil)
     }
 }
 
@@ -1420,6 +1503,108 @@ struct RecordingNoticeToastView: View {
             RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .fill(Color.black)
         )
+    }
+}
+
+/// Informational panel for a degraded combined-capture start. No Continue
+/// action — recording behavior is identical whether or not this is ever
+/// interacted with — and no Stop action, since the pill above already
+/// provides one (toggle mode's Stop button, or hold mode's release-to-stop).
+/// The only control is a dismiss (×) that fades in on hover, matching macOS
+/// notification conventions, so the default state stays a plain status line.
+struct DegradedCaptureNoticeView: View {
+    let message: String
+    let onDismiss: () -> Void
+    @State private var isHovering = false
+
+    var body: some View {
+        ZStack {
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.circle.fill")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(Color.red.opacity(0.92))
+                Text(message)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                if isHovering {
+                    Button(action: onDismiss) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 9, weight: .bold))
+                            .foregroundStyle(.white)
+                            .frame(width: 18, height: 18)
+                            .background(Circle().fill(Color.white.opacity(0.14)))
+                    }
+                    .buttonStyle(.plain)
+                    .transition(.opacity)
+                }
+            }
+            .padding(.horizontal, 14)
+            // SwiftUI's own hover tracking (see InputSwitchMenu above) is not
+            // reliable inside this borderless, non-activating panel, so hover
+            // is reported through an NSTrackingArea catcher instead.
+            DegradedCaptureNoticeHoverCatcher { hovering in
+                withAnimation(.easeOut(duration: 0.14)) {
+                    isHovering = hovering
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.black)
+        )
+    }
+}
+
+private struct DegradedCaptureNoticeHoverCatcher: NSViewRepresentable {
+    let onHoverChange: (Bool) -> Void
+
+    func makeNSView(context: Context) -> HoverView {
+        let view = HoverView()
+        view.onHoverChange = onHoverChange
+        return view
+    }
+
+    func updateNSView(_ nsView: HoverView, context: Context) {
+        nsView.onHoverChange = onHoverChange
+    }
+
+    final class HoverView: NSView {
+        var onHoverChange: ((Bool) -> Void)?
+        private var hoverTrackingArea: NSTrackingArea?
+
+        override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            if let hoverTrackingArea {
+                removeTrackingArea(hoverTrackingArea)
+            }
+            // .activeAlways so hover fires even though the overlay panel
+            // never becomes key; .inVisibleRect keeps it sized to the view.
+            let area = NSTrackingArea(
+                rect: bounds,
+                options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+                owner: self,
+                userInfo: nil
+            )
+            addTrackingArea(area)
+            hoverTrackingArea = area
+        }
+
+        override func mouseEntered(with event: NSEvent) {
+            onHoverChange?(true)
+        }
+
+        override func mouseExited(with event: NSEvent) {
+            onHoverChange?(false)
+        }
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            // Track hover across the whole panel without intercepting the
+            // dismiss button's own clicks.
+            nil
+        }
     }
 }
 

--- a/Sources/RecordingOverlay.swift
+++ b/Sources/RecordingOverlay.swift
@@ -161,6 +161,165 @@ private func makeTransparentContent<V: View>(
     return hosting
 }
 
+struct DegradedCombinedCaptureNoticeLifecycle {
+    struct Request: Equatable {
+        let sessionID: UUID
+        let token: UUID
+        let message: String
+        let reminderFrame: NSRect?
+    }
+
+    enum Effect: Equatable {
+        case none
+        case present(Request)
+        case hide(UUID)
+    }
+
+    private(set) var activeSessionID: UUID?
+    private(set) var isPresentationReady = false
+    private(set) var pendingRequest: Request?
+    private(set) var visibleRequest: Request?
+
+    mutating func beginSession(_ sessionID: UUID) -> Effect {
+        let effect = visibleRequest.map { Effect.hide($0.token) } ?? .none
+        activeSessionID = sessionID
+        isPresentationReady = false
+        pendingRequest = nil
+        visibleRequest = nil
+        return effect
+    }
+
+    mutating func reconcile(_ request: Request?, sessionID: UUID) -> Effect {
+        guard activeSessionID == sessionID else { return .none }
+        guard let request else {
+            pendingRequest = nil
+            guard let visibleRequest else { return .none }
+            self.visibleRequest = nil
+            return .hide(visibleRequest.token)
+        }
+        guard request.sessionID == sessionID else { return .none }
+
+        if isPresentationReady {
+            pendingRequest = nil
+            visibleRequest = request
+            return .present(request)
+        }
+        pendingRequest = request
+        return .none
+    }
+
+    mutating func markPresentationReady(sessionID: UUID) -> Effect {
+        guard activeSessionID == sessionID else { return .none }
+        guard !isPresentationReady else { return .none }
+        isPresentationReady = true
+        guard let pendingRequest else { return .none }
+        self.pendingRequest = nil
+        visibleRequest = pendingRequest
+        return .present(pendingRequest)
+    }
+
+    mutating func updateReminderFrame(_ reminderFrame: NSRect?) -> Effect {
+        if let pendingRequest {
+            self.pendingRequest = Request(
+                sessionID: pendingRequest.sessionID,
+                token: pendingRequest.token,
+                message: pendingRequest.message,
+                reminderFrame: reminderFrame
+            )
+        }
+        guard let visibleRequest else { return .none }
+        let updatedRequest = Request(
+            sessionID: visibleRequest.sessionID,
+            token: visibleRequest.token,
+            message: visibleRequest.message,
+            reminderFrame: reminderFrame
+        )
+        guard updatedRequest != visibleRequest else { return .none }
+        self.visibleRequest = updatedRequest
+        return .present(updatedRequest)
+    }
+
+    mutating func dismiss(sessionID: UUID, token: UUID) -> Effect {
+        guard activeSessionID == sessionID,
+              visibleRequest?.token == token else {
+            return .none
+        }
+        visibleRequest = nil
+        return .hide(token)
+    }
+
+    mutating func endSession(_ sessionID: UUID? = nil) -> Effect {
+        guard let activeSessionID,
+              sessionID == nil || sessionID == activeSessionID else {
+            return .none
+        }
+        let effect = visibleRequest.map { Effect.hide($0.token) } ?? .none
+        self.activeSessionID = nil
+        isPresentationReady = false
+        pendingRequest = nil
+        visibleRequest = nil
+        return effect
+    }
+}
+
+struct RecordingNoticeStackGeometry {
+    static func lowestVisibleFrame(_ frames: [NSRect]) -> NSRect? {
+        frames.min(by: { $0.minY < $1.minY })
+    }
+
+    static func overlayAnchorFrame(
+        visibleFrame: NSRect?,
+        targetFrame: NSRect
+    ) -> NSRect? {
+        guard let visibleFrame else { return nil }
+        return targetFrame.isEmpty ? visibleFrame : targetFrame
+    }
+
+    static func fittedNoticeWidth(
+        message: String,
+        horizontalChromeWidth: CGFloat,
+        minimumWidth: CGFloat,
+        maximumWidth: CGFloat
+    ) -> CGFloat {
+        let textWidth = (message as NSString).size(
+            withAttributes: [
+                .font: NSFont.systemFont(ofSize: 12, weight: .medium)
+            ]
+        ).width
+        return min(
+            maximumWidth,
+            max(minimumWidth, ceil(textWidth + horizontalChromeWidth))
+        )
+    }
+
+    static func degradedCaptureNoticeWidth(
+        message: String,
+        anchorWidth: CGFloat,
+        maximumWidth: CGFloat
+    ) -> CGFloat {
+        fittedNoticeWidth(
+            message: message,
+            horizontalChromeWidth: 88,
+            minimumWidth: max(200, anchorWidth),
+            maximumWidth: maximumWidth
+        )
+    }
+
+    static func anchoredFrame(
+        below anchor: NSRect,
+        width: CGFloat,
+        height: CGFloat,
+        gap: CGFloat
+    ) -> NSRect {
+        NSRect(
+            x: anchor.midX - width / 2,
+            y: anchor.minY - gap - height,
+            width: width,
+            height: height
+        )
+    }
+}
+
 struct RecordingOverlayGeometry {
     static func lockedTranscribingWidth(
         existingLockedWidth: CGFloat?,
@@ -205,12 +364,14 @@ final class RecordingOverlayManager {
     /// Identifies the in-flight notice so its scheduled dismissal only fires if
     /// that same notice is still showing.
     private var noticeToken: UUID?
+    private var recordingNoticeReminderFrame: NSRect?
     /// Separate panel for the degraded combined-capture notice, kept apart from
     /// `noticeWindow` so an unrelated transient notice (which reuses and
     /// auto-dismisses `noticeWindow`) can never silently overwrite or expire
     /// this persistent, user-dismissed-only notice.
     private var degradedCaptureNoticeWindow: NSPanel?
-    private var degradedCaptureNoticeToken: UUID?
+    private var degradedCaptureNoticePresentationToken: UUID?
+    private var degradedCaptureNoticeLifecycle = DegradedCombinedCaptureNoticeLifecycle()
     private let notchSideRegionWidth: CGFloat = 92
     private let notchSidePanelHeight: CGFloat = 38
     private let notchSideHorizontalInset: CGFloat = 8
@@ -329,7 +490,11 @@ final class RecordingOverlayManager {
         }
     }
 
-    func showRecording(mode: RecordingTriggerMode = .hold, isCommandMode: Bool = false) {
+    func showRecording(
+        mode: RecordingTriggerMode = .hold,
+        isCommandMode: Bool = false,
+        noticeSessionID: UUID? = nil
+    ) {
         DispatchQueue.main.async {
             self.lockedOverlayWidth = nil
             self.overlayState.recordingTriggerMode = mode
@@ -337,16 +502,22 @@ final class RecordingOverlayManager {
             self.overlayState.phase = .recording
             self.overlayState.audioLevel = 0
             self.showOverlayPanel(animatedResize: true)
+            self.markDegradedCaptureNoticePresentationReady(sessionID: noticeSessionID)
         }
     }
 
-    func transitionToRecording(mode: RecordingTriggerMode = .hold, isCommandMode: Bool = false) {
+    func transitionToRecording(
+        mode: RecordingTriggerMode = .hold,
+        isCommandMode: Bool = false,
+        noticeSessionID: UUID? = nil
+    ) {
         DispatchQueue.main.async {
             self.lockedOverlayWidth = nil
             self.overlayState.recordingTriggerMode = mode
             self.overlayState.isCommandMode = isCommandMode
             self.overlayState.phase = .recording
             self.updateOverlayLayout(animated: true)
+            self.markDegradedCaptureNoticePresentationReady(sessionID: noticeSessionID)
         }
     }
 
@@ -410,7 +581,7 @@ final class RecordingOverlayManager {
                 }
                 self.overlayState.errorMessage = nil
                 self.overlayState.toastID = nil
-                self.dismissAll()
+                self.dismissAll(endingDegradedCaptureSession: false)
             }
         }
     }
@@ -431,23 +602,45 @@ final class RecordingOverlayManager {
         let truncated = Self.truncatedToastMessage(message)
         DispatchQueue.main.async {
             guard self.overlayState.phase == .recording,
-                  let anchor = self.noticeAnchorFrame(reminderFrame: reminderFrame) else {
+                  let anchor = self.recordingNoticeAnchorFrame(reminderFrame: reminderFrame) else {
                 // No recording overlay on screen — fall back to the standard toast.
+                self.recordingNoticeReminderFrame = nil
                 self.showError(message)
                 return
             }
+            self.recordingNoticeReminderFrame = reminderFrame
             self.showAnchoredRecordingNotice(truncated, anchor: anchor)
         }
     }
 
     /// Bottom-most visible overlay frame (recording pill vs. the taller reminder
-    /// card), used as the anchor for the toast. Smaller minY = lower on screen.
-    private func noticeAnchorFrame(reminderFrame: NSRect?) -> NSRect? {
-        // Only anchor to actually-visible frames so the toast never attaches to
-        // a stale/hidden overlay position.
-        [visibleOverlayFrame, reminderFrame]
-            .compactMap { $0 }
-            .min(by: { $0.minY < $1.minY })
+    /// card), used as the base anchor for persistent recording notices.
+    private func baseNoticeAnchorFrame(reminderFrame: NSRect?) -> NSRect? {
+        let recordingOverlayFrame = RecordingNoticeStackGeometry.overlayAnchorFrame(
+                visibleFrame: visibleOverlayFrame,
+                targetFrame: overlayFrame
+            )
+        return RecordingNoticeStackGeometry.lowestVisibleFrame(
+            [recordingOverlayFrame, reminderFrame].compactMap { $0 }
+        )
+    }
+
+    private var visibleDegradedCaptureNoticeFrame: NSRect? {
+        guard degradedCaptureNoticeLifecycle.visibleRequest != nil,
+              let panel = degradedCaptureNoticeWindow,
+              panel.isVisible else { return nil }
+        return panel.frame
+    }
+
+    /// Transient notices stack below the persistent degraded-capture notice
+    /// instead of competing for the same position and obscuring its dismiss UI.
+    private func recordingNoticeAnchorFrame(reminderFrame: NSRect?) -> NSRect? {
+        RecordingNoticeStackGeometry.lowestVisibleFrame(
+            [
+                baseNoticeAnchorFrame(reminderFrame: reminderFrame),
+                visibleDegradedCaptureNoticeFrame
+            ].compactMap { $0 }
+        )
     }
 
     /// Show a standalone toast panel just below `anchor`, matching its width but
@@ -464,11 +657,11 @@ final class RecordingOverlayManager {
         if let screenWidth = screenGeometry?.screenFrame.width {
             width = min(width, screenWidth - 32)
         }
-        let frame = NSRect(
-            x: anchor.midX - width / 2,
-            y: anchor.minY - gap - height,
+        let frame = RecordingNoticeStackGeometry.anchoredFrame(
+            below: anchor,
             width: width,
-            height: height
+            height: height,
+            gap: gap
         )
 
         let panel = noticeWindow ?? makeOverlayPanel(width: frame.width, height: frame.height)
@@ -501,42 +694,132 @@ final class RecordingOverlayManager {
         }
     }
 
-    /// Surface that a combined recording started with only one source: the
-    /// pill above keeps showing the surviving source's waveform untouched
-    /// (the phase stays `.recording`); this is a separate informational
-    /// panel below it, like `showRecordingNotice`. Unlike that notice, it
-    /// does not auto-dismiss — nothing about it changes what gets recorded,
-    /// so there is no decision to time out, but it must stay long enough
-    /// that a user who missed it while joining the meeting still sees it
-    /// later. It is dismissed only by the user (hover-reveal ×) or when the
-    /// recording session ends.
-    func showDegradedCombinedCaptureNotice(_ message: String, reminderFrame: NSRect?) {
+    /// Start a recording-scoped lifecycle for the persistent degraded-capture
+    /// notice. A session ID prevents late recorder results from an older start
+    /// from affecting a newer recording.
+    func beginDegradedCombinedCaptureNoticeSession(_ sessionID: UUID) {
         DispatchQueue.main.async {
-            guard self.overlayState.phase == .recording,
-                  let anchor = self.noticeAnchorFrame(reminderFrame: reminderFrame) else {
-                return
-            }
-            self.showAnchoredDegradedCaptureNotice(message, anchor: anchor)
+            self.applyDegradedCaptureNoticeEffect(
+                self.degradedCaptureNoticeLifecycle.beginSession(sessionID)
+            )
         }
     }
 
-    private func showAnchoredDegradedCaptureNotice(_ message: String, anchor: NSRect) {
-        let token = UUID()
-        degradedCaptureNoticeToken = token
+    /// Reconcile the current capture state. A message presents or updates the
+    /// dedicated persistent panel; nil clears a stale notice after a healthy or
+    /// intentional single-source input switch.
+    func reconcileDegradedCombinedCaptureNotice(
+        message: String?,
+        sessionID: UUID,
+        reminderFrame: NSRect?
+    ) {
+        DispatchQueue.main.async {
+            let request = message.map {
+                DegradedCombinedCaptureNoticeLifecycle.Request(
+                    sessionID: sessionID,
+                    token: UUID(),
+                    message: $0,
+                    reminderFrame: reminderFrame
+                )
+            }
+            self.applyDegradedCaptureNoticeEffect(
+                self.degradedCaptureNoticeLifecycle.reconcile(
+                    request,
+                    sessionID: sessionID
+                )
+            )
+        }
+    }
 
+    func recordingReminderFrameDidChange(_ reminderFrame: NSRect?) {
+        DispatchQueue.main.async {
+            self.recordingNoticeReminderFrame = reminderFrame
+            self.applyDegradedCaptureNoticeEffect(
+                self.degradedCaptureNoticeLifecycle.updateReminderFrame(
+                    reminderFrame
+                )
+            )
+            self.repositionVisibleRecordingNotice()
+        }
+    }
+
+    func endDegradedCombinedCaptureNoticeSession(_ sessionID: UUID? = nil) {
+        DispatchQueue.main.async {
+            self.endDegradedCombinedCaptureNoticeSessionNow(sessionID)
+        }
+    }
+
+    private func endDegradedCombinedCaptureNoticeSessionNow(_ sessionID: UUID? = nil) {
+        applyDegradedCaptureNoticeEffect(
+            degradedCaptureNoticeLifecycle.endSession(sessionID)
+        )
+    }
+
+    private func markDegradedCaptureNoticePresentationReady(sessionID: UUID?) {
+        guard overlayState.phase == .recording,
+              let sessionID,
+              degradedCaptureNoticeLifecycle.activeSessionID == sessionID,
+              degradedCaptureNoticeAnchor(
+                  reminderFrame: degradedCaptureNoticeLifecycle.pendingRequest?.reminderFrame
+              ) != nil else {
+            return
+        }
+        applyDegradedCaptureNoticeEffect(
+            degradedCaptureNoticeLifecycle.markPresentationReady(sessionID: sessionID)
+        )
+    }
+
+    private func degradedCaptureNoticeAnchor(reminderFrame: NSRect?) -> NSRect? {
+        if let anchor = baseNoticeAnchorFrame(reminderFrame: reminderFrame) {
+            return anchor
+        }
+        if let frame = overlayWindow?.frame, !frame.isEmpty {
+            return frame
+        }
+        let fallback = overlayFrame
+        return fallback.isEmpty ? nil : fallback
+    }
+
+    private func applyDegradedCaptureNoticeEffect(
+        _ effect: DegradedCombinedCaptureNoticeLifecycle.Effect
+    ) {
+        switch effect {
+        case .none:
+            break
+        case .present(let request):
+            guard degradedCaptureNoticeLifecycle.activeSessionID == request.sessionID,
+                  let anchor = degradedCaptureNoticeAnchor(
+                      reminderFrame: request.reminderFrame
+                  ) else {
+                return
+            }
+            showAnchoredDegradedCaptureNotice(request, anchor: anchor)
+        case .hide(let token):
+            dismissDegradedCaptureNotice(expectedToken: token)
+        }
+    }
+
+    private func showAnchoredDegradedCaptureNotice(
+        _ request: DegradedCombinedCaptureNoticeLifecycle.Request,
+        anchor: NSRect
+    ) {
+        degradedCaptureNoticePresentationToken = request.token
         let height: CGFloat = 34
         let gap: CGFloat = 6
-        let estimatedFit = CGFloat(message.count) * 6.8 + 66
-        let minFit = min(360, max(200, estimatedFit))
-        var width = minFit
-        if let screenWidth = screenGeometry?.screenFrame.width {
-            width = min(width, screenWidth - 32)
-        }
-        let frame = NSRect(
-            x: anchor.midX - width / 2,
-            y: anchor.minY - gap - height,
+        let maximumWidth = max(
+            200,
+            (screenGeometry?.screenFrame.width ?? 520) - 32
+        )
+        let width = RecordingNoticeStackGeometry.degradedCaptureNoticeWidth(
+            message: request.message,
+            anchorWidth: anchor.width,
+            maximumWidth: maximumWidth
+        )
+        let frame = RecordingNoticeStackGeometry.anchoredFrame(
+            below: anchor,
             width: width,
-            height: height
+            height: height,
+            gap: gap
         )
 
         let panel = degradedCaptureNoticeWindow ?? makeOverlayPanel(width: frame.width, height: frame.height)
@@ -545,10 +828,14 @@ final class RecordingOverlayManager {
         panel.contentView = makeTransparentContent(
             width: frame.width,
             height: frame.height,
-            rootView: DegradedCaptureNoticeView(message: message) { [weak self] in
-                guard let self, self.degradedCaptureNoticeToken == token else { return }
-                self.degradedCaptureNoticeToken = nil
-                self.dismissDegradedCaptureNotice()
+            rootView: DegradedCaptureNoticeView(message: request.message) { [weak self] in
+                guard let self else { return }
+                self.applyDegradedCaptureNoticeEffect(
+                    self.degradedCaptureNoticeLifecycle.dismiss(
+                        sessionID: request.sessionID,
+                        token: request.token
+                    )
+                )
             }
         )
         let isAlreadyVisible = panel.isVisible && panel.alphaValue > 0
@@ -558,6 +845,7 @@ final class RecordingOverlayManager {
         }
         panel.orderFrontRegardless()
         degradedCaptureNoticeWindow = panel
+        repositionVisibleRecordingNotice(below: panel.frame)
 
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.16
@@ -565,14 +853,53 @@ final class RecordingOverlayManager {
         }
     }
 
-    private func dismissDegradedCaptureNotice() {
-        guard let panel = degradedCaptureNoticeWindow else { return }
+    private func repositionVisibleDegradedCaptureNotice() {
+        guard let request = degradedCaptureNoticeLifecycle.visibleRequest,
+              let anchor = degradedCaptureNoticeAnchor(
+                  reminderFrame: request.reminderFrame
+              ) else { return }
+        showAnchoredDegradedCaptureNotice(request, anchor: anchor)
+    }
+
+    private func repositionVisibleRecordingNotice() {
+        guard let anchor = recordingNoticeAnchorFrame(
+            reminderFrame: recordingNoticeReminderFrame
+        ) else {
+            return
+        }
+        repositionVisibleRecordingNotice(below: anchor)
+    }
+
+    private func repositionVisibleRecordingNotice(below anchor: NSRect) {
+        guard let panel = noticeWindow,
+              panel.isVisible,
+              panel.alphaValue > 0 else { return }
+        let frame = RecordingNoticeStackGeometry.anchoredFrame(
+            below: anchor,
+            width: panel.frame.width,
+            height: panel.frame.height,
+            gap: 6
+        )
+        panel.setFrame(frame, display: true)
+    }
+
+    private func dismissDegradedCaptureNotice(expectedToken: UUID) {
+        guard degradedCaptureNoticePresentationToken == expectedToken,
+              let panel = degradedCaptureNoticeWindow else {
+            return
+        }
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = 0.16
             panel.animator().alphaValue = 0
         }, completionHandler: { [weak self, weak panel] in
-            guard let self, self.degradedCaptureNoticeToken == nil else { return }
+            guard let self else { return }
+            if self.degradedCaptureNoticePresentationToken != expectedToken {
+                panel?.alphaValue = 1
+                return
+            }
+            self.degradedCaptureNoticePresentationToken = nil
             panel?.orderOut(nil)
+            self.repositionVisibleRecordingNotice()
         })
     }
 
@@ -585,6 +912,7 @@ final class RecordingOverlayManager {
             // A newer notice may have been scheduled mid-fade; only hide the
             // panel if nothing is showing now.
             guard let self, self.noticeToken == nil else { return }
+            self.recordingNoticeReminderFrame = nil
             panel?.orderOut(nil)
         })
     }
@@ -644,13 +972,19 @@ final class RecordingOverlayManager {
         panel.ignoresMouseEvents = !overlayAcceptsMouseEvents
         panel.contentView = makeOverlayContent(frame: frame)
         resize(panel: panel, to: frame, animated: animated)
+        repositionVisibleDegradedCaptureNotice()
+        repositionVisibleRecordingNotice()
     }
 
     private func handleScreenParametersChanged() {
         updateOverlayLayout(animated: false)
+        markDegradedCaptureNoticePresentationReady(
+            sessionID: degradedCaptureNoticeLifecycle.activeSessionID
+        )
     }
 
     private func setTranscribingPhase() {
+        endDegradedCombinedCaptureNoticeSessionNow()
         let wasNotchSideRecordingLayout = overlayState.phase == .recording && usesNotchSideLayout
         lockedOverlayWidth = RecordingOverlayGeometry.lockedTranscribingWidth(
             existingLockedWidth: lockedOverlayWidth,
@@ -795,7 +1129,7 @@ final class RecordingOverlayManager {
         showOverlayPanel(animatedResize: true)
     }
 
-    private func dismissAll() {
+    private func dismissAll(endingDegradedCaptureSession: Bool = true) {
         lockedOverlayWidth = nil
         overlayState.isCommandMode = false
         overlayState.updateVersion = ""
@@ -811,9 +1145,12 @@ final class RecordingOverlayManager {
         // Tear down any transient notice toast alongside the overlay so it
         // doesn't linger after the session ends.
         noticeToken = nil
+        recordingNoticeReminderFrame = nil
         noticeWindow?.orderOut(nil)
-        degradedCaptureNoticeToken = nil
-        degradedCaptureNoticeWindow?.orderOut(nil)
+        if endingDegradedCaptureSession {
+            endDegradedCombinedCaptureNoticeSessionNow()
+            degradedCaptureNoticeWindow?.orderOut(nil)
+        }
     }
 }
 
@@ -1518,43 +1855,47 @@ struct DegradedCaptureNoticeView: View {
     @State private var isHovering = false
 
     var body: some View {
-        ZStack {
-            HStack(spacing: 6) {
-                Image(systemName: "exclamationmark.circle.fill")
-                    .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(Color.red.opacity(0.92))
-                Text(message)
-                    .font(.system(size: 12, weight: .medium))
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.circle.fill")
+                .font(.system(size: 12, weight: .bold))
+                .foregroundStyle(Color.red.opacity(0.92))
+            Text(message)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .padding(.horizontal, 14)
+        .padding(.trailing, 28)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.black)
+        )
+        .overlay(alignment: .trailing) {
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
                     .foregroundStyle(.white)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                if isHovering {
-                    Button(action: onDismiss) {
-                        Image(systemName: "xmark")
-                            .font(.system(size: 9, weight: .bold))
-                            .foregroundStyle(.white)
-                            .frame(width: 18, height: 18)
-                            .background(Circle().fill(Color.white.opacity(0.14)))
-                    }
-                    .buttonStyle(.plain)
-                    .transition(.opacity)
-                }
+                    .frame(width: 18, height: 18)
+                    .background(Circle().fill(Color.white.opacity(0.14)))
             }
-            .padding(.horizontal, 14)
-            // SwiftUI's own hover tracking (see InputSwitchMenu above) is not
-            // reliable inside this borderless, non-activating panel, so hover
-            // is reported through an NSTrackingArea catcher instead.
+            .buttonStyle(.plain)
+            .padding(.trailing, 10)
+            .opacity(isHovering ? 1 : 0)
+            .allowsHitTesting(isHovering)
+            .accessibilityHidden(!isHovering)
+        }
+        // SwiftUI's own hover tracking (see InputSwitchMenu above) is not
+        // reliable inside this borderless, non-activating panel, so hover
+        // is reported through an NSTrackingArea catcher instead.
+        .overlay {
             DegradedCaptureNoticeHoverCatcher { hovering in
                 withAnimation(.easeOut(duration: 0.14)) {
                     isHovering = hovering
                 }
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(Color.black)
-        )
     }
 }
 

--- a/Sources/SegmentedRecordingArtifactFinalizer.swift
+++ b/Sources/SegmentedRecordingArtifactFinalizer.swift
@@ -95,7 +95,9 @@ struct SegmentedRecordingArtifactFinalizer {
                         segmentIssues.append(RecordingRecoveryIssue(
                             segmentSequence: segment.sequence,
                             sourceKind: source.kind,
-                            reason: .noCommittedAudio
+                            reason: source.unavailableDuringRecording == true
+                                ? .sourceUnavailableDuringRecording
+                                : .noCommittedAudio
                         ))
                     }
                 case .unavailable(let reason):

--- a/Sources/SegmentedRecordingArtifactFinalizer.swift
+++ b/Sources/SegmentedRecordingArtifactFinalizer.swift
@@ -82,8 +82,22 @@ struct SegmentedRecordingArtifactFinalizer {
                 case .usable(let finalized):
                     usableByKind[source.kind] = finalized
                     hasCommittedOrDamagedAudio = true
+                    if source.unavailableDuringRecording == true {
+                        segmentIssues.append(RecordingRecoveryIssue(
+                            segmentSequence: segment.sequence,
+                            sourceKind: source.kind,
+                            reason: .sourceUnavailableDuringRecording
+                        ))
+                    }
                 case .noCommittedAudio:
-                    break
+                    if source.unavailableAtStart != true {
+                        hasCommittedOrDamagedAudio = true
+                        segmentIssues.append(RecordingRecoveryIssue(
+                            segmentSequence: segment.sequence,
+                            sourceKind: source.kind,
+                            reason: .noCommittedAudio
+                        ))
+                    }
                 case .unavailable(let reason):
                     hasCommittedOrDamagedAudio = true
                     segmentIssues.append(RecordingRecoveryIssue(
@@ -99,15 +113,6 @@ struct SegmentedRecordingArtifactFinalizer {
                     issues.append(contentsOf: segmentIssues)
                 }
                 continue
-            }
-            for source in sources
-                where source.committedDataByteCount == 0
-                    && usableByKind[source.kind] == nil {
-                segmentIssues.append(RecordingRecoveryIssue(
-                    segmentSequence: segment.sequence,
-                    sourceKind: source.kind,
-                    reason: .noCommittedAudio
-                ))
             }
             issues.append(contentsOf: segmentIssues)
             renderedSegments.append(AudioMixdownSegment(

--- a/Sources/SegmentedRecordingJournalController.swift
+++ b/Sources/SegmentedRecordingJournalController.swift
@@ -196,6 +196,76 @@ final class SegmentedRecordingJournalController {
         }
     }
 
+    func markActiveSourceUnavailableAtStart(
+        _ sourceKind: RecordingJournalSourceKind
+    ) throws {
+        guard claimedTerminalFailure() == nil else {
+            throw SegmentedRecordingJournalControllerError.controllerClosed
+        }
+        try lifecycleQueue.sync {
+            guard claimedTerminalFailure() == nil,
+                  case .recording = state,
+                  let segment else {
+                throw SegmentedRecordingJournalControllerError.controllerClosed
+            }
+            guard let source = segment.sourcesByKind[sourceKind] else {
+                throw RecordingJournalStoreError.invalidSegmentSourceShape
+            }
+            do {
+                var commits: [UUID: RecordingJournalSourceCommit] = [:]
+                for activeSource in segment.sourcesByKind.values {
+                    commits[activeSource.id] = try activeSource.writer.checkpointSnapshot()
+                }
+                _ = try store.recordCheckpointsMarkingSourceUnavailableAtStart(
+                    recordingID: recordingID,
+                    commitsBySourceID: commits,
+                    sourceID: source.id
+                )
+            } catch {
+                handlePersistenceFailureIfNeeded(
+                    error,
+                    segmentSequence: segment.sequence
+                )
+                throw error
+            }
+        }
+    }
+
+    func markActiveSourceUnavailableDuringRecording(
+        _ sourceKind: RecordingJournalSourceKind
+    ) throws {
+        guard claimedTerminalFailure() == nil else {
+            throw SegmentedRecordingJournalControllerError.controllerClosed
+        }
+        try lifecycleQueue.sync {
+            guard claimedTerminalFailure() == nil,
+                  case .recording = state,
+                  let segment else {
+                throw SegmentedRecordingJournalControllerError.controllerClosed
+            }
+            guard let source = segment.sourcesByKind[sourceKind] else {
+                throw RecordingJournalStoreError.invalidSegmentSourceShape
+            }
+            do {
+                var commits: [UUID: RecordingJournalSourceCommit] = [:]
+                for activeSource in segment.sourcesByKind.values {
+                    commits[activeSource.id] = try activeSource.writer.checkpointSnapshot()
+                }
+                _ = try store.recordCheckpointsMarkingSourceUnavailableDuringRecording(
+                    recordingID: recordingID,
+                    commitsBySourceID: commits,
+                    sourceID: source.id
+                )
+            } catch {
+                handlePersistenceFailureIfNeeded(
+                    error,
+                    segmentSequence: segment.sequence
+                )
+                throw error
+            }
+        }
+    }
+
     func switchSegment(
         segmentID: UUID,
         sources: [RecordingJournalSegmentSourceRequest]

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -180,6 +180,21 @@ struct DebugSettingsView: View {
                         }
                     }
                 }
+
+                SettingsCard("Combined Capture", icon: "mic.and.signal.meter") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Force one side of the next Microphone + System Audio recording to fail to start, so the degraded-capture notice can be checked without touching real permissions. Each button arms one attempt only.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        Button("Force Microphone Failure Next Start") {
+                            appState.systemDefaultAndSystemAudioRecorder.debugForcesMicrophoneStartFailure = true
+                        }
+                        Button("Force System Audio Failure Next Start") {
+                            appState.systemDefaultAndSystemAudioRecorder.debugForcesSystemAudioStartFailure = true
+                        }
+                    }
+                }
             }
             .padding(24)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/SystemAudioRecorder.swift
+++ b/Sources/SystemAudioRecorder.swift
@@ -38,6 +38,43 @@ enum SystemAudioRecorderError: LocalizedError {
     }
 }
 
+struct SystemAudioRecorderGenerationLifecycle {
+    private(set) var currentID: UUID?
+    private var streamID: ObjectIdentifier?
+
+    mutating func begin(_ id: UUID) {
+        currentID = id
+        streamID = nil
+    }
+
+    func owns(_ id: UUID) -> Bool {
+        currentID == id
+    }
+
+    mutating func bind(_ stream: AnyObject, to id: UUID) -> Bool {
+        guard owns(id) else { return false }
+        streamID = ObjectIdentifier(stream)
+        return true
+    }
+
+    func generation(for stream: AnyObject) -> UUID? {
+        guard streamID == ObjectIdentifier(stream) else { return nil }
+        return currentID
+    }
+
+    mutating func invalidate(_ id: UUID) -> Bool {
+        guard owns(id) else { return false }
+        currentID = nil
+        streamID = nil
+        return true
+    }
+
+    mutating func invalidateCurrent() {
+        currentID = nil
+        streamID = nil
+    }
+}
+
 final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCStreamDelegate, @unchecked Sendable {
     private static let sessionQueueKey = DispatchSpecificKey<UInt8>()
     private static let watchdogTimeout: TimeInterval = 2.0
@@ -52,6 +89,9 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
     private let recordingConverterLock = OSAllocatedUnfairLock<AVAudioConverter?>(initialState: nil)
     private let pcm16ConverterLock = OSAllocatedUnfairLock<AVAudioConverter?>(initialState: nil)
     private let callbacksLock = OSAllocatedUnfairLock(initialState: CallbackState())
+    private let generationLock = OSAllocatedUnfairLock(
+        initialState: SystemAudioRecorderGenerationLifecycle()
+    )
     private let normalizedPCM16SinkLock =
         OSAllocatedUnfairLock<(any NormalizedPCM16Sink)?>(initialState: nil)
 
@@ -111,6 +151,7 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
     deinit {
         let cleanup = {
             self.cancelWatchdog()
+            self.generationLock.withLock { $0.invalidateCurrent() }
             self._recording.withLock { $0 = false }
             self.stream = nil
             if let url = self.resetSampleBufferState(outputURL: nil) {
@@ -126,6 +167,10 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
     }
 
     func startRecording() async throws {
+        let generationID = UUID()
+        generationLock.withLock { generation in
+            generation.begin(generationID)
+        }
         let t0 = CFAbsoluteTimeGetCurrent()
         _bufferCount.withLock { $0 = 0 }
         failureReported = false
@@ -133,6 +178,11 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
 
         let outputURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".wav")
         let content = try await Self.loadShareableContent()
+        guard generationLock.withLock({ generation in
+            generation.owns(generationID)
+        }) else {
+            throw CancellationError()
+        }
         guard let display = content.displays.first else {
             throw SystemAudioRecorderError.noDisplayAvailable
         }
@@ -155,24 +205,58 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
             throw SystemAudioRecorderError.failedToAddAudioOutput(error.localizedDescription)
         }
 
-        await withCheckedContinuation { continuation in
+        guard generationLock.withLock({ generation in
+            generation.bind(stream, to: generationID)
+        }) else {
+            throw CancellationError()
+        }
+        let installed = await withCheckedContinuation { continuation in
             sessionQueue.async {
+                guard self.generationLock.withLock({ generation in
+                    generation.generation(for: stream) == generationID
+                }) else {
+                    continuation.resume(returning: false)
+                    return
+                }
                 self.stream = stream
                 let staleOutputURL = self.resetSampleBufferState(outputURL: outputURL, recordingStartTime: t0)
                 if let staleOutputURL {
                     try? FileManager.default.removeItem(at: staleOutputURL)
                 }
                 self._recording.withLock { $0 = true }
-                self.startBufferWatchdog()
-                continuation.resume()
+                self.startBufferWatchdog(
+                    expectedStream: stream,
+                    generationID: generationID
+                )
+                continuation.resume(returning: true)
             }
+        }
+        guard installed else {
+            throw CancellationError()
         }
 
         do {
             try await stream.startCapture()
         } catch {
-            await discardFailedStart(outputURL: outputURL)
+            guard currentStreamSnapshot() === stream,
+                  generationLock.withLock({ generation in
+                      generation.generation(for: stream) == generationID
+                  }) else {
+                try? await stream.stopCapture()
+                throw CancellationError()
+            }
+            await discardFailedStart(
+                expectedStream: stream,
+                outputURL: outputURL
+            )
             throw SystemAudioRecorderError.failedToStartCapture(error.localizedDescription)
+        }
+        guard currentStreamSnapshot() === stream,
+              generationLock.withLock({ generation in
+                  generation.generation(for: stream) == generationID
+              }) else {
+            try? await stream.stopCapture()
+            throw CancellationError()
         }
 
         await MainActor.run {
@@ -183,6 +267,7 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
     }
 
     func stopRecording(completion: @escaping (URL?) -> Void) {
+        invalidateCurrentGeneration()
         let currentStream = currentStreamSnapshot()
         Task {
             var shouldDiscardRecording = false
@@ -194,7 +279,11 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
                     os_log(.error, log: systemAudioRecordingLog, "stopCapture failed: %{public}@", error.localizedDescription)
                 }
             }
-            finishRecording(discard: shouldDiscardRecording, completion: completion)
+            finishRecording(
+                expectedStream: currentStream,
+                discard: shouldDiscardRecording,
+                completion: completion
+            )
         }
     }
 
@@ -203,12 +292,16 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
     }
 
     func cancelRecording(completion: (() -> Void)?) {
+        invalidateCurrentGeneration()
         let currentStream = currentStreamSnapshot()
         Task {
             if let currentStream {
                 try? await currentStream.stopCapture()
             }
-            finishRecording(discard: true) { _ in
+            finishRecording(
+                expectedStream: currentStream,
+                discard: true
+            ) { _ in
                 completion?()
             }
         }
@@ -229,6 +322,9 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
 
     func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
         guard type == .audio else { return }
+        guard let generationID = generationLock.withLock({ generation in
+            generation.generation(for: stream)
+        }) else { return }
         guard _recording.withLock({ $0 }) else { return }
         guard CMSampleBufferIsValid(sampleBuffer) else { return }
 
@@ -236,7 +332,7 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
             try appendSampleBufferToFile(sampleBuffer)
         } catch {
             fileWriteErrorLock.withLock { _ in fileWriteError = error }
-            reportRecordingFailure(error)
+            reportRecordingFailure(error, expectedStream: stream)
             return
         }
 
@@ -245,7 +341,11 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
             value += 1
             return value
         }
-        let rms = updateAudioLevel(from: sampleBuffer)
+        let rms = updateAudioLevel(
+            from: sampleBuffer,
+            stream: stream,
+            generationID: generationID
+        )
         if count <= Self.sampleRateLogLimit {
             let elapsed = (CFAbsoluteTimeGetCurrent() - recordingStartTime) * 1000
             os_log(.info, log: systemAudioRecordingLog, "buffer #%d at %.3fms, rms=%.6f", count, elapsed, rms)
@@ -253,12 +353,17 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
         if !readyFired {
             readyFired = true
             let onRecordingReady = self.onRecordingReady
-            DispatchQueue.main.async { onRecordingReady?() }
+            DispatchQueue.main.async {
+                guard self.generationLock.withLock({ generation in
+                    generation.generation(for: stream) == generationID
+                }) else { return }
+                onRecordingReady?()
+            }
         }
     }
 
     func stream(_ stream: SCStream, didStopWithError error: Error) {
-        reportRecordingFailure(error)
+        reportRecordingFailure(error, expectedStream: stream)
     }
 
     private static func loadShareableContent() async throws -> SCShareableContent {
@@ -274,10 +379,18 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
         }
     }
 
-    private func discardFailedStart(outputURL: URL) async {
+    private func discardFailedStart(
+        expectedStream: SCStream,
+        outputURL: URL
+    ) async {
         await withCheckedContinuation { continuation in
             sessionQueue.async {
+                guard self.stream === expectedStream else {
+                    continuation.resume()
+                    return
+                }
                 self.cancelWatchdog()
+                self.generationLock.withLock { $0.invalidateCurrent() }
                 self.stream = nil
                 let fileURLToDelete = self.resetSampleBufferState(outputURL: nil) ?? outputURL
                 self._recording.withLock { $0 = false }
@@ -289,6 +402,12 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
                     continuation.resume()
                 }
             }
+        }
+    }
+
+    private func invalidateCurrentGeneration() {
+        generationLock.withLock { generation in
+            generation.invalidateCurrent()
         }
     }
 
@@ -319,8 +438,16 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
         return staleOutputURL
     }
 
-    private func finishRecording(discard: Bool, completion: ((URL?) -> Void)?) {
+    private func finishRecording(
+        expectedStream: SCStream?,
+        discard: Bool,
+        completion: ((URL?) -> Void)?
+    ) {
         sessionQueue.async {
+            guard self.stream === expectedStream else {
+                DispatchQueue.main.async { completion?(nil) }
+                return
+            }
             self.cancelWatchdog()
             let finishedRecording = self.finishAudioFileLocked(discard: discard)
             self.stream = nil
@@ -337,11 +464,22 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
         }
     }
 
-    private func reportRecordingFailure(_ error: Error) {
+    private func reportRecordingFailure(
+        _ error: Error,
+        expectedStream: SCStream? = nil
+    ) {
+        let onRecordingFailure = self.onRecordingFailure
         sessionQueue.async {
+            if let expectedStream {
+                guard self.stream === expectedStream,
+                      self.generationLock.withLock({ generation in
+                          generation.generation(for: expectedStream) != nil
+                      }) else { return }
+            }
             guard !self.failureReported else { return }
             self.failureReported = true
             self.cancelWatchdog()
+            self.generationLock.withLock { $0.invalidateCurrent() }
             self._recording.withLock { $0 = false }
 
             let finishedRecording = self.finishAudioFileLocked(discard: true)
@@ -351,7 +489,6 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
                 try? FileManager.default.removeItem(at: fileURLToDelete)
             }
 
-            let onRecordingFailure = self.onRecordingFailure
             DispatchQueue.main.async {
                 self.isRecording = false
                 self.audioLevel = 0.0
@@ -360,7 +497,10 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
         }
     }
 
-    private func startBufferWatchdog() {
+    private func startBufferWatchdog(
+        expectedStream: SCStream,
+        generationID: UUID
+    ) {
         let baselineCount = _bufferCount.withLock { $0 }
         cancelWatchdog()
 
@@ -368,12 +508,18 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
         timer.schedule(deadline: .now() + Self.watchdogTimeout)
         timer.setEventHandler { [weak self] in
             guard let self else { return }
+            guard self.generationLock.withLock({ generation in
+                generation.generation(for: expectedStream) == generationID
+            }) else { return }
             guard self._recording.withLock({ $0 }) else { return }
 
             let count = self._bufferCount.withLock { $0 }
             if count == baselineCount {
                 os_log(.error, log: systemAudioRecordingLog, "watchdog: no new buffers after %.1fs — giving up", Self.watchdogTimeout)
-                self.reportRecordingFailure(SystemAudioRecorderError.noAudioBuffersReceived)
+                self.reportRecordingFailure(
+                    SystemAudioRecorderError.noAudioBuffersReceived,
+                    expectedStream: expectedStream
+                )
             } else {
                 os_log(.info, log: systemAudioRecordingLog, "watchdog: %d new buffers after %.1fs — healthy", count - baselineCount, Self.watchdogTimeout)
             }
@@ -658,7 +804,11 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
         return ConversionResult(buffer: outputBuffer, status: String(describing: status))
     }
 
-    private func updateAudioLevel(from sampleBuffer: CMSampleBuffer) -> Float {
+    private func updateAudioLevel(
+        from sampleBuffer: CMSampleBuffer,
+        stream: SCStream,
+        generationID: UUID
+    ) -> Float {
         guard let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer) else { return 0 }
         guard let sourceFormat = try? validatedPCMBufferFormat(
             AVAudioFormat(cmAudioFormatDescription: formatDescription),
@@ -679,6 +829,9 @@ final class SystemAudioRecorder: NSObject, ObservableObject, SCStreamOutput, SCS
         }
 
         DispatchQueue.main.async {
+            guard self.generationLock.withLock({ generation in
+                generation.generation(for: stream) == generationID
+            }) else { return }
             self.audioLevel = normalizedDisplayLevel
         }
         return rms

--- a/Sources/SystemDefaultAndSystemAudioRecorder.swift
+++ b/Sources/SystemDefaultAndSystemAudioRecorder.swift
@@ -2,10 +2,24 @@ import Combine
 import Foundation
 import os
 
+enum DegradedCombinedCaptureSource: Equatable {
+    case microphone
+    case systemAudio
+}
+
 struct CombinedRecordingStartResult: Equatable {
     let microphoneStarted: Bool
     let systemAudioStarted: Bool
     let microphoneUsedSystemDefaultFallback: Bool
+
+    /// Which source is missing when exactly one side of a combined start
+    /// failed, or nil when both started (startRecording throws instead of
+    /// returning a result when neither did).
+    var missingSource: DegradedCombinedCaptureSource? {
+        if !microphoneStarted { return .microphone }
+        if !systemAudioStarted { return .systemAudio }
+        return nil
+    }
 }
 
 struct CombinedStoppedRecordingSources: Equatable {
@@ -22,6 +36,13 @@ final class SystemDefaultAndSystemAudioRecorder: ObservableObject {
 
     var onRecordingReady: (() -> Void)?
     var onRecordingFailure: ((Error) -> Void)?
+
+    /// Manual QA hooks: force one side of the next combined start to fail
+    /// without touching real hardware/permissions, so the degraded-capture
+    /// notice can be exercised on demand. Each flag resets itself after the
+    /// attempt it triggers.
+    var debugForcesMicrophoneStartFailure = false
+    var debugForcesSystemAudioStartFailure = false
 
     private enum RecordingSource: Hashable {
         case microphone
@@ -78,6 +99,10 @@ final class SystemDefaultAndSystemAudioRecorder: ObservableObject {
         var microphoneUsedSystemDefaultFallback = false
 
         do {
+            if debugForcesMicrophoneStartFailure {
+                debugForcesMicrophoneStartFailure = false
+                throw SystemDefaultAndSystemAudioRecorderError.debugSimulatedStartFailure
+            }
             let result = try microphoneRecorder.startRecording(
                 deviceUID: microphoneDeviceUID
             )
@@ -91,6 +116,10 @@ final class SystemDefaultAndSystemAudioRecorder: ObservableObject {
         }
 
         do {
+            if debugForcesSystemAudioStartFailure {
+                debugForcesSystemAudioStartFailure = false
+                throw SystemDefaultAndSystemAudioRecorderError.debugSimulatedStartFailure
+            }
             try await systemAudioRecorder.startRecording()
             stateLock.withLock { state in
                 state.systemStarted = true
@@ -313,12 +342,15 @@ final class SystemDefaultAndSystemAudioRecorder: ObservableObject {
 
 enum SystemDefaultAndSystemAudioRecorderError: LocalizedError {
     case failedToStartAnyRecorder([Error])
+    case debugSimulatedStartFailure
 
     var errorDescription: String? {
         switch self {
         case .failedToStartAnyRecorder(let errors):
             let details = errors.map(\.localizedDescription).joined(separator: "; ")
             return details.isEmpty ? "Could not start Microphone + System Audio recording." : "Could not start Microphone + System Audio recording: \(details)"
+        case .debugSimulatedStartFailure:
+            return "Debug: simulated start failure."
         }
     }
 }

--- a/Sources/SystemDefaultAndSystemAudioRecorder.swift
+++ b/Sources/SystemDefaultAndSystemAudioRecorder.swift
@@ -22,6 +22,25 @@ struct CombinedRecordingStartResult: Equatable {
     }
 }
 
+struct CombinedRecordingStartOperations {
+    let startMicrophone: (String) throws -> AudioRecorderStartResult
+    let startSystemAudio: () async throws -> Void
+    let cancelMicrophone: () async -> Void
+    let cancelSystemAudio: () async -> Void
+
+    init(
+        startMicrophone: @escaping (String) throws -> AudioRecorderStartResult,
+        startSystemAudio: @escaping () async throws -> Void,
+        cancelMicrophone: @escaping () async -> Void = {},
+        cancelSystemAudio: @escaping () async -> Void = {}
+    ) {
+        self.startMicrophone = startMicrophone
+        self.startSystemAudio = startSystemAudio
+        self.cancelMicrophone = cancelMicrophone
+        self.cancelSystemAudio = cancelSystemAudio
+    }
+}
+
 struct CombinedStoppedRecordingSources: Equatable {
     let microphoneURL: URL?
     let systemAudioURL: URL?
@@ -31,11 +50,24 @@ final class SystemDefaultAndSystemAudioRecorder: ObservableObject {
     let microphoneRecorder: AudioRecorder
     let systemAudioRecorder: SystemAudioRecorder
     let mixdownService: AudioMixdownService
+    private let startOperations: CombinedRecordingStartOperations
 
     @Published var audioLevel: Float = 0.0
 
+    var currentMissingSource: DegradedCombinedCaptureSource? {
+        stateLock.withLock { state in
+            let microphoneActive = state.activeSources.contains(.microphone)
+                && !state.failedSources.contains(.microphone)
+            let systemAudioActive = state.activeSources.contains(.systemAudio)
+                && !state.failedSources.contains(.systemAudio)
+            if microphoneActive == systemAudioActive { return nil }
+            return microphoneActive ? .systemAudio : .microphone
+        }
+    }
+
     var onRecordingReady: (() -> Void)?
     var onRecordingFailure: ((Error) -> Void)?
+    var onRecordingDegraded: ((DegradedCombinedCaptureSource) -> Void)?
 
     /// Manual QA hooks: force one side of the next combined start to fail
     /// without touching real hardware/permissions, so the degraded-capture
@@ -47,27 +79,97 @@ final class SystemDefaultAndSystemAudioRecorder: ObservableObject {
     private enum RecordingSource: Hashable {
         case microphone
         case systemAudio
+
+        var degradedSource: DegradedCombinedCaptureSource {
+            switch self {
+            case .microphone: .microphone
+            case .systemAudio: .systemAudio
+            }
+        }
+    }
+
+    private enum SourceFailureEffect {
+        case none
+        case degraded(DegradedCombinedCaptureSource)
+        case overallFailure
+    }
+
+    private enum MicrophoneStartAttempt {
+        case started(AudioRecorderStartResult)
+        case failed(Error)
+        case cancelled
+    }
+
+    private enum SystemAudioStartAttempt {
+        case started
+        case failed(Error)
+        case cancelled
     }
 
     private struct RecordingState {
+        var startID: UUID?
+        var startInProgress = false
+        var startCompletionGroup: DispatchGroup?
         var microphoneStarted = false
         var systemStarted = false
         var readyFired = false
+        var readySources: Set<RecordingSource> = []
         var activeSources: Set<RecordingSource> = []
         var failedSources: Set<RecordingSource> = []
+        var failuresDuringStart: [Error] = []
         var overallFailureReported = false
 
-        mutating func resetForStart() {
+        mutating func admitStartedSource(_ source: RecordingSource) {
+            switch source {
+            case .microphone:
+                microphoneStarted = true
+            case .systemAudio:
+                systemStarted = true
+            }
+            activeSources.insert(source)
+        }
+
+        mutating func consumeReadyIfPossible() -> Bool {
+            guard !readyFired,
+                  activeSources.contains(where: {
+                      readySources.contains($0)
+                          && !failedSources.contains($0)
+                  }) else {
+                return false
+            }
+            readyFired = true
+            return true
+        }
+
+        mutating func resetForStart(
+            startID: UUID,
+            startCompletionGroup: DispatchGroup
+        ) {
+            self.startID = startID
+            startInProgress = true
+            self.startCompletionGroup = startCompletionGroup
             microphoneStarted = false
             systemStarted = false
             readyFired = false
+            readySources = []
             activeSources = []
             failedSources = []
+            failuresDuringStart = []
             overallFailureReported = false
         }
 
         mutating func resetIdle() {
-            resetForStart()
+            startID = nil
+            startInProgress = false
+            startCompletionGroup = nil
+            microphoneStarted = false
+            systemStarted = false
+            readyFired = false
+            readySources = []
+            activeSources = []
+            failedSources = []
+            failuresDuringStart = []
+            overallFailureReported = false
         }
     }
 
@@ -79,67 +181,207 @@ final class SystemDefaultAndSystemAudioRecorder: ObservableObject {
     private let stateLock = OSAllocatedUnfairLock(initialState: RecordingState())
     private var cancellables: Set<AnyCancellable> = []
 
-    init(microphoneRecorder: AudioRecorder, systemAudioRecorder: SystemAudioRecorder, mixdownService: AudioMixdownService = AudioMixdownService()) {
+    convenience init(microphoneRecorder: AudioRecorder, systemAudioRecorder: SystemAudioRecorder, mixdownService: AudioMixdownService = AudioMixdownService()) {
+        self.init(
+            microphoneRecorder: microphoneRecorder,
+            systemAudioRecorder: systemAudioRecorder,
+            mixdownService: mixdownService,
+            startOperations: CombinedRecordingStartOperations(
+                startMicrophone: { deviceUID in
+                    try microphoneRecorder.startRecording(deviceUID: deviceUID)
+                },
+                startSystemAudio: {
+                    try await systemAudioRecorder.startRecording()
+                },
+                cancelMicrophone: {
+                    await withCheckedContinuation { continuation in
+                        microphoneRecorder.cancelRecording {
+                            continuation.resume()
+                        }
+                    }
+                },
+                cancelSystemAudio: {
+                    await withCheckedContinuation { continuation in
+                        systemAudioRecorder.cancelRecording {
+                            continuation.resume()
+                        }
+                    }
+                }
+            )
+        )
+    }
+
+    init(
+        microphoneRecorder: AudioRecorder,
+        systemAudioRecorder: SystemAudioRecorder,
+        mixdownService: AudioMixdownService,
+        startOperations: CombinedRecordingStartOperations
+    ) {
         self.microphoneRecorder = microphoneRecorder
         self.systemAudioRecorder = systemAudioRecorder
         self.mixdownService = mixdownService
-        configureChildCallbacks()
+        self.startOperations = startOperations
         subscribeToAudioLevelsIfNeeded()
     }
 
     func startRecording(microphoneDeviceUID: String) async throws -> CombinedRecordingStartResult {
-        configureChildCallbacks()
+        let startID = UUID()
+        let startCompletionGroup = DispatchGroup()
+        startCompletionGroup.enter()
+        defer { startCompletionGroup.leave() }
+        stateLock.withLock { state in
+            state.resetForStart(
+                startID: startID,
+                startCompletionGroup: startCompletionGroup
+            )
+        }
+        configureChildCallbacks(startID: startID)
         subscribeToAudioLevelsIfNeeded()
 
-        stateLock.withLock { state in
-            state.resetForStart()
+        let forceMicrophoneFailure = debugForcesMicrophoneStartFailure
+        let forceSystemAudioFailure = debugForcesSystemAudioStartFailure
+        debugForcesMicrophoneStartFailure = false
+        debugForcesSystemAudioStartFailure = false
+
+        async let microphoneAttempt = attemptMicrophoneStart(
+            microphoneDeviceUID: microphoneDeviceUID,
+            startID: startID,
+            forceFailure: forceMicrophoneFailure
+        )
+        async let systemAudioAttempt = attemptSystemAudioStart(
+            startID: startID,
+            forceFailure: forceSystemAudioFailure
+        )
+        let (microphoneOutcome, systemAudioOutcome) = await (
+            microphoneAttempt,
+            systemAudioAttempt
+        )
+
+        let startWasCancelled: Bool
+        switch (microphoneOutcome, systemAudioOutcome) {
+        case (.cancelled, _), (_, .cancelled):
+            startWasCancelled = true
+        default:
+            startWasCancelled = false
+        }
+        if startWasCancelled {
+            let shouldRollbackStartedSources = stateLock.withLock { state -> Bool in
+                guard state.startID == startID else { return false }
+                state.resetIdle()
+                return true
+            }
+            if shouldRollbackStartedSources {
+                if case .started = microphoneOutcome {
+                    await startOperations.cancelMicrophone()
+                }
+                if case .started = systemAudioOutcome {
+                    await startOperations.cancelSystemAudio()
+                }
+            }
+            throw CancellationError()
         }
 
         var startErrors: [Error] = []
         var microphoneUsedSystemDefaultFallback = false
-
-        do {
-            if debugForcesMicrophoneStartFailure {
-                debugForcesMicrophoneStartFailure = false
-                throw SystemDefaultAndSystemAudioRecorderError.debugSimulatedStartFailure
-            }
-            let result = try microphoneRecorder.startRecording(
-                deviceUID: microphoneDeviceUID
-            )
+        if case .started(let result) = microphoneOutcome {
             microphoneUsedSystemDefaultFallback = result.usedSystemDefaultFallback
-            stateLock.withLock { state in
-                state.microphoneStarted = true
+        } else if case .failed(let error) = microphoneOutcome {
+            startErrors.append(error)
+        }
+        if case .failed(let error) = systemAudioOutcome {
+            startErrors.append(error)
+        }
+
+        guard let (microphoneStarted, systemStarted, failuresDuringStart) = stateLock.withLock({ state -> (Bool, Bool, [Error])? in
+            guard state.startID == startID else { return nil }
+            state.startInProgress = false
+            state.microphoneStarted = state.microphoneStarted
+                && !state.failedSources.contains(.microphone)
+            state.systemStarted = state.systemStarted
+                && !state.failedSources.contains(.systemAudio)
+            state.activeSources = []
+            if state.microphoneStarted {
                 state.activeSources.insert(.microphone)
             }
-        } catch {
-            startErrors.append(error)
-        }
-
-        do {
-            if debugForcesSystemAudioStartFailure {
-                debugForcesSystemAudioStartFailure = false
-                throw SystemDefaultAndSystemAudioRecorderError.debugSimulatedStartFailure
-            }
-            try await systemAudioRecorder.startRecording()
-            stateLock.withLock { state in
-                state.systemStarted = true
+            if state.systemStarted {
                 state.activeSources.insert(.systemAudio)
             }
-        } catch {
-            startErrors.append(error)
-        }
-
-        let (microphoneStarted, systemStarted) = stateLock.withLock { state in
-            (state.microphoneStarted, state.systemStarted)
+            return (
+                state.microphoneStarted,
+                state.systemStarted,
+                state.failuresDuringStart
+            )
+        }) else {
+            throw CancellationError()
         }
         guard microphoneStarted || systemStarted else {
-            throw SystemDefaultAndSystemAudioRecorderError.failedToStartAnyRecorder(startErrors)
+            throw SystemDefaultAndSystemAudioRecorderError.failedToStartAnyRecorder(
+                startErrors + failuresDuringStart
+            )
         }
         return CombinedRecordingStartResult(
             microphoneStarted: microphoneStarted,
             systemAudioStarted: systemStarted,
             microphoneUsedSystemDefaultFallback: microphoneUsedSystemDefaultFallback
         )
+    }
+
+    private func acceptStartedSource(
+        _ source: RecordingSource,
+        startID: UUID
+    ) -> Bool {
+        let (accepted, shouldFireReady) = stateLock.withLock { state in
+            guard state.startID == startID else { return (false, false) }
+            state.admitStartedSource(source)
+            return (true, state.consumeReadyIfPossible())
+        }
+        if shouldFireReady {
+            onRecordingReady?()
+        }
+        return accepted
+    }
+
+    private func attemptMicrophoneStart(
+        microphoneDeviceUID: String,
+        startID: UUID,
+        forceFailure: Bool
+    ) async -> MicrophoneStartAttempt {
+        do {
+            if forceFailure {
+                throw SystemDefaultAndSystemAudioRecorderError.debugSimulatedStartFailure
+            }
+            let result = try startOperations.startMicrophone(microphoneDeviceUID)
+            guard acceptStartedSource(.microphone, startID: startID) else {
+                await startOperations.cancelMicrophone()
+                return .cancelled
+            }
+            return .started(result)
+        } catch is CancellationError {
+            return .cancelled
+        } catch {
+            return .failed(error)
+        }
+    }
+
+    private func attemptSystemAudioStart(
+        startID: UUID,
+        forceFailure: Bool
+    ) async -> SystemAudioStartAttempt {
+        do {
+            if forceFailure {
+                throw SystemDefaultAndSystemAudioRecorderError.debugSimulatedStartFailure
+            }
+            try await startOperations.startSystemAudio()
+            guard acceptStartedSource(.systemAudio, startID: startID) else {
+                await startOperations.cancelSystemAudio()
+                return .cancelled
+            }
+            return .started
+        } catch is CancellationError {
+            return .cancelled
+        } catch {
+            return .failed(error)
+        }
     }
 
     func stopRecording(completion: @escaping (URL?) -> Void) {
@@ -154,18 +396,18 @@ final class SystemDefaultAndSystemAudioRecorder: ObservableObject {
     func stopRecordingSources(
         completion: @escaping (CombinedStoppedRecordingSources) -> Void
     ) {
-        let (shouldStopMicrophone, shouldStopSystemAudio) = stateLock.withLock { state in
-            let result = (state.microphoneStarted, state.systemStarted)
+        let (
+            shouldStopMicrophone,
+            shouldStopSystemAudio,
+            startCompletionGroup
+        ) = stateLock.withLock { state in
+            let result = (
+                state.microphoneStarted,
+                state.systemStarted,
+                state.startCompletionGroup
+            )
             state.resetIdle()
             return result
-        }
-
-        guard shouldStopMicrophone || shouldStopSystemAudio else {
-            completion(CombinedStoppedRecordingSources(
-                microphoneURL: nil,
-                systemAudioURL: nil
-            ))
-            return
         }
 
         let group = DispatchGroup()
@@ -191,12 +433,14 @@ final class SystemDefaultAndSystemAudioRecorder: ObservableObject {
             }
         }
 
-        group.notify(queue: .main) {
-            let urls = stoppedURLs.withLock { $0 }
-            completion(CombinedStoppedRecordingSources(
-                microphoneURL: urls.microphoneURL,
-                systemAudioURL: urls.systemAudioURL
-            ))
+        notifyAfterPendingStart(startCompletionGroup) {
+            group.notify(queue: .main) {
+                let urls = stoppedURLs.withLock { $0 }
+                completion(CombinedStoppedRecordingSources(
+                    microphoneURL: urls.microphoneURL,
+                    systemAudioURL: urls.systemAudioURL
+                ))
+            }
         }
     }
 
@@ -205,8 +449,16 @@ final class SystemDefaultAndSystemAudioRecorder: ObservableObject {
     }
 
     func cancelRecording(completion: (() -> Void)?) {
-        let (shouldCancelMicrophone, shouldCancelSystemAudio) = stateLock.withLock { state in
-            let result = (state.microphoneStarted, state.systemStarted)
+        let (
+            shouldCancelMicrophone,
+            shouldCancelSystemAudio,
+            startCompletionGroup
+        ) = stateLock.withLock { state in
+            let result = (
+                state.microphoneStarted,
+                state.systemStarted,
+                state.startCompletionGroup
+            )
             state.resetIdle()
             return result
         }
@@ -224,10 +476,23 @@ final class SystemDefaultAndSystemAudioRecorder: ObservableObject {
                 group.leave()
             })
         }
-        group.notify(queue: .main) {
-            self.audioLevel = 0.0
-            completion?()
+        notifyAfterPendingStart(startCompletionGroup) {
+            group.notify(queue: .main) {
+                self.audioLevel = 0.0
+                completion?()
+            }
         }
+    }
+
+    private func notifyAfterPendingStart(
+        _ startCompletionGroup: DispatchGroup?,
+        completion: @escaping () -> Void
+    ) {
+        guard let startCompletionGroup else {
+            completion()
+            return
+        }
+        startCompletionGroup.notify(queue: .main, execute: completion)
     }
 
     func temporaryCombinedFallback(
@@ -259,18 +524,24 @@ final class SystemDefaultAndSystemAudioRecorder: ObservableObject {
         systemAudioRecorder.onPCM16Samples = nil
     }
 
-    private func configureChildCallbacks() {
+    private func configureChildCallbacks(startID: UUID) {
         microphoneRecorder.onRecordingReady = { [weak self] in
-            self?.fireRecordingReadyOnce()
+            self?.fireRecordingReadyOnce(
+                source: .microphone,
+                startID: startID
+            )
         }
         systemAudioRecorder.onRecordingReady = { [weak self] in
-            self?.fireRecordingReadyOnce()
+            self?.fireRecordingReadyOnce(
+                source: .systemAudio,
+                startID: startID
+            )
         }
         microphoneRecorder.onRecordingFailure = { [weak self] failure in
-            self?.handleSourceFailure(.microphone, error: failure)
+            self?.handleSourceFailure(.microphone, error: failure, startID: startID)
         }
         systemAudioRecorder.onRecordingFailure = { [weak self] failure in
-            self?.handleSourceFailure(.systemAudio, error: failure)
+            self?.handleSourceFailure(.systemAudio, error: failure, startID: startID)
         }
     }
 
@@ -288,30 +559,52 @@ final class SystemDefaultAndSystemAudioRecorder: ObservableObject {
             .store(in: &cancellables)
     }
 
-    private func handleSourceFailure(_ source: RecordingSource, error failure: Error) {
-        let shouldReportOverallFailure = stateLock.withLock { state in
-            guard state.activeSources.contains(source), !state.failedSources.contains(source), !state.overallFailureReported else {
-                return false
+    private func handleSourceFailure(
+        _ source: RecordingSource,
+        error failure: Error,
+        startID: UUID
+    ) {
+        let effect = stateLock.withLock { state -> SourceFailureEffect in
+            guard state.startID == startID,
+                  !state.failedSources.contains(source),
+                  !state.overallFailureReported,
+                  state.startInProgress || state.activeSources.contains(source) else {
+                return .none
             }
 
             state.failedSources.insert(source)
-            let sourceFailuresExhaustedRecording = !state.activeSources.isEmpty && state.activeSources.isSubset(of: state.failedSources)
+            if state.startInProgress {
+                state.failuresDuringStart.append(failure)
+                return .none
+            }
+
+            let sourceFailuresExhaustedRecording = !state.activeSources.isEmpty
+                && state.activeSources.isSubset(of: state.failedSources)
             if sourceFailuresExhaustedRecording {
                 state.overallFailureReported = true
+                return .overallFailure
             }
-            return sourceFailuresExhaustedRecording
+            return .degraded(source.degradedSource)
         }
 
-        if shouldReportOverallFailure {
+        switch effect {
+        case .none:
+            break
+        case .degraded(let degradedSource):
+            onRecordingDegraded?(degradedSource)
+        case .overallFailure:
             onRecordingFailure?(failure)
         }
     }
 
-    private func fireRecordingReadyOnce() {
+    private func fireRecordingReadyOnce(
+        source: RecordingSource,
+        startID: UUID
+    ) {
         let shouldFire = stateLock.withLock { state in
-            guard !state.readyFired else { return false }
-            state.readyFired = true
-            return true
+            guard state.startID == startID else { return false }
+            state.readySources.insert(source)
+            return state.consumeReadyIfPossible()
         }
         if shouldFire {
             onRecordingReady?()

--- a/Tests/AppStateAIProcessingBackendTests.swift
+++ b/Tests/AppStateAIProcessingBackendTests.swift
@@ -207,7 +207,7 @@ struct AppStateAIProcessingBackendTests {
 
         let recordingStart = sourceBlock(
             in: try appStateSource(),
-            from: "private func startRecording(triggerMode: RecordingTriggerMode",
+            from: "private func startRecording(",
             to: "/// Whether the configured recording flow will actually exercise Accessibility."
         )
         let flush = requiredRange(

--- a/Tests/AppStateHistoryProtectionSourceTests.swift
+++ b/Tests/AppStateHistoryProtectionSourceTests.swift
@@ -94,14 +94,17 @@ struct AppStateHistoryProtectionSourceTests {
         // callback) is disproportionate to this suite; the occurrence count is
         // the cheapest faithful proxy for "the recheck was not deleted."
         let recordingStartRange = try source.range(
-            from: "private func startRecording(triggerMode: RecordingTriggerMode",
+            from: "private func startRecording(",
             to: "/// Whether the configured recording flow will actually exercise Accessibility."
         )
         let recordingStart = String(source[recordingStartRange])
         try expect(
             source.contains("private var pendingRecordingStartCount = 0")
                 && recordingStart.contains("pendingRecordingStartCount += 1")
-                && recordingStart.contains("defer { self.pendingRecordingStartCount -= 1 }"),
+                && recordingStart.contains("defer {")
+                && recordingStart.contains(
+                    "self.completePendingRecordingStartTask(startRequestID)"
+                ),
             "an awaited recording start tracks itself as pending via defer, so an early throw or return still decrements the count"
         )
         try expect(
@@ -109,14 +112,15 @@ struct AppStateHistoryProtectionSourceTests {
             "an awaited recording start rechecks archive protection before creating writers"
         )
         let microphonePermissionRange = try source.range(
-            from: "private func ensureMicrophoneAccess() -> Bool",
+            from: "private func ensureMicrophoneAccess(",
             to: "private func applyAudioInterruptionIfNeeded()"
         )
         let microphonePermission = String(source[microphonePermissionRange])
         try expect(
             microphonePermission.contains("pendingRecordingStartCount += 1")
+                && microphonePermission.contains("defer {")
                 && microphonePermission.contains(
-                    "defer { strongSelf.pendingRecordingStartCount -= 1 }"
+                    "strongSelf.completePendingRecordingStartTask("
                 ),
             "microphone permission resumption tracks itself as pending via defer, so an early throw or return still decrements the count"
         )

--- a/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
+++ b/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
@@ -199,6 +199,10 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         let startRange = try requiredRange(of: "startPhysicalAudioRecorder(selection: newSelection)", in: switchBody)
         precondition(stopRange.lowerBound < switchRange.lowerBound)
         precondition(switchRange.lowerBound < startRange.lowerBound)
+        precondition(
+            switchBody.contains("self.showDegradedCombinedCaptureNoticeIfNeeded(degradedSource)"),
+            "switching into a combined input surfaces a degraded combined-capture notice, same as an initial start"
+        )
 
         // The live transcriber must be torn down off the main thread so the
         // audio-source menu action returns immediately instead of stalling the
@@ -505,6 +509,10 @@ struct AppStateRecordingJournalIntegrationSourceTests {
 
         assert(begin.contains("try await self.startSelectedAudioRecorder(selection: audioSelection)"))
         assert(begin.contains("self.audioLevelCancellable = self.activeRecorderAudioLevelPublisher"))
+        assert(
+            begin.components(separatedBy: "self.showDegradedCombinedCaptureNoticeIfNeeded(degradedSource)").count - 1 == 2,
+            "both selected-audio-recorder start paths in beginRecording surface a degraded combined-capture notice"
+        )
     }
 
     private static func switchCaseBody(

--- a/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
+++ b/Tests/AppStateRecordingJournalIntegrationSourceTests.swift
@@ -16,6 +16,9 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         precondition(source.contains("private var activeSegmentedJournalController: SegmentedRecordingJournalController?"))
         precondition(source.contains("private var activeRecordingID: UUID?"))
         precondition(source.contains("private var activeInputSwitchToken: UUID?"))
+        precondition(source.contains("struct RecordingStartLifecycle"))
+        precondition(source.contains("private var recordingStartAdmissionLifecycle = RecordingStartLifecycle()"))
+        precondition(source.contains("private var physicalAudioStartLifecycle = RecordingStartLifecycle()"))
         precondition(source.contains("private var isActiveInputSwitchPhysicalStopInProgress = false"))
         precondition(source.contains("private var activeRecordingStorageFailureID: UUID?"))
         precondition(!source.contains("recordingSegmentURLs"))
@@ -65,10 +68,87 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         precondition(startBody.contains("makeActiveSegmentedJournalController(inputID: inputID)"))
         precondition(startBody.contains("attachSegmentedJournalSinks("))
         precondition(startBody.contains("startPhysicalAudioRecorder(selection: selection)"))
+        precondition(startBody.contains("if let degradedSource"))
+        precondition(startBody.contains("markDegradedJournalSourceUnavailableAtStart("))
+        precondition(source.contains("selection: RecordingAudioSelection,\n        sessionID: UUID"))
         precondition(startBody.contains("let inputID = selection.inputID"))
+        precondition(
+            ranges(
+                of: "isCurrentRecordingSession(sessionID)",
+                in: startBody
+            ).count == 2,
+            "both success and failure cleanup must require the current active recording session"
+        )
+        precondition(!startBody.contains("guard activeRecordingID == sessionID"))
         precondition(startBody.contains("controller.startCheckpointing"))
+        let terminalFailureRange = try requiredRange(
+            of: "if let sourceFailure = controller.terminalPersistenceFailure",
+            in: startBody
+        )
+        let terminalRecoveryRange = try requiredRange(
+            of: "handleRecordingJournalPersistenceFailure(sourceFailure)",
+            in: startBody
+        )
+        let failedStartCancelRange = try requiredRange(
+            of: "await cancelPhysicalAudioRecorder(inputID: inputID)",
+            in: startBody
+        )
+        let failedStartDiscardRange = try requiredRange(
+            of: "discardSegmentedJournal(controller)",
+            in: startBody
+        )
+        precondition(
+            terminalFailureRange.lowerBound < terminalRecoveryRange.lowerBound
+                && terminalRecoveryRange.lowerBound < failedStartCancelRange.lowerBound,
+            "classified startup persistence failures enter recovery instead of discard"
+        )
+        precondition(
+            failedStartCancelRange.lowerBound < failedStartDiscardRange.lowerBound,
+            "a current unclassified failed start stops physical capture before discarding its journal"
+        )
         precondition(!startBody.contains("SingleSourceRecordingJournalController"))
         precondition(!startBody.contains("CombinedRecordingJournalController"))
+
+        let degradedSourceBody = try functionBody(
+            named: "markDegradedJournalSourceUnavailableAtStart",
+            in: source
+        )
+        precondition(degradedSourceBody.contains("case .microphone: .microphone"))
+        precondition(degradedSourceBody.contains("case .systemAudio: .systemAudio"))
+        precondition(degradedSourceBody.contains(
+            "controller.markActiveSourceUnavailableAtStart(sourceKind)"
+        ))
+        let runtimeDegradedSourceBody = try functionBody(
+            named: "markDegradedJournalSourceUnavailableDuringRecording",
+            in: source
+        )
+        precondition(runtimeDegradedSourceBody.contains("case .microphone: .microphone"))
+        precondition(runtimeDegradedSourceBody.contains("case .systemAudio: .systemAudio"))
+        precondition(runtimeDegradedSourceBody.contains(
+            "controller.markActiveSourceUnavailableDuringRecording(sourceKind)"
+        ))
+        let physicalStartBody = try functionBody(
+            named: "startPhysicalAudioRecorder",
+            in: source
+        )
+        precondition(physicalStartBody.contains("degradedSource = result.missingSource"))
+        precondition(!physicalStartBody.contains(
+            "degradedSource = systemDefaultAndSystemAudioRecorder.currentMissingSource"
+        ))
+        let firstReadyCheckpointBody = try functionBody(
+            named: "checkpointCombinedRecordingJournalAfterFirstReady",
+            in: source
+        )
+        precondition(firstReadyCheckpointBody.contains(
+            "guard AudioInputDevice.isSystemDefaultAndSystemAudio(inputID) else"
+        ))
+        precondition(firstReadyCheckpointBody.contains(
+            "controller.recordingID == sessionID"
+        ))
+        precondition(firstReadyCheckpointBody.contains("try controller.checkpoint()"))
+        precondition(firstReadyCheckpointBody.contains(
+            "reportRecordingJournalCheckpointFailure(error)"
+        ))
 
         let makeControllerBody = try functionBody(
             named: "makeActiveSegmentedJournalController",
@@ -93,16 +173,26 @@ struct AppStateRecordingJournalIntegrationSourceTests {
             of: "prepareForRecordingJournalPersistenceFailure(sourceFailure)",
             in: storageFailureBody
         )
+        let cleanupBeginRange = try requiredRange(
+            of: "let cleanupID = beginPhysicalAudioCleanup()",
+            in: storageFailureBody
+        )
         let physicalStopRange = try requiredRange(
             of: "stopPhysicalAudioRecorder(",
+            in: storageFailureBody
+        )
+        let cleanupFinishRange = try requiredRange(
+            of: "physicalAudioStartLifecycle.finish(cleanupID)",
             in: storageFailureBody
         )
         let finishFailureRange = try requiredRange(
             of: "finishRecordingAfterJournalPersistenceFailure(",
             in: storageFailureBody
         )
-        precondition(preparationRange.lowerBound < physicalStopRange.lowerBound)
-        precondition(physicalStopRange.lowerBound < finishFailureRange.lowerBound)
+        precondition(preparationRange.lowerBound < cleanupBeginRange.lowerBound)
+        precondition(cleanupBeginRange.lowerBound < physicalStopRange.lowerBound)
+        precondition(physicalStopRange.lowerBound < cleanupFinishRange.lowerBound)
+        precondition(cleanupFinishRange.lowerBound < finishFailureRange.lowerBound)
 
         let alreadyStoppedFailureBody = try body(
             startingWith: "alreadyStoppedTemporaryURLs temporaryURLs: [URL]",
@@ -188,7 +278,37 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         }
 
         let switchBody = try functionBody(named: "switchActiveRecordingInput", in: source)
+        let switchReadyCallback = try body(
+            startingWith: "onReady: { [weak self] in",
+            in: switchBody
+        )
+        precondition(switchReadyCallback.contains(
+            "checkpointCombinedRecordingJournalAfterFirstReady("
+        ))
+        precondition(switchReadyCallback.contains("inputID: newInputID"))
+        precondition(switchReadyCallback.contains(
+            "sessionID: controller.recordingID"
+        ))
+        let switchDegradedCallback = try body(
+            startingWith: "onDegraded: { [weak self] degradedSource in",
+            in: switchBody
+        )
+        let switchRuntimeMarkerRange = try requiredRange(
+            of: "markDegradedJournalSourceUnavailableDuringRecording(",
+            in: switchDegradedCallback
+        )
+        let switchRuntimeNoticeRange = try requiredRange(
+            of: "reconcileDegradedCombinedCaptureNotice(",
+            in: switchDegradedCallback
+        )
+        precondition(
+            switchRuntimeMarkerRange.lowerBound < switchRuntimeNoticeRange.lowerBound,
+            "runtime source loss after an input switch is journaled before notice reconciliation"
+        )
         precondition(switchBody.contains("activeInputSwitchToken = switchToken"))
+        precondition(switchBody.contains("guard physicalAudioStartLifecycle.isIdle else"))
+        precondition(switchBody.contains("physicalAudioStartLifecycle.begin(switchToken)"))
+        precondition(switchBody.contains("rollbackStalePhysicalAudioStart("))
         precondition(switchBody.contains("isActiveInputSwitchPhysicalStopInProgress = true"))
         precondition(switchBody.contains("isActiveInputSwitchPhysicalStopInProgress = false"))
         let readinessGuardRange = try requiredRange(of: "guard isAudioInputSelectable(newInputID) else", in: switchBody)
@@ -197,11 +317,34 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         let stopRange = try requiredRange(of: "stopPhysicalAudioRecorder(", in: switchBody)
         let switchRange = try requiredRange(of: "controller.switchSegment(", in: switchBody)
         let startRange = try requiredRange(of: "startPhysicalAudioRecorder(selection: newSelection)", in: switchBody)
+        precondition(switchBody.contains("if let degradedSource"))
+        let degradedMarkerRange = try requiredRange(
+            of: "markDegradedJournalSourceUnavailableAtStart(",
+            in: switchBody
+        )
         precondition(stopRange.lowerBound < switchRange.lowerBound)
         precondition(switchRange.lowerBound < startRange.lowerBound)
+        precondition(startRange.lowerBound < degradedMarkerRange.lowerBound)
+        let switchSessionGuardRanges = ranges(
+            of: "self.isCurrentRecordingSession(controller.recordingID) else",
+            in: switchBody
+        )
+        let switchReconcileRanges = ranges(
+            of: "self.reconcileDegradedCombinedCaptureNotice(",
+            in: switchBody
+        )
+        let switchReconcileRange = switchReconcileRanges.first {
+            startRange.lowerBound < $0.lowerBound
+        }
+        let switchSessionGuardRange = switchSessionGuardRanges.first {
+            guard let switchReconcileRange else { return false }
+            return startRange.lowerBound < $0.lowerBound
+                && $0.lowerBound < switchReconcileRange.lowerBound
+        }
+        precondition(switchBody.contains("sessionID: controller.recordingID"))
         precondition(
-            switchBody.contains("self.showDegradedCombinedCaptureNoticeIfNeeded(degradedSource)"),
-            "switching into a combined input surfaces a degraded combined-capture notice, same as an initial start"
+            switchSessionGuardRange != nil && switchReconcileRange != nil,
+            "only the accepted current input switch can reconcile degraded-capture state"
         )
 
         // The live transcriber must be torn down off the main thread so the
@@ -249,10 +392,20 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         precondition(!switchBody.contains("discardSingleSourceJournal"))
         precondition(!switchBody.contains("removeInflightRecording"))
 
+        let cleanupBody = try functionBody(
+            named: "beginPhysicalAudioCleanup",
+            in: source
+        )
+        precondition(cleanupBody.contains(
+            "physicalAudioStartLifecycle.beginOrAdoptCleanup("
+        ))
+
         let stopBody = try functionBody(named: "stopActiveAudioRecorder", in: source)
+        precondition(stopBody.contains("let cleanupID = beginPhysicalAudioCleanup()"))
         precondition(stopBody.contains("stopPhysicalAudioRecorder("))
         precondition(stopBody.contains("detachSegmentedJournalSinks()"))
         precondition(stopBody.contains("finishStoppedSegmentedRecording("))
+        precondition(stopBody.contains("physicalAudioStartLifecycle.finish(cleanupID)"))
 
         let finishBody = try functionBody(
             named: "finishStoppedSegmentedRecording",
@@ -285,7 +438,9 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         precondition(!partialBody.contains("PostProcessingService"))
 
         let cancelBody = try functionBody(named: "cancelActiveAudioRecorder", in: source)
+        precondition(cancelBody.contains("let cleanupID = beginPhysicalAudioCleanup()"))
         precondition(cancelBody.contains("detachSegmentedJournalSinks()"))
+        precondition(cancelBody.contains("physicalAudioStartLifecycle.finish(cleanupID)"))
         precondition(cancelBody.contains("discardActiveSegmentedJournal()"))
 
         let preserveBody = try functionBody(
@@ -298,6 +453,15 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         try testRecordOnlySessionSnapshotsAndGatesAIComponents()
         try testAppleSpeechStartWithoutTriggerModeClearsSessionSnapshot()
         try testRecordOnlyStillStartsSelectedAudioRecorder()
+        try testDegradedCombinedCaptureNoticeSessionWiring()
+        try testRecordingStartCallbacksStaySessionScoped()
+        try testDegradedCombinedCaptureNoticeEndsWithRecording()
+        try testMCPStartReportsLifecycleRejection()
+        try testSecondToggleCancelsPendingRecordingStart()
+        try testPermissionResumeRetainsStartAdmission()
+        try testCancelledPhysicalStartReleasesOnlyItsLifecycle()
+        try testDuplicateCalendarReminderPreservesPendingSnapshot()
+        try testRejectedRecordingEntryPointsResetShortcutSession()
         try testMCPStopUsesRecordingSessionSnapshot()
         try testRecordOnlyBranchesBeforeTranscriptionJobCreation()
         try testAudioOnlyStopUsesExistingRecorderFinalizationCases()
@@ -306,6 +470,226 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         try testAudioOnlyCompletionOwnsForegroundUIAndTermination()
 
         print("AppStateRecordingJournalIntegrationSourceTests passed")
+    }
+
+    private static func testMCPStartReportsLifecycleRejection() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let start = try body(startingWith: "private func startRecording(", in: source)
+        let mcpStart = try body(startingWith: "func startRecordingFromMCP()", in: source)
+
+        assert(source.contains("private func startRecording(\n        triggerMode: RecordingTriggerMode,\n        onStarted: (@MainActor () -> Void)? = nil\n    ) -> Bool"))
+        assert(start.contains("guard physicalAudioStartLifecycle.isIdle else { return false }"))
+        let admissionBegin = try requiredRange(
+            of: "recordingStartAdmissionLifecycle.begin(startRequestID)",
+            in: start
+        )
+        let taskStart = try requiredRange(of: "Task { [weak self] in", in: start)
+        let admissionCompletion = try requiredRange(
+            of: "completePendingRecordingStartTask(startRequestID)",
+            in: start
+        )
+        assert(admissionBegin.lowerBound < taskStart.lowerBound)
+        assert(taskStart.lowerBound < admissionCompletion.lowerBound)
+        assert(start.contains("defer"))
+        assert(start.contains("return true"))
+        assert(mcpStart.contains("guard startRecording(triggerMode: .toggle) else"))
+        assert(mcpStart.contains("shortcutSessionController.reset()"))
+        assert(mcpStart.contains("return false"))
+    }
+
+    private static func testSecondToggleCancelsPendingRecordingStart() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let start = try body(startingWith: "private func startRecording(", in: source)
+        let toggle = try body(startingWith: "func toggleRecording()", in: source)
+        let cancel = try functionBody(
+            named: "cancelPendingRecordingStart",
+            in: source
+        )
+        let cancelToggle = try functionBody(
+            named: "cancelToggleShortcutSession",
+            in: source
+        )
+
+        assert(source.contains(
+            "private var pendingRecordingStartTask: Task<Void, Never>?"
+        ))
+        assert(start.contains("let startTask = Task { [weak self] in"))
+        assert(start.contains("pendingRecordingStartTask = startTask"))
+        assert(start.contains("recordingStartAdmissionLifecycle.activeID == startRequestID"))
+        assert(start.contains("guard !Task.isCancelled else { return }"))
+        assert(toggle.contains("if cancelPendingRecordingStart()"))
+        assert(cancel.contains("pendingRecordingStartTask?.cancel()"))
+        assert(cancel.contains("pendingRecordingStartTask = nil"))
+        assert(cancel.contains("recordingStartAdmissionLifecycle.finish(startRequestID)"))
+        assert(cancel.contains("restoreAudioInterruptionIfNeeded()"))
+        let escapeAdmissionCancel = try requiredRange(
+            of: "_ = cancelPendingRecordingStart()",
+            in: cancelToggle
+        )
+        let escapeTriggerReset = try requiredRange(
+            of: "activeRecordingTriggerMode = nil",
+            in: cancelToggle
+        )
+        assert(
+            escapeAdmissionCancel.lowerBound < escapeTriggerReset.lowerBound,
+            "Escape cancellation invalidates the admitted async start before clearing UI state"
+        )
+    }
+
+    private static func testPermissionResumeRetainsStartAdmission() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let context = try body(
+            startingWith: "private struct PendingRecordingPermissionContext",
+            in: source
+        )
+        let start = try body(startingWith: "private func startRecording(", in: source)
+        let complete = try functionBody(
+            named: "completePendingRecordingStartTask",
+            in: source
+        )
+        let microphoneAccess = try functionBody(
+            named: "ensureMicrophoneAccess",
+            in: source
+        )
+        let accessibleSelection = try functionBody(
+            named: "accessibleCurrentRecordingAudioSelection",
+            in: source
+        )
+        let speechPrompt = try functionBody(
+            named: "prepareForSpeechRecognitionPermissionPrompt",
+            in: source
+        )
+        let begin = try body(startingWith: "private func beginRecording(", in: source)
+
+        assert(context.contains("let startRequestID: UUID"))
+        assert(context.contains("let onStarted: (@MainActor () -> Void)?"))
+        assert(start.contains(
+            "completePendingRecordingStartTask(startRequestID)"
+        ))
+        assert(start.contains("guard !isAwaitingMicrophonePermission"))
+        assert(start.contains("!isAwaitingSpeechRecognitionPermission"))
+        assert(complete.contains("pendingMicrophonePermissionContext?.startRequestID"))
+        assert(complete.contains("pendingSpeechPermissionContext?.startRequestID"))
+        assert(microphoneAccess.contains(
+            "recordingStartAdmissionLifecycle.activeID"
+        ))
+        assert(microphoneAccess.contains("== pendingContext.startRequestID"))
+        assert(microphoneAccess.contains(
+            "startRequestID: pendingContext.startRequestID"
+        ))
+        assert(microphoneAccess.contains(
+            "onStarted: pendingContext.onStarted"
+        ))
+        assert(accessibleSelection.contains("onStarted: onStarted"))
+        assert(speechPrompt.contains("startRequestID: startRequestID"))
+        assert(speechPrompt.contains("onStarted: onStarted"))
+        assert(source.contains(
+            "private func beginRecording(\n        startRequestID: UUID"
+        ))
+        assert(begin.contains(
+            "recordingStartAdmissionLifecycle.activeID == startRequestID"
+        ))
+    }
+
+    private static func testCancelledPhysicalStartReleasesOnlyItsLifecycle() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let cancel = try functionBody(named: "cancelActiveAudioRecorder", in: source)
+        let rollback = try functionBody(
+            named: "rollbackStalePhysicalAudioStart",
+            in: source
+        )
+
+        assert(cancel.contains(
+            "let cleanupID = beginPhysicalAudioCleanup()"
+        ))
+        assert(cancel.contains("physicalAudioStartLifecycle.finish(cleanupID)"))
+        let finish = try requiredRange(
+            of: "physicalAudioStartLifecycle.finish(cleanupID)",
+            in: cancel
+        )
+        let discard = try requiredRange(
+            of: "discardActiveSegmentedJournal()",
+            in: cancel
+        )
+        assert(finish.lowerBound < discard.lowerBound)
+
+        let ownershipGuard = try requiredRange(
+            of: "physicalAudioStartLifecycle.beginCleanup(for: operationID)",
+            in: rollback
+        )
+        let physicalCancel = try requiredRange(
+            of: "cancelPhysicalAudioRecorder(inputID: inputID)",
+            in: rollback
+        )
+        assert(ownershipGuard.lowerBound < physicalCancel.lowerBound)
+    }
+
+    private static func testDuplicateCalendarReminderPreservesPendingSnapshot() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let initializer = try body(
+            startingWith: "init(dependencies: AppStateDependencies = .live)",
+            in: source
+        )
+        let calendarStart = try functionBody(
+            named: "beginCalendarReminderRecording",
+            in: source
+        )
+        let callbackStart = try requiredRange(
+            of: "meetingReminderOverlayManager.onStart =",
+            in: initializer
+        )
+        guard let callbackEnd = initializer.range(
+            of: "self.startRecordingFromCalendarReminder()",
+            range: callbackStart.upperBound..<initializer.endIndex
+        ) else {
+            throw TestFailure("missing calendar reminder start callback")
+        }
+        let callback = String(
+            initializer[callbackStart.lowerBound..<callbackEnd.upperBound]
+        )
+
+        let callbackAdmissionGuard = try requiredRange(
+            of: "recordingStartAdmissionLifecycle.isIdle",
+            in: callback
+        )
+        let callbackSnapshot = try requiredRange(
+            of: "activeRecordingCalendarSnapshot = RecordingCalendarSnapshot(",
+            in: callback
+        )
+        assert(callbackAdmissionGuard.lowerBound < callbackSnapshot.lowerBound)
+        assert(calendarStart.contains("recordingStartAdmissionLifecycle.isIdle"))
+        assert(calendarStart.contains("physicalAudioStartLifecycle.isIdle"))
+        let admissionGuard = try requiredRange(
+            of: "recordingStartAdmissionLifecycle.isIdle",
+            in: calendarStart
+        )
+        let rejectionCleanup = try requiredRange(
+            of: "activeRecordingCalendarSnapshot = nil",
+            in: calendarStart
+        )
+        assert(admissionGuard.lowerBound < rejectionCleanup.lowerBound)
+    }
+
+    private static func testRejectedRecordingEntryPointsResetShortcutSession() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let toggle = try body(startingWith: "func toggleRecording()", in: source)
+        let calendar = try functionBody(
+            named: "beginCalendarReminderRecording",
+            in: source
+        )
+        let shortcut = try functionBody(named: "scheduleShortcutStart", in: source)
+
+        assert(toggle.contains("if !startRecording(triggerMode: .toggle)"))
+        assert(toggle.contains("shortcutSessionController.reset()"))
+        assert(calendar.contains("if !startRecording("))
+        assert(calendar.contains("shortcutSessionController.reset()"))
+        assert(calendar.contains("activeRecordingCalendarSnapshot = nil"))
+        assert(
+            ranges(of: "startRecording(triggerMode:", in: shortcut).count == 2
+        )
+        assert(
+            ranges(of: "shortcutSessionController.reset()", in: shortcut).count == 2
+        )
     }
 
     private static func testMCPStopUsesRecordingSessionSnapshot() throws {
@@ -459,7 +843,8 @@ struct AppStateRecordingJournalIntegrationSourceTests {
 
         assert(source.contains("private var activeRecordingTranscriptionEnabled: Bool?"))
         assert(begin.contains("activeRecordingTranscriptionEnabled = transcriptionEnabled"))
-        assert(begin.contains("activeRecordingID = UUID()"))
+        assert(begin.contains("let recordingSessionID = UUID()"))
+        assert(begin.contains("activeRecordingID = recordingSessionID"))
         assert(!begin.contains("AudioInputDevice.isSingleSource(audioInputID)"))
         assert(begin.contains("if shouldTranscribe"))
         assert(begin.contains("startRealtimeStreamingIfEnabled()"))
@@ -480,10 +865,15 @@ struct AppStateRecordingJournalIntegrationSourceTests {
 """))
         assert(begin.contains("""
                     guard let pendingContext else {
-                        self.activeRecordingID = nil
+                        if self.pendingRecordingStartCount > 0 {
+                            self.pendingRecordingStartCount -= 1
+                        }
                         return
                     }
 """))
+        assert(begin.contains(
+            "recordingStartAdmissionLifecycle.activeID\n                            == pendingContext.startRequestID"
+        ))
         assert(begin.contains("""
                     } else {
                         self.restoreAudioInterruptionIfNeeded()
@@ -507,11 +897,196 @@ struct AppStateRecordingJournalIntegrationSourceTests {
         let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
         let begin = try body(startingWith: "private func beginRecording(", in: source)
 
-        assert(begin.contains("try await self.startSelectedAudioRecorder(selection: audioSelection)"))
+        assert(begin.contains("try await self.startSelectedAudioRecorder("))
+        assert(begin.contains("sessionID: recordingSessionID"))
         assert(begin.contains("self.audioLevelCancellable = self.activeRecorderAudioLevelPublisher"))
+    }
+
+    private static func testDegradedCombinedCaptureNoticeSessionWiring() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let begin = try body(startingWith: "private func beginRecording(", in: source)
+        let sessionCreationRange = try requiredRange(of: "let recordingSessionID = UUID()", in: begin)
+        let activeIDRange = try requiredRange(of: "activeRecordingID = recordingSessionID", in: begin)
+        let recordingRange = try requiredRange(of: "isRecording = true", in: begin)
+        let beginNoticeRange = try requiredRange(
+            of: "overlayManager.beginDegradedCombinedCaptureNoticeSession(recordingSessionID)",
+            in: begin
+        )
+        precondition(sessionCreationRange.lowerBound < activeIDRange.lowerBound)
+        precondition(activeIDRange.lowerBound < recordingRange.lowerBound)
+        precondition(
+            recordingRange.lowerBound < beginNoticeRange.lowerBound,
+            "the degraded-notice session begins only after recording is active"
+        )
+
+        let startRanges = ranges(
+            of: "let degradedSource = try await self.startSelectedAudioRecorder(",
+            in: begin
+        )
+        let sessionGuardRanges = ranges(
+            of: "guard self.isCurrentRecordingSession(recordingSessionID) else",
+            in: begin
+        )
+        let reconcileRanges = ranges(
+            of: "self.reconcileDegradedCombinedCaptureNotice(",
+            in: begin
+        )
+        precondition(startRanges.count == 2)
+        precondition(sessionGuardRanges.count >= 2)
+        precondition(reconcileRanges.count >= 2)
+        for startRange in startRanges {
+            let reconcileRange = reconcileRanges.first {
+                startRange.lowerBound < $0.lowerBound
+            }
+            let guardRange = sessionGuardRanges.first {
+                guard let reconcileRange else { return false }
+                return startRange.lowerBound < $0.lowerBound
+                    && $0.lowerBound < reconcileRange.lowerBound
+            }
+            precondition(
+                guardRange != nil && reconcileRange != nil,
+                "both start paths reject stale sessions before reconciling the notice"
+            )
+        }
+
+        let reconcile = try functionBody(named: "reconcileDegradedCombinedCaptureNotice", in: source)
+        precondition(reconcile.contains("let message = degradedSource.map"))
+        precondition(reconcile.contains("overlayManager.reconcileDegradedCombinedCaptureNotice("))
+        precondition(reconcile.contains("message: message"))
+        precondition(reconcile.contains("sessionID: sessionID"))
+        precondition(!reconcile.contains("guard let degradedSource else { return }"))
+        precondition(source.contains(
+            "manager.onVisibleOverlayFrameChange = { [weak self] frame in"
+        ))
+        precondition(source.contains(
+            "self?.overlayManager.recordingReminderFrameDidChange(frame)"
+        ))
+    }
+
+    private static func testRecordingStartCallbacksStaySessionScoped() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let start = try body(startingWith: "private func startRecording(", in: source)
+        let begin = try body(startingWith: "private func beginRecording(", in: source)
+        let configure = try functionBody(
+            named: "configureSelectedAudioRecorderCallbacks",
+            in: source
+        )
+        let rollback = try functionBody(
+            named: "rollbackStalePhysicalAudioStart",
+            in: source
+        )
+        let beginCleanup = try functionBody(
+            named: "beginPhysicalAudioCleanup",
+            in: source
+        )
+        let readyCallback = try body(
+            startingWith: "onReady: { [weak self] in",
+            in: begin
+        )
+        let degradedCallback = try body(
+            startingWith: "onDegraded: { [weak self] degradedSource in",
+            in: begin
+        )
+        let takeLiveTranscriber = try functionBody(
+            named: "takeLiveTranscriberIfOwned",
+            in: source
+        )
+        let currentSession = try functionBody(
+            named: "isCurrentRecordingSession",
+            in: source
+        )
+
+        assert(start.contains("guard physicalAudioStartLifecycle.isIdle else { return false }"))
+        assert(begin.contains("physicalAudioStartLifecycle.isIdle else"))
+        let lifecycleBegin = try requiredRange(
+            of: "physicalAudioStartLifecycle.begin(recordingSessionID)",
+            in: begin
+        )
+        let noticeBegin = try requiredRange(
+            of: "overlayManager.beginDegradedCombinedCaptureNoticeSession(recordingSessionID)",
+            in: begin
+        )
+        assert(lifecycleBegin.lowerBound < noticeBegin.lowerBound)
+        assert(begin.contains("guard self.isCurrentRecordingSession(recordingSessionID) else { return }"))
+        assert(begin.contains("noticeSessionID: recordingSessionID"))
+        assert(begin.contains("self.liveTranscriber = transcriber"))
+        let transcriberStart = try requiredRange(
+            of: "try await transcriber.start(locale:",
+            in: begin
+        )
+        let transcriberAssignment = try requiredRange(
+            of: "self.liveTranscriber = transcriber",
+            in: begin
+        )
+        let transcriberStartupContinuation = String(
+            begin[transcriberStart.upperBound..<transcriberAssignment.lowerBound]
+        )
         assert(
-            begin.components(separatedBy: "self.showDegradedCombinedCaptureNoticeIfNeeded(degradedSource)").count - 1 == 2,
-            "both selected-audio-recorder start paths in beginRecording surface a degraded combined-capture notice"
+            transcriberStartupContinuation.contains(
+                "guard self.isCurrentRecordingSession(recordingSessionID) else"
+            )
+        )
+        assert(begin.contains("self.rollbackStalePhysicalAudioStart("))
+        assert(begin.contains("self.finishPhysicalAudioStart(recordingSessionID)"))
+        assert(currentSession.contains("activeRecordingID == sessionID"))
+        assert(currentSession.contains("isRecording"))
+        assert(currentSession.contains("activeRecordingTriggerMode != nil"))
+        assert(source.contains("onDegraded: ((DegradedCombinedCaptureSource) -> Void)? = nil"))
+        assert(configure.contains("systemDefaultAndSystemAudioRecorder.onRecordingDegraded = onDegraded"))
+        assert(takeLiveTranscriber.contains("current === transcriber"))
+        assert(takeLiveTranscriber.contains("liveTranscriber = nil"))
+        assert(begin.contains("takeLiveTranscriberIfOwned(transcriber)"))
+        assert(readyCallback.contains(
+            "checkpointCombinedRecordingJournalAfterFirstReady("
+        ))
+        assert(readyCallback.contains("inputID: audioInputID"))
+        assert(readyCallback.contains("sessionID: recordingSessionID"))
+        let runtimeMarkerRange = try requiredRange(
+            of: "markDegradedJournalSourceUnavailableDuringRecording(",
+            in: degradedCallback
+        )
+        let runtimeNoticeRange = try requiredRange(
+            of: "reconcileDegradedCombinedCaptureNotice(",
+            in: degradedCallback
+        )
+        assert(runtimeMarkerRange.lowerBound < runtimeNoticeRange.lowerBound)
+        assert(beginCleanup.contains(
+            "physicalAudioStartLifecycle.beginOrAdoptCleanup("
+        ))
+        assert(rollback.contains(
+            "physicalAudioStartLifecycle.beginCleanup(for: operationID)"
+        ))
+        assert(rollback.contains("cancelPhysicalAudioRecorder(inputID: inputID)"))
+        assert(rollback.contains("physicalAudioStartLifecycle.finish(operationID)"))
+    }
+
+    private static func testDegradedCombinedCaptureNoticeEndsWithRecording() throws {
+        let source = try String(contentsOfFile: "Sources/AppState.swift", encoding: .utf8)
+        let stop = try functionBody(named: "stopAndTranscribe", in: source)
+        let stopEndRange = try requiredRange(
+            of: "overlayManager.endDegradedCombinedCaptureNoticeSession()",
+            in: stop
+        )
+        let audioOnlyBranchRange = try requiredRange(of: "if !shouldTranscribe", in: stop)
+        precondition(
+            stopEndRange.lowerBound < audioOnlyBranchRange.lowerBound,
+            "the degraded notice ends before transcription or audio-only saving begins"
+        )
+
+        let storageFailure = try functionBody(
+            named: "prepareForRecordingJournalPersistenceFailure",
+            in: source
+        )
+        let storageEndRange = try requiredRange(
+            of: "overlayManager.endDegradedCombinedCaptureNoticeSession()",
+            in: storageFailure
+        )
+        let recordingStoppedRange = try requiredRange(of: "isRecording = false", in: storageFailure)
+        let storageNoticeRange = try requiredRange(of: "overlayManager.showRecordingNotice(", in: storageFailure)
+        precondition(storageEndRange.lowerBound < recordingStoppedRange.lowerBound)
+        precondition(
+            storageEndRange.lowerBound < storageNoticeRange.lowerBound,
+            "the stale degraded notice ends before the storage-failure notice is shown"
         )
     }
 
@@ -528,6 +1103,17 @@ struct AppStateRecordingJournalIntegrationSourceTests {
             throw TestFailure("missing switch case boundary")
         }
         return String(text[startRange.upperBound..<endRange.lowerBound])
+    }
+
+    private static func ranges(of needle: String, in text: String) -> [Range<String.Index>] {
+        var result: [Range<String.Index>] = []
+        var searchStart = text.startIndex
+        while searchStart < text.endIndex,
+              let range = text.range(of: needle, range: searchStart..<text.endIndex) {
+            result.append(range)
+            searchStart = range.upperBound
+        }
+        return result
     }
 
     private static func requiredRange(

--- a/Tests/AppStateStorageSafetyTests.swift
+++ b/Tests/AppStateStorageSafetyTests.swift
@@ -11,6 +11,7 @@ struct AppStateStorageSafetyTests {
         try await verifiesSharedAssetsRemainWhileHistoryStillReferencesThem()
         try verifiesRemovedRowsDoNotProtectEachOthersSharedAssets()
         try verifiesAudioOnlyPersistenceFailureCleanupDecisions()
+        try verifiesDegradedCombinedCaptureMessages()
         try await verifiesArchiveUsesOriginatingHistoryStoreFactory()
         try await verifiesHistoryCreatedAfterAssetsDoesNotSweep()
         try await verifiesHistoryRowsLostAfterSnapshotDoesNotSweep()
@@ -396,6 +397,35 @@ struct AppStateStorageSafetyTests {
                 "audio-only persistence failure preserves uncertain ownership"
             )
         }
+    }
+
+    // A degraded combined-capture message must name which source is
+    // missing and which one recording continues with, so the notice never
+    // reads as a generic, actionless "something failed".
+    private static func verifiesDegradedCombinedCaptureMessages() throws {
+        let missingMicMessage = AppState.degradedCombinedCaptureMessage(missing: .microphone)
+        try expect(
+            missingMicMessage.localizedCaseInsensitiveContains("mic"),
+            "missing-microphone message names the mic"
+        )
+        try expect(
+            missingMicMessage.localizedCaseInsensitiveContains("system audio"),
+            "missing-microphone message names the surviving source"
+        )
+
+        let missingSystemAudioMessage = AppState.degradedCombinedCaptureMessage(missing: .systemAudio)
+        try expect(
+            missingSystemAudioMessage.localizedCaseInsensitiveContains("system audio"),
+            "missing-System-Audio message names System Audio"
+        )
+        try expect(
+            missingSystemAudioMessage.localizedCaseInsensitiveContains("mic"),
+            "missing-System-Audio message names the surviving source"
+        )
+        try expect(
+            missingMicMessage != missingSystemAudioMessage,
+            "the two degraded messages are distinct"
+        )
     }
 
     private static func makeHistoryItem(

--- a/Tests/CombinedCaptureDegradationTests.swift
+++ b/Tests/CombinedCaptureDegradationTests.swift
@@ -1,0 +1,891 @@
+import Foundation
+
+#if !QUILL_GROUPED_TEST_RUNNER
+@main
+#endif
+struct CombinedCaptureDegradationTests {
+    static func main() async throws {
+        try await bothSourcesSucceed()
+        try await sourceStartsRunConcurrently()
+        try await microphoneOnlySuccessReturnsMissingSystemAudio()
+        try await systemAudioOnlySuccessReturnsMissingMicrophone()
+        try await totalFailureAttemptsBothSourcesAndThrows()
+        try await readyCallbackAfterTotalFailureIsIgnored()
+        try await readyCallbackBeforeStartReturnIsRetained()
+        try await microphoneDebugFailureIsConsumedOnce()
+        try await systemAudioDebugFailureIsConsumedOnce()
+        try await bothDebugFailuresAreConsumedTogether()
+        try await runtimeSourceLossReportsDegradationBeforeOverallFailure()
+        try await sourceLossWhileOtherSourceStartsWaitsForItsOutcome()
+        try await staleChildReadyCallbackCannotReadyReplacementStart()
+        try await cancellingPendingCombinedStartRollsBackLateSystemAudio()
+        try await cancellationCompletionWaitsForPendingStartCleanup()
+        try await systemAudioCancellationRollsBackStartedMicrophone()
+        try physicalAudioStartLifecycleKeepsNewStartsBlockedUntilCleanup()
+        try physicalAudioCleanupPreventsStaleRollbackFromReleasingOwnership()
+        try microphoneGenerationRejectsOldCallbacksAfterReplacement()
+        try systemAudioGenerationRejectsPendingAndOldStreamsAfterReplacement()
+        try degradedNoticeWaitsForRecordingPresentation()
+        try reminderArrivalReanchorsVisibleDegradedNotice()
+        try staleDismissCannotHideReplacementNotice()
+        try healthyReconciliationClearsAndLaterDegradationCanReappear()
+        try endingSessionPreventsPendingNoticeResurrection()
+        try oldSessionRequestsAreIgnored()
+        print("CombinedCaptureDegradationTests passed")
+    }
+
+    private static func bothSourcesSucceed() async throws {
+        var microphoneAttempts = 0
+        var systemAudioAttempts = 0
+        let recorder = makeRecorder(
+            startMicrophone: { deviceUID in
+                microphoneAttempts += 1
+                return AudioRecorderStartResult(
+                    requestedDeviceUID: deviceUID,
+                    resolvedDeviceUID: "resolved-microphone",
+                    usedSystemDefaultFallback: true
+                )
+            },
+            startSystemAudio: {
+                systemAudioAttempts += 1
+            }
+        )
+
+        let result = try await recorder.startRecording(microphoneDeviceUID: "requested-microphone")
+
+        try expect(microphoneAttempts == 1, "both-success start attempts the microphone once")
+        try expect(systemAudioAttempts == 1, "both-success start attempts System Audio once")
+        try expect(result.microphoneStarted, "both-success result marks the microphone started")
+        try expect(result.systemAudioStarted, "both-success result marks System Audio started")
+        try expect(result.microphoneUsedSystemDefaultFallback, "microphone fallback metadata is preserved")
+        try expect(result.missingSource == nil, "both-success result has no missing source")
+    }
+
+    private static func sourceStartsRunConcurrently() async throws {
+        let systemAudioStarted = DispatchSemaphore(value: 0)
+        let recorder = makeRecorder(
+            startMicrophone: { deviceUID in
+                guard systemAudioStarted.wait(timeout: .now() + 1) == .success else {
+                    throw TestFailure(
+                        "System Audio must be attempted without waiting for microphone startup"
+                    )
+                }
+                return successfulMicrophoneResult(deviceUID: deviceUID)
+            },
+            startSystemAudio: {
+                systemAudioStarted.signal()
+            }
+        )
+
+        let result = try await recorder.startRecording(
+            microphoneDeviceUID: "microphone"
+        )
+
+        try expect(
+            result.microphoneStarted && result.systemAudioStarted,
+            "a slow microphone start does not delay the independent System Audio attempt"
+        )
+    }
+
+    private static func microphoneOnlySuccessReturnsMissingSystemAudio() async throws {
+        var microphoneAttempts = 0
+        var systemAudioAttempts = 0
+        let recorder = makeRecorder(
+            startMicrophone: { deviceUID in
+                microphoneAttempts += 1
+                return successfulMicrophoneResult(deviceUID: deviceUID)
+            },
+            startSystemAudio: {
+                systemAudioAttempts += 1
+                throw StartFailure.systemAudio
+            }
+        )
+
+        let result = try await recorder.startRecording(microphoneDeviceUID: "microphone")
+
+        try expect(microphoneAttempts == 1, "microphone-only result attempts the microphone")
+        try expect(systemAudioAttempts == 1, "microphone-only result still attempts System Audio")
+        try expect(result.microphoneStarted, "microphone-only result keeps the successful microphone")
+        try expect(!result.systemAudioStarted, "microphone-only result marks System Audio unavailable")
+        try expect(result.missingSource == .systemAudio, "microphone-only result identifies System Audio as missing")
+    }
+
+    private static func systemAudioOnlySuccessReturnsMissingMicrophone() async throws {
+        var microphoneAttempts = 0
+        var systemAudioAttempts = 0
+        let recorder = makeRecorder(
+            startMicrophone: { _ in
+                microphoneAttempts += 1
+                throw StartFailure.microphone
+            },
+            startSystemAudio: {
+                systemAudioAttempts += 1
+            }
+        )
+
+        let result = try await recorder.startRecording(microphoneDeviceUID: "microphone")
+
+        try expect(microphoneAttempts == 1, "System-Audio-only result attempts the microphone")
+        try expect(systemAudioAttempts == 1, "System-Audio-only result still attempts System Audio")
+        try expect(!result.microphoneStarted, "System-Audio-only result marks the microphone unavailable")
+        try expect(result.systemAudioStarted, "System-Audio-only result keeps the successful System Audio source")
+        try expect(result.missingSource == .microphone, "System-Audio-only result identifies the microphone as missing")
+    }
+
+    private static func totalFailureAttemptsBothSourcesAndThrows() async throws {
+        var microphoneAttempts = 0
+        var systemAudioAttempts = 0
+        let recorder = makeRecorder(
+            startMicrophone: { _ in
+                microphoneAttempts += 1
+                throw StartFailure.microphone
+            },
+            startSystemAudio: {
+                systemAudioAttempts += 1
+                throw StartFailure.systemAudio
+            }
+        )
+
+        do {
+            _ = try await recorder.startRecording(microphoneDeviceUID: "microphone")
+            throw TestFailure("total failure must throw")
+        } catch SystemDefaultAndSystemAudioRecorderError.failedToStartAnyRecorder(let errors) {
+            try expect(errors.count == 2, "total failure preserves both source errors")
+        }
+
+        try expect(microphoneAttempts == 1, "total failure attempts the microphone")
+        try expect(systemAudioAttempts == 1, "total failure attempts System Audio after microphone failure")
+    }
+
+    private static func readyCallbackAfterTotalFailureIsIgnored() async throws {
+        let recorder = makeRecorder(
+            startMicrophone: { _ in throw StartFailure.microphone },
+            startSystemAudio: { throw StartFailure.systemAudio }
+        )
+        var readyCount = 0
+        recorder.onRecordingReady = { readyCount += 1 }
+
+        do {
+            _ = try await recorder.startRecording(microphoneDeviceUID: "microphone")
+            throw TestFailure("total failure must throw")
+        } catch SystemDefaultAndSystemAudioRecorderError.failedToStartAnyRecorder {
+            // Expected.
+        }
+
+        recorder.microphoneRecorder.onRecordingReady?()
+        try expect(
+            readyCount == 0,
+            "a queued ready callback cannot revive a failed combined start"
+        )
+    }
+
+    private static func readyCallbackBeforeStartReturnIsRetained() async throws {
+        var recorder: SystemDefaultAndSystemAudioRecorder!
+        recorder = makeRecorder(
+            startMicrophone: { deviceUID in
+                recorder.microphoneRecorder.onRecordingReady?()
+                return successfulMicrophoneResult(deviceUID: deviceUID)
+            },
+            startSystemAudio: {}
+        )
+        var readyCount = 0
+        recorder.onRecordingReady = { readyCount += 1 }
+
+        _ = try await recorder.startRecording(microphoneDeviceUID: "microphone")
+
+        try expect(
+            readyCount == 1,
+            "a child ready callback is retained until its successful source is admitted"
+        )
+    }
+
+    private static func microphoneDebugFailureIsConsumedOnce() async throws {
+        var microphoneAttempts = 0
+        var systemAudioAttempts = 0
+        let recorder = makeRecorder(
+            startMicrophone: { deviceUID in
+                microphoneAttempts += 1
+                return successfulMicrophoneResult(deviceUID: deviceUID)
+            },
+            startSystemAudio: {
+                systemAudioAttempts += 1
+            }
+        )
+        recorder.debugForcesMicrophoneStartFailure = true
+
+        let first = try await recorder.startRecording(microphoneDeviceUID: "microphone")
+        let second = try await recorder.startRecording(microphoneDeviceUID: "microphone")
+
+        try expect(first.missingSource == .microphone, "armed microphone debug failure affects the next start")
+        try expect(!recorder.debugForcesMicrophoneStartFailure, "microphone debug failure resets after use")
+        try expect(second.missingSource == nil, "microphone debug failure does not affect a later start")
+        try expect(microphoneAttempts == 1, "injected microphone failure skips only the armed physical attempt")
+        try expect(systemAudioAttempts == 2, "System Audio remains attempted on both starts")
+    }
+
+    private static func systemAudioDebugFailureIsConsumedOnce() async throws {
+        var microphoneAttempts = 0
+        var systemAudioAttempts = 0
+        let recorder = makeRecorder(
+            startMicrophone: { deviceUID in
+                microphoneAttempts += 1
+                return successfulMicrophoneResult(deviceUID: deviceUID)
+            },
+            startSystemAudio: {
+                systemAudioAttempts += 1
+            }
+        )
+        recorder.debugForcesSystemAudioStartFailure = true
+
+        let first = try await recorder.startRecording(microphoneDeviceUID: "microphone")
+        let second = try await recorder.startRecording(microphoneDeviceUID: "microphone")
+
+        try expect(first.missingSource == .systemAudio, "armed System Audio debug failure affects the next start")
+        try expect(!recorder.debugForcesSystemAudioStartFailure, "System Audio debug failure resets after use")
+        try expect(second.missingSource == nil, "System Audio debug failure does not affect a later start")
+        try expect(microphoneAttempts == 2, "microphone remains attempted on both starts")
+        try expect(systemAudioAttempts == 1, "injected System Audio failure skips only the armed physical attempt")
+    }
+
+    private static func bothDebugFailuresAreConsumedTogether() async throws {
+        var microphoneAttempts = 0
+        var systemAudioAttempts = 0
+        let recorder = makeRecorder(
+            startMicrophone: { deviceUID in
+                microphoneAttempts += 1
+                return successfulMicrophoneResult(deviceUID: deviceUID)
+            },
+            startSystemAudio: {
+                systemAudioAttempts += 1
+            }
+        )
+        recorder.debugForcesMicrophoneStartFailure = true
+        recorder.debugForcesSystemAudioStartFailure = true
+
+        do {
+            _ = try await recorder.startRecording(microphoneDeviceUID: "microphone")
+            throw TestFailure("arming both debug failures must produce total failure")
+        } catch SystemDefaultAndSystemAudioRecorderError.failedToStartAnyRecorder(let errors) {
+            try expect(errors.count == 2, "both injected failures are reported")
+        }
+
+        try expect(!recorder.debugForcesMicrophoneStartFailure, "microphone flag is consumed on total failure")
+        try expect(!recorder.debugForcesSystemAudioStartFailure, "System Audio flag is consumed on total failure")
+        try expect(microphoneAttempts == 0, "injected microphone failure bypasses the physical start")
+        try expect(systemAudioAttempts == 0, "injected System Audio failure bypasses the physical start")
+    }
+
+    private static func runtimeSourceLossReportsDegradationBeforeOverallFailure() async throws {
+        let recorder = makeRecorder(
+            startMicrophone: { deviceUID in
+                successfulMicrophoneResult(deviceUID: deviceUID)
+            },
+            startSystemAudio: {}
+        )
+        var degradedSources: [DegradedCombinedCaptureSource] = []
+        var overallFailures = 0
+        recorder.onRecordingDegraded = { degradedSources.append($0) }
+        recorder.onRecordingFailure = { _ in overallFailures += 1 }
+
+        _ = try await recorder.startRecording(microphoneDeviceUID: "microphone")
+        recorder.systemAudioRecorder.onRecordingFailure?(StartFailure.systemAudio)
+
+        try expect(
+            degradedSources == [.systemAudio],
+            "losing one active source reports which side disappeared"
+        )
+        try expect(
+            overallFailures == 0,
+            "one surviving source keeps the combined recording alive"
+        )
+        try expect(
+            recorder.currentMissingSource == .systemAudio,
+            "a startup result consumer can reconcile against the latest source state"
+        )
+
+        recorder.microphoneRecorder.onRecordingFailure?(StartFailure.microphone)
+
+        try expect(
+            degradedSources == [.systemAudio],
+            "the final source failure is not reported as another degraded state"
+        )
+        try expect(
+            overallFailures == 1,
+            "losing every active source reports one overall failure"
+        )
+    }
+
+    private static func sourceLossWhileOtherSourceStartsWaitsForItsOutcome() async throws {
+        let gate = AsyncStartGate()
+        let recorder = makeRecorder(
+            startMicrophone: { deviceUID in
+                successfulMicrophoneResult(deviceUID: deviceUID)
+            },
+            startSystemAudio: {
+                await gate.run()
+            }
+        )
+        var degradedSources: [DegradedCombinedCaptureSource] = []
+        var overallFailures = 0
+        recorder.onRecordingDegraded = { degradedSources.append($0) }
+        recorder.onRecordingFailure = { _ in overallFailures += 1 }
+
+        let startTask = Task {
+            try await recorder.startRecording(microphoneDeviceUID: "microphone")
+        }
+        await gate.waitUntilStarted()
+        recorder.microphoneRecorder.onRecordingFailure?(StartFailure.microphone)
+
+        try expect(
+            overallFailures == 0,
+            "a source loss does not fail the session while the other start is pending"
+        )
+        try expect(
+            degradedSources.isEmpty,
+            "startup reconciliation owns the eventual degraded notice"
+        )
+
+        await gate.open()
+        let result = try await startTask.value
+
+        try expect(!result.microphoneStarted, "the failed microphone is excluded from the start result")
+        try expect(result.systemAudioStarted, "System Audio keeps the combined attempt alive")
+        try expect(result.missingSource == .microphone, "the result reports the source lost during startup")
+        try expect(overallFailures == 0, "the surviving source avoids overall failure")
+    }
+
+    private static func staleChildReadyCallbackCannotReadyReplacementStart() async throws {
+        let recorder = makeRecorder(
+            startMicrophone: { deviceUID in
+                successfulMicrophoneResult(deviceUID: deviceUID)
+            },
+            startSystemAudio: {}
+        )
+        var readyCount = 0
+        recorder.onRecordingReady = { readyCount += 1 }
+
+        _ = try await recorder.startRecording(microphoneDeviceUID: "first")
+        let staleReady = recorder.systemAudioRecorder.onRecordingReady
+        recorder.cancelRecording()
+        _ = try await recorder.startRecording(microphoneDeviceUID: "second")
+
+        staleReady?()
+        try expect(
+            readyCount == 0,
+            "a ready callback captured by the old combined start is ignored"
+        )
+
+        recorder.systemAudioRecorder.onRecordingReady?()
+        try expect(
+            readyCount == 1,
+            "the current combined start can still become ready"
+        )
+    }
+
+    private static func cancellingPendingCombinedStartRollsBackLateSystemAudio() async throws {
+        let gate = AsyncStartGate()
+        let cancellationCounter = AsyncCounter()
+        let recorder = makeRecorder(
+            startMicrophone: { deviceUID in
+                successfulMicrophoneResult(deviceUID: deviceUID)
+            },
+            startSystemAudio: {
+                await gate.run()
+            },
+            cancelSystemAudio: {
+                await cancellationCounter.increment()
+            }
+        )
+
+        let startTask = Task {
+            try await recorder.startRecording(microphoneDeviceUID: "microphone")
+        }
+        await gate.waitUntilStarted()
+        recorder.cancelRecording()
+        await gate.open()
+
+        do {
+            _ = try await startTask.value
+            throw TestFailure("a cancelled pending combined start must not report success")
+        } catch is CancellationError {
+            // Expected: the late System Audio start was rolled back.
+        }
+        let cancellationCount = await cancellationCounter.value
+        try expect(
+            cancellationCount == 1,
+            "late System Audio is cancelled exactly once after session invalidation"
+        )
+    }
+
+    private static func cancellationCompletionWaitsForPendingStartCleanup() async throws {
+        let startGate = AsyncStartGate()
+        let completion = AsyncEvent()
+        let recorder = makeRecorder(
+            startMicrophone: { deviceUID in
+                successfulMicrophoneResult(deviceUID: deviceUID)
+            },
+            startSystemAudio: {
+                await startGate.run()
+            }
+        )
+        let startTask = Task {
+            try await recorder.startRecording(microphoneDeviceUID: "microphone")
+        }
+        await startGate.waitUntilStarted()
+
+        recorder.cancelRecording {
+            Task { await completion.signal() }
+        }
+        let completionFiredEarly = await eventFired(
+            completion,
+            withinAttempts: 20
+        )
+        try expect(
+            !completionFiredEarly,
+            "combined cancellation cannot finish while a child start can still roll back"
+        )
+
+        await startGate.open()
+        do {
+            _ = try await startTask.value
+            throw TestFailure("the cancelled combined start must not report success")
+        } catch is CancellationError {
+            // Expected.
+        }
+        await completion.wait()
+    }
+
+    private static func systemAudioCancellationRollsBackStartedMicrophone() async throws {
+        let microphoneCancellationCounter = AsyncCounter()
+        let recorder = makeRecorder(
+            startMicrophone: { deviceUID in
+                successfulMicrophoneResult(deviceUID: deviceUID)
+            },
+            startSystemAudio: {
+                throw CancellationError()
+            },
+            cancelMicrophone: {
+                await microphoneCancellationCounter.increment()
+            }
+        )
+
+        do {
+            _ = try await recorder.startRecording(microphoneDeviceUID: "microphone")
+            throw TestFailure("a cancelled child start must cancel the combined attempt")
+        } catch is CancellationError {
+            // Expected: the successful microphone side is rolled back.
+        }
+
+        let microphoneCancellationCount = await microphoneCancellationCounter.value
+        try expect(
+            microphoneCancellationCount == 1,
+            "System Audio cancellation rolls back the already-started microphone"
+        )
+    }
+
+    private static func physicalAudioStartLifecycleKeepsNewStartsBlockedUntilCleanup() throws {
+        let firstID = UUID(uuidString: "00000000-0000-0000-0000-000000000061")!
+        let secondID = UUID(uuidString: "00000000-0000-0000-0000-000000000062")!
+        var lifecycle = RecordingStartLifecycle()
+
+        try expect(lifecycle.begin(firstID), "the first physical start acquires ownership")
+        try expect(!lifecycle.begin(secondID), "a second start is blocked while cleanup is pending")
+        try expect(!lifecycle.finish(secondID), "an unrelated completion cannot release the active start")
+        try expect(lifecycle.activeID == firstID, "the first start retains ownership")
+        try expect(lifecycle.finish(firstID), "the owning completion releases the start")
+        try expect(lifecycle.begin(secondID), "a new start is accepted after cleanup finishes")
+    }
+
+    private static func physicalAudioCleanupPreventsStaleRollbackFromReleasingOwnership() throws {
+        let startID = UUID(
+            uuidString: "00000000-0000-0000-0000-000000000071"
+        )!
+        let fallbackCleanupID = UUID(
+            uuidString: "00000000-0000-0000-0000-000000000072"
+        )!
+        var lifecycle = RecordingStartLifecycle()
+
+        try expect(lifecycle.begin(startID), "the physical start acquires ownership")
+        let cleanupID = lifecycle.beginOrAdoptCleanup(
+            fallbackID: fallbackCleanupID
+        )
+        try expect(cleanupID == startID, "Stop adopts the pending start operation")
+        try expect(
+            !lifecycle.beginCleanup(for: startID),
+            "a stale startup continuation cannot become a second cleanup owner"
+        )
+        try expect(
+            lifecycle.activeID == startID,
+            "the original Stop cleanup retains ownership until its callback finishes"
+        )
+        try expect(
+            lifecycle.finish(cleanupID),
+            "the owning Stop callback releases physical cleanup"
+        )
+    }
+
+    private static func microphoneGenerationRejectsOldCallbacksAfterReplacement() throws {
+        let firstID = UUID(
+            uuidString: "00000000-0000-0000-0000-000000000081"
+        )!
+        let replacementID = UUID(
+            uuidString: "00000000-0000-0000-0000-000000000082"
+        )!
+        let firstOutput = NSObject()
+        let replacementOutput = NSObject()
+        var lifecycle = AudioRecorderGenerationLifecycle()
+
+        lifecycle.begin(firstID)
+        try expect(
+            lifecycle.bind(firstOutput, to: firstID),
+            "the first microphone output is owned by its recording generation"
+        )
+        try expect(
+            lifecycle.generation(for: firstOutput) == firstID,
+            "callbacks from the active microphone output retain their generation"
+        )
+
+        lifecycle.invalidateCurrent()
+        try expect(
+            !lifecycle.owns(firstID),
+            "stopping the microphone invalidates queued failure and ready callbacks"
+        )
+
+        lifecycle.begin(replacementID)
+        try expect(
+            !lifecycle.owns(firstID),
+            "a replacement microphone generation invalidates delayed callbacks from the old input"
+        )
+        try expect(
+            lifecycle.generation(for: firstOutput) == nil,
+            "the old capture output cannot borrow replacement-generation ownership"
+        )
+        try expect(
+            lifecycle.bind(replacementOutput, to: replacementID),
+            "the replacement microphone output acquires current generation ownership"
+        )
+        try expect(
+            lifecycle.generation(for: replacementOutput) == replacementID,
+            "callbacks from the replacement output remain accepted"
+        )
+    }
+
+    private static func systemAudioGenerationRejectsPendingAndOldStreamsAfterReplacement() throws {
+        let pendingID = UUID(
+            uuidString: "00000000-0000-0000-0000-000000000091"
+        )!
+        let replacementID = UUID(
+            uuidString: "00000000-0000-0000-0000-000000000092"
+        )!
+        let pendingStream = NSObject()
+        let replacementStream = NSObject()
+        var lifecycle = SystemAudioRecorderGenerationLifecycle()
+
+        lifecycle.begin(pendingID)
+        try expect(
+            lifecycle.invalidate(pendingID),
+            "Stop invalidates a System Audio start before SCStream installation"
+        )
+        try expect(
+            !lifecycle.bind(pendingStream, to: pendingID),
+            "a delayed pending start cannot install a stream after Stop"
+        )
+
+        lifecycle.begin(replacementID)
+        try expect(
+            lifecycle.bind(replacementStream, to: replacementID),
+            "the replacement System Audio stream acquires ownership"
+        )
+        try expect(
+            lifecycle.generation(for: pendingStream) == nil,
+            "callbacks from the stale stream cannot borrow replacement state"
+        )
+        try expect(
+            lifecycle.generation(for: replacementStream) == replacementID,
+            "callbacks from the current stream retain replacement ownership"
+        )
+    }
+
+    private static func degradedNoticeWaitsForRecordingPresentation() throws {
+        let sessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        let token = UUID(uuidString: "00000000-0000-0000-0000-000000000011")!
+        let request = DegradedCombinedCaptureNoticeLifecycle.Request(
+            sessionID: sessionID,
+            token: token,
+            message: "No mic",
+            reminderFrame: nil
+        )
+        var lifecycle = DegradedCombinedCaptureNoticeLifecycle()
+
+        try expect(lifecycle.beginSession(sessionID) == .none, "starting an empty notice session has no panel effect")
+        try expect(
+            lifecycle.reconcile(request, sessionID: sessionID) == .none,
+            "a request waits while the recording overlay is not ready"
+        )
+        try expect(lifecycle.pendingRequest == request, "the early degraded request is retained")
+        try expect(lifecycle.visibleRequest == nil, "the early degraded request is not marked visible")
+
+        let effect = lifecycle.markPresentationReady(sessionID: sessionID)
+
+        try expect(effect == .present(request), "recording presentation flushes the retained request")
+        try expect(lifecycle.pendingRequest == nil, "the retained request is consumed once")
+        try expect(lifecycle.visibleRequest == request, "the retained request becomes visible")
+        try expect(
+            lifecycle.markPresentationReady(sessionID: sessionID) == .none,
+            "repeated recording presentation does not present the request twice"
+        )
+    }
+
+    private static func reminderArrivalReanchorsVisibleDegradedNotice() throws {
+        let sessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000007")!
+        let token = UUID(uuidString: "00000000-0000-0000-0000-000000000071")!
+        let request = DegradedCombinedCaptureNoticeLifecycle.Request(
+            sessionID: sessionID,
+            token: token,
+            message: "No mic",
+            reminderFrame: nil
+        )
+        let reminderFrame = CGRect(x: 576, y: 870, width: 360, height: 112)
+        let reanchoredRequest = DegradedCombinedCaptureNoticeLifecycle.Request(
+            sessionID: sessionID,
+            token: token,
+            message: "No mic",
+            reminderFrame: reminderFrame
+        )
+        var lifecycle = DegradedCombinedCaptureNoticeLifecycle()
+        _ = lifecycle.beginSession(sessionID)
+        _ = lifecycle.markPresentationReady(sessionID: sessionID)
+        _ = lifecycle.reconcile(request, sessionID: sessionID)
+
+        try expect(
+            lifecycle.updateReminderFrame(reminderFrame) == .present(reanchoredRequest),
+            "a reminder arriving during degraded recording re-presents the notice below the card"
+        )
+        try expect(
+            lifecycle.visibleRequest == reanchoredRequest,
+            "the visible notice retains the new reminder anchor for later layout updates"
+        )
+    }
+
+    private static func staleDismissCannotHideReplacementNotice() throws {
+        let sessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+        let firstToken = UUID(uuidString: "00000000-0000-0000-0000-000000000021")!
+        let secondToken = UUID(uuidString: "00000000-0000-0000-0000-000000000022")!
+        let first = DegradedCombinedCaptureNoticeLifecycle.Request(
+            sessionID: sessionID,
+            token: firstToken,
+            message: "No mic",
+            reminderFrame: nil
+        )
+        let replacement = DegradedCombinedCaptureNoticeLifecycle.Request(
+            sessionID: sessionID,
+            token: secondToken,
+            message: "No System Audio",
+            reminderFrame: nil
+        )
+        var lifecycle = DegradedCombinedCaptureNoticeLifecycle()
+        _ = lifecycle.beginSession(sessionID)
+        _ = lifecycle.markPresentationReady(sessionID: sessionID)
+        _ = lifecycle.reconcile(first, sessionID: sessionID)
+        _ = lifecycle.reconcile(replacement, sessionID: sessionID)
+
+        try expect(
+            lifecycle.dismiss(sessionID: sessionID, token: firstToken) == .none,
+            "a stale dismiss callback cannot hide a replacement notice"
+        )
+        try expect(lifecycle.visibleRequest == replacement, "the replacement notice remains visible")
+        try expect(
+            lifecycle.dismiss(sessionID: sessionID, token: secondToken) == .hide(secondToken),
+            "the current dismiss callback hides its own notice"
+        )
+        try expect(lifecycle.visibleRequest == nil, "the current notice is cleared after dismissal")
+    }
+
+    private static func healthyReconciliationClearsAndLaterDegradationCanReappear() throws {
+        let sessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000003")!
+        let firstToken = UUID(uuidString: "00000000-0000-0000-0000-000000000031")!
+        let laterToken = UUID(uuidString: "00000000-0000-0000-0000-000000000032")!
+        let first = DegradedCombinedCaptureNoticeLifecycle.Request(
+            sessionID: sessionID,
+            token: firstToken,
+            message: "No mic",
+            reminderFrame: nil
+        )
+        let later = DegradedCombinedCaptureNoticeLifecycle.Request(
+            sessionID: sessionID,
+            token: laterToken,
+            message: "No System Audio",
+            reminderFrame: nil
+        )
+        var lifecycle = DegradedCombinedCaptureNoticeLifecycle()
+        _ = lifecycle.beginSession(sessionID)
+        _ = lifecycle.markPresentationReady(sessionID: sessionID)
+        _ = lifecycle.reconcile(first, sessionID: sessionID)
+
+        try expect(
+            lifecycle.reconcile(nil, sessionID: sessionID) == .hide(firstToken),
+            "healthy or single-source reconciliation hides a stale degraded notice"
+        )
+        try expect(lifecycle.visibleRequest == nil, "healthy reconciliation clears visible state")
+        try expect(
+            lifecycle.reconcile(later, sessionID: sessionID) == .present(later),
+            "a later degraded input switch can show a new notice"
+        )
+    }
+
+    private static func endingSessionPreventsPendingNoticeResurrection() throws {
+        let sessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000004")!
+        let token = UUID(uuidString: "00000000-0000-0000-0000-000000000041")!
+        let request = DegradedCombinedCaptureNoticeLifecycle.Request(
+            sessionID: sessionID,
+            token: token,
+            message: "No mic",
+            reminderFrame: nil
+        )
+        var lifecycle = DegradedCombinedCaptureNoticeLifecycle()
+        _ = lifecycle.beginSession(sessionID)
+        _ = lifecycle.reconcile(request, sessionID: sessionID)
+
+        try expect(lifecycle.endSession(sessionID) == .none, "ending a pending-only session needs no panel hide")
+        try expect(lifecycle.activeSessionID == nil, "session end clears the active session")
+        try expect(lifecycle.pendingRequest == nil, "session end clears the pending request")
+        try expect(
+            lifecycle.markPresentationReady(sessionID: sessionID) == .none,
+            "a late recording callback cannot resurrect an ended session"
+        )
+    }
+
+    private static func oldSessionRequestsAreIgnored() throws {
+        let oldSessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000005")!
+        let currentSessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000006")!
+        let oldRequest = DegradedCombinedCaptureNoticeLifecycle.Request(
+            sessionID: oldSessionID,
+            token: UUID(uuidString: "00000000-0000-0000-0000-000000000051")!,
+            message: "No mic",
+            reminderFrame: nil
+        )
+        var lifecycle = DegradedCombinedCaptureNoticeLifecycle()
+        _ = lifecycle.beginSession(oldSessionID)
+        _ = lifecycle.beginSession(currentSessionID)
+        _ = lifecycle.markPresentationReady(sessionID: currentSessionID)
+
+        try expect(
+            lifecycle.reconcile(oldRequest, sessionID: oldSessionID) == .none,
+            "an old start result cannot update a newer recording session"
+        )
+        try expect(lifecycle.visibleRequest == nil, "the current session remains free of stale notices")
+    }
+
+    private static func makeRecorder(
+        startMicrophone: @escaping (String) throws -> AudioRecorderStartResult,
+        startSystemAudio: @escaping () async throws -> Void,
+        cancelMicrophone: @escaping () async -> Void = {},
+        cancelSystemAudio: @escaping () async -> Void = {}
+    ) -> SystemDefaultAndSystemAudioRecorder {
+        SystemDefaultAndSystemAudioRecorder(
+            microphoneRecorder: AudioRecorder(),
+            systemAudioRecorder: SystemAudioRecorder(),
+            mixdownService: AudioMixdownService(),
+            startOperations: CombinedRecordingStartOperations(
+                startMicrophone: startMicrophone,
+                startSystemAudio: startSystemAudio,
+                cancelMicrophone: cancelMicrophone,
+                cancelSystemAudio: cancelSystemAudio
+            )
+        )
+    }
+
+    private static func successfulMicrophoneResult(deviceUID: String) -> AudioRecorderStartResult {
+        AudioRecorderStartResult(
+            requestedDeviceUID: deviceUID,
+            resolvedDeviceUID: deviceUID,
+            usedSystemDefaultFallback: false
+        )
+    }
+
+    private static func eventFired(
+        _ event: AsyncEvent,
+        withinAttempts attempts: Int
+    ) async -> Bool {
+        for _ in 0..<attempts {
+            if await event.hasFired { return true }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return await event.hasFired
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+        guard condition() else { throw TestFailure(message) }
+    }
+
+    private actor AsyncStartGate {
+        private var hasStarted = false
+        private var startWaiters: [CheckedContinuation<Void, Never>] = []
+        private var resumeContinuation: CheckedContinuation<Void, Never>?
+
+        func run() async {
+            hasStarted = true
+            let waiters = startWaiters
+            startWaiters.removeAll()
+            for waiter in waiters { waiter.resume() }
+            await withCheckedContinuation { continuation in
+                resumeContinuation = continuation
+            }
+        }
+
+        func waitUntilStarted() async {
+            guard !hasStarted else { return }
+            await withCheckedContinuation { continuation in
+                startWaiters.append(continuation)
+            }
+        }
+
+        func open() {
+            resumeContinuation?.resume()
+            resumeContinuation = nil
+        }
+    }
+
+    private actor AsyncCounter {
+        private(set) var value = 0
+
+        func increment() {
+            value += 1
+        }
+    }
+
+    private actor AsyncEvent {
+        private(set) var hasFired = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func signal() {
+            guard !hasFired else { return }
+            hasFired = true
+            let continuations = waiters
+            waiters.removeAll()
+            for continuation in continuations {
+                continuation.resume()
+            }
+        }
+
+        func wait() async {
+            guard !hasFired else { return }
+            await withCheckedContinuation { continuation in
+                waiters.append(continuation)
+            }
+        }
+    }
+
+    private enum StartFailure: Error {
+        case microphone
+        case systemAudio
+    }
+
+    private struct TestFailure: Error, CustomStringConvertible {
+        let description: String
+
+        init(_ description: String) {
+            self.description = description
+        }
+    }
+}

--- a/Tests/FullSourceAppStateTestRunner.swift
+++ b/Tests/FullSourceAppStateTestRunner.swift
@@ -22,6 +22,7 @@ struct FullSourceAppStateTestRunner {
             try await NativeWhisperModelWorkflowTests.main()
             try await LocalAIModelWorkflowTests.main()
             try await AppStateStorageSafetyTests.main()
+            try await CombinedCaptureDegradationTests.main()
             try AppStateHistoryProtectionSourceTests.main()
             try await AppStateTranscriptionConfigurationTests.main()
             try await AppStateAIProcessingBackendTests.main()

--- a/Tests/MeetingReminderOverlayGeometryTests.swift
+++ b/Tests/MeetingReminderOverlayGeometryTests.swift
@@ -18,6 +18,7 @@ struct MeetingReminderOverlayGeometryTests {
         testCenterRecordingMatchesIdleHeight()
         testFrameUsesSharedScreenGeometryForUpdatedFrames()
         testFrameUsesSharedNotchSideGeometryWidth()
+        testNoticeAnchorUsesTargetFrameWhileReminderResizes()
         try testMeetingReminderUsesSharedScreenGeometry()
         try testMeetingReminderObservesScreenParameterChanges()
         try testMeetingReminderKeepsPersistentAnimationHost()
@@ -187,6 +188,34 @@ struct MeetingReminderOverlayGeometryTests {
         assert(frame.origin.y == 890)
     }
 
+    private static func testNoticeAnchorUsesTargetFrameWhileReminderResizes() {
+        let idlePresentationFrame = NSRect(
+            x: 576,
+            y: 902,
+            width: 360,
+            height: 80
+        )
+        let recordingTargetFrame = NSRect(
+            x: 576,
+            y: 870,
+            width: 360,
+            height: 112
+        )
+        let anchor = MeetingReminderOverlayGeometry.noticeAnchorFrame(
+            visibleFrame: idlePresentationFrame,
+            targetFrame: recordingTargetFrame
+        )
+        let notice = RecordingNoticeStackGeometry.anchoredFrame(
+            below: anchor,
+            width: 360,
+            height: 34,
+            gap: 6
+        )
+
+        assert(anchor == recordingTargetFrame)
+        assert(notice.maxY <= recordingTargetFrame.minY - 6)
+    }
+
     private static func testMeetingReminderUsesSharedScreenGeometry() throws {
         let source = try String(contentsOfFile: "Sources/MeetingReminderOverlay.swift", encoding: .utf8)
         assert(source.contains("OverlayScreenGeometry(screen: screen)"))
@@ -207,6 +236,13 @@ struct MeetingReminderOverlayGeometryTests {
     private static func testMeetingReminderKeepsPersistentAnimationHost() throws {
         let source = try String(contentsOfFile: "Sources/MeetingReminderOverlay.swift", encoding: .utf8)
         assert(source.contains("private var contentContainer: FixedHostingContainer<AnyView>?"))
+        assert(source.contains("private var targetFrame: NSRect?"))
+        assert(source.contains("var onVisibleOverlayFrameChange:"))
+        assert(source.contains("targetFrame = frame"))
+        assert(source.contains("onVisibleOverlayFrameChange?(frame)"))
+        assert(source.contains("targetFrame = nil"))
+        assert(source.contains("onVisibleOverlayFrameChange?(nil)"))
+        assert(source.contains("MeetingReminderOverlayGeometry.noticeAnchorFrame("))
         assert(source.contains("if let panel, let viewModel, let contentContainer"))
         assert(source.contains("viewModel.update(displayData: displayData, frameSize: frame.size, animated: animated)"))
         assert(source.contains("contentContainer.setFixedContentSize(frame.size)"))

--- a/Tests/RecordingJournalManifestTests.swift
+++ b/Tests/RecordingJournalManifestTests.swift
@@ -6,6 +6,7 @@ struct RecordingJournalManifestTests {
         do {
             try canonicalFormatMatchesRecorderContract()
             try manifestRoundTripPreservesStableMetadata()
+            try legacySourceWithoutUnavailableMarkerRemainsExpected()
             try manifestDecodesLegacyPreserveExactWordingKey()
             try legacyPromotionWithoutRecoveryModeDefaultsToComplete()
             try promotionRoundTripPreservesRecoveryMode()
@@ -53,6 +54,34 @@ struct RecordingJournalManifestTests {
 
         try expectEqual(decoded, manifest, "manifest round trip")
         try decoded.validate()
+    }
+
+    private static func legacySourceWithoutUnavailableMarkerRemainsExpected() throws {
+        let manifest = try makeManifest()
+        let data = try RecordingJournalCoding.makeEncoder().encode(manifest)
+        let json = String(decoding: data, as: UTF8.self)
+        guard !json.contains("unavailableAtStart"),
+              !json.contains("unavailableDuringRecording") else {
+            throw TestFailure(
+                "legacy source availability must remain absent from schema-v1 JSON"
+            )
+        }
+
+        let decoded = try RecordingJournalCoding.makeDecoder().decode(
+            RecordingJournalManifest.self,
+            from: data
+        )
+
+        try expectEqual(
+            decoded.sources[0].unavailableAtStart,
+            nil,
+            "legacy source remains expected to provide audio"
+        )
+        try expectEqual(
+            decoded.sources[0].unavailableDuringRecording,
+            nil,
+            "legacy source has no runtime-loss marker"
+        )
     }
 
     private static func manifestDecodesLegacyPreserveExactWordingKey() throws {

--- a/Tests/RecordingOverlayGeometryTests.swift
+++ b/Tests/RecordingOverlayGeometryTests.swift
@@ -8,6 +8,10 @@ struct RecordingOverlayGeometryTests {
         testTranscribingWidthFallsBackToCenteredWidthAfterNotchSideRecording()
         testTranscribingWidthKeepsExistingLockOnRepeatedTranscribingUpdate()
         testNotchSideLayoutPhaseEligibility()
+        testTransientNoticeStacksBelowPersistentDegradedNotice()
+        testNoticeAnchorUsesTargetFrameWhileOverlayAnimates()
+        testLocalizedNoticeWidthUsesMeasuredText()
+        testDegradedNoticeKeepsWiderAnchorWidth()
         testNSScreenNumberBridgesThroughNSNumber()
         testRecordingOverlayUsesSharedScreenGeometry()
         try testNotchSideOverlayAvoidsContainerAudioLevelAnimation()
@@ -79,6 +83,93 @@ struct RecordingOverlayGeometryTests {
             phase: .recording,
             hasNotchGeometry: false
         ))
+    }
+
+    private static func testTransientNoticeStacksBelowPersistentDegradedNotice() {
+        let overlay = NSRect(x: 700, y: 900, width: 150, height: 38)
+        let degraded = RecordingNoticeStackGeometry.anchoredFrame(
+            below: overlay,
+            width: 260,
+            height: 34,
+            gap: 6
+        )
+        let transientAnchor = RecordingNoticeStackGeometry.lowestVisibleFrame([
+            overlay,
+            degraded
+        ])
+        let transient = RecordingNoticeStackGeometry.anchoredFrame(
+            below: transientAnchor!,
+            width: 300,
+            height: 30,
+            gap: 6
+        )
+
+        assert(transient.maxY <= degraded.minY - 6)
+        assert(transient.midX == degraded.midX)
+    }
+
+    private static func testNoticeAnchorUsesTargetFrameWhileOverlayAnimates() {
+        let hiddenPresentationFrame = NSRect(
+            x: 700,
+            y: 982,
+            width: 150,
+            height: 38
+        )
+        let targetRecordingFrame = NSRect(
+            x: 700,
+            y: 906,
+            width: 150,
+            height: 76
+        )
+
+        assert(
+            RecordingNoticeStackGeometry.overlayAnchorFrame(
+                visibleFrame: hiddenPresentationFrame,
+                targetFrame: targetRecordingFrame
+            ) == targetRecordingFrame
+        )
+        assert(
+            RecordingNoticeStackGeometry.overlayAnchorFrame(
+                visibleFrame: hiddenPresentationFrame,
+                targetFrame: .zero
+            ) == hiddenPresentationFrame
+        )
+        assert(
+            RecordingNoticeStackGeometry.overlayAnchorFrame(
+                visibleFrame: nil,
+                targetFrame: targetRecordingFrame
+            ) == nil
+        )
+    }
+
+    private static func testLocalizedNoticeWidthUsesMeasuredText() {
+        let message = "시스템 오디오 없음 — 마이크만으로 녹음 중"
+        let width = RecordingNoticeStackGeometry.fittedNoticeWidth(
+            message: message,
+            horizontalChromeWidth: 66,
+            minimumWidth: 200,
+            maximumWidth: 1_000
+        )
+        let characterCountEstimate = CGFloat(message.count) * 6.8 + 66
+        let measuredTextWidth = (message as NSString).size(
+            withAttributes: [
+                .font: NSFont.systemFont(ofSize: 12, weight: .medium)
+            ]
+        ).width
+
+        assert(width == ceil(measuredTextWidth + 66))
+        assert(width > characterCountEstimate)
+    }
+
+    private static func testDegradedNoticeKeepsWiderAnchorWidth() {
+        let anchorWidth: CGFloat = 335
+        let width = RecordingNoticeStackGeometry.degradedCaptureNoticeWidth(
+            message: "마이크 없음 — 시스템 오디오만으로 녹음 중",
+            anchorWidth: anchorWidth,
+            maximumWidth: 1_000
+        )
+
+        assert(width == anchorWidth)
     }
 
     private static func testNSScreenNumberBridgesThroughNSNumber() {

--- a/Tests/RecordingOverlayNoticeSourceTests.swift
+++ b/Tests/RecordingOverlayNoticeSourceTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+@main
+struct RecordingOverlayNoticeSourceTests {
+    static func main() throws {
+        let source = try String(contentsOfFile: "Sources/RecordingOverlay.swift", encoding: .utf8)
+
+        precondition(
+            source.contains("func showDegradedCombinedCaptureNotice("),
+            "RecordingOverlayManager exposes a way to surface a degraded combined-capture notice"
+        )
+        precondition(
+            source.contains("struct DegradedCaptureNoticeView: View"),
+            "a dedicated view renders the degraded-capture notice"
+        )
+
+        guard let managerRange = source.range(of: "func showDegradedCombinedCaptureNotice("),
+              let anchoredRange = source.range(
+                of: "private func showAnchoredDegradedCaptureNotice(",
+                range: managerRange.upperBound..<source.endIndex
+              ) else {
+            preconditionFailure("Could not locate showDegradedCombinedCaptureNotice / showAnchoredDegradedCaptureNotice")
+        }
+        let managerBody = source[managerRange.lowerBound..<anchoredRange.lowerBound]
+        precondition(
+            managerBody.contains("overlayState.phase == .recording"),
+            "the notice only surfaces while the recording phase is showing"
+        )
+        precondition(
+            managerBody.contains("noticeAnchorFrame("),
+            "the notice reuses the existing anchor-frame logic"
+        )
+
+        guard let nextMethodRange = source.range(
+            of: "func showUpdateAvailable(",
+            range: anchoredRange.upperBound..<source.endIndex
+        ) else {
+            preconditionFailure("Could not locate the end of showAnchoredDegradedCaptureNotice")
+        }
+        let anchoredBody = source[anchoredRange.lowerBound..<nextMethodRange.lowerBound]
+        precondition(
+            anchoredBody.contains("panel.ignoresMouseEvents = false"),
+            "unlike the plain notice toast, this panel must accept mouse events so hover/dismiss work"
+        )
+        precondition(
+            !anchoredBody.contains("asyncAfter"),
+            "the degraded-capture notice must not auto-dismiss like the plain notice toast — it stays until explicitly dismissed"
+        )
+        precondition(
+            anchoredBody.contains("DegradedCaptureNoticeView("),
+            "the anchored panel's content is the dedicated degraded-capture view"
+        )
+        precondition(
+            anchoredBody.contains("degradedCaptureNoticeWindow"),
+            "the degraded-capture notice must use its own panel, not the shared transient noticeWindow — otherwise an unrelated toast (e.g. showRecordingNotice on a rejected input switch) can silently overwrite and auto-dismiss this persistent notice"
+        )
+
+        // The view must use the codebase's existing NSTrackingArea-based hover
+        // approach (SwiftUI's own .onHover is documented elsewhere in this
+        // file as unreliable inside this borderless, non-activating panel),
+        // and must not duplicate a Stop action the pill already provides.
+        guard let viewRange = source.range(of: "struct DegradedCaptureNoticeView: View") else {
+            preconditionFailure("Could not locate DegradedCaptureNoticeView")
+        }
+        let viewBody = source[viewRange.lowerBound..<source.endIndex]
+        precondition(
+            viewBody.contains("NSTrackingArea("),
+            "hover is tracked via NSTrackingArea, matching this file's existing InputSwitchMenu approach, not SwiftUI's .onHover"
+        )
+        precondition(
+            !viewBody.contains("stop.fill"),
+            "the notice must not duplicate the pill's own Stop button"
+        )
+        precondition(
+            viewBody.contains("onDismiss"),
+            "dismissing the notice is driven by an explicit callback, not a timer"
+        )
+
+        print("RecordingOverlayNoticeSourceTests passed")
+    }
+}

--- a/Tests/RecordingOverlayNoticeSourceTests.swift
+++ b/Tests/RecordingOverlayNoticeSourceTests.swift
@@ -5,77 +5,224 @@ struct RecordingOverlayNoticeSourceTests {
     static func main() throws {
         let source = try String(contentsOfFile: "Sources/RecordingOverlay.swift", encoding: .utf8)
 
-        precondition(
-            source.contains("func showDegradedCombinedCaptureNotice("),
-            "RecordingOverlayManager exposes a way to surface a degraded combined-capture notice"
+        precondition(source.contains("private var degradedCaptureNoticeLifecycle = DegradedCombinedCaptureNoticeLifecycle()"))
+        precondition(source.contains("func beginDegradedCombinedCaptureNoticeSession("))
+        precondition(source.contains("func reconcileDegradedCombinedCaptureNotice("))
+        precondition(source.contains("func recordingReminderFrameDidChange("))
+        precondition(source.contains("func endDegradedCombinedCaptureNoticeSession("))
+        precondition(source.contains("struct DegradedCaptureNoticeView: View"))
+
+        let showRecordingBody = try functionBody(named: "showRecording", in: source)
+        let showOverlayRange = try requiredRange(of: "self.showOverlayPanel(animatedResize: true)", in: showRecordingBody)
+        let showFlushRange = try requiredRange(
+            of: "self.markDegradedCaptureNoticePresentationReady(sessionID: noticeSessionID)",
+            in: showRecordingBody
         )
+        precondition(showRecordingBody.contains("noticeSessionID: UUID? = nil"))
         precondition(
-            source.contains("struct DegradedCaptureNoticeView: View"),
-            "a dedicated view renders the degraded-capture notice"
+            showOverlayRange.lowerBound < showFlushRange.lowerBound,
+            "showRecording flushes a pending degraded notice only after the overlay is on screen"
         )
 
-        guard let managerRange = source.range(of: "func showDegradedCombinedCaptureNotice("),
-              let anchoredRange = source.range(
-                of: "private func showAnchoredDegradedCaptureNotice(",
-                range: managerRange.upperBound..<source.endIndex
-              ) else {
-            preconditionFailure("Could not locate showDegradedCombinedCaptureNotice / showAnchoredDegradedCaptureNotice")
-        }
-        let managerBody = source[managerRange.lowerBound..<anchoredRange.lowerBound]
-        precondition(
-            managerBody.contains("overlayState.phase == .recording"),
-            "the notice only surfaces while the recording phase is showing"
+        let transitionBody = try functionBody(named: "transitionToRecording", in: source)
+        let updateLayoutRange = try requiredRange(of: "self.updateOverlayLayout(animated: true)", in: transitionBody)
+        let transitionFlushRange = try requiredRange(
+            of: "self.markDegradedCaptureNoticePresentationReady(sessionID: noticeSessionID)",
+            in: transitionBody
         )
+        precondition(transitionBody.contains("noticeSessionID: UUID? = nil"))
         precondition(
-            managerBody.contains("noticeAnchorFrame("),
-            "the notice reuses the existing anchor-frame logic"
+            updateLayoutRange.lowerBound < transitionFlushRange.lowerBound,
+            "transitionToRecording flushes a pending degraded notice only after layout is updated"
         )
 
-        guard let nextMethodRange = source.range(
-            of: "func showUpdateAvailable(",
-            range: anchoredRange.upperBound..<source.endIndex
-        ) else {
-            preconditionFailure("Could not locate the end of showAnchoredDegradedCaptureNotice")
-        }
-        let anchoredBody = source[anchoredRange.lowerBound..<nextMethodRange.lowerBound]
-        precondition(
-            anchoredBody.contains("panel.ignoresMouseEvents = false"),
-            "unlike the plain notice toast, this panel must accept mouse events so hover/dismiss work"
-        )
-        precondition(
-            !anchoredBody.contains("asyncAfter"),
-            "the degraded-capture notice must not auto-dismiss like the plain notice toast — it stays until explicitly dismissed"
-        )
-        precondition(
-            anchoredBody.contains("DegradedCaptureNoticeView("),
-            "the anchored panel's content is the dedicated degraded-capture view"
-        )
-        precondition(
-            anchoredBody.contains("degradedCaptureNoticeWindow"),
-            "the degraded-capture notice must use its own panel, not the shared transient noticeWindow — otherwise an unrelated toast (e.g. showRecordingNotice on a rejected input switch) can silently overwrite and auto-dismiss this persistent notice"
-        )
+        let reconcileBody = try functionBody(named: "reconcileDegradedCombinedCaptureNotice", in: source)
+        precondition(reconcileBody.contains("degradedCaptureNoticeLifecycle.reconcile("))
+        precondition(reconcileBody.contains("DegradedCombinedCaptureNoticeLifecycle.Request("))
+        precondition(!reconcileBody.contains("guard let message else { return }"))
+        precondition(!reconcileBody.contains("showError("), "persistent degraded notices never use the transient error fallback")
 
-        // The view must use the codebase's existing NSTrackingArea-based hover
-        // approach (SwiftUI's own .onHover is documented elsewhere in this
-        // file as unreliable inside this borderless, non-activating panel),
-        // and must not duplicate a Stop action the pill already provides.
-        guard let viewRange = source.range(of: "struct DegradedCaptureNoticeView: View") else {
-            preconditionFailure("Could not locate DegradedCaptureNoticeView")
-        }
-        let viewBody = source[viewRange.lowerBound..<source.endIndex]
-        precondition(
-            viewBody.contains("NSTrackingArea("),
-            "hover is tracked via NSTrackingArea, matching this file's existing InputSwitchMenu approach, not SwiftUI's .onHover"
+        let reminderFrameChangeBody = try functionBody(
+            named: "recordingReminderFrameDidChange",
+            in: source
         )
-        precondition(
-            !viewBody.contains("stop.fill"),
-            "the notice must not duplicate the pill's own Stop button"
+        precondition(reminderFrameChangeBody.contains(
+            "degradedCaptureNoticeLifecycle.updateReminderFrame("
+        ))
+        precondition(reminderFrameChangeBody.contains(
+            "recordingNoticeReminderFrame = reminderFrame"
+        ))
+        precondition(reminderFrameChangeBody.contains(
+            "repositionVisibleRecordingNotice()"
+        ))
+
+        let baseAnchorBody = try functionBody(
+            named: "baseNoticeAnchorFrame",
+            in: source
         )
-        precondition(
-            viewBody.contains("onDismiss"),
-            "dismissing the notice is driven by an explicit callback, not a timer"
+        precondition(baseAnchorBody.contains(
+            "RecordingNoticeStackGeometry.overlayAnchorFrame("
+        ))
+        precondition(baseAnchorBody.contains("visibleFrame: visibleOverlayFrame"))
+        precondition(baseAnchorBody.contains("targetFrame: overlayFrame"))
+
+        let anchorBody = try functionBody(named: "degradedCaptureNoticeAnchor", in: source)
+        precondition(anchorBody.contains("baseNoticeAnchorFrame(reminderFrame:"))
+        precondition(anchorBody.contains("overlayWindow?.frame"))
+        precondition(anchorBody.contains("overlayFrame"))
+        precondition(!anchorBody.contains("showError("))
+
+        let recordingNoticeAnchorBody = try functionBody(
+            named: "recordingNoticeAnchorFrame",
+            in: source
         )
+        precondition(recordingNoticeAnchorBody.contains("visibleDegradedCaptureNoticeFrame"))
+        precondition(recordingNoticeAnchorBody.contains("RecordingNoticeStackGeometry.lowestVisibleFrame"))
+        let showErrorBody = try functionBody(named: "showError", in: source)
+        precondition(showErrorBody.contains("dismissAll(endingDegradedCaptureSession: false)"))
+
+        let presentBody = try functionBody(named: "showAnchoredDegradedCaptureNotice", in: source)
+        precondition(presentBody.contains("panel.ignoresMouseEvents = false"))
+        precondition(!presentBody.contains("asyncAfter"), "the persistent notice never auto-dismisses")
+        precondition(presentBody.contains("DegradedCaptureNoticeView("))
+        precondition(presentBody.contains("degradedCaptureNoticeWindow"))
+        precondition(presentBody.contains(
+            "RecordingNoticeStackGeometry.degradedCaptureNoticeWidth("
+        ))
+        precondition(presentBody.contains("anchorWidth: anchor.width"))
+        precondition(!presentBody.contains("request.message.count"))
+        precondition(!presentBody.contains("degradedCaptureNoticeToken"), "the lifecycle owns notice tokens")
+        precondition(presentBody.contains(
+            "degradedCaptureNoticePresentationToken = request.token"
+        ))
+
+        let dismissBody = try functionBody(
+            named: "dismissDegradedCaptureNotice",
+            in: source
+        )
+        precondition(dismissBody.contains(
+            "degradedCaptureNoticePresentationToken == expectedToken"
+        ))
+        precondition(dismissBody.contains(
+            "degradedCaptureNoticePresentationToken != expectedToken"
+        ))
+        precondition(dismissBody.contains("panel?.alphaValue = 1"))
+        precondition(dismissBody.contains("repositionVisibleRecordingNotice()"))
+        precondition(source.contains(
+            "private var recordingNoticeReminderFrame: NSRect?"
+        ))
+        precondition(source.contains(
+            "recordingNoticeReminderFrame = reminderFrame"
+        ))
+
+        let updateLayoutBody = try functionBody(
+            named: "updateOverlayLayout",
+            in: source
+        )
+        precondition(updateLayoutBody.contains(
+            "repositionVisibleDegradedCaptureNotice()"
+        ))
+
+        let screenChangeBody = try functionBody(
+            named: "handleScreenParametersChanged",
+            in: source
+        )
+        precondition(screenChangeBody.contains("updateOverlayLayout(animated: false)"))
+        precondition(!screenChangeBody.contains("repositionVisibleDegradedCaptureNotice()"))
+        let repositionBody = try functionBody(
+            named: "repositionVisibleDegradedCaptureNotice",
+            in: source
+        )
+        precondition(repositionBody.contains("degradedCaptureNoticeLifecycle.visibleRequest"))
+        precondition(repositionBody.contains("degradedCaptureNoticeAnchor("))
+        precondition(repositionBody.contains("showAnchoredDegradedCaptureNotice("))
+
+        let transcribingBody = try functionBody(named: "setTranscribingPhase", in: source)
+        precondition(
+            transcribingBody.contains("endDegradedCombinedCaptureNoticeSessionNow()"),
+            "the degraded notice ends as soon as recording leaves the active phase"
+        )
+        let dismissAllBody = try functionBody(named: "dismissAll", in: source)
+        precondition(dismissAllBody.contains("endingDegradedCaptureSession: Bool = true"))
+        precondition(dismissAllBody.contains("if endingDegradedCaptureSession"))
+        precondition(dismissAllBody.contains("endDegradedCombinedCaptureNoticeSessionNow()"))
+        precondition(dismissAllBody.contains("degradedCaptureNoticeWindow?.orderOut(nil)"))
+
+        let viewBody = try typeBody(named: "DegradedCaptureNoticeView", in: source)
+        precondition(viewBody.contains("DegradedCaptureNoticeHoverCatcher"))
+        precondition(viewBody.contains("Button(action: onDismiss)"))
+        precondition(
+            !viewBody.contains("if isHovering"),
+            "hovering must not insert a new control and compress the message"
+        )
+        precondition(viewBody.contains(".opacity(isHovering ? 1 : 0)"))
+        precondition(viewBody.contains(".allowsHitTesting(isHovering)"))
+        precondition(
+            viewBody.contains(".padding(.trailing, 28)"),
+            "the message keeps a fixed trailing slot for the dismiss control"
+        )
+        precondition(!viewBody.contains("onContinue"))
+        precondition(!viewBody.contains("onStop"))
+        precondition(!viewBody.contains("stop.fill"))
+        precondition(!viewBody.contains("Continue"))
+        let hoverBody = try typeBody(named: "DegradedCaptureNoticeHoverCatcher", in: source)
+        precondition(hoverBody.contains("NSTrackingArea("))
+
+        precondition(source.contains("private var noticeWindow: NSPanel?"))
+        precondition(source.contains("private var degradedCaptureNoticeWindow: NSPanel?"))
+        precondition(source.contains(
+            "private var degradedCaptureNoticePresentationToken: UUID?"
+        ))
+        precondition(!source.contains("private var degradedCaptureNoticeToken: UUID?"))
 
         print("RecordingOverlayNoticeSourceTests passed")
+    }
+
+    private static func functionBody(named name: String, in source: String) throws -> String {
+        try body(startingWith: "func \(name)(", in: source)
+    }
+
+    private static func typeBody(named name: String, in source: String) throws -> String {
+        try body(startingWith: "struct \(name)", in: source)
+    }
+
+    private static func body(startingWith signature: String, in source: String) throws -> String {
+        guard let signatureRange = source.range(of: signature),
+              let openBrace = source[signatureRange.upperBound...].firstIndex(of: "{") else {
+            throw TestFailure("missing body starting with \(signature)")
+        }
+
+        var depth = 0
+        var index = openBrace
+        while index < source.endIndex {
+            switch source[index] {
+            case "{":
+                depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 {
+                    return String(source[signatureRange.lowerBound...index])
+                }
+            default:
+                break
+            }
+            index = source.index(after: index)
+        }
+        throw TestFailure("unterminated body starting with \(signature)")
+    }
+
+    private static func requiredRange(of needle: String, in source: String) throws -> Range<String.Index> {
+        guard let range = source.range(of: needle) else {
+            throw TestFailure("missing text: \(needle)")
+        }
+        return range
+    }
+
+    private struct TestFailure: Error, CustomStringConvertible {
+        let description: String
+
+        init(_ description: String) {
+            self.description = description
+        }
     }
 }

--- a/Tests/SegmentedRecordingArtifactFinalizerTests.swift
+++ b/Tests/SegmentedRecordingArtifactFinalizerTests.swift
@@ -7,8 +7,10 @@ struct SegmentedRecordingArtifactFinalizerTests {
         do {
             try completeSegmentsPromoteOneOrderedWAV()
             try damagedSourcesProduceDeterministicPartialRecovery()
-            try emptyCompanionSourceProducesPartialRecovery()
-            try emptyPreparationSegmentDoesNotMakeRecoveryPartial()
+            try unavailableCompanionSourceProducesCompleteArtifact()
+            try runtimeUnavailableSourceProducesPartialArtifact()
+            try expectedZeroByteSourceProducesPartialArtifact()
+            try emptySwitchedSourceProducesPartialArtifact()
             try noUsableAudioPreservesInflightRecording()
             try promotedPartialResultReusesStoredMetadataWithoutSources()
             try interruptionReasonSurvivesCompleteAndPartialPromotion()
@@ -167,9 +169,10 @@ struct SegmentedRecordingArtifactFinalizerTests {
         }
     }
 
-    private static func emptyCompanionSourceProducesPartialRecovery() throws {
+    private static func unavailableCompanionSourceProducesCompleteArtifact() throws {
         try withFixture { fixture in
             let controller = try fixture.makeController()
+            controller.activeSegment.microphoneSink?.enqueue(pcmData([1, 2]))
             let microphoneSourceID = UUID()
             let systemSourceID = UUID()
             let combined = try controller.switchSegment(
@@ -186,13 +189,128 @@ struct SegmentedRecordingArtifactFinalizerTests {
                 ]
             )
             combined.systemAudioSink?.enqueue(pcmData([7, 8]))
+            try controller.markActiveSourceUnavailableAtStart(.microphone)
+            let admittedManifest = try fixture.store.loadManifest(
+                recordingID: fixture.recordingID
+            )
+            try expectEqual(
+                admittedManifest.sources.first(where: {
+                    $0.id == microphoneSourceID
+                })?.unavailableAtStart,
+                true,
+                "degraded companion is marked unavailable"
+            )
+            try expectEqual(
+                admittedManifest.sources.first(where: {
+                    $0.id == systemSourceID
+                })?.unavailableAtStart,
+                nil,
+                "surviving source remains expected"
+            )
+            guard let survivingSource = admittedManifest.sources.first(where: {
+                $0.id == systemSourceID
+            }), survivingSource.committedDataByteCount > 0 else {
+                throw TestFailure(
+                    "degraded-start availability and surviving audio must commit atomically"
+                )
+            }
             try controller.stopAndClose()
 
             let result = try fixture.finalizer.finalizeAndPromote(
                 recordingID: fixture.recordingID
             )
 
-            try expectEqual(result.mode, .partial, "empty companion mode")
+            try expectEqual(result.mode, .complete, "empty companion mode")
+            try expectEqual(
+                result.promotion.resolvedRecoveryIssues,
+                [],
+                "an unavailable companion source is a healthy degraded segment"
+            )
+            try expectEqual(
+                try readSamples(from: result.destinationURL),
+                [1, 2, 7, 8],
+                "empty companion survivor"
+            )
+        }
+    }
+
+    private static func runtimeUnavailableSourceProducesPartialArtifact() throws {
+        try withFixture { fixture in
+            let controller = try fixture.makeController()
+            controller.activeSegment.microphoneSink?.enqueue(pcmData([1, 2]))
+            let microphoneSourceID = UUID()
+            let systemSourceID = UUID()
+            let combined = try controller.switchSegment(
+                segmentID: UUID(),
+                sources: [
+                    RecordingJournalSegmentSourceRequest(
+                        id: microphoneSourceID,
+                        kind: .microphone
+                    ),
+                    RecordingJournalSegmentSourceRequest(
+                        id: systemSourceID,
+                        kind: .systemAudio
+                    )
+                ]
+            )
+            combined.microphoneSink?.enqueue(pcmData([3, 4]))
+            combined.systemAudioSink?.enqueue(pcmData([5, 6]))
+            try controller.markActiveSourceUnavailableDuringRecording(.systemAudio)
+
+            let degradedManifest = try fixture.store.loadManifest(
+                recordingID: fixture.recordingID
+            )
+            try expectEqual(
+                degradedManifest.sources.first(where: {
+                    $0.id == systemSourceID
+                })?.unavailableDuringRecording,
+                true,
+                "runtime source loss is persisted"
+            )
+            try controller.stopAndClose()
+
+            let result = try fixture.finalizer.finalizeAndPromote(
+                recordingID: fixture.recordingID
+            )
+
+            try expectEqual(result.mode, .partial, "runtime degraded mode")
+            try expectEqual(
+                result.promotion.resolvedRecoveryIssues,
+                [RecordingRecoveryIssue(
+                    segmentSequence: 1,
+                    sourceKind: .systemAudio,
+                    reason: .sourceUnavailableDuringRecording
+                )],
+                "runtime source loss remains visible in recovery metadata"
+            )
+        }
+    }
+
+    private static func expectedZeroByteSourceProducesPartialArtifact() throws {
+        try withFixture { fixture in
+            let controller = try fixture.makeController()
+            controller.activeSegment.microphoneSink?.enqueue(pcmData([3, 4]))
+            let combined = try controller.switchSegment(
+                segmentID: UUID(),
+                sources: [
+                    RecordingJournalSegmentSourceRequest(
+                        id: UUID(),
+                        kind: .microphone
+                    ),
+                    RecordingJournalSegmentSourceRequest(
+                        id: UUID(),
+                        kind: .systemAudio
+                    )
+                ]
+            )
+            combined.systemAudioSink?.enqueue(pcmData([9, 10]))
+            try controller.stopAndClose()
+
+            let result = try fixture.finalizer.finalizeAndPromote(
+                recordingID: fixture.recordingID
+            )
+
+            try expectEqual(result.mode, .partial, "expected zero-byte mode")
             try expectEqual(
                 result.promotion.resolvedRecoveryIssues,
                 [RecordingRecoveryIssue(
@@ -200,17 +318,17 @@ struct SegmentedRecordingArtifactFinalizerTests {
                     sourceKind: .microphone,
                     reason: .noCommittedAudio
                 )],
-                "empty companion issue"
+                "expected zero-byte source issue"
             )
             try expectEqual(
                 try readSamples(from: result.destinationURL),
-                [7, 8],
-                "empty companion survivor"
+                [3, 4, 9, 10],
+                "expected zero-byte survivor"
             )
         }
     }
 
-    private static func emptyPreparationSegmentDoesNotMakeRecoveryPartial() throws {
+    private static func emptySwitchedSourceProducesPartialArtifact() throws {
         try withFixture { fixture in
             let controller = try fixture.makeController()
             controller.activeSegment.microphoneSink?.enqueue(pcmData([1, 2, 3]))
@@ -227,12 +345,20 @@ struct SegmentedRecordingArtifactFinalizerTests {
                 recordingID: fixture.recordingID
             )
 
-            try expectEqual(result.mode, .complete, "empty preparation mode")
-            try expectEqual(result.promotion.resolvedRecoveryIssues, [], "empty preparation issues")
+            try expectEqual(result.mode, .partial, "empty switched-source mode")
+            try expectEqual(
+                result.promotion.resolvedRecoveryIssues,
+                [RecordingRecoveryIssue(
+                    segmentSequence: 1,
+                    sourceKind: .systemAudio,
+                    reason: .noCommittedAudio
+                )],
+                "empty switched-source issue"
+            )
             try expectEqual(
                 try readSamples(from: result.destinationURL),
                 [1, 2, 3],
-                "empty preparation samples"
+                "empty switched-source samples"
             )
         }
     }

--- a/Tests/SegmentedRecordingArtifactFinalizerTests.swift
+++ b/Tests/SegmentedRecordingArtifactFinalizerTests.swift
@@ -9,6 +9,7 @@ struct SegmentedRecordingArtifactFinalizerTests {
             try damagedSourcesProduceDeterministicPartialRecovery()
             try unavailableCompanionSourceProducesCompleteArtifact()
             try runtimeUnavailableSourceProducesPartialArtifact()
+            try runtimeUnavailableBeforeFirstFrameProducesPartialArtifact()
             try expectedZeroByteSourceProducesPartialArtifact()
             try emptySwitchedSourceProducesPartialArtifact()
             try noUsableAudioPreservesInflightRecording()
@@ -282,6 +283,44 @@ struct SegmentedRecordingArtifactFinalizerTests {
                     reason: .sourceUnavailableDuringRecording
                 )],
                 "runtime source loss remains visible in recovery metadata"
+            )
+        }
+    }
+
+    private static func runtimeUnavailableBeforeFirstFrameProducesPartialArtifact() throws {
+        try withFixture { fixture in
+            let controller = try fixture.makeController()
+            controller.activeSegment.microphoneSink?.enqueue(pcmData([1, 2]))
+            let combined = try controller.switchSegment(
+                segmentID: UUID(),
+                sources: [
+                    RecordingJournalSegmentSourceRequest(
+                        id: UUID(),
+                        kind: .microphone
+                    ),
+                    RecordingJournalSegmentSourceRequest(
+                        id: UUID(),
+                        kind: .systemAudio
+                    )
+                ]
+            )
+            combined.microphoneSink?.enqueue(pcmData([3, 4]))
+            try controller.markActiveSourceUnavailableDuringRecording(.systemAudio)
+            try controller.stopAndClose()
+
+            let result = try fixture.finalizer.finalizeAndPromote(
+                recordingID: fixture.recordingID
+            )
+
+            try expectEqual(result.mode, .partial, "zero-frame runtime degraded mode")
+            try expectEqual(
+                result.promotion.resolvedRecoveryIssues,
+                [RecordingRecoveryIssue(
+                    segmentSequence: 1,
+                    sourceKind: .systemAudio,
+                    reason: .sourceUnavailableDuringRecording
+                )],
+                "zero-frame runtime loss preserves its reason"
             )
         }
     }

--- a/Tests/SystemAudioAppStateRoutingTests.swift
+++ b/Tests/SystemAudioAppStateRoutingTests.swift
@@ -29,6 +29,8 @@ struct SystemAudioAppStateRoutingTests {
         precondition(physicalStartBody.contains("systemAudioRecorder.startRecording"))
         precondition(physicalStartBody.contains("audioRecorder.startRecording"))
         precondition(physicalStartBody.contains("applySystemDefaultMicrophoneFallback"))
+        precondition(physicalStartBody.contains("degradedSource = result.missingSource"))
+        precondition(!physicalStartBody.contains("systemDefaultAndSystemAudioRecorder.currentMissingSource"))
 
         let inputAccessBody = try functionBody(named: "ensureRecordingInputAccess", in: source)
         precondition(inputAccessBody.contains("switch AudioRecordingSource(inputID: selection.inputID)"))
@@ -39,14 +41,16 @@ struct SystemAudioAppStateRoutingTests {
         let beginRecordingBody = try functionBody(named: "beginRecording", in: source)
         precondition(beginRecordingBody.contains(".supportsLiveTranscription"))
         precondition(beginRecordingBody.contains("startRealtimeStreamingIfEnabled()"))
-        precondition(beginRecordingBody.contains("startSelectedAudioRecorder(selection: audioSelection)"))
+        precondition(beginRecordingBody.contains("startSelectedAudioRecorder("))
+        precondition(beginRecordingBody.contains("sessionID: recordingSessionID"))
 
         let accessibleSelectionBody = try functionBody(
             named: "accessibleCurrentRecordingAudioSelection",
             in: source
         )
         precondition(accessibleSelectionBody.contains("let selection = currentRecordingAudioSelection()"))
-        precondition(accessibleSelectionBody.contains("ensureRecordingInputAccess(for: selection)"))
+        precondition(accessibleSelectionBody.contains("ensureRecordingInputAccess("))
+        precondition(accessibleSelectionBody.contains("startRequestID: startRequestID"))
         precondition(accessibleSelectionBody.contains("selection == currentRecordingAudioSelection()"))
 
         precondition(noteBrowserSource.contains("ForEach(transcriptionChoiceDisplays(in: \"Cloud\"))"))
@@ -56,14 +60,22 @@ struct SystemAudioAppStateRoutingTests {
         precondition(source.contains("private struct PendingRecordingPermissionContext"))
         precondition(source.contains("pendingMicrophonePermissionContext"))
         precondition(source.contains("pendingSpeechPermissionContext"))
-        precondition(source.contains("Task { @MainActor [weak strongSelf] in"))
+        precondition(source.contains(
+            "let resumeTask = Task { @MainActor [weak strongSelf] in"
+        ))
+        precondition(source.contains(
+            "let resumeTask = Task { @MainActor [weak self] in"
+        ))
         precondition(!source.contains("pendingMicrophonePermissionAudioSelection"))
         precondition(!source.contains("pendingSpeechPermissionAudioSelection"))
 
         let systemDefaultAndSystemAudioAccessBody = try functionBody(named: "ensureSystemDefaultAndSystemAudioAccess", in: source)
         let microphoneUndeterminedBranch = """
         if microphoneStatus == .notDetermined {
-            _ = ensureMicrophoneAccess()
+            _ = ensureMicrophoneAccess(
+                startRequestID: startRequestID,
+                onStarted: onStarted
+            )
             return false
         }
 """

--- a/Tests/SystemAudioRecorderSourceTests.swift
+++ b/Tests/SystemAudioRecorderSourceTests.swift
@@ -4,6 +4,10 @@ import Foundation
 struct SystemAudioRecorderSourceTests {
     static func main() throws {
         let source = try String(contentsOfFile: "Sources/SystemAudioRecorder.swift", encoding: .utf8)
+        let microphoneSource = try String(
+            contentsOfFile: "Sources/AudioRecorder.swift",
+            encoding: .utf8
+        )
 
         precondition(source.contains("final class SystemAudioRecorder"))
         precondition(source.contains("SCStreamOutput"))
@@ -16,19 +20,129 @@ struct SystemAudioRecorderSourceTests {
         precondition(source.contains("func cancelRecording()"))
         precondition(source.contains("func cancelRecording(completion: (() -> Void)?)"))
         precondition(source.contains("cancelRecording(completion: nil)"))
-        precondition(source.contains("finishRecording(discard: true) { _ in"))
+        precondition(source.contains("expectedStream: currentStream"))
         precondition(source.contains("completion?()"))
         precondition(source.contains("func cleanup()"))
+        precondition(source.contains("struct SystemAudioRecorderGenerationLifecycle"))
+        precondition(source.contains("private let generationLock = OSAllocatedUnfairLock("))
+        precondition(source.contains("initialState: SystemAudioRecorderGenerationLifecycle()"))
+        let startBody = try functionBody(named: "startRecording", in: source)
+        precondition(startBody.contains("let generationID = UUID()"))
+        precondition(startBody.contains("generation.begin(generationID)"))
+        precondition(startBody.contains("generation.bind(stream, to: generationID)"))
+        precondition(startBody.contains("guard currentStreamSnapshot() === stream,"))
+        precondition(startBody.contains("try? await stream.stopCapture()"))
+        let outputBody = try functionBody(named: "stream", in: source)
+        precondition(outputBody.contains("guard let generationID = generationLock.withLock"))
+        precondition(outputBody.contains("generation.generation(for: stream)"))
+        precondition(outputBody.contains("generation.generation(for: stream) == generationID"))
+        let stoppedBody = try functionBody(named: "stream", in: source, occurrence: 2)
+        precondition(stoppedBody.contains("expectedStream: stream"))
+        precondition(source.contains("expectedStream: SCStream? = nil"))
+        precondition(source.contains("guard self.stream === expectedStream else {"))
         precondition(source.contains("var onPCM16Samples: ((Data) -> Void)?"))
         precondition(source.contains("onRecordingFailure?(error)"))
         precondition(!source.contains("if !readyFired && rms > 0"))
         precondition(source.contains("if !readyFired {\n            readyFired = true"))
+        precondition(source.contains("let onRecordingReady = self.onRecordingReady"))
+        precondition(microphoneSource.contains("if !readyFired {"))
+        precondition(!microphoneSource.contains("if !readyFired && rms > 0"))
+        precondition(microphoneSource.contains("let onRecordingReady = self.onRecordingReady"))
+        precondition(microphoneSource.contains("struct AudioRecorderGenerationLifecycle"))
+        precondition(microphoneSource.contains("private let generationLock = OSAllocatedUnfairLock("))
+        precondition(microphoneSource.contains("initialState: AudioRecorderGenerationLifecycle()"))
+        precondition(microphoneSource.contains("let generationID = UUID()"))
+        precondition(microphoneSource.contains("generation.begin(generationID)"))
+        precondition(microphoneSource.contains("generation.bind(dataOutput, to: generationID)"))
+        precondition(microphoneSource.contains("private let callbacksLock = OSAllocatedUnfairLock(initialState: CallbackState())"))
+        precondition(microphoneSource.contains("get { callbacksLock.withLock { $0.onRecordingReady } }"))
+        precondition(microphoneSource.contains("set { callbacksLock.withLock { $0.onRecordingReady = newValue } }"))
+        precondition(microphoneSource.contains("get { callbacksLock.withLock { $0.onRecordingFailure } }"))
+        precondition(microphoneSource.contains("set { callbacksLock.withLock { $0.onRecordingFailure = newValue } }"))
+        precondition(microphoneSource.contains("get { callbacksLock.withLock { $0.onPCM16Samples } }"))
+        precondition(microphoneSource.contains("set { callbacksLock.withLock { $0.onPCM16Samples = newValue } }"))
+        let microphoneFailureBody = try functionBody(
+            named: "reportRecordingFailure",
+            in: microphoneSource
+        )
+        let failureCaptureRange = try requiredRange(
+            of: "let onRecordingFailure = self.onRecordingFailure",
+            in: microphoneFailureBody
+        )
+        let failureQueueRange = try requiredRange(
+            of: "sessionQueue.async",
+            in: microphoneFailureBody
+        )
+        precondition(failureCaptureRange.lowerBound < failureQueueRange.lowerBound)
+        precondition(microphoneSource.contains("expectedGenerationID: UUID"))
+        precondition(
+            countOccurrences(
+                of: "generation.owns(expectedGenerationID)",
+                in: microphoneFailureBody
+            ) == 2
+        )
+        precondition(microphoneFailureBody.contains("onRecordingFailure?(error)"))
+        precondition(!microphoneFailureBody.contains("self.onRecordingFailure?(error)"))
+        let microphoneCaptureBody = try functionBody(
+            named: "captureOutput",
+            in: microphoneSource
+        )
+        precondition(microphoneCaptureBody.contains(
+            "generation.generation(for: output)"
+        ))
+        precondition(microphoneCaptureBody.contains(
+            "generation.owns(generationID)"
+        ))
+        let microphoneStopBody = try functionBody(
+            named: "stopRecording",
+            in: microphoneSource
+        )
+        precondition(microphoneStopBody.contains("generation.invalidateCurrent()"))
+        let microphoneCancelBody = try functionBody(
+            named: "cancelRecording",
+            in: microphoneSource,
+            occurrence: 2
+        )
+        precondition(microphoneCancelBody.contains("generation.invalidateCurrent()"))
+        let systemFailureBody = try functionBody(
+            named: "reportRecordingFailure",
+            in: source
+        )
+        let systemFailureCaptureRange = try requiredRange(
+            of: "let onRecordingFailure = self.onRecordingFailure",
+            in: systemFailureBody
+        )
+        let systemFailureQueueRange = try requiredRange(
+            of: "sessionQueue.async",
+            in: systemFailureBody
+        )
+        precondition(systemFailureCaptureRange.lowerBound < systemFailureQueueRange.lowerBound)
         precondition(!source.contains("if discard, let outputURL"))
         precondition(source.contains("fileURLToDelete = finalizedURL"))
         precondition(source.contains("if let fileURLToDelete = finishedRecording.fileURLToDelete"))
         precondition(source.contains("var shouldDiscardRecording = false"))
         precondition(source.contains("shouldDiscardRecording = true"))
-        precondition(source.contains("finishRecording(discard: shouldDiscardRecording, completion: completion)"))
+        let stopBody = try functionBody(named: "stopRecording", in: source)
+        precondition(stopBody.contains("invalidateCurrentGeneration()"))
+        precondition(stopBody.contains("expectedStream: currentStream"))
+        let cancelBody = try functionBody(
+            named: "cancelRecording",
+            in: source,
+            occurrence: 2
+        )
+        precondition(cancelBody.contains("invalidateCurrentGeneration()"))
+        precondition(cancelBody.contains("expectedStream: currentStream"))
+        let watchdogBody = try functionBody(named: "startBufferWatchdog", in: source)
+        precondition(source.contains("expectedStream: SCStream,"))
+        precondition(watchdogBody.contains("generation.generation(for: expectedStream)"))
+        precondition(watchdogBody.contains("expectedStream: expectedStream"))
+        let finishBody = try functionBody(named: "finishRecording", in: source)
+        precondition(finishBody.contains(
+            "guard self.stream === expectedStream else"
+        ))
+        precondition(source.contains(
+            "finishRecording(\n                expectedStream: currentStream,"
+        ))
         precondition(source.contains("private let callbacksLock = OSAllocatedUnfairLock(initialState: CallbackState())"))
         precondition(source.contains("private let normalizedPCM16SinkLock ="))
         precondition(source.contains("OSAllocatedUnfairLock<(any NormalizedPCM16Sink)?>(initialState: nil)"))
@@ -63,6 +177,8 @@ struct SystemAudioRecorderSourceTests {
         let realtimeBody = try functionBody(named: "emitPCM16IfNeeded", in: source)
         precondition(realtimeBody.contains("pcm16TargetFormat"))
         precondition(realtimeBody.contains("handler(data)"))
+        let levelBody = try functionBody(named: "updateAudioLevel", in: source)
+        precondition(levelBody.contains("generation.generation(for: stream) == generationID"))
 
         let bannedSymbols = [
             "SCRecordingOutput",
@@ -81,9 +197,34 @@ struct SystemAudioRecorderSourceTests {
         text.components(separatedBy: needle).count - 1
     }
 
-    private static func functionBody(named name: String, in text: String) throws -> String {
-        let signatures = ["private func \(name)", "func \(name)"]
-        guard let signatureRange = signatures.compactMap({ text.range(of: $0) }).first,
+    private static func requiredRange(
+        of needle: String,
+        in text: String
+    ) throws -> Range<String.Index> {
+        guard let range = text.range(of: needle) else {
+            throw TestFailure("missing text: \(needle)")
+        }
+        return range
+    }
+
+    private static func functionBody(
+        named name: String,
+        in text: String,
+        occurrence: Int = 1
+    ) throws -> String {
+        var searchStart = text.startIndex
+        var signatureRange: Range<String.Index>?
+        for _ in 0..<occurrence {
+            signatureRange = text.range(
+                of: "func \(name)",
+                range: searchStart..<text.endIndex
+            )
+            guard let signatureRange else {
+                throw TestFailure("missing function \(name) occurrence \(occurrence)")
+            }
+            searchStart = signatureRange.upperBound
+        }
+        guard let signatureRange,
               let openBrace = text[signatureRange.upperBound...].firstIndex(of: "{") else {
             throw TestFailure("missing function \(name)")
         }

--- a/Tests/SystemDefaultAndSystemAudioRecorderSourceTests.swift
+++ b/Tests/SystemDefaultAndSystemAudioRecorderSourceTests.swift
@@ -14,6 +14,29 @@ struct SystemDefaultAndSystemAudioRecorderSourceTests {
         precondition(source.contains("let microphoneStarted: Bool"))
         precondition(source.contains("let systemAudioStarted: Bool"))
         precondition(source.contains("let microphoneUsedSystemDefaultFallback: Bool"))
+
+        // A partial combined start (exactly one source) must be identifiable
+        // as a single typed value so callers don't re-derive it from the two
+        // booleans, and so the notice can name which source is missing.
+        precondition(source.contains("enum DegradedCombinedCaptureSource: Equatable"))
+        precondition(source.contains("case microphone"))
+        precondition(source.contains("case systemAudio"))
+        precondition(source.contains("var missingSource: DegradedCombinedCaptureSource?"))
+        guard let missingSourceRange = source.range(of: "var missingSource: DegradedCombinedCaptureSource?") else {
+            preconditionFailure("Could not locate missingSource computed property")
+        }
+        let missingSourceBody = source[missingSourceRange.lowerBound..<source.index(missingSourceRange.lowerBound, offsetBy: 260)]
+        precondition(missingSourceBody.contains("!microphoneStarted"), "missingSource identifies a failed microphone")
+        precondition(missingSourceBody.contains("!systemAudioStarted"), "missingSource identifies a failed System Audio source")
+
+        // Manual QA hook: let a developer force one side of the combined
+        // start to fail deterministically, without touching real hardware
+        // permissions, to exercise the degraded-capture notice on demand.
+        // Each flag is consumed (reset) by the attempt it triggers, so it
+        // only affects the next recording, never a later one.
+        precondition(source.contains("var debugForcesMicrophoneStartFailure = false"))
+        precondition(source.contains("var debugForcesSystemAudioStartFailure = false"))
+        precondition(source.contains("case debugSimulatedStartFailure"))
         precondition(source.contains("struct CombinedStoppedRecordingSources: Equatable"))
         precondition(source.contains("func startRecording(microphoneDeviceUID: String) async throws -> CombinedRecordingStartResult"))
         precondition(source.contains("func stopRecordingSources("))
@@ -45,6 +68,10 @@ struct SystemDefaultAndSystemAudioRecorderSourceTests {
         let startRecordingSource = source[startRecordingRange.lowerBound..<stopRecordingRange.lowerBound]
         precondition(startRecordingSource.contains("configureChildCallbacks()"), "startRecording should configure child callbacks each time it starts")
         precondition(startRecordingSource.contains("subscribeToAudioLevelsIfNeeded()"), "startRecording should restore audio level subscriptions when needed")
+        precondition(startRecordingSource.contains("if debugForcesMicrophoneStartFailure {"), "startRecording checks the microphone debug-failure hook")
+        precondition(startRecordingSource.contains("if debugForcesSystemAudioStartFailure {"), "startRecording checks the System Audio debug-failure hook")
+        precondition(startRecordingSource.contains("debugForcesMicrophoneStartFailure = false"), "the microphone debug hook resets itself after one use")
+        precondition(startRecordingSource.contains("debugForcesSystemAudioStartFailure = false"), "the System Audio debug hook resets itself after one use")
 
         precondition(source.contains("Publishers.CombineLatest(microphoneRecorder.$audioLevel, systemAudioRecorder.$audioLevel)"))
         precondition(source.contains("max(microphoneLevel, systemAudioLevel)"))

--- a/Tests/SystemDefaultAndSystemAudioRecorderSourceTests.swift
+++ b/Tests/SystemDefaultAndSystemAudioRecorderSourceTests.swift
@@ -9,25 +9,24 @@ struct SystemDefaultAndSystemAudioRecorderSourceTests {
         precondition(source.contains("@Published var audioLevel: Float"))
         precondition(source.contains("var onRecordingReady: (() -> Void)?"))
         precondition(source.contains("var onRecordingFailure: ((Error) -> Void)?"))
+        precondition(source.contains("var onRecordingDegraded: ((DegradedCombinedCaptureSource) -> Void)?"))
         precondition(source.contains("init(microphoneRecorder: AudioRecorder, systemAudioRecorder: SystemAudioRecorder, mixdownService: AudioMixdownService = AudioMixdownService())"))
         precondition(source.contains("struct CombinedRecordingStartResult: Equatable"))
         precondition(source.contains("let microphoneStarted: Bool"))
         precondition(source.contains("let systemAudioStarted: Bool"))
         precondition(source.contains("let microphoneUsedSystemDefaultFallback: Bool"))
 
-        // A partial combined start (exactly one source) must be identifiable
-        // as a single typed value so callers don't re-derive it from the two
-        // booleans, and so the notice can name which source is missing.
+        // Execution coverage in CombinedCaptureDegradationTests owns the four
+        // start outcomes; this source contract only keeps the typed API stable.
         precondition(source.contains("enum DegradedCombinedCaptureSource: Equatable"))
         precondition(source.contains("case microphone"))
         precondition(source.contains("case systemAudio"))
         precondition(source.contains("var missingSource: DegradedCombinedCaptureSource?"))
-        guard let missingSourceRange = source.range(of: "var missingSource: DegradedCombinedCaptureSource?") else {
-            preconditionFailure("Could not locate missingSource computed property")
-        }
-        let missingSourceBody = source[missingSourceRange.lowerBound..<source.index(missingSourceRange.lowerBound, offsetBy: 260)]
-        precondition(missingSourceBody.contains("!microphoneStarted"), "missingSource identifies a failed microphone")
-        precondition(missingSourceBody.contains("!systemAudioStarted"), "missingSource identifies a failed System Audio source")
+        precondition(source.contains("var currentMissingSource: DegradedCombinedCaptureSource?"))
+        precondition(source.contains("var startInProgress = false"))
+        precondition(source.contains("var startCompletionGroup: DispatchGroup?"))
+        precondition(source.contains("var readySources: Set<RecordingSource> = []"))
+        precondition(source.contains("state.failuresDuringStart.append(failure)"))
 
         // Manual QA hook: let a developer force one side of the combined
         // start to fail deterministically, without touching real hardware
@@ -49,15 +48,31 @@ struct SystemDefaultAndSystemAudioRecorderSourceTests {
         precondition(source.contains("let microphoneRecorder: AudioRecorder"))
         precondition(source.contains("let systemAudioRecorder: SystemAudioRecorder"))
         precondition(source.contains("let mixdownService: AudioMixdownService"))
-        precondition(source.contains("let result = try microphoneRecorder.startRecording("))
-        precondition(source.contains("deviceUID: microphoneDeviceUID"))
+        precondition(source.contains("struct CombinedRecordingStartOperations"))
+        precondition(source.contains("private let startOperations: CombinedRecordingStartOperations"))
+        precondition(source.contains("try microphoneRecorder.startRecording(deviceUID: deviceUID)"))
+        precondition(source.contains("try await systemAudioRecorder.startRecording()"))
+        precondition(source.contains("microphoneRecorder.cancelRecording"))
+        precondition(source.contains("cancelMicrophone: {"))
+        precondition(source.contains("async let microphoneAttempt"))
+        precondition(source.contains("async let systemAudioAttempt"))
+        precondition(source.contains("try startOperations.startMicrophone(microphoneDeviceUID)"))
+        precondition(source.contains("try await startOperations.startSystemAudio()"))
         precondition(source.contains("result.usedSystemDefaultFallback"))
         precondition(!source.contains("deviceUID: AudioInputDevice.defaultMicrophoneID"))
-        precondition(source.contains("try await systemAudioRecorder.startRecording()"))
         precondition(source.contains("guard microphoneStarted || systemStarted else"))
         precondition(source.contains("return CombinedRecordingStartResult("))
-        precondition(source.contains("fireRecordingReadyOnce()"))
+        precondition(source.contains("let startID = UUID()"))
+        precondition(source.contains("startCompletionGroup: startCompletionGroup"))
+        precondition(source.contains("configureChildCallbacks(startID: startID)"))
+        precondition(source.contains("source: .microphone"))
+        precondition(source.contains("source: .systemAudio"))
+        precondition(source.contains("state.readySources.insert(source)"))
+        precondition(source.contains("state.consumeReadyIfPossible()"))
+        precondition(source.contains("state.activeSources.contains"))
+        precondition(source.contains("!failedSources.contains($0)"))
         precondition(source.contains("handleSourceFailure"), "SystemDefaultAndSystemAudioRecorder should aggregate child recorder failures before reporting overall failure")
+        precondition(source.contains("onRecordingDegraded?(degradedSource)"))
         precondition(!source.contains("self?.onRecordingFailure?(error)"), "Child recorder failures should not be forwarded directly as overall failures")
         precondition(source.contains("subscribeToAudioLevelsIfNeeded()"), "startRecording should be able to restore audio level subscriptions after cleanup")
 
@@ -66,12 +81,13 @@ struct SystemDefaultAndSystemAudioRecorderSourceTests {
             preconditionFailure("Could not locate startRecording body")
         }
         let startRecordingSource = source[startRecordingRange.lowerBound..<stopRecordingRange.lowerBound]
-        precondition(startRecordingSource.contains("configureChildCallbacks()"), "startRecording should configure child callbacks each time it starts")
+        precondition(startRecordingSource.contains("configureChildCallbacks(startID: startID)"), "startRecording should scope child callbacks to each start")
         precondition(startRecordingSource.contains("subscribeToAudioLevelsIfNeeded()"), "startRecording should restore audio level subscriptions when needed")
-        precondition(startRecordingSource.contains("if debugForcesMicrophoneStartFailure {"), "startRecording checks the microphone debug-failure hook")
-        precondition(startRecordingSource.contains("if debugForcesSystemAudioStartFailure {"), "startRecording checks the System Audio debug-failure hook")
-        precondition(startRecordingSource.contains("debugForcesMicrophoneStartFailure = false"), "the microphone debug hook resets itself after one use")
-        precondition(startRecordingSource.contains("debugForcesSystemAudioStartFailure = false"), "the System Audio debug hook resets itself after one use")
+        precondition(startRecordingSource.contains("let forceMicrophoneFailure = debugForcesMicrophoneStartFailure"), "startRecording consumes the microphone debug-failure hook")
+        precondition(startRecordingSource.contains("let forceSystemAudioFailure = debugForcesSystemAudioStartFailure"), "startRecording consumes the System Audio debug-failure hook")
+        precondition(startRecordingSource.contains("debugForcesMicrophoneStartFailure = false"))
+        precondition(startRecordingSource.contains("debugForcesSystemAudioStartFailure = false"))
+        precondition(source.contains("if forceFailure {"), "each source attempt applies its consumed debug-failure hook")
 
         precondition(source.contains("Publishers.CombineLatest(microphoneRecorder.$audioLevel, systemAudioRecorder.$audioLevel)"))
         precondition(source.contains("max(microphoneLevel, systemAudioLevel)"))
@@ -79,6 +95,8 @@ struct SystemDefaultAndSystemAudioRecorderSourceTests {
         precondition(source.contains("systemAudioRecorder.stopRecording"))
         precondition(source.contains("stopRecordingSources { sources in"))
         precondition(source.contains("group.notify(queue: .main)"), "source drain completion should return on the main queue")
+        precondition(source.contains("notifyAfterPendingStart(startCompletionGroup)"))
+        precondition(source.contains("startCompletionGroup.notify(queue: .main"))
         precondition(source.contains("completion(CombinedStoppedRecordingSources("))
         precondition(source.contains("DispatchQueue.global(qos: .userInitiated).async"), "mixdown should not run on the main queue")
         precondition(source.contains("let finalURL = self.finalRecordingURL("))


### PR DESCRIPTION
## Summary

- Start the microphone and System Audio independently for `System default + System Audio`, preserving both-success, microphone-only, System-Audio-only, and total-failure outcomes.
- Automatically continue with the successful source when exactly one source starts, while showing a recording-scoped persistent notice that identifies the missing and active sources.
- Keep the existing recording pill/shortcut as the only Stop control; the notice has no Continue action and can only be dismissed with its hover-revealed × button.
- Protect startup, permission-resume, input-switch, and recorder callback paths with session ownership so cancellation and stale callbacks cannot revive a recording or notice.
- Atomically checkpoint the surviving audio with the startup-unavailable marker, and persist later runtime source loss so intentional zero-byte companions remain complete while truncated or unexpectedly empty sources stay partial/recoverable.
- Keep persistent and transient notices in separate stacked panels, measure localized text using AppKit glyph widths, reserve a fixed dismiss-button slot, and dynamically re-anchor notices when a meeting reminder appears, disappears, or resizes.
- Add deterministic debug failure hooks plus execution tests for combined startup outcomes, runtime degradation, cancellation rollback, notice lifecycle, and journal finalization.

## Test plan

- [x] `make test` — core, recording, transcription, and grouped AppState suites pass
- [x] `make test-recording`
- [x] `make localization-bundle-test CODESIGN_IDENTITY=Quill`
- [x] `make check-test-wiring`
- [x] `git diff --check`
- [x] `/code-review medium`
- [x] Isolated GUI verification: microphone-only and System-Audio-only degraded starts
- [x] Korean notice width and hover-dismiss layout
- [x] Meeting reminder visible before degraded recording
- [x] Meeting reminder arriving during an already-degraded recording
- [x] Recording stop and notice dismissal lifecycle

Closes #246


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 마이크 또는 시스템 오디오 중 하나를 사용할 수 없는 경우에도 가능한 입력으로 녹음을 계속할 수 있습니다.
  - 누락된 오디오 입력과 현재 녹음 중인 입력을 안내하는 알림 패널이 표시됩니다.
  - 관련 상태 안내가 영어와 한국어로 제공됩니다.

- **개선 사항**
  - 녹음 시작 및 입력 전환 중 부분 녹음 상태를 더 정확하게 안내합니다.
  - 알림 패널이 다른 화면 요소와 겹치지 않도록 배치가 개선되었습니다.
  - 녹음 전환과 취소 처리의 안정성이 향상되었습니다.
  - 디버그 설정에서 각 오디오 입력 실패 상황을 테스트할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->